### PR TITLE
[codex] Add SQLite JSON query service

### DIFF
--- a/specs/002-sqlite-json-querying/data-model.md
+++ b/specs/002-sqlite-json-querying/data-model.md
@@ -1,0 +1,88 @@
+# Data Model: SQLite JSON Querying (Phase 2A)
+
+## Existing Persisted Tables
+
+### `resource_versions`
+
+Stores immutable `Resource` version snapshots.
+
+| Column | Purpose |
+|---|---|
+| `resource_id` | Logical resource identity shared across versions |
+| `version` | Ordinal resource version |
+| `id` | Version-specific identifier |
+| `definition_id` | Resource definition id |
+| `definition_version` | Optional definition version at creation time |
+| `created` | ISO-8601 timestamp for the version snapshot |
+| `owner` | Optional owner metadata |
+| `hash` | Optional payload hash |
+| `payload` | JSON serialized `Resource` snapshot |
+
+### `activation_states`
+
+Stores channel activation state.
+
+| Column | Purpose |
+|---|---|
+| `resource_id` | Logical resource identity |
+| `channel` | Activation channel |
+| `payload` | JSON serialized `ActivationState` |
+
+## Query Inputs
+
+### `ResourceQuery`
+
+Provider query service consumes the existing `ResourceQuery` model:
+
+- `Scope`
+- `ActivationChannel`
+- `DefinitionId`
+- `Filter`
+- `Sorts`
+- `Skip`
+- `Take`
+
+### Supported `FilterExpression` Shapes
+
+- `MetadataFilter`
+- `AspectPresenceFilter`
+- `FacetValueFilter`
+- `LogicalExpression`
+
+## Internal Provider Helpers
+
+### `SqliteQueryBuilder`
+
+Internal mutable query assembly helper:
+
+- selected payload expression
+- `FROM`/joins/subqueries
+- `WHERE` fragments
+- `ORDER BY` fragments
+- `LIMIT`/`OFFSET`
+- parameters
+
+### `SqliteWhereTranslator`
+
+Translates supported `FilterExpression` nodes into SQL fragments and parameters.
+
+### `SqliteJsonPath`
+
+Creates safe SQLite JSON paths for:
+
+- aspect presence: path to `Resource.Aspects[aspectKey]`
+- facet value: path to `Resource.Aspects[aspectKey][facetDefinitionId]`
+
+The helper must not pass unchecked user text directly into SQL.
+
+### `SqliteParameterBag`
+
+Allocates deterministic parameter names and stores values for `SqliteCommand`.
+
+## Validation Rules
+
+- `Active` scope requires a non-empty `ActivationChannel`.
+- `Skip` and `Take` must be non-negative when provided.
+- `RangeValue` must specify at least one bound.
+- Facet sorting is unsupported unless implemented and tested.
+- Unsupported metadata fields fail with `UnsupportedQueryFeatureException`.

--- a/specs/002-sqlite-json-querying/plan.md
+++ b/specs/002-sqlite-json-querying/plan.md
@@ -1,0 +1,114 @@
+# Implementation Plan: SQLite JSON Querying (Phase 2A)
+
+**Branch**: `002-sqlite-json-querying` | **Date**: 2026-05-15 | **Spec**: [spec.md](./spec.md)  
+**Input**: Feature specification from `/specs/002-sqlite-json-querying/spec.md`
+
+## Summary
+
+Implement a SQLite-specific `IResourceQueryService` for `Aster.Persistence.SqliteJson` that executes supported `ResourceQuery` shapes directly in SQLite. The first slice supports metadata filters, version scopes, metadata sorting, and paging. The second slice adds simple scalar JSON facet filtering using SQLite JSON functions. Unsupported query shapes fail explicitly with `UnsupportedQueryFeatureException`; there is no hidden in-memory fallback.
+
+## Technical Context
+
+**Language/Version**: C# / .NET 8.0, 9.0, 10.0 multi-targeted libraries  
+**Primary Dependencies**: `Aster.Core`, `Microsoft.Data.Sqlite` 9.0.0  
+**Storage**: SQLite file database with table-plus-JSON-payload schema from `Aster.Persistence.SqliteJson`  
+**Testing**: xUnit via `dotnet test Aster.sln`  
+**Target Platform**: Cross-platform .NET library  
+**Project Type**: Library/provider package plus integration tests  
+**Performance Goals**: Avoid full-table materialization for supported metadata/scope/paging queries; keep query execution in SQLite for supported predicates  
+**Constraints**: No `IQueryable` provider, no new runtime dependency, no generic cross-provider query planner, no silent in-memory fallback  
+**Scale/Scope**: Phase 2A provider query path for SQLite JSON; not a full indexing/capability framework
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+- **SDK-first/headless**: PASS — adds provider implementation behind existing SDK contracts; no host/UI coupling.
+- **Immutable versioning**: PASS — queries read existing immutable resource version snapshots.
+- **Channel activation**: PASS — active/draft scopes continue to use activation state separate from payloads.
+- **Typed/queryable**: PASS — keeps `ResourceQuery` AST as the contract and explicitly rejects public `IQueryable`.
+- **Provider agnostic**: PASS — SQLite-specific code remains in `Aster.Persistence.SqliteJson`; core contracts remain provider-neutral.
+- **Simplicity first**: PASS — direct provider translator for current query shapes; no generic planner.
+- **Modern C# idioms**: PASS — use records/existing models, pattern matching, collection expressions where they clarify.
+- **Readability over cleverness**: PASS — prefer small translator helpers over dynamic metaprogramming.
+- **Explicitness over magic**: PASS — provider query service is explicitly registered by `AddAsterSqliteJson(...)`.
+- **Abstractions justified**: PASS — any helper abstractions are internal and exist only to separate SQL text, parameters, and AST translation.
+- **Optimize for deletion**: PASS — SQLite query service can be removed/replaced without changing core AST contracts.
+- **Composition over inheritance**: PASS — uses service composition and small helpers; no inheritance hierarchy.
+- **Intentional dependencies**: PASS — no new dependency beyond existing `Microsoft.Data.Sqlite`.
+- **Operational simplicity**: PASS — file-based SQLite and `dotnet test`; no external services.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/002-sqlite-json-querying/
+├── spec.md
+├── plan.md
+├── research.md
+├── data-model.md
+├── quickstart.md
+└── tasks.md
+```
+
+### Source Code (repository root)
+
+```text
+src/
+├── core/
+│   └── Aster.Core/
+│       ├── Abstractions/
+│       ├── Exceptions/
+│       └── Models/Querying/
+└── persistence/
+    └── Aster.Persistence.SqliteJson/
+        ├── SqliteJsonResourceStore.cs
+        ├── SqliteJsonQueryService.cs
+        ├── SqliteJsonAsterServiceCollectionExtensions.cs
+        └── Querying/
+            ├── SqliteQueryBuilder.cs
+            ├── SqliteWhereTranslator.cs
+            ├── SqliteJsonPath.cs
+            └── SqliteParameterBag.cs
+
+test/
+└── Aster.Tests/
+    └── SqliteJson/
+        ├── SqliteJsonResourceStoreTests.cs
+        └── SqliteJsonQueryServiceTests.cs
+```
+
+**Structure Decision**: Keep SQLite-specific query translation inside the provider package. Core remains unchanged except for possible error-message refinements if tests expose unclear unsupported-query diagnostics.
+
+## Complexity Tracking
+
+No constitution violations identified.
+
+## Phase 0: Research
+
+See [research.md](./research.md).
+
+## Phase 1: Design
+
+Design outputs:
+
+- [data-model.md](./data-model.md)
+- [quickstart.md](./quickstart.md)
+- No new public API contracts are expected beyond provider registration behavior; existing `IResourceQueryService` is the contract.
+
+## Implementation Strategy
+
+1. Add failing SQLite query integration tests for P1 metadata/scope/sort/page behavior.
+2. Implement `SqliteJsonQueryService` and register it from `AddAsterSqliteJson(...)`.
+3. Add failing P2 tests for aspect presence and scalar facet `Equals`, `Contains`, and `Range`.
+4. Implement SQLite JSON path translation using provider-owned helpers.
+5. Add P3 tests for unsupported query shapes and invalid query inputs.
+6. Verify in-memory query tests still pass unchanged.
+7. Update provider README and query docs with supported SQLite subset.
+
+## Risk Notes
+
+- SQLite JSON path construction is the primary injection-sensitive area; paths must be built from validated segments, not interpolated arbitrary user strings.
+- `Contains` semantics are simple SQLite substring matching for this feature, not full-text or culture-aware search.
+- Date-like facet range behavior is out of scope until typed index metadata exists. Numeric facet ranges and metadata `Created` sorting/filtering are the only range-like behavior in this slice.

--- a/specs/002-sqlite-json-querying/quickstart.md
+++ b/specs/002-sqlite-json-querying/quickstart.md
@@ -1,0 +1,80 @@
+# Quickstart: SQLite JSON Querying (Phase 2A)
+
+## Goal
+
+Run Aster with SQLite JSON persistence and execute provider-backed `ResourceQuery` instances through `IResourceQueryService`.
+
+## Setup
+
+```csharp
+using Aster.Core.Extensions;
+using Aster.Persistence.SqliteJson;
+
+var services = new ServiceCollection();
+
+services.AddAsterCore();
+services.AddAsterSqliteJson(options =>
+{
+    options.ConnectionString = "Data Source=aster.db";
+});
+
+await using var provider = services.BuildServiceProvider();
+```
+
+`AddAsterSqliteJson(...)` registers SQLite-backed definition, version reader/writer, and query service primitives. `IResourceManager` remains the provider-backed core manager.
+
+## Seed Data
+
+```csharp
+var definitions = provider.GetRequiredService<IResourceDefinitionStore>();
+var manager = provider.GetRequiredService<IResourceManager>();
+
+await definitions.RegisterDefinitionAsync(new ResourceDefinitionBuilder()
+    .WithDefinitionId("Product")
+    .Build());
+
+var product = await manager.CreateAsync("Product", new CreateResourceRequest
+{
+    InitialAspects = new Dictionary<string, object>
+    {
+        ["TitleAspect"] = new { Title = "Super Gadget" },
+        ["PriceAspect"] = new { Amount = 49.99m, Currency = "USD" },
+    },
+});
+
+await manager.ActivateAsync(product.ResourceId, product.Version, "Published");
+```
+
+## Query Metadata
+
+```csharp
+var queryService = provider.GetRequiredService<IResourceQueryService>();
+
+var latestProducts = await queryService.QueryAsync(new ResourceQuery
+{
+    DefinitionId = "Product",
+    Scope = ResourceVersionScope.Latest,
+    Sorts = [new SortExpression("Created", SortDirection.Descending)],
+    Take = 20,
+});
+```
+
+## Query Facets
+
+```csharp
+var gadgets = await queryService.QueryAsync(new ResourceQuery
+{
+    DefinitionId = "Product",
+    Scope = ResourceVersionScope.Active,
+    ActivationChannel = "Published",
+    Filter = new FacetValueFilter(
+        "TitleAspect",
+        "Title",
+        "Gadget",
+        ComparisonOperator.Contains),
+});
+```
+
+## Unsupported Queries
+
+Unsupported query shapes throw `UnsupportedQueryFeatureException`. They do not silently fall back to in-memory filtering.

--- a/specs/002-sqlite-json-querying/research.md
+++ b/specs/002-sqlite-json-querying/research.md
@@ -1,0 +1,45 @@
+# Research: SQLite JSON Querying (Phase 2A)
+
+## Decision: Provider-specific query services own SQL translation
+
+**Decision**: Implement `SqliteJsonQueryService` inside `Aster.Persistence.SqliteJson` rather than adding a generic SQL generator or `IQueryable` provider.
+
+**Rationale**: Aster query semantics include resource version scopes, activation channels, JSON aspect payloads, and provider-specific JSON behavior. The hard part is not generic SQL generation; it is preserving portable Aster semantics for each provider. Keeping translation provider-specific is simpler and more explicit.
+
+**Alternatives considered**:
+
+- **Generic SQL builder package**: Helpful for SQL string composition, but does not solve JSON path semantics, activation scope semantics, or provider capability decisions. Reconsider if internal SQL helper code grows beyond the current subset.
+- **EF Core**: Adds an ORM model that does not match Aster's provider-defined snapshot/JSON storage shape. It would likely require raw SQL for the interesting JSON queries anyway.
+- **Dapper**: Useful row mapping/parameter helper, but not necessary while `Microsoft.Data.Sqlite` is already sufficient and dependency minimization is preferred.
+- **Public `IQueryable` provider**: Rejected. It would imply broad LINQ support and provider behavior leakage. Future typed query helpers should compile a small expression subset into `ResourceQuery` instead.
+
+## Decision: Use `Microsoft.Data.Sqlite` directly for Phase 2A
+
+**Decision**: Continue using `Microsoft.Data.Sqlite` directly for query execution.
+
+**Rationale**: It is already a provider dependency, supports parameterized commands, and keeps operational/dependency complexity low.
+
+**Alternatives considered**:
+
+- **SqlKata**: A reasonable future option if SQL composition becomes noisy. Not needed for the first provider-specific translator.
+- **Dapper**: Not needed for payload deserialization and simple row reading currently handled directly.
+
+## Decision: SQLite JSON lookup uses provider-owned JSON path helper
+
+**Decision**: Add a small helper to create SQLite JSON paths for aspect keys and facet identifiers.
+
+**Rationale**: JSON paths are not ordinary SQL parameters in SQLite expressions, so the provider must avoid unsafe path interpolation. The helper should validate or safely quote path segments before SQL assembly.
+
+**Source context**: SQLite JSON functions are built into SQLite by default as of SQLite 3.38.0, and `json_extract()` returns SQL scalar values for single-path scalar lookups. See SQLite JSON functions documentation: https://www.sqlite.org/json1.html
+
+## Decision: Unsupported means typed failure, not fallback
+
+**Decision**: Unsupported SQLite query shapes throw `UnsupportedQueryFeatureException`.
+
+**Rationale**: Silent in-memory fallback hides performance and semantic differences. Explicit failure matches the provider honesty goal and keeps future capability negotiation possible.
+
+## Decision: Typed LINQ-like helpers are future AST authoring, not this feature
+
+**Decision**: Do not implement typed LINQ-like query builders in this feature. Future helpers may parse a small subset of `Expression<Func<TAspect, bool>>`, but must emit `ResourceQuery`.
+
+**Rationale**: SQLite query execution correctness should come before authoring ergonomics. Keeping the AST as the contract avoids the `IQueryable` trap and keeps provider behavior explicit.

--- a/specs/002-sqlite-json-querying/spec.md
+++ b/specs/002-sqlite-json-querying/spec.md
@@ -1,0 +1,131 @@
+# Feature Specification: SQLite JSON Querying (Phase 2A)
+
+**Feature Branch**: `002-sqlite-json-querying`  
+**Created**: 2026-05-15  
+**Status**: Draft  
+**Input**: User description: "Create the Spec Kit feature spec for SQLite JSON query translation, provider capability/error behavior, and SQLite-backed query execution."
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Query Persisted Resources By Metadata (Priority: P1)
+
+Developers using the SQLite JSON provider can execute `ResourceQuery` against persisted resources without first loading every version into an in-memory LINQ evaluator.
+
+**Why this priority**: This is the smallest useful provider-backed query slice. It proves the SQLite provider can execute the portable query model directly while keeping the behavior simple and observable.
+
+**Independent Test**: Persist several resource versions through `IResourceManager`, recreate the service provider against the same SQLite database, query through `IResourceQueryService`, and verify metadata filters, version scopes, paging, and metadata sorting are executed correctly.
+
+**Acceptance Scenarios**:
+
+1. **Given** persisted `Product` and `Order` resources, **When** a query specifies `DefinitionId = "Product"`, **Then** only persisted Product resources are returned.
+2. **Given** a resource with versions 1 and 2, **When** a query uses `ResourceVersionScope.Latest`, **Then** only version 2 is returned.
+3. **Given** a resource with versions 1 and 2, **When** a query uses `ResourceVersionScope.AllVersions`, **Then** both versions are returned in deterministic order when a sort is supplied.
+4. **Given** active and draft resources, **When** a query uses `ResourceVersionScope.Active` with `ActivationChannel = "Published"`, **Then** only versions active in that channel are returned.
+5. **Given** a query with `Skip`, `Take`, and metadata sort expressions, **When** it runs against SQLite, **Then** paging is applied after filtering and sorting.
+
+---
+
+### User Story 2 - Filter Persisted Facet Values In SQLite JSON (Priority: P2)
+
+Developers can query persisted aspect/facet values stored inside SQLite JSON payloads using the existing portable `FacetValueFilter` model.
+
+**Why this priority**: Facet querying is the core reason for the query AST. It should build on the simpler metadata/scope implementation after the provider-backed query path is proven.
+
+**Independent Test**: Persist resources with typed aspect payloads, recreate the service provider, execute facet-value queries through `IResourceQueryService`, and verify `Equals`, `Contains`, and `Range` behavior for simple scalar facets.
+
+**Acceptance Scenarios**:
+
+1. **Given** persisted Product resources with `TitleAspect.Title`, **When** a `Contains` query searches for `"Gadget"`, **Then** only matching resources are returned.
+2. **Given** persisted Product resources with `PriceAspect.Amount`, **When** a `RangeValue` query specifies `Min = 10` and `Max = 100`, **Then** only resources within the inclusive range are returned.
+3. **Given** persisted resources with missing aspect keys or missing facets, **When** a facet filter targets the missing value, **Then** those resources do not match.
+4. **Given** a named aspect key such as `"PriceAspect:Sale"`, **When** a facet filter targets that key, **Then** SQLite JSON lookup uses the exact aspect key and facet path.
+
+---
+
+### User Story 3 - Reject Unsupported Query Shapes Explicitly (Priority: P3)
+
+Developers receive a typed, actionable error when the SQLite provider cannot execute a query shape with portable semantics.
+
+**Why this priority**: Provider-backed querying must be honest. Failing explicitly is preferable to silent client-side fallback or provider-specific behavior that looks portable but is not.
+
+**Independent Test**: Execute intentionally unsupported query shapes against the SQLite query service and verify `UnsupportedQueryFeatureException` identifies the unsupported predicate, sort, or scope.
+
+**Acceptance Scenarios**:
+
+1. **Given** a query with an unsupported metadata field, **When** it runs against SQLite, **Then** the provider throws `UnsupportedQueryFeatureException`.
+2. **Given** a query with a facet sort the provider does not yet support, **When** it runs against SQLite, **Then** the provider throws `UnsupportedQueryFeatureException` instead of sorting in memory.
+3. **Given** a query that attempts facet sorting, **When** facet sorting has not been implemented for SQLite, **Then** the provider rejects the query with a typed error.
+
+---
+
+### Edge Cases
+
+- Active scope without `ActivationChannel` MUST fail before executing SQL.
+- `RangeValue` with both `Min` and `Max` as `null` SHOULD be treated as unsupported because it does not constrain results.
+- `Skip` and `Take` values below zero MUST be rejected.
+- `Take = 0` MUST return an empty result set without error.
+- Missing JSON aspect keys or facet properties MUST evaluate as non-matches, not errors.
+- SQLite `NULL`, missing JSON properties, and empty strings MUST NOT be treated as equal unless explicitly supported by a future query operator.
+- Facet paths MUST be built safely and MUST NOT allow SQL injection through aspect keys or facet identifiers.
+- Query result ordering MUST be deterministic when sorts are supplied.
+- Provider behavior MUST be the same after service/provider restart against the same SQLite database.
+
+### Constitution Alignment *(mandatory)*
+
+- **Simplicity**: Implement direct SQLite query translation for the currently supported `ResourceQuery` model. Do not introduce a generic query planner, expression-tree compiler, or cross-provider capability framework in this slice.
+- **Explicitness**: SQLite-backed query execution is enabled through explicit DI registration. Unsupported query shapes fail with `UnsupportedQueryFeatureException`; no hidden fallback to in-memory evaluation.
+- **Dependencies**: No new runtime dependency is expected beyond the existing `Microsoft.Data.Sqlite` package already used by `Aster.Persistence.SqliteJson`.
+- **Operational Impact**: Queries run against the existing SQLite database file. Local development remains `dotnet test`; no external database server, background service, or migration runner is required for this slice.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The SQLite JSON provider MUST expose an `IResourceQueryService` implementation that executes supported `ResourceQuery` instances against SQLite.
+- **FR-002**: The SQLite query service MUST support `ResourceQuery.DefinitionId` filtering.
+- **FR-003**: The SQLite query service MUST support `ResourceVersionScope.Latest`, `AllVersions`, `Active`, and `Draft`.
+- **FR-004**: `ResourceVersionScope.Active` MUST require `ActivationChannel`.
+- **FR-005**: The SQLite query service MUST support `MetadataFilter` for `ResourceId`, `Id`, `DefinitionId`, `Owner`, `Version`, and `Created`.
+- **FR-006**: The SQLite query service MUST support logical `And`, `Or`, and `Not` over supported child predicates.
+- **FR-007**: The SQLite query service MUST support metadata sorting for supported metadata fields.
+- **FR-008**: The SQLite query service MUST apply `Skip` and `Take` after filtering and sorting.
+- **FR-009**: The SQLite query service MUST support `AspectPresenceFilter` against persisted JSON payloads.
+- **FR-010**: The SQLite query service MUST support `FacetValueFilter` with `Equals` for simple scalar JSON facet values.
+- **FR-011**: The SQLite query service SHOULD support `FacetValueFilter` with `Contains` for simple string JSON facet values.
+- **FR-012**: The SQLite query service SHOULD support `FacetValueFilter` with `Range` for numeric simple scalar JSON facet values.
+- **FR-013**: Unsupported query shapes MUST throw `UnsupportedQueryFeatureException`.
+- **FR-014**: The provider MUST NOT silently fall back to in-memory filtering, sorting, or paging for unsupported predicates.
+- **FR-015**: SQL generation MUST use parameters for user-supplied values and MUST safely encode JSON paths for aspect/facet lookup.
+- **FR-016**: The SQLite provider registration SHOULD replace the default `IResourceQueryService` when `AddAsterSqliteJson(...)` is called after `AddAsterCore()`.
+- **FR-017**: Existing in-memory query behavior MUST remain unchanged.
+- **FR-018**: Tests MUST cover persisted data across service-provider/store recreation.
+- **FR-019**: This feature MUST NOT expose `IQueryable<Resource>` or implement a LINQ provider.
+- **FR-020**: Typed LINQ-like query helpers MAY be introduced by a later feature, but they MUST compile into `ResourceQuery` rather than bypassing the AST.
+
+### Key Entities *(include if feature involves data)*
+
+- **ResourceQuery**: Portable query request containing version scope, optional definition shortcut, filter tree, sort expressions, skip, and take.
+- **FilterExpression**: Query predicate tree containing metadata, aspect presence, facet value, and logical expressions.
+- **SortExpression**: Ordering instruction over metadata fields for this slice; facet sorting is explicitly unsupported unless implemented and tested.
+- **RangeValue**: Inclusive/exclusive lower and upper bounds for range comparisons.
+- **SQLite Resource Payload**: JSON serialized `Resource` snapshot persisted in `resource_versions.payload`.
+- **SQLite Activation Payload**: JSON serialized `ActivationState` persisted in `activation_states.payload`.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Metadata/scope/paging/sorting queries over persisted SQLite resources pass integration tests after recreating the service provider.
+- **SC-002**: Facet `Equals`, string `Contains`, and numeric `Range` behavior is covered by integration tests for simple scalar JSON values.
+- **SC-003**: Unsupported query shapes consistently throw `UnsupportedQueryFeatureException` with no silent in-memory fallback.
+- **SC-004**: The full solution test suite passes with no new warnings.
+- **SC-005**: SQLite provider setup remains a single explicit `AddAsterSqliteJson(...)` registration and requires no external service.
+
+## Assumptions
+
+- The existing SQLite provider schema remains table-plus-JSON-payload based for this slice.
+- JSON facet lookup targets simple aspect objects stored under `Resource.Aspects[aspectKey]`.
+- Full provider capability negotiation (`IQueryCapabilities`) is out of scope for this spec; typed unsupported errors are sufficient.
+- Typed LINQ-like AST authoring helpers are out of scope for this spec. The intended future direction is a small expression-subset compiler that produces `ResourceQuery`, not an `IQueryable` provider.
+- Date-like facet ranges, full-text search, culture-aware collation, diacritic normalization, array operators, and facet sorting are out of scope unless explicitly added by a later spec.
+- The current in-memory query service remains the reference behavior for unsupported SQLite work during development, but production execution MUST NOT silently fall back.

--- a/specs/002-sqlite-json-querying/tasks.md
+++ b/specs/002-sqlite-json-querying/tasks.md
@@ -1,0 +1,165 @@
+# Tasks: SQLite JSON Querying (Phase 2A)
+
+**Input**: Design documents from `/specs/002-sqlite-json-querying/`  
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, quickstart.md
+
+**Tests**: Tests are required for each user story because this feature changes provider query execution semantics.
+
+**Organization**: Tasks are grouped by user story to enable independent implementation and testing.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story the task belongs to
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Prepare provider query service files and registration points.
+
+- [ ] T001 Confirm Constitution Check gates in `specs/002-sqlite-json-querying/plan.md` still pass before implementation begins
+- [ ] T002 Create `src/persistence/Aster.Persistence.SqliteJson/SqliteJsonQueryService.cs`
+- [ ] T003 [P] Create `src/persistence/Aster.Persistence.SqliteJson/Querying/SqliteParameterBag.cs`
+- [ ] T004 [P] Create `src/persistence/Aster.Persistence.SqliteJson/Querying/SqliteQueryBuilder.cs`
+- [ ] T005 [P] Create `src/persistence/Aster.Persistence.SqliteJson/Querying/SqliteWhereTranslator.cs`
+- [ ] T006 [P] Create `src/persistence/Aster.Persistence.SqliteJson/Querying/SqliteJsonPath.cs`
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Core translation/execution structure required before user stories.
+
+**CRITICAL**: No user story work can be completed until this phase is complete.
+
+- [ ] T007 Register `SqliteJsonQueryService` as `IResourceQueryService` in `src/persistence/Aster.Persistence.SqliteJson/SqliteJsonAsterServiceCollectionExtensions.cs`
+- [ ] T008 Implement shared SQLite command execution and payload deserialization in `src/persistence/Aster.Persistence.SqliteJson/SqliteJsonQueryService.cs`
+- [ ] T009 Implement query input validation for `Scope`, `ActivationChannel`, `Skip`, `Take`, and empty `RangeValue` in `src/persistence/Aster.Persistence.SqliteJson/SqliteJsonQueryService.cs`
+- [ ] T010 Implement unsupported-feature helper methods that throw `UnsupportedQueryFeatureException` with actionable messages in `src/persistence/Aster.Persistence.SqliteJson/Querying/SqliteWhereTranslator.cs`
+- [ ] T011 Document and justify that no new abstraction or third-party dependency is introduced for this feature
+
+**Checkpoint**: SQLite query service can be resolved but does not yet need to support all query stories.
+
+---
+
+## Phase 3: User Story 1 - Query Persisted Resources By Metadata (Priority: P1)
+
+**Goal**: Execute metadata, scope, sort, and paging queries in SQLite.
+
+**Independent Test**: Persist resources, recreate the service provider, query through `IResourceQueryService`, and verify metadata filters, scopes, sorting, and paging.
+
+### Tests for User Story 1
+
+- [ ] T012 [P] [US1] Add SQLite metadata filtering tests in `test/Aster.Tests/SqliteJson/SqliteJsonQueryServiceTests.cs`
+- [ ] T013 [P] [US1] Add latest/all/active/draft scope tests in `test/Aster.Tests/SqliteJson/SqliteJsonQueryServiceTests.cs`
+- [ ] T014 [P] [US1] Add metadata sort, `Skip`, and `Take` tests in `test/Aster.Tests/SqliteJson/SqliteJsonQueryServiceTests.cs`
+
+### Implementation for User Story 1
+
+- [ ] T015 [US1] Implement base scope SQL for `Latest` and `AllVersions` in `src/persistence/Aster.Persistence.SqliteJson/SqliteJsonQueryService.cs`
+- [ ] T016 [US1] Implement `Active` and `Draft` scope SQL using `activation_states` in `src/persistence/Aster.Persistence.SqliteJson/SqliteJsonQueryService.cs`
+- [ ] T017 [US1] Implement `DefinitionId` shortcut filtering in `src/persistence/Aster.Persistence.SqliteJson/SqliteJsonQueryService.cs`
+- [ ] T018 [US1] Implement `MetadataFilter` translation for supported metadata fields in `src/persistence/Aster.Persistence.SqliteJson/Querying/SqliteWhereTranslator.cs`
+- [ ] T019 [US1] Implement `LogicalExpression` translation for `And`, `Or`, and `Not` in `src/persistence/Aster.Persistence.SqliteJson/Querying/SqliteWhereTranslator.cs`
+- [ ] T020 [US1] Implement metadata `SortExpression` translation in `src/persistence/Aster.Persistence.SqliteJson/SqliteJsonQueryService.cs`
+- [ ] T021 [US1] Implement SQL `LIMIT`/`OFFSET` for `Take`/`Skip` in `src/persistence/Aster.Persistence.SqliteJson/SqliteJsonQueryService.cs`
+
+**Checkpoint**: User Story 1 works independently and all US1 tests pass.
+
+---
+
+## Phase 4: User Story 2 - Filter Persisted Facet Values In SQLite JSON (Priority: P2)
+
+**Goal**: Execute simple scalar JSON aspect/facet filters in SQLite.
+
+**Independent Test**: Persist typed aspect payloads, recreate the provider, and verify facet `Equals`, `Contains`, and `Range` queries.
+
+### Tests for User Story 2
+
+- [ ] T022 [P] [US2] Add `AspectPresenceFilter` tests in `test/Aster.Tests/SqliteJson/SqliteJsonQueryServiceTests.cs`
+- [ ] T023 [P] [US2] Add `FacetValueFilter` `Equals` tests for strings/numbers in `test/Aster.Tests/SqliteJson/SqliteJsonQueryServiceTests.cs`
+- [ ] T024 [P] [US2] Add `FacetValueFilter` `Contains` tests for string facets in `test/Aster.Tests/SqliteJson/SqliteJsonQueryServiceTests.cs`
+- [ ] T025 [P] [US2] Add `FacetValueFilter` `Range` tests for numeric facets in `test/Aster.Tests/SqliteJson/SqliteJsonQueryServiceTests.cs`
+- [ ] T026 [P] [US2] Add missing aspect/facet non-match tests in `test/Aster.Tests/SqliteJson/SqliteJsonQueryServiceTests.cs`
+
+### Implementation for User Story 2
+
+- [ ] T027 [US2] Implement safe JSON path segment encoding in `src/persistence/Aster.Persistence.SqliteJson/Querying/SqliteJsonPath.cs`
+- [ ] T028 [US2] Implement `AspectPresenceFilter` translation using SQLite JSON functions in `src/persistence/Aster.Persistence.SqliteJson/Querying/SqliteWhereTranslator.cs`
+- [ ] T029 [US2] Implement facet `Equals` translation in `src/persistence/Aster.Persistence.SqliteJson/Querying/SqliteWhereTranslator.cs`
+- [ ] T030 [US2] Implement facet `Contains` translation for strings in `src/persistence/Aster.Persistence.SqliteJson/Querying/SqliteWhereTranslator.cs`
+- [ ] T031 [US2] Implement facet `Range` translation for numeric scalar values in `src/persistence/Aster.Persistence.SqliteJson/Querying/SqliteWhereTranslator.cs`
+
+**Checkpoint**: User Story 2 works independently and all US2 tests pass.
+
+---
+
+## Phase 5: User Story 3 - Reject Unsupported Query Shapes Explicitly (Priority: P3)
+
+**Goal**: Fail unsupported provider query shapes with clear typed errors.
+
+**Independent Test**: Execute unsupported query shapes and verify `UnsupportedQueryFeatureException`.
+
+### Tests for User Story 3
+
+- [ ] T032 [P] [US3] Add unsupported metadata field tests in `test/Aster.Tests/SqliteJson/SqliteJsonQueryServiceTests.cs`
+- [ ] T033 [P] [US3] Add unsupported facet sort tests in `test/Aster.Tests/SqliteJson/SqliteJsonQueryServiceTests.cs`
+- [ ] T034 [P] [US3] Add invalid active scope and invalid paging tests in `test/Aster.Tests/SqliteJson/SqliteJsonQueryServiceTests.cs`
+- [ ] T035 [P] [US3] Add no in-memory fallback regression test in `test/Aster.Tests/SqliteJson/SqliteJsonQueryServiceTests.cs`
+- [ ] T036 [P] [US3] Add no `IQueryable<Resource>` / no LINQ-provider API regression check in `test/Aster.Tests/SqliteJson/SqliteJsonQueryServiceTests.cs`
+
+### Implementation for User Story 3
+
+- [ ] T037 [US3] Ensure unsupported sorts fail before SQL execution in `src/persistence/Aster.Persistence.SqliteJson/SqliteJsonQueryService.cs`
+- [ ] T038 [US3] Ensure unsupported predicates fail before SQL execution in `src/persistence/Aster.Persistence.SqliteJson/Querying/SqliteWhereTranslator.cs`
+- [ ] T039 [US3] Ensure invalid query inputs fail before SQL execution in `src/persistence/Aster.Persistence.SqliteJson/SqliteJsonQueryService.cs`
+
+**Checkpoint**: User Story 3 works independently and unsupported behavior is explicit.
+
+---
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+**Purpose**: Documentation, cleanup, and final verification.
+
+- [ ] T040 [P] Update `src/persistence/Aster.Persistence.SqliteJson/README.md` with SQLite query support and unsupported behavior
+- [ ] T041 [P] Update `wiki/Querying.md` with SQLite provider query subset and future typed-helper direction
+- [ ] T042 Re-run Constitution Check and remove unnecessary abstractions/dependencies before final verification
+- [ ] T043 Run `dotnet test Aster.sln`
+- [ ] T044 Review generated SQL helpers for readability, explicitness, parameter usage, and safe JSON path construction
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies.
+- **Foundational (Phase 2)**: Depends on Setup completion and blocks all user stories.
+- **US1 (Phase 3)**: Depends on Foundational.
+- **US2 (Phase 4)**: Depends on Foundational; can start after US1 structure exists, but tests should remain independently understandable.
+- **US3 (Phase 5)**: Depends on Foundational; can run alongside US1/US2 once translator shape exists.
+- **Polish (Phase 6)**: Depends on desired user stories being complete.
+
+### Parallel Opportunities
+
+- T003-T006 can run in parallel.
+- T012-T014 can run in parallel.
+- T022-T026 can run in parallel.
+- T032-T036 can run in parallel.
+- T040-T041 can run in parallel.
+
+## Implementation Strategy
+
+### MVP First (US1 Only)
+
+1. Complete Setup and Foundational tasks.
+2. Complete US1 tests and implementation.
+3. Run `dotnet test Aster.sln`.
+4. Validate provider-backed metadata/scope queries independently before starting facet JSON filters.
+
+### Full Feature
+
+1. Complete MVP.
+2. Add US2 facet JSON filtering.
+3. Add US3 unsupported-query behavior.
+4. Complete docs and final verification.

--- a/specs/002-sqlite-json-querying/tasks.md
+++ b/specs/002-sqlite-json-querying/tasks.md
@@ -16,12 +16,12 @@
 
 **Purpose**: Prepare provider query service files and registration points.
 
-- [ ] T001 Confirm Constitution Check gates in `specs/002-sqlite-json-querying/plan.md` still pass before implementation begins
-- [ ] T002 Create `src/persistence/Aster.Persistence.SqliteJson/SqliteJsonQueryService.cs`
-- [ ] T003 [P] Create `src/persistence/Aster.Persistence.SqliteJson/Querying/SqliteParameterBag.cs`
-- [ ] T004 [P] Create `src/persistence/Aster.Persistence.SqliteJson/Querying/SqliteQueryBuilder.cs`
-- [ ] T005 [P] Create `src/persistence/Aster.Persistence.SqliteJson/Querying/SqliteWhereTranslator.cs`
-- [ ] T006 [P] Create `src/persistence/Aster.Persistence.SqliteJson/Querying/SqliteJsonPath.cs`
+- [x] T001 Confirm Constitution Check gates in `specs/002-sqlite-json-querying/plan.md` still pass before implementation begins
+- [x] T002 Create `src/persistence/Aster.Persistence.SqliteJson/SqliteJsonQueryService.cs`
+- [x] T003 [P] Create `src/persistence/Aster.Persistence.SqliteJson/Querying/SqliteParameterBag.cs`
+- [x] T004 [P] Create `src/persistence/Aster.Persistence.SqliteJson/Querying/SqliteQueryBuilder.cs`
+- [x] T005 [P] Create `src/persistence/Aster.Persistence.SqliteJson/Querying/SqliteWhereTranslator.cs`
+- [x] T006 [P] Create `src/persistence/Aster.Persistence.SqliteJson/Querying/SqliteJsonPath.cs`
 
 ---
 
@@ -31,11 +31,11 @@
 
 **CRITICAL**: No user story work can be completed until this phase is complete.
 
-- [ ] T007 Register `SqliteJsonQueryService` as `IResourceQueryService` in `src/persistence/Aster.Persistence.SqliteJson/SqliteJsonAsterServiceCollectionExtensions.cs`
-- [ ] T008 Implement shared SQLite command execution and payload deserialization in `src/persistence/Aster.Persistence.SqliteJson/SqliteJsonQueryService.cs`
-- [ ] T009 Implement query input validation for `Scope`, `ActivationChannel`, `Skip`, `Take`, and empty `RangeValue` in `src/persistence/Aster.Persistence.SqliteJson/SqliteJsonQueryService.cs`
-- [ ] T010 Implement unsupported-feature helper methods that throw `UnsupportedQueryFeatureException` with actionable messages in `src/persistence/Aster.Persistence.SqliteJson/Querying/SqliteWhereTranslator.cs`
-- [ ] T011 Document and justify that no new abstraction or third-party dependency is introduced for this feature
+- [x] T007 Register `SqliteJsonQueryService` as `IResourceQueryService` in `src/persistence/Aster.Persistence.SqliteJson/SqliteJsonAsterServiceCollectionExtensions.cs`
+- [x] T008 Implement shared SQLite command execution and payload deserialization in `src/persistence/Aster.Persistence.SqliteJson/SqliteJsonQueryService.cs`
+- [x] T009 Implement query input validation for `Scope`, `ActivationChannel`, `Skip`, `Take`, and empty `RangeValue` in `src/persistence/Aster.Persistence.SqliteJson/SqliteJsonQueryService.cs`
+- [x] T010 Implement unsupported-feature helper methods that throw `UnsupportedQueryFeatureException` with actionable messages in `src/persistence/Aster.Persistence.SqliteJson/Querying/SqliteWhereTranslator.cs`
+- [x] T011 Document and justify that no new abstraction or third-party dependency is introduced for this feature
 
 **Checkpoint**: SQLite query service can be resolved but does not yet need to support all query stories.
 
@@ -49,19 +49,19 @@
 
 ### Tests for User Story 1
 
-- [ ] T012 [P] [US1] Add SQLite metadata filtering tests in `test/Aster.Tests/SqliteJson/SqliteJsonQueryServiceTests.cs`
-- [ ] T013 [P] [US1] Add latest/all/active/draft scope tests in `test/Aster.Tests/SqliteJson/SqliteJsonQueryServiceTests.cs`
-- [ ] T014 [P] [US1] Add metadata sort, `Skip`, and `Take` tests in `test/Aster.Tests/SqliteJson/SqliteJsonQueryServiceTests.cs`
+- [x] T012 [P] [US1] Add SQLite metadata filtering tests in `test/Aster.Tests/SqliteJson/SqliteJsonQueryServiceTests.cs`
+- [x] T013 [P] [US1] Add latest/all/active/draft scope tests in `test/Aster.Tests/SqliteJson/SqliteJsonQueryServiceTests.cs`
+- [x] T014 [P] [US1] Add metadata sort, `Skip`, and `Take` tests in `test/Aster.Tests/SqliteJson/SqliteJsonQueryServiceTests.cs`
 
 ### Implementation for User Story 1
 
-- [ ] T015 [US1] Implement base scope SQL for `Latest` and `AllVersions` in `src/persistence/Aster.Persistence.SqliteJson/SqliteJsonQueryService.cs`
-- [ ] T016 [US1] Implement `Active` and `Draft` scope SQL using `activation_states` in `src/persistence/Aster.Persistence.SqliteJson/SqliteJsonQueryService.cs`
-- [ ] T017 [US1] Implement `DefinitionId` shortcut filtering in `src/persistence/Aster.Persistence.SqliteJson/SqliteJsonQueryService.cs`
-- [ ] T018 [US1] Implement `MetadataFilter` translation for supported metadata fields in `src/persistence/Aster.Persistence.SqliteJson/Querying/SqliteWhereTranslator.cs`
-- [ ] T019 [US1] Implement `LogicalExpression` translation for `And`, `Or`, and `Not` in `src/persistence/Aster.Persistence.SqliteJson/Querying/SqliteWhereTranslator.cs`
-- [ ] T020 [US1] Implement metadata `SortExpression` translation in `src/persistence/Aster.Persistence.SqliteJson/SqliteJsonQueryService.cs`
-- [ ] T021 [US1] Implement SQL `LIMIT`/`OFFSET` for `Take`/`Skip` in `src/persistence/Aster.Persistence.SqliteJson/SqliteJsonQueryService.cs`
+- [x] T015 [US1] Implement base scope SQL for `Latest` and `AllVersions` in `src/persistence/Aster.Persistence.SqliteJson/SqliteJsonQueryService.cs`
+- [x] T016 [US1] Implement `Active` and `Draft` scope SQL using `activation_states` in `src/persistence/Aster.Persistence.SqliteJson/SqliteJsonQueryService.cs`
+- [x] T017 [US1] Implement `DefinitionId` shortcut filtering in `src/persistence/Aster.Persistence.SqliteJson/SqliteJsonQueryService.cs`
+- [x] T018 [US1] Implement `MetadataFilter` translation for supported metadata fields in `src/persistence/Aster.Persistence.SqliteJson/Querying/SqliteWhereTranslator.cs`
+- [x] T019 [US1] Implement `LogicalExpression` translation for `And`, `Or`, and `Not` in `src/persistence/Aster.Persistence.SqliteJson/Querying/SqliteWhereTranslator.cs`
+- [x] T020 [US1] Implement metadata `SortExpression` translation in `src/persistence/Aster.Persistence.SqliteJson/SqliteJsonQueryService.cs`
+- [x] T021 [US1] Implement SQL `LIMIT`/`OFFSET` for `Take`/`Skip` in `src/persistence/Aster.Persistence.SqliteJson/SqliteJsonQueryService.cs`
 
 **Checkpoint**: User Story 1 works independently and all US1 tests pass.
 
@@ -75,19 +75,19 @@
 
 ### Tests for User Story 2
 
-- [ ] T022 [P] [US2] Add `AspectPresenceFilter` tests in `test/Aster.Tests/SqliteJson/SqliteJsonQueryServiceTests.cs`
-- [ ] T023 [P] [US2] Add `FacetValueFilter` `Equals` tests for strings/numbers in `test/Aster.Tests/SqliteJson/SqliteJsonQueryServiceTests.cs`
-- [ ] T024 [P] [US2] Add `FacetValueFilter` `Contains` tests for string facets in `test/Aster.Tests/SqliteJson/SqliteJsonQueryServiceTests.cs`
-- [ ] T025 [P] [US2] Add `FacetValueFilter` `Range` tests for numeric facets in `test/Aster.Tests/SqliteJson/SqliteJsonQueryServiceTests.cs`
-- [ ] T026 [P] [US2] Add missing aspect/facet non-match tests in `test/Aster.Tests/SqliteJson/SqliteJsonQueryServiceTests.cs`
+- [x] T022 [P] [US2] Add `AspectPresenceFilter` tests in `test/Aster.Tests/SqliteJson/SqliteJsonQueryServiceTests.cs`
+- [x] T023 [P] [US2] Add `FacetValueFilter` `Equals` tests for strings/numbers in `test/Aster.Tests/SqliteJson/SqliteJsonQueryServiceTests.cs`
+- [x] T024 [P] [US2] Add `FacetValueFilter` `Contains` tests for string facets in `test/Aster.Tests/SqliteJson/SqliteJsonQueryServiceTests.cs`
+- [x] T025 [P] [US2] Add `FacetValueFilter` `Range` tests for numeric facets in `test/Aster.Tests/SqliteJson/SqliteJsonQueryServiceTests.cs`
+- [x] T026 [P] [US2] Add missing aspect/facet non-match tests in `test/Aster.Tests/SqliteJson/SqliteJsonQueryServiceTests.cs`
 
 ### Implementation for User Story 2
 
-- [ ] T027 [US2] Implement safe JSON path segment encoding in `src/persistence/Aster.Persistence.SqliteJson/Querying/SqliteJsonPath.cs`
-- [ ] T028 [US2] Implement `AspectPresenceFilter` translation using SQLite JSON functions in `src/persistence/Aster.Persistence.SqliteJson/Querying/SqliteWhereTranslator.cs`
-- [ ] T029 [US2] Implement facet `Equals` translation in `src/persistence/Aster.Persistence.SqliteJson/Querying/SqliteWhereTranslator.cs`
-- [ ] T030 [US2] Implement facet `Contains` translation for strings in `src/persistence/Aster.Persistence.SqliteJson/Querying/SqliteWhereTranslator.cs`
-- [ ] T031 [US2] Implement facet `Range` translation for numeric scalar values in `src/persistence/Aster.Persistence.SqliteJson/Querying/SqliteWhereTranslator.cs`
+- [x] T027 [US2] Implement safe JSON path segment encoding in `src/persistence/Aster.Persistence.SqliteJson/Querying/SqliteJsonPath.cs`
+- [x] T028 [US2] Implement `AspectPresenceFilter` translation using SQLite JSON functions in `src/persistence/Aster.Persistence.SqliteJson/Querying/SqliteWhereTranslator.cs`
+- [x] T029 [US2] Implement facet `Equals` translation in `src/persistence/Aster.Persistence.SqliteJson/Querying/SqliteWhereTranslator.cs`
+- [x] T030 [US2] Implement facet `Contains` translation for strings in `src/persistence/Aster.Persistence.SqliteJson/Querying/SqliteWhereTranslator.cs`
+- [x] T031 [US2] Implement facet `Range` translation for numeric scalar values in `src/persistence/Aster.Persistence.SqliteJson/Querying/SqliteWhereTranslator.cs`
 
 **Checkpoint**: User Story 2 works independently and all US2 tests pass.
 
@@ -101,17 +101,17 @@
 
 ### Tests for User Story 3
 
-- [ ] T032 [P] [US3] Add unsupported metadata field tests in `test/Aster.Tests/SqliteJson/SqliteJsonQueryServiceTests.cs`
-- [ ] T033 [P] [US3] Add unsupported facet sort tests in `test/Aster.Tests/SqliteJson/SqliteJsonQueryServiceTests.cs`
-- [ ] T034 [P] [US3] Add invalid active scope and invalid paging tests in `test/Aster.Tests/SqliteJson/SqliteJsonQueryServiceTests.cs`
-- [ ] T035 [P] [US3] Add no in-memory fallback regression test in `test/Aster.Tests/SqliteJson/SqliteJsonQueryServiceTests.cs`
-- [ ] T036 [P] [US3] Add no `IQueryable<Resource>` / no LINQ-provider API regression check in `test/Aster.Tests/SqliteJson/SqliteJsonQueryServiceTests.cs`
+- [x] T032 [P] [US3] Add unsupported metadata field tests in `test/Aster.Tests/SqliteJson/SqliteJsonQueryServiceTests.cs`
+- [x] T033 [P] [US3] Add unsupported facet sort tests in `test/Aster.Tests/SqliteJson/SqliteJsonQueryServiceTests.cs`
+- [x] T034 [P] [US3] Add invalid active scope and invalid paging tests in `test/Aster.Tests/SqliteJson/SqliteJsonQueryServiceTests.cs`
+- [x] T035 [P] [US3] Add no in-memory fallback regression test in `test/Aster.Tests/SqliteJson/SqliteJsonQueryServiceTests.cs`
+- [x] T036 [P] [US3] Add no `IQueryable<Resource>` / no LINQ-provider API regression check in `test/Aster.Tests/SqliteJson/SqliteJsonQueryServiceTests.cs`
 
 ### Implementation for User Story 3
 
-- [ ] T037 [US3] Ensure unsupported sorts fail before SQL execution in `src/persistence/Aster.Persistence.SqliteJson/SqliteJsonQueryService.cs`
-- [ ] T038 [US3] Ensure unsupported predicates fail before SQL execution in `src/persistence/Aster.Persistence.SqliteJson/Querying/SqliteWhereTranslator.cs`
-- [ ] T039 [US3] Ensure invalid query inputs fail before SQL execution in `src/persistence/Aster.Persistence.SqliteJson/SqliteJsonQueryService.cs`
+- [x] T037 [US3] Ensure unsupported sorts fail before SQL execution in `src/persistence/Aster.Persistence.SqliteJson/SqliteJsonQueryService.cs`
+- [x] T038 [US3] Ensure unsupported predicates fail before SQL execution in `src/persistence/Aster.Persistence.SqliteJson/Querying/SqliteWhereTranslator.cs`
+- [x] T039 [US3] Ensure invalid query inputs fail before SQL execution in `src/persistence/Aster.Persistence.SqliteJson/SqliteJsonQueryService.cs`
 
 **Checkpoint**: User Story 3 works independently and unsupported behavior is explicit.
 
@@ -121,11 +121,11 @@
 
 **Purpose**: Documentation, cleanup, and final verification.
 
-- [ ] T040 [P] Update `src/persistence/Aster.Persistence.SqliteJson/README.md` with SQLite query support and unsupported behavior
-- [ ] T041 [P] Update `wiki/Querying.md` with SQLite provider query subset and future typed-helper direction
-- [ ] T042 Re-run Constitution Check and remove unnecessary abstractions/dependencies before final verification
-- [ ] T043 Run `dotnet test Aster.sln`
-- [ ] T044 Review generated SQL helpers for readability, explicitness, parameter usage, and safe JSON path construction
+- [x] T040 [P] Update `src/persistence/Aster.Persistence.SqliteJson/README.md` with SQLite query support and unsupported behavior
+- [x] T041 [P] Update `wiki/Querying.md` with SQLite provider query subset and future typed-helper direction
+- [x] T042 Re-run Constitution Check and remove unnecessary abstractions/dependencies before final verification
+- [x] T043 Run `dotnet test Aster.sln`
+- [x] T044 Review generated SQL helpers for readability, explicitness, parameter usage, and safe JSON path construction
 
 ---
 

--- a/src/persistence/Aster.Persistence.SqliteJson/Querying/SqliteJsonPath.cs
+++ b/src/persistence/Aster.Persistence.SqliteJson/Querying/SqliteJsonPath.cs
@@ -1,0 +1,23 @@
+namespace Aster.Persistence.SqliteJson.Querying;
+
+internal static class SqliteJsonPath
+{
+    public static string Aspect(string aspectKey) =>
+        "$" + Segment("aspects") + Segment(aspectKey);
+
+    public static IReadOnlyList<string> FacetCandidates(string aspectKey, string facetDefinitionId)
+    {
+        var camel = ToCamelCase(facetDefinitionId);
+        return string.Equals(facetDefinitionId, camel, StringComparison.Ordinal)
+            ? [Aspect(aspectKey) + Segment(facetDefinitionId)]
+            : [Aspect(aspectKey) + Segment(facetDefinitionId), Aspect(aspectKey) + Segment(camel)];
+    }
+
+    private static string Segment(string value) =>
+        ".\"" + value.Replace("\\", "\\\\", StringComparison.Ordinal).Replace("\"", "\\\"", StringComparison.Ordinal) + "\"";
+
+    private static string ToCamelCase(string value) =>
+        string.IsNullOrEmpty(value) || char.IsLower(value[0])
+            ? value
+            : char.ToLowerInvariant(value[0]) + value[1..];
+}

--- a/src/persistence/Aster.Persistence.SqliteJson/Querying/SqliteJsonPath.cs
+++ b/src/persistence/Aster.Persistence.SqliteJson/Querying/SqliteJsonPath.cs
@@ -2,19 +2,15 @@ namespace Aster.Persistence.SqliteJson.Querying;
 
 internal static class SqliteJsonPath
 {
-    public static string Aspect(string aspectKey) =>
-        "$" + Segment("aspects") + Segment(aspectKey);
+    public const string Aspects = "$.aspects";
 
-    public static IReadOnlyList<string> FacetCandidates(string aspectKey, string facetDefinitionId)
+    public static IReadOnlyList<string> FacetCandidates(string facetDefinitionId)
     {
         var camel = ToCamelCase(facetDefinitionId);
         return string.Equals(facetDefinitionId, camel, StringComparison.Ordinal)
-            ? [Aspect(aspectKey) + Segment(facetDefinitionId)]
-            : [Aspect(aspectKey) + Segment(facetDefinitionId), Aspect(aspectKey) + Segment(camel)];
+            ? [facetDefinitionId]
+            : [facetDefinitionId, camel];
     }
-
-    private static string Segment(string value) =>
-        ".\"" + value.Replace("\\", "\\\\", StringComparison.Ordinal).Replace("\"", "\\\"", StringComparison.Ordinal) + "\"";
 
     private static string ToCamelCase(string value) =>
         string.IsNullOrEmpty(value) || char.IsLower(value[0])

--- a/src/persistence/Aster.Persistence.SqliteJson/Querying/SqliteMetadataField.cs
+++ b/src/persistence/Aster.Persistence.SqliteJson/Querying/SqliteMetadataField.cs
@@ -1,0 +1,23 @@
+using Aster.Core.Exceptions;
+
+namespace Aster.Persistence.SqliteJson.Querying;
+
+internal static class SqliteMetadataField
+{
+    public static string ResolveColumn(string field, string description) => field.ToLowerInvariant() switch
+    {
+        "resourceid" => "rv.resource_id",
+        "id" => "rv.id",
+        "definitionid" => "rv.definition_id",
+        "owner" => "rv.owner",
+        "version" => "rv.version",
+        "created" => "rv.created",
+        _ => throw Unsupported($"{description} '{field}'")
+    };
+
+    public static bool IsNumeric(string field) =>
+        string.Equals(field, "Version", StringComparison.OrdinalIgnoreCase);
+
+    private static UnsupportedQueryFeatureException Unsupported(string feature) =>
+        new($"{feature} is not supported by the SQLite JSON query provider.");
+}

--- a/src/persistence/Aster.Persistence.SqliteJson/Querying/SqliteParameterBag.cs
+++ b/src/persistence/Aster.Persistence.SqliteJson/Querying/SqliteParameterBag.cs
@@ -1,0 +1,21 @@
+using Microsoft.Data.Sqlite;
+
+namespace Aster.Persistence.SqliteJson.Querying;
+
+internal sealed class SqliteParameterBag
+{
+    private readonly List<(string Name, object? Value)> parameters = [];
+
+    public string Add(object? value)
+    {
+        var name = $"$p{parameters.Count}";
+        parameters.Add((name, value));
+        return name;
+    }
+
+    public void ApplyTo(SqliteCommand command)
+    {
+        foreach (var (name, value) in parameters)
+            command.Parameters.AddWithValue(name, value ?? DBNull.Value);
+    }
+}

--- a/src/persistence/Aster.Persistence.SqliteJson/Querying/SqliteQueryBuilder.cs
+++ b/src/persistence/Aster.Persistence.SqliteJson/Querying/SqliteQueryBuilder.cs
@@ -1,0 +1,153 @@
+using System.Text;
+using Aster.Core.Exceptions;
+using Aster.Core.Models.Querying;
+
+namespace Aster.Persistence.SqliteJson.Querying;
+
+internal sealed class SqliteQueryBuilder(ResourceQuery query)
+{
+    private readonly List<string> predicates = [];
+    private readonly List<string> orderings = [];
+
+    public SqliteParameterBag Parameters { get; } = new();
+
+    public void AddPredicate(string predicate)
+    {
+        if (!string.IsNullOrWhiteSpace(predicate))
+            predicates.Add(predicate);
+    }
+
+    public void AddSorts(IReadOnlyList<SortExpression> sorts)
+    {
+        foreach (var sort in sorts)
+            orderings.Add($"{ResolveMetadataColumn(sort)} {ResolveDirection(sort.Direction)}");
+    }
+
+    public string Build()
+    {
+        var sql = new StringBuilder(BaseSql());
+
+        AddScopePredicates();
+
+        if (!string.IsNullOrWhiteSpace(query.DefinitionId))
+        {
+            var parameter = Parameters.Add(query.DefinitionId);
+            predicates.Add($"rv.definition_id = {parameter}");
+        }
+
+        if (predicates.Count > 0)
+        {
+            sql.AppendLine();
+            sql.Append("WHERE ");
+            sql.AppendJoin(" AND ", predicates.Select(predicate => $"({predicate})"));
+        }
+
+        sql.AppendLine();
+        sql.Append("ORDER BY ");
+        sql.Append(orderings.Count == 0 ? "rv.resource_id ASC, rv.version ASC" : string.Join(", ", orderings));
+
+        if (query.Take.HasValue)
+        {
+            sql.AppendLine();
+            sql.Append("LIMIT ");
+            sql.Append(Parameters.Add(query.Take.Value));
+        }
+        else if (query.Skip.HasValue)
+        {
+            sql.AppendLine();
+            sql.Append("LIMIT -1");
+        }
+
+        if (query.Skip.HasValue)
+        {
+            sql.AppendLine();
+            sql.Append("OFFSET ");
+            sql.Append(Parameters.Add(query.Skip.Value));
+        }
+
+        sql.Append(';');
+        return sql.ToString();
+    }
+
+    private string BaseSql() => query.Scope switch
+    {
+        ResourceVersionScope.Latest => """
+            SELECT rv.payload
+            FROM resource_versions rv
+            INNER JOIN (
+                SELECT resource_id, MAX(version) AS version
+                FROM resource_versions
+                GROUP BY resource_id
+            ) latest
+                ON latest.resource_id = rv.resource_id
+                AND latest.version = rv.version
+            """,
+        ResourceVersionScope.AllVersions => """
+            SELECT rv.payload
+            FROM resource_versions rv
+            """,
+        ResourceVersionScope.Active => ActiveSql(),
+        ResourceVersionScope.Draft => """
+            SELECT rv.payload
+            FROM resource_versions rv
+            """,
+        _ => throw Unsupported($"Resource version scope '{query.Scope}'")
+    };
+
+    private void AddScopePredicates()
+    {
+        if (query.Scope == ResourceVersionScope.Active)
+        {
+            predicates.Add("""
+                EXISTS (
+                    SELECT 1
+                    FROM json_each(json_extract(active_state.payload, '$.activeVersions')) active_version
+                    WHERE CAST(active_version.value AS INTEGER) = rv.version
+                )
+                """);
+        }
+
+        if (query.Scope == ResourceVersionScope.Draft)
+        {
+            predicates.Add("""
+                NOT EXISTS (
+                    SELECT 1
+                    FROM activation_states active_state
+                    JOIN json_each(json_extract(active_state.payload, '$.activeVersions')) active_version
+                    WHERE active_state.resource_id = rv.resource_id
+                      AND CAST(active_version.value AS INTEGER) = rv.version
+                )
+                """);
+        }
+    }
+
+    private string ActiveSql()
+    {
+        var channel = Parameters.Add(query.ActivationChannel);
+        return $$"""
+            SELECT rv.payload
+            FROM resource_versions rv
+            INNER JOIN activation_states active_state
+                ON active_state.resource_id = rv.resource_id
+                AND active_state.channel = {{channel}}
+            """;
+    }
+
+    private static string ResolveMetadataColumn(SortExpression sort)
+    {
+        if (!string.IsNullOrWhiteSpace(sort.AspectKey))
+            throw Unsupported("Facet sorting");
+
+        return SqliteMetadataField.ResolveColumn(sort.Field, "Metadata sort field");
+    }
+
+    private static string ResolveDirection(SortDirection direction) => direction switch
+    {
+        SortDirection.Ascending => "ASC",
+        SortDirection.Descending => "DESC",
+        _ => throw Unsupported($"Sort direction '{direction}'")
+    };
+
+    private static UnsupportedQueryFeatureException Unsupported(string feature) =>
+        new($"{feature} is not supported by the SQLite JSON query provider.");
+}

--- a/src/persistence/Aster.Persistence.SqliteJson/Querying/SqliteQueryBuilder.cs
+++ b/src/persistence/Aster.Persistence.SqliteJson/Querying/SqliteQueryBuilder.cs
@@ -25,9 +25,9 @@ internal sealed class SqliteQueryBuilder(ResourceQuery query)
 
     public string Build()
     {
-        var sql = new StringBuilder(BaseSql());
-
-        AddScopePredicates();
+        var (baseSql, scopePredicates) = BuildScopeSql();
+        var sql = new StringBuilder(baseSql);
+        predicates.AddRange(scopePredicates);
 
         if (!string.IsNullOrWhiteSpace(query.DefinitionId))
         {
@@ -44,7 +44,7 @@ internal sealed class SqliteQueryBuilder(ResourceQuery query)
 
         sql.AppendLine();
         sql.Append("ORDER BY ");
-        sql.Append(orderings.Count == 0 ? "rv.resource_id ASC, rv.version ASC" : string.Join(", ", orderings));
+        sql.Append(string.Join(", ", Orderings()));
 
         if (query.Take.HasValue)
         {
@@ -69,9 +69,14 @@ internal sealed class SqliteQueryBuilder(ResourceQuery query)
         return sql.ToString();
     }
 
-    private string BaseSql() => query.Scope switch
+    private IEnumerable<string> Orderings() =>
+        orderings.Count == 0
+            ? ["rv.resource_id ASC", "rv.version ASC"]
+            : [.. orderings, "rv.resource_id ASC", "rv.version ASC"];
+
+    private (string Sql, IReadOnlyList<string> ScopePredicates) BuildScopeSql() => query.Scope switch
     {
-        ResourceVersionScope.Latest => """
+        ResourceVersionScope.Latest => ("""
             SELECT rv.payload
             FROM resource_versions rv
             INNER JOIN (
@@ -81,35 +86,16 @@ internal sealed class SqliteQueryBuilder(ResourceQuery query)
             ) latest
                 ON latest.resource_id = rv.resource_id
                 AND latest.version = rv.version
-            """,
-        ResourceVersionScope.AllVersions => """
+            """, []),
+        ResourceVersionScope.AllVersions => ("""
             SELECT rv.payload
             FROM resource_versions rv
-            """,
+            """, []),
         ResourceVersionScope.Active => ActiveSql(),
-        ResourceVersionScope.Draft => """
+        ResourceVersionScope.Draft => ("""
             SELECT rv.payload
             FROM resource_versions rv
-            """,
-        _ => throw Unsupported($"Resource version scope '{query.Scope}'")
-    };
-
-    private void AddScopePredicates()
-    {
-        if (query.Scope == ResourceVersionScope.Active)
-        {
-            predicates.Add("""
-                EXISTS (
-                    SELECT 1
-                    FROM json_each(json_extract(active_state.payload, '$.activeVersions')) active_version
-                    WHERE CAST(active_version.value AS INTEGER) = rv.version
-                )
-                """);
-        }
-
-        if (query.Scope == ResourceVersionScope.Draft)
-        {
-            predicates.Add("""
+            """, ["""
                 NOT EXISTS (
                     SELECT 1
                     FROM activation_states active_state
@@ -117,20 +103,26 @@ internal sealed class SqliteQueryBuilder(ResourceQuery query)
                     WHERE active_state.resource_id = rv.resource_id
                       AND CAST(active_version.value AS INTEGER) = rv.version
                 )
-                """);
-        }
-    }
+                """]),
+        _ => throw Unsupported($"Resource version scope '{query.Scope}'")
+    };
 
-    private string ActiveSql()
+    private (string Sql, IReadOnlyList<string> ScopePredicates) ActiveSql()
     {
         var channel = Parameters.Add(query.ActivationChannel);
-        return $$"""
+        return ($$"""
             SELECT rv.payload
             FROM resource_versions rv
             INNER JOIN activation_states active_state
                 ON active_state.resource_id = rv.resource_id
                 AND active_state.channel = {{channel}}
-            """;
+            """, ["""
+                EXISTS (
+                    SELECT 1
+                    FROM json_each(json_extract(active_state.payload, '$.activeVersions')) active_version
+                    WHERE CAST(active_version.value AS INTEGER) = rv.version
+                )
+                """]);
     }
 
     private static string ResolveMetadataColumn(SortExpression sort)

--- a/src/persistence/Aster.Persistence.SqliteJson/Querying/SqliteWhereTranslator.cs
+++ b/src/persistence/Aster.Persistence.SqliteJson/Querying/SqliteWhereTranslator.cs
@@ -36,17 +36,18 @@ internal sealed class SqliteWhereTranslator(SqliteParameterBag parameters)
             ComparisonOperator.Equals when SqliteMetadataField.IsNumeric(filter.Field) =>
                 $"{column} = {parameters.Add(ParseInt(filter.Value, filter.Field))}",
             ComparisonOperator.Equals =>
-                $"LOWER(CAST({column} AS TEXT)) = LOWER(CAST({parameters.Add(filter.Value)} AS TEXT))",
+                $"aster_text_equals(CAST({column} AS TEXT), CAST({parameters.Add(filter.Value)} AS TEXT))",
             ComparisonOperator.Contains when !SqliteMetadataField.IsNumeric(filter.Field) =>
-                $"LOWER(CAST({column} AS TEXT)) LIKE '%' || LOWER(CAST({parameters.Add(filter.Value)} AS TEXT)) || '%'",
+                $"aster_text_contains(CAST({column} AS TEXT), CAST({parameters.Add(filter.Value)} AS TEXT))",
             _ => throw Unsupported($"Metadata filter '{filter.Field}' with operator '{filter.Operator}'")
         };
     }
 
     private string TranslateAspectPresence(AspectPresenceFilter filter)
     {
-        var path = parameters.Add(SqliteJsonPath.Aspect(filter.AspectKey));
-        return $"json_type(rv.payload, {path}) IS NOT NULL";
+        var path = parameters.Add(SqliteJsonPath.Aspects);
+        var aspectKey = parameters.Add(filter.AspectKey);
+        return $"EXISTS (SELECT 1 FROM json_each(json_extract(rv.payload, {path})) aspect WHERE aspect.key = {aspectKey})";
     }
 
     private string TranslateFacetValue(FacetValueFilter filter)
@@ -56,11 +57,11 @@ internal sealed class SqliteWhereTranslator(SqliteParameterBag parameters)
         return filter.Operator switch
         {
             ComparisonOperator.Equals when TryConvertDouble(filter.Value, out var number) =>
-                $"CAST({value} AS REAL) = {parameters.Add(number)}",
+                $"{value.IsNumericPredicate} AND CAST({value.ValueExpression} AS REAL) = {parameters.Add(number)}",
             ComparisonOperator.Equals =>
-                $"LOWER(CAST({value} AS TEXT)) = LOWER(CAST({parameters.Add(FormatValue(filter.Value))} AS TEXT))",
+                $"aster_text_equals(CAST({value.ValueExpression} AS TEXT), CAST({parameters.Add(FormatValue(filter.Value))} AS TEXT))",
             ComparisonOperator.Contains =>
-                $"LOWER(CAST({value} AS TEXT)) LIKE '%' || LOWER(CAST({parameters.Add(FormatValue(filter.Value))} AS TEXT)) || '%'",
+                $"aster_text_contains(CAST({value.ValueExpression} AS TEXT), CAST({parameters.Add(FormatValue(filter.Value))} AS TEXT))",
             ComparisonOperator.Range when filter.Value is RangeValue range =>
                 TranslateRange(value, range),
             ComparisonOperator.Range =>
@@ -89,23 +90,51 @@ internal sealed class SqliteWhereTranslator(SqliteParameterBag parameters)
         return string.Join($" {sqlOperator} ", operands.Select(operand => $"({Translate(operand)})"));
     }
 
-    private string FacetValueSql(string aspectKey, string facetDefinitionId)
+    private FacetValueSqlExpression FacetValueSql(string aspectKey, string facetDefinitionId)
     {
-        var paths = SqliteJsonPath.FacetCandidates(aspectKey, facetDefinitionId)
-            .Select(path => $"json_extract(rv.payload, {parameters.Add(path)})");
+        var aspectsPath = parameters.Add(SqliteJsonPath.Aspects);
+        var typeAspectsPath = parameters.Add(SqliteJsonPath.Aspects);
+        var aspectKeyParameter = parameters.Add(aspectKey);
+        var typeAspectKeyParameter = parameters.Add(aspectKey);
+        var facetKeys = SqliteJsonPath.FacetCandidates(facetDefinitionId).ToList();
+        var facetKeyParameters = facetKeys.Select(parameters.Add).ToList();
+        var typeFacetKeyParameters = facetKeys.Select(parameters.Add).ToList();
+        var facetKeyList = string.Join(", ", facetKeyParameters);
+        var typeFacetKeyList = string.Join(", ", typeFacetKeyParameters);
 
-        return $"COALESCE({string.Join(", ", paths)})";
+        return new($"""
+            (
+                SELECT facet.value
+                FROM json_each(json_extract(rv.payload, {aspectsPath})) aspect
+                JOIN json_each(aspect.value) facet
+                WHERE aspect.key = {aspectKeyParameter}
+                  AND facet.key IN ({facetKeyList})
+                ORDER BY CASE facet.key WHEN {facetKeyParameters[0]} THEN 0 ELSE 1 END
+                LIMIT 1
+            )
+            """,
+            $"""
+            (
+                SELECT facet.type
+                FROM json_each(json_extract(rv.payload, {typeAspectsPath})) aspect
+                JOIN json_each(aspect.value) facet
+                WHERE aspect.key = {typeAspectKeyParameter}
+                  AND facet.key IN ({typeFacetKeyList})
+                ORDER BY CASE facet.key WHEN {typeFacetKeyParameters[0]} THEN 0 ELSE 1 END
+                LIMIT 1
+            ) IN ('integer', 'real')
+            """);
     }
 
-    private string TranslateRange(string value, RangeValue range)
+    private string TranslateRange(FacetValueSqlExpression value, RangeValue range)
     {
-        var predicates = new List<string>();
+        var predicates = new List<string> { value.IsNumericPredicate };
 
         if (range.Min is not null)
-            predicates.Add($"CAST({value} AS REAL) {(range.IncludeMin ? ">=" : ">")} {parameters.Add(ConvertToDouble(range.Min, "minimum range bound"))}");
+            predicates.Add($"CAST({value.ValueExpression} AS REAL) {(range.IncludeMin ? ">=" : ">")} {parameters.Add(ConvertToDouble(range.Min, "minimum range bound"))}");
 
         if (range.Max is not null)
-            predicates.Add($"CAST({value} AS REAL) {(range.IncludeMax ? "<=" : "<")} {parameters.Add(ConvertToDouble(range.Max, "maximum range bound"))}");
+            predicates.Add($"CAST({value.ValueExpression} AS REAL) {(range.IncludeMax ? "<=" : "<")} {parameters.Add(ConvertToDouble(range.Max, "maximum range bound"))}");
 
         if (predicates.Count == 0)
             throw Unsupported("Empty range predicates");
@@ -162,4 +191,6 @@ internal sealed class SqliteWhereTranslator(SqliteParameterBag parameters)
 
     private static UnsupportedQueryFeatureException Unsupported(string feature) =>
         new($"{feature} is not supported by the SQLite JSON query provider.");
+
+    private sealed record FacetValueSqlExpression(string ValueExpression, string IsNumericPredicate);
 }

--- a/src/persistence/Aster.Persistence.SqliteJson/Querying/SqliteWhereTranslator.cs
+++ b/src/persistence/Aster.Persistence.SqliteJson/Querying/SqliteWhereTranslator.cs
@@ -1,0 +1,165 @@
+using System.Globalization;
+using Aster.Core.Exceptions;
+using Aster.Core.Models.Querying;
+
+namespace Aster.Persistence.SqliteJson.Querying;
+
+internal sealed class SqliteWhereTranslator(SqliteParameterBag parameters)
+{
+    public string Translate(FilterExpression expression) => expression switch
+    {
+        MetadataFilter metadata => TranslateMetadata(metadata),
+        AspectPresenceFilter aspect => TranslateAspectPresence(aspect),
+        FacetValueFilter facet => TranslateFacetValue(facet),
+        LogicalExpression logical => TranslateLogical(logical),
+        _ => throw Unsupported($"Filter expression '{expression.GetType().Name}'")
+    };
+
+    public void Validate(FilterExpression expression)
+    {
+        if (expression is FacetValueFilter { Operator: ComparisonOperator.Range, Value: RangeValue { Min: null, Max: null } })
+            throw Unsupported("Empty range predicates");
+
+        if (expression is LogicalExpression logical)
+        {
+            foreach (var operand in logical.Operands)
+                Validate(operand);
+        }
+    }
+
+    private string TranslateMetadata(MetadataFilter filter)
+    {
+        var column = SqliteMetadataField.ResolveColumn(filter.Field, "Metadata field");
+
+        return filter.Operator switch
+        {
+            ComparisonOperator.Equals when SqliteMetadataField.IsNumeric(filter.Field) =>
+                $"{column} = {parameters.Add(ParseInt(filter.Value, filter.Field))}",
+            ComparisonOperator.Equals =>
+                $"LOWER(CAST({column} AS TEXT)) = LOWER(CAST({parameters.Add(filter.Value)} AS TEXT))",
+            ComparisonOperator.Contains when !SqliteMetadataField.IsNumeric(filter.Field) =>
+                $"LOWER(CAST({column} AS TEXT)) LIKE '%' || LOWER(CAST({parameters.Add(filter.Value)} AS TEXT)) || '%'",
+            _ => throw Unsupported($"Metadata filter '{filter.Field}' with operator '{filter.Operator}'")
+        };
+    }
+
+    private string TranslateAspectPresence(AspectPresenceFilter filter)
+    {
+        var path = parameters.Add(SqliteJsonPath.Aspect(filter.AspectKey));
+        return $"json_type(rv.payload, {path}) IS NOT NULL";
+    }
+
+    private string TranslateFacetValue(FacetValueFilter filter)
+    {
+        var value = FacetValueSql(filter.AspectKey, filter.FacetDefinitionId);
+
+        return filter.Operator switch
+        {
+            ComparisonOperator.Equals when TryConvertDouble(filter.Value, out var number) =>
+                $"CAST({value} AS REAL) = {parameters.Add(number)}",
+            ComparisonOperator.Equals =>
+                $"LOWER(CAST({value} AS TEXT)) = LOWER(CAST({parameters.Add(FormatValue(filter.Value))} AS TEXT))",
+            ComparisonOperator.Contains =>
+                $"LOWER(CAST({value} AS TEXT)) LIKE '%' || LOWER(CAST({parameters.Add(FormatValue(filter.Value))} AS TEXT)) || '%'",
+            ComparisonOperator.Range when filter.Value is RangeValue range =>
+                TranslateRange(value, range),
+            ComparisonOperator.Range =>
+                throw Unsupported("Range predicates without RangeValue"),
+            _ => throw Unsupported($"Facet filter operator '{filter.Operator}'")
+        };
+    }
+
+    private string TranslateLogical(LogicalExpression expression)
+    {
+        return expression.Operator switch
+        {
+            LogicalOperator.And => JoinLogical("AND", expression.Operands),
+            LogicalOperator.Or => JoinLogical("OR", expression.Operands),
+            LogicalOperator.Not when expression.Operands is [var operand] => $"NOT ({Translate(operand)})",
+            LogicalOperator.Not => throw Unsupported("NOT logical expressions with anything other than one operand"),
+            _ => throw Unsupported($"Logical operator '{expression.Operator}'")
+        };
+    }
+
+    private string JoinLogical(string sqlOperator, IReadOnlyList<FilterExpression> operands)
+    {
+        if (operands.Count == 0)
+            throw Unsupported($"Empty {sqlOperator} logical expressions");
+
+        return string.Join($" {sqlOperator} ", operands.Select(operand => $"({Translate(operand)})"));
+    }
+
+    private string FacetValueSql(string aspectKey, string facetDefinitionId)
+    {
+        var paths = SqliteJsonPath.FacetCandidates(aspectKey, facetDefinitionId)
+            .Select(path => $"json_extract(rv.payload, {parameters.Add(path)})");
+
+        return $"COALESCE({string.Join(", ", paths)})";
+    }
+
+    private string TranslateRange(string value, RangeValue range)
+    {
+        var predicates = new List<string>();
+
+        if (range.Min is not null)
+            predicates.Add($"CAST({value} AS REAL) {(range.IncludeMin ? ">=" : ">")} {parameters.Add(ConvertToDouble(range.Min, "minimum range bound"))}");
+
+        if (range.Max is not null)
+            predicates.Add($"CAST({value} AS REAL) {(range.IncludeMax ? "<=" : "<")} {parameters.Add(ConvertToDouble(range.Max, "maximum range bound"))}");
+
+        if (predicates.Count == 0)
+            throw Unsupported("Empty range predicates");
+
+        return string.Join(" AND ", predicates);
+    }
+
+    private static int ParseInt(string value, string field) =>
+        int.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var parsed)
+            ? parsed
+            : throw Unsupported($"Metadata field '{field}' requires an integer value");
+
+    private static bool TryConvertDouble(object? value, out double result)
+    {
+        if (value is null)
+        {
+            result = default;
+            return false;
+        }
+
+        try
+        {
+            result = Convert.ToDouble(value, CultureInfo.InvariantCulture);
+            return value is not string || double.TryParse((string)value, NumberStyles.Float, CultureInfo.InvariantCulture, out _);
+        }
+        catch (FormatException)
+        {
+            result = default;
+            return false;
+        }
+        catch (InvalidCastException)
+        {
+            result = default;
+            return false;
+        }
+        catch (OverflowException)
+        {
+            result = default;
+            return false;
+        }
+    }
+
+    private static double ConvertToDouble(object value, string description) =>
+        TryConvertDouble(value, out var result)
+            ? result
+            : throw Unsupported($"{description} must be numeric");
+
+    private static string? FormatValue(object? value) => value switch
+    {
+        null => null,
+        IFormattable formattable => formattable.ToString(null, CultureInfo.InvariantCulture),
+        _ => value.ToString()
+    };
+
+    private static UnsupportedQueryFeatureException Unsupported(string feature) =>
+        new($"{feature} is not supported by the SQLite JSON query provider.");
+}

--- a/src/persistence/Aster.Persistence.SqliteJson/README.md
+++ b/src/persistence/Aster.Persistence.SqliteJson/README.md
@@ -5,11 +5,14 @@ SQLite JSON persistence primitives for Aster.
 This package currently provides:
 
 - `SqliteJsonResourceStore`
+- `SqliteJsonQueryService`
 - `IResourceDefinitionStore`
 - `IResourceVersionReader`
 - `IResourceVersionWriter`
+- `IResourceQueryService`
 
 It persists resource definitions, resource version snapshots, and activation state using SQLite tables with JSON payload columns.
+Query execution is provider-backed: `ResourceQuery` ASTs are translated to parameterized SQLite SQL and JSON1 expressions instead of materializing the full store in memory.
 
 ```csharp
 services.AddAsterSqliteJson(options =>
@@ -18,4 +21,17 @@ services.AddAsterSqliteJson(options =>
 });
 ```
 
-Use this after `AddAsterCore()` to replace the default in-memory definition and version primitives while keeping the provider-backed `DefaultResourceManager` and query service orchestration.
+Use this after `AddAsterCore()` to replace the default in-memory definition, version, and query primitives while keeping the provider-backed `DefaultResourceManager`.
+
+Supported query shapes:
+
+- `Latest`, `AllVersions`, `Active`, and `Draft` scopes (`Active` requires `ActivationChannel`)
+- `DefinitionId` shortcut filtering
+- metadata filters over `ResourceId`, `Id`, `DefinitionId`, `Owner`, `Version`, and `Created`
+- metadata sorting over the same fields
+- `Skip` and `Take`
+- aspect presence checks
+- scalar facet `Equals`, string `Contains`, and numeric `Range`
+- `And`, `Or`, and single-operand `Not`
+
+Unsupported query shapes throw `UnsupportedQueryFeatureException` with an actionable message. Facet sorting, unknown metadata fields, empty ranges, negative paging values, and date-like facet ranges are intentionally out of scope for this phase.

--- a/src/persistence/Aster.Persistence.SqliteJson/SqliteJsonAsterServiceCollectionExtensions.cs
+++ b/src/persistence/Aster.Persistence.SqliteJson/SqliteJsonAsterServiceCollectionExtensions.cs
@@ -26,9 +26,11 @@ public static class SqliteJsonAsterServiceCollectionExtensions
 
         services.AddSingleton(options);
         services.AddSingleton<SqliteJsonResourceStore>();
+        services.AddSingleton<SqliteJsonQueryService>();
         services.AddSingleton<IResourceDefinitionStore>(sp => sp.GetRequiredService<SqliteJsonResourceStore>());
         services.AddSingleton<IResourceVersionReader>(sp => sp.GetRequiredService<SqliteJsonResourceStore>());
         services.AddSingleton<IResourceVersionWriter>(sp => sp.GetRequiredService<SqliteJsonResourceStore>());
+        services.AddSingleton<IResourceQueryService>(sp => sp.GetRequiredService<SqliteJsonQueryService>());
 
         return services;
     }

--- a/src/persistence/Aster.Persistence.SqliteJson/SqliteJsonQueryService.cs
+++ b/src/persistence/Aster.Persistence.SqliteJson/SqliteJsonQueryService.cs
@@ -1,0 +1,98 @@
+using System.Text.Json;
+using Aster.Core.Abstractions;
+using Aster.Core.Exceptions;
+using Aster.Core.Models.Instances;
+using Aster.Core.Models.Querying;
+using Aster.Persistence.SqliteJson.Querying;
+using Microsoft.Data.Sqlite;
+
+namespace Aster.Persistence.SqliteJson;
+
+/// <summary>
+/// SQLite JSON implementation of <see cref="IResourceQueryService"/>.
+/// </summary>
+public sealed class SqliteJsonQueryService : IResourceQueryService
+{
+    private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web);
+
+    private readonly string connectionString;
+
+    /// <summary>
+    /// Initializes a new instance of <see cref="SqliteJsonQueryService"/>.
+    /// </summary>
+    /// <param name="options">Provider options.</param>
+    public SqliteJsonQueryService(SqliteJsonAsterOptions options)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+        ArgumentException.ThrowIfNullOrWhiteSpace(options.ConnectionString);
+
+        connectionString = options.ConnectionString;
+    }
+
+    /// <inheritdoc />
+    public async ValueTask<IEnumerable<Resource>> QueryAsync(
+        ResourceQuery query,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(query);
+        Validate(query);
+
+        var builder = new SqliteQueryBuilder(query);
+        var translator = new SqliteWhereTranslator(builder.Parameters);
+
+        if (query.Filter is not null)
+        {
+            translator.Validate(query.Filter);
+            builder.AddPredicate(translator.Translate(query.Filter));
+        }
+
+        builder.AddSorts(query.Sorts);
+
+        await using var connection = new SqliteConnection(connectionString);
+        await connection.OpenAsync(cancellationToken);
+
+        await using var command = connection.CreateCommand();
+        command.CommandText = builder.Build();
+        builder.Parameters.ApplyTo(command);
+
+        return await ReadResourcesAsync(command, cancellationToken);
+    }
+
+    private static void Validate(ResourceQuery query)
+    {
+        if (!Enum.IsDefined(query.Scope))
+            throw Unsupported($"Resource version scope '{query.Scope}'");
+
+        if (query.Scope == ResourceVersionScope.Active && string.IsNullOrWhiteSpace(query.ActivationChannel))
+            throw Unsupported("Active scope without an activation channel");
+
+        if (query.Skip is < 0)
+            throw Unsupported("Negative Skip");
+
+        if (query.Take is < 0)
+            throw Unsupported("Negative Take");
+    }
+
+    private static async Task<List<Resource>> ReadResourcesAsync(
+        SqliteCommand command,
+        CancellationToken cancellationToken)
+    {
+        var resources = new List<Resource>();
+        await using var reader = await command.ExecuteReaderAsync(cancellationToken);
+
+        while (await reader.ReadAsync(cancellationToken))
+        {
+            var payload = reader.GetString(0);
+            resources.Add(Deserialize(payload));
+        }
+
+        return resources;
+    }
+
+    private static Resource Deserialize(string payload) =>
+        JsonSerializer.Deserialize<Resource>(payload, JsonOptions)
+        ?? throw new InvalidOperationException("Unable to deserialize persisted Resource payload.");
+
+    private static UnsupportedQueryFeatureException Unsupported(string feature) =>
+        new($"{feature} is not supported by the SQLite JSON query provider.");
+}

--- a/src/persistence/Aster.Persistence.SqliteJson/SqliteJsonQueryService.cs
+++ b/src/persistence/Aster.Persistence.SqliteJson/SqliteJsonQueryService.cs
@@ -27,6 +27,9 @@ public sealed class SqliteJsonQueryService : IResourceQueryService
         ArgumentException.ThrowIfNullOrWhiteSpace(options.ConnectionString);
 
         connectionString = options.ConnectionString;
+
+        if (options.InitializeSchema)
+            SqliteJsonSchema.Initialize(connectionString);
     }
 
     /// <inheritdoc />
@@ -50,6 +53,7 @@ public sealed class SqliteJsonQueryService : IResourceQueryService
 
         await using var connection = new SqliteConnection(connectionString);
         await connection.OpenAsync(cancellationToken);
+        RegisterTextFunctions(connection);
 
         await using var command = connection.CreateCommand();
         command.CommandText = builder.Build();
@@ -92,6 +96,20 @@ public sealed class SqliteJsonQueryService : IResourceQueryService
     private static Resource Deserialize(string payload) =>
         JsonSerializer.Deserialize<Resource>(payload, JsonOptions)
         ?? throw new InvalidOperationException("Unable to deserialize persisted Resource payload.");
+
+    private static void RegisterTextFunctions(SqliteConnection connection)
+    {
+        connection.CreateFunction<string?, string?, bool>(
+            "aster_text_equals",
+            (actual, expected) => string.Equals(actual, expected, StringComparison.OrdinalIgnoreCase));
+
+        connection.CreateFunction<string?, string?, bool>(
+            "aster_text_contains",
+            (actual, expected) =>
+                actual is not null
+                && expected is not null
+                && actual.Contains(expected, StringComparison.OrdinalIgnoreCase));
+    }
 
     private static UnsupportedQueryFeatureException Unsupported(string feature) =>
         new($"{feature} is not supported by the SQLite JSON query provider.");

--- a/src/persistence/Aster.Persistence.SqliteJson/SqliteJsonResourceStore.cs
+++ b/src/persistence/Aster.Persistence.SqliteJson/SqliteJsonResourceStore.cs
@@ -31,7 +31,7 @@ public sealed class SqliteJsonResourceStore :
         connectionString = options.ConnectionString;
 
         if (options.InitializeSchema)
-            InitializeSchema();
+            SqliteJsonSchema.Initialize(connectionString);
     }
 
     /// <inheritdoc />
@@ -309,50 +309,6 @@ public sealed class SqliteJsonResourceStore :
         }
 
         return active;
-    }
-
-    private void InitializeSchema()
-    {
-        using var connection = new SqliteConnection(connectionString);
-        connection.Open();
-
-        using var command = connection.CreateCommand();
-        command.CommandText = """
-            PRAGMA journal_mode = WAL;
-
-            CREATE TABLE IF NOT EXISTS resource_definitions (
-                definition_id TEXT NOT NULL,
-                version INTEGER NOT NULL,
-                id TEXT NOT NULL,
-                payload TEXT NOT NULL,
-                PRIMARY KEY (definition_id, version)
-            );
-
-            CREATE TABLE IF NOT EXISTS resource_versions (
-                resource_id TEXT NOT NULL,
-                version INTEGER NOT NULL,
-                id TEXT NOT NULL,
-                definition_id TEXT NOT NULL,
-                definition_version INTEGER NULL,
-                created TEXT NOT NULL,
-                owner TEXT NULL,
-                hash TEXT NULL,
-                payload TEXT NOT NULL,
-                PRIMARY KEY (resource_id, version)
-            );
-
-            CREATE INDEX IF NOT EXISTS ix_resource_versions_definition_id
-                ON resource_versions (definition_id);
-
-            CREATE TABLE IF NOT EXISTS activation_states (
-                resource_id TEXT NOT NULL,
-                channel TEXT NOT NULL,
-                payload TEXT NOT NULL,
-                PRIMARY KEY (resource_id, channel)
-            );
-            """;
-
-        command.ExecuteNonQuery();
     }
 
     private async Task<SqliteConnection> OpenConnectionAsync(CancellationToken cancellationToken)

--- a/src/persistence/Aster.Persistence.SqliteJson/SqliteJsonSchema.cs
+++ b/src/persistence/Aster.Persistence.SqliteJson/SqliteJsonSchema.cs
@@ -1,0 +1,50 @@
+using Microsoft.Data.Sqlite;
+
+namespace Aster.Persistence.SqliteJson;
+
+internal static class SqliteJsonSchema
+{
+    public static void Initialize(string connectionString)
+    {
+        using var connection = new SqliteConnection(connectionString);
+        connection.Open();
+
+        using var command = connection.CreateCommand();
+        command.CommandText = """
+            PRAGMA journal_mode = WAL;
+
+            CREATE TABLE IF NOT EXISTS resource_definitions (
+                definition_id TEXT NOT NULL,
+                version INTEGER NOT NULL,
+                id TEXT NOT NULL,
+                payload TEXT NOT NULL,
+                PRIMARY KEY (definition_id, version)
+            );
+
+            CREATE TABLE IF NOT EXISTS resource_versions (
+                resource_id TEXT NOT NULL,
+                version INTEGER NOT NULL,
+                id TEXT NOT NULL,
+                definition_id TEXT NOT NULL,
+                definition_version INTEGER NULL,
+                created TEXT NOT NULL,
+                owner TEXT NULL,
+                hash TEXT NULL,
+                payload TEXT NOT NULL,
+                PRIMARY KEY (resource_id, version)
+            );
+
+            CREATE INDEX IF NOT EXISTS ix_resource_versions_definition_id
+                ON resource_versions (definition_id);
+
+            CREATE TABLE IF NOT EXISTS activation_states (
+                resource_id TEXT NOT NULL,
+                channel TEXT NOT NULL,
+                payload TEXT NOT NULL,
+                PRIMARY KEY (resource_id, channel)
+            );
+            """;
+
+        command.ExecuteNonQuery();
+    }
+}

--- a/test/Aster.Tests/SqliteJson/SqliteJsonQueryServiceTests.cs
+++ b/test/Aster.Tests/SqliteJson/SqliteJsonQueryServiceTests.cs
@@ -1,0 +1,305 @@
+using System.Linq;
+using Aster.Core.Abstractions;
+using Aster.Core.Exceptions;
+using Aster.Core.Extensions;
+using Aster.Core.Models.Instances;
+using Aster.Core.Models.Querying;
+using Aster.Persistence.SqliteJson;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Aster.Tests.SqliteJson;
+
+public sealed class SqliteJsonQueryServiceTests : IDisposable
+{
+    private readonly string databasePath =
+        Path.Combine(Path.GetTempPath(), $"aster-query-{Guid.NewGuid():N}.db");
+
+    public void Dispose()
+    {
+        TryDelete(databasePath);
+        TryDelete($"{databasePath}-shm");
+        TryDelete($"{databasePath}-wal");
+    }
+
+    [Fact]
+    public async Task QueryAsync_MetadataFilters_ReturnMatchingPersistedResources()
+    {
+        var store = CreateStore();
+        await store.SaveVersionAsync(CreateResource("product-a", "Product", owner: "alice", aspects: new()
+        {
+            ["Title"] = new { Title = "Alpha" },
+        }));
+        await store.SaveVersionAsync(CreateResource("product-b", "Product", owner: "bob", aspects: new()
+        {
+            ["Title"] = new { Title = "Beta" },
+        }));
+        await store.SaveVersionAsync(CreateResource("order-a", "Order", owner: "alice"));
+
+        await using var provider = CreateServiceProvider();
+        var query = provider.GetRequiredService<IResourceQueryService>();
+
+        var results = (await query.QueryAsync(new ResourceQuery
+        {
+            DefinitionId = "Product",
+            Filter = new MetadataFilter("Owner", "alice", ComparisonOperator.Equals),
+        })).ToList();
+
+        Assert.Single(results);
+        Assert.Equal("product-a", results[0].ResourceId);
+    }
+
+    [Fact]
+    public async Task QueryAsync_Scopes_SelectLatestAllActiveAndDraftVersions()
+    {
+        var store = CreateStore();
+        await store.SaveVersionAsync(CreateResource("product-a", "Product", version: 1));
+        await store.SaveVersionAsync(CreateResource("product-a", "Product", version: 2));
+        await store.SaveVersionAsync(CreateResource("product-b", "Product", version: 1));
+        await store.UpdateActivationAsync("product-a", "Published", new ActivationState
+        {
+            ResourceId = "product-a",
+            Channel = "Published",
+            ActiveVersions = [2],
+            LastUpdated = DateTime.UtcNow,
+        });
+
+        await using var provider = CreateServiceProvider();
+        var query = provider.GetRequiredService<IResourceQueryService>();
+
+        var latest = (await query.QueryAsync(new ResourceQuery
+        {
+            DefinitionId = "Product",
+            Sorts = [new SortExpression("ResourceId")],
+        })).ToList();
+        var all = (await query.QueryAsync(new ResourceQuery
+        {
+            Scope = ResourceVersionScope.AllVersions,
+            DefinitionId = "Product",
+            Sorts = [new SortExpression("ResourceId"), new SortExpression("Version")],
+        })).ToList();
+        var active = (await query.QueryAsync(new ResourceQuery
+        {
+            Scope = ResourceVersionScope.Active,
+            ActivationChannel = "Published",
+            DefinitionId = "Product",
+        })).ToList();
+        var draft = (await query.QueryAsync(new ResourceQuery
+        {
+            Scope = ResourceVersionScope.Draft,
+            DefinitionId = "Product",
+            Sorts = [new SortExpression("ResourceId"), new SortExpression("Version")],
+        })).ToList();
+
+        Assert.Equal([("product-a", 2), ("product-b", 1)], latest.Select(r => (r.ResourceId, r.Version)).ToList());
+        Assert.Equal([("product-a", 1), ("product-a", 2), ("product-b", 1)], all.Select(r => (r.ResourceId, r.Version)).ToList());
+        Assert.Equal(("product-a", 2), (active.Single().ResourceId, active.Single().Version));
+        Assert.Equal([("product-a", 1), ("product-b", 1)], draft.Select(r => (r.ResourceId, r.Version)).ToList());
+    }
+
+    [Fact]
+    public async Task QueryAsync_MetadataSortSkipAndTake_AreExecutedInSqlite()
+    {
+        var store = CreateStore();
+        await store.SaveVersionAsync(CreateResource("product-c", "Product", created: Utc(2026, 1, 3)));
+        await store.SaveVersionAsync(CreateResource("product-a", "Product", created: Utc(2026, 1, 1)));
+        await store.SaveVersionAsync(CreateResource("product-b", "Product", created: Utc(2026, 1, 2)));
+
+        await using var provider = CreateServiceProvider();
+        var query = provider.GetRequiredService<IResourceQueryService>();
+
+        var results = (await query.QueryAsync(new ResourceQuery
+        {
+            DefinitionId = "Product",
+            Sorts = [new SortExpression("Created", SortDirection.Descending)],
+            Skip = 1,
+            Take = 1,
+        })).ToList();
+
+        Assert.Single(results);
+        Assert.Equal("product-b", results[0].ResourceId);
+    }
+
+    [Fact]
+    public async Task QueryAsync_AspectPresenceAndFacetFilters_ReadPersistedJson()
+    {
+        var store = CreateStore();
+        await store.SaveVersionAsync(CreateResource("product-a", "Product", aspects: new()
+        {
+            ["Title"] = new { Title = "Super Gadget" },
+            ["Price"] = new { Amount = 20 },
+            ["Inventory"] = new { Count = 5 },
+        }));
+        await store.SaveVersionAsync(CreateResource("product-b", "Product", aspects: new()
+        {
+            ["Title"] = new { Title = "Regular Widget" },
+            ["Price"] = new { Amount = 30 },
+            ["Inventory"] = new { Count = 10 },
+        }));
+        await store.SaveVersionAsync(CreateResource("product-c", "Product", aspects: new()
+        {
+            ["Title"] = new { Title = "Another Gadget" },
+        }));
+
+        await using var provider = CreateServiceProvider();
+        var query = provider.GetRequiredService<IResourceQueryService>();
+
+        var filter = new LogicalExpression(LogicalOperator.And, [
+            new AspectPresenceFilter("Price"),
+            new FacetValueFilter("Title", "Title", "Gadget", ComparisonOperator.Contains),
+            new FacetValueFilter("Inventory", "Count", 5, ComparisonOperator.Equals),
+            new FacetValueFilter("Price", "Amount", new RangeValue(Min: 10, Max: 25), ComparisonOperator.Range),
+        ]);
+        var results = (await query.QueryAsync(new ResourceQuery
+        {
+            DefinitionId = "Product",
+            Filter = filter,
+        })).ToList();
+
+        Assert.Single(results);
+        Assert.Equal("product-a", results[0].ResourceId);
+    }
+
+    [Fact]
+    public async Task QueryAsync_MissingAspectOrFacet_DoesNotMatch()
+    {
+        var store = CreateStore();
+        await store.SaveVersionAsync(CreateResource("product-a", "Product", aspects: new()
+        {
+            ["Title"] = new { Title = "Gadget" },
+        }));
+
+        await using var provider = CreateServiceProvider();
+        var query = provider.GetRequiredService<IResourceQueryService>();
+
+        var results = await query.QueryAsync(new ResourceQuery
+        {
+            Filter = new FacetValueFilter("Price", "Amount", 10, ComparisonOperator.Equals),
+        });
+
+        Assert.Empty(results);
+    }
+
+    [Fact]
+    public async Task QueryAsync_UnsupportedQueryShapes_ThrowTypedException()
+    {
+        await using var provider = CreateServiceProvider();
+        var query = provider.GetRequiredService<IResourceQueryService>();
+
+        await Assert.ThrowsAsync<UnsupportedQueryFeatureException>(() =>
+            query.QueryAsync(new ResourceQuery
+            {
+                Filter = new MetadataFilter("Unknown", "value", ComparisonOperator.Equals),
+            }).AsTask());
+
+        await Assert.ThrowsAsync<UnsupportedQueryFeatureException>(() =>
+            query.QueryAsync(new ResourceQuery
+            {
+                Sorts = [new SortExpression("Title", AspectKey: "Title")],
+            }).AsTask());
+
+        await Assert.ThrowsAsync<UnsupportedQueryFeatureException>(() =>
+            query.QueryAsync(new ResourceQuery
+            {
+                Scope = ResourceVersionScope.Active,
+            }).AsTask());
+
+        await Assert.ThrowsAsync<UnsupportedQueryFeatureException>(() =>
+            query.QueryAsync(new ResourceQuery { Skip = -1 }).AsTask());
+
+        await Assert.ThrowsAsync<UnsupportedQueryFeatureException>(() =>
+            query.QueryAsync(new ResourceQuery { Take = -1 }).AsTask());
+
+        await Assert.ThrowsAsync<UnsupportedQueryFeatureException>(() =>
+            query.QueryAsync(new ResourceQuery
+            {
+                Filter = new FacetValueFilter("Price", "Amount", new RangeValue(null, null), ComparisonOperator.Range),
+            }).AsTask());
+    }
+
+    [Fact]
+    public async Task QueryAsync_DoesNotUseInMemoryReaderFallback()
+    {
+        var store = CreateStore();
+        await store.SaveVersionAsync(CreateResource("product-a", "Product"));
+
+        var services = CreateServices();
+        services.AddSingleton<IResourceVersionReader, ThrowingVersionReader>();
+
+        await using var provider = services.BuildServiceProvider();
+        var query = provider.GetRequiredService<IResourceQueryService>();
+
+        var results = (await query.QueryAsync(new ResourceQuery
+        {
+            DefinitionId = "Product",
+        })).ToList();
+
+        Assert.Single(results);
+        Assert.Equal("product-a", results[0].ResourceId);
+    }
+
+    [Fact]
+    public void SqliteJsonQueryService_DoesNotExposeQueryableApi()
+    {
+        Assert.False(typeof(IQueryable<Resource>).IsAssignableFrom(typeof(SqliteJsonQueryService)));
+    }
+
+    private ServiceProvider CreateServiceProvider() => CreateServices().BuildServiceProvider();
+
+    private ServiceCollection CreateServices()
+    {
+        var services = new ServiceCollection();
+        services.AddAsterCore();
+        services.AddAsterSqliteJson(options =>
+        {
+            options.ConnectionString = $"Data Source={databasePath}";
+        });
+
+        return services;
+    }
+
+    private SqliteJsonResourceStore CreateStore() =>
+        new(new SqliteJsonAsterOptions
+        {
+            ConnectionString = $"Data Source={databasePath}",
+        });
+
+    private static Resource CreateResource(
+        string resourceId,
+        string definitionId,
+        int version = 1,
+        string? owner = null,
+        DateTime? created = null,
+        Dictionary<string, object>? aspects = null) =>
+        new()
+        {
+            ResourceId = resourceId,
+            Id = $"{resourceId}-v{version}",
+            DefinitionId = definitionId,
+            DefinitionVersion = 1,
+            Version = version,
+            Created = created ?? Utc(2026, 1, version),
+            Owner = owner,
+            Aspects = aspects ?? [],
+        };
+
+    private static DateTime Utc(int year, int month, int day) =>
+        new(year, month, day, 0, 0, 0, DateTimeKind.Utc);
+
+    private static void TryDelete(string path)
+    {
+        try
+        {
+            File.Delete(path);
+        }
+        catch (IOException) { }
+        catch (UnauthorizedAccessException) { }
+    }
+
+    private sealed class ThrowingVersionReader : IResourceVersionReader
+    {
+        public ValueTask<IEnumerable<Resource>> ReadVersionsAsync(
+            ResourceVersionReadRequest request,
+            CancellationToken cancellationToken = default) =>
+            throw new InvalidOperationException("SQLite query service should execute SQL directly.");
+    }
+}

--- a/test/Aster.Tests/SqliteJson/SqliteJsonQueryServiceTests.cs
+++ b/test/Aster.Tests/SqliteJson/SqliteJsonQueryServiceTests.cs
@@ -22,6 +22,17 @@ public sealed class SqliteJsonQueryServiceTests : IDisposable
     }
 
     [Fact]
+    public async Task QueryAsync_WithFreshQueryOnlyProvider_InitializesSchemaAndReturnsEmptyResults()
+    {
+        await using var provider = CreateServiceProvider();
+        var query = provider.GetRequiredService<IResourceQueryService>();
+
+        var results = await query.QueryAsync(new ResourceQuery());
+
+        Assert.Empty(results);
+    }
+
+    [Fact]
     public async Task QueryAsync_MetadataFilters_ReturnMatchingPersistedResources()
     {
         var store = CreateStore();
@@ -120,6 +131,29 @@ public sealed class SqliteJsonQueryServiceTests : IDisposable
     }
 
     [Fact]
+    public async Task QueryAsync_MetadataSorts_UseStableTieBreakerForPaging()
+    {
+        var store = CreateStore();
+        await store.SaveVersionAsync(CreateResource("product-c", "Product", owner: "same"));
+        await store.SaveVersionAsync(CreateResource("product-a", "Product", owner: "same"));
+        await store.SaveVersionAsync(CreateResource("product-b", "Product", owner: "same"));
+
+        await using var provider = CreateServiceProvider();
+        var query = provider.GetRequiredService<IResourceQueryService>();
+
+        var results = (await query.QueryAsync(new ResourceQuery
+        {
+            DefinitionId = "Product",
+            Sorts = [new SortExpression("Owner")],
+            Skip = 1,
+            Take = 1,
+        })).ToList();
+
+        Assert.Single(results);
+        Assert.Equal("product-b", results[0].ResourceId);
+    }
+
+    [Fact]
     public async Task QueryAsync_AspectPresenceAndFacetFilters_ReadPersistedJson()
     {
         var store = CreateStore();
@@ -153,6 +187,125 @@ public sealed class SqliteJsonQueryServiceTests : IDisposable
         {
             DefinitionId = "Product",
             Filter = filter,
+        })).ToList();
+
+        Assert.Single(results);
+        Assert.Equal("product-a", results[0].ResourceId);
+    }
+
+    [Fact]
+    public async Task QueryAsync_LogicalOrAndNot_AreExecutedInSqlite()
+    {
+        var store = CreateStore();
+        await store.SaveVersionAsync(CreateResource("product-a", "Product", aspects: new()
+        {
+            ["Title"] = new { Title = "Gadget" },
+        }));
+        await store.SaveVersionAsync(CreateResource("product-b", "Product", aspects: new()
+        {
+            ["Title"] = new { Title = "Widget" },
+            ["Archived"] = new { Flag = true },
+        }));
+        await store.SaveVersionAsync(CreateResource("product-c", "Product", aspects: new()
+        {
+            ["Title"] = new { Title = "Other" },
+        }));
+
+        await using var provider = CreateServiceProvider();
+        var query = provider.GetRequiredService<IResourceQueryService>();
+
+        var results = (await query.QueryAsync(new ResourceQuery
+        {
+            DefinitionId = "Product",
+            Filter = new LogicalExpression(LogicalOperator.And, [
+                new LogicalExpression(LogicalOperator.Or, [
+                    new FacetValueFilter("Title", "Title", "Gadget", ComparisonOperator.Equals),
+                    new FacetValueFilter("Title", "Title", "Widget", ComparisonOperator.Equals),
+                ]),
+                new LogicalExpression(LogicalOperator.Not, [
+                    new AspectPresenceFilter("Archived"),
+                ]),
+            ]),
+        })).ToList();
+
+        Assert.Single(results);
+        Assert.Equal("product-a", results[0].ResourceId);
+    }
+
+    [Fact]
+    public async Task QueryAsync_NumericFacetPredicates_IgnoreNonNumericJsonValues()
+    {
+        var store = CreateStore();
+        await store.SaveVersionAsync(CreateResource("product-a", "Product", aspects: new()
+        {
+            ["Price"] = new { Amount = "not a number" },
+        }));
+        await store.SaveVersionAsync(CreateResource("product-b", "Product", aspects: new()
+        {
+            ["Price"] = new { Amount = 0 },
+        }));
+
+        await using var provider = CreateServiceProvider();
+        var query = provider.GetRequiredService<IResourceQueryService>();
+
+        var equalsResults = (await query.QueryAsync(new ResourceQuery
+        {
+            Filter = new FacetValueFilter("Price", "Amount", 0, ComparisonOperator.Equals),
+        })).ToList();
+        var rangeResults = (await query.QueryAsync(new ResourceQuery
+        {
+            Filter = new FacetValueFilter("Price", "Amount", new RangeValue(-1, 1), ComparisonOperator.Range),
+        })).ToList();
+
+        Assert.Equal(["product-b"], equalsResults.Select(r => r.ResourceId).ToList());
+        Assert.Equal(["product-b"], rangeResults.Select(r => r.ResourceId).ToList());
+    }
+
+    [Fact]
+    public async Task QueryAsync_TextComparisons_UseOrdinalIgnoreCaseForNonAsciiValues()
+    {
+        var store = CreateStore();
+        await store.SaveVersionAsync(CreateResource("product-a", "Product", owner: "Élodie", aspects: new()
+        {
+            ["Title"] = new { Title = "Crème Gadget" },
+        }));
+
+        await using var provider = CreateServiceProvider();
+        var query = provider.GetRequiredService<IResourceQueryService>();
+
+        var metadataResults = (await query.QueryAsync(new ResourceQuery
+        {
+            Filter = new MetadataFilter("Owner", "élodie", ComparisonOperator.Equals),
+        })).ToList();
+        var facetResults = (await query.QueryAsync(new ResourceQuery
+        {
+            Filter = new FacetValueFilter("Title", "Title", "crème", ComparisonOperator.Contains),
+        })).ToList();
+
+        Assert.Single(metadataResults);
+        Assert.Single(facetResults);
+    }
+
+    [Fact]
+    public async Task QueryAsync_JsonPathEscaping_SupportsNamedAndSpecialCharacterAspectKeys()
+    {
+        const string specialAspectKey = "PriceAspect:Sale\\\"Quoted";
+
+        var store = CreateStore();
+        await store.SaveVersionAsync(CreateResource("product-a", "Product", aspects: new()
+        {
+            [specialAspectKey] = new { Amount = 10 },
+        }));
+
+        await using var provider = CreateServiceProvider();
+        var query = provider.GetRequiredService<IResourceQueryService>();
+
+        var results = (await query.QueryAsync(new ResourceQuery
+        {
+            Filter = new LogicalExpression(LogicalOperator.And, [
+                new AspectPresenceFilter(specialAspectKey),
+                new FacetValueFilter(specialAspectKey, "Amount", 10, ComparisonOperator.Equals),
+            ]),
         })).ToList();
 
         Assert.Single(results);

--- a/wiki/Querying.md
+++ b/wiki/Querying.md
@@ -1,6 +1,6 @@
 # Querying
 
-Aster provides a portable **query AST** (`ResourceQuery`) that can be translated to any backend. The Phase 1 in-memory evaluator executes it via LINQ.
+Aster provides a portable **query AST** (`ResourceQuery`) that can be translated to any backend. The in-memory evaluator executes it via LINQ; the SQLite JSON provider translates the same AST to parameterized SQLite SQL plus JSON1 expressions.
 
 ---
 
@@ -9,8 +9,11 @@ Aster provides a portable **query AST** (`ResourceQuery`) that can be translated
 ```csharp
 public sealed record ResourceQuery
 {
+    public ResourceVersionScope Scope { get; init; } = ResourceVersionScope.Latest;
+    public string? ActivationChannel { get; init; }
     public string? DefinitionId { get; init; }   // filter by resource type
     public FilterExpression? Filter { get; init; } // filter expression tree
+    public IReadOnlyList<SortExpression> Sorts { get; init; }
     public int? Skip { get; init; }               // pagination
     public int? Take { get; init; }               // pagination
 }
@@ -34,7 +37,7 @@ new MetadataFilter(
 )
 ```
 
-Supported fields: `ResourceId`, `DefinitionId`, `Owner`, `Version`.
+Supported fields: `ResourceId`, `Id`, `DefinitionId`, `Owner`, `Version`, `Created`.
 
 ### `AspectPresenceFilter`
 
@@ -82,11 +85,11 @@ new LogicalExpression(LogicalOperator.Not, [
 
 ## Comparison Operators
 
-| Operator | Description | Phase 1 support |
-|---|---|---|
-| `Equals` | Exact match (case-insensitive for strings) | ✅ |
-| `Contains` | Substring match (strings only) | ✅ |
-| `Range` | Min/max bounds (numeric / date) via `RangeValue` | ✅ |
+| Operator | Description | In-memory support | SQLite JSON support |
+|---|---|---|---|
+| `Equals` | Exact match (case-insensitive for strings) | Yes | Yes |
+| `Contains` | Substring match (strings only) | Yes | Yes |
+| `Range` | Min/max bounds via `RangeValue` | Numeric / date | Numeric scalar facets |
 
 `Range` values use `new RangeValue(min, max, includeMin, includeMax)`. A `null` min or max means the range is unbounded on that side.
 
@@ -141,15 +144,28 @@ var results = await queryService.QueryAsync(new ResourceQuery
 
 ---
 
-## Phase 1 Limitations
+## SQLite JSON Provider
 
-The in-memory evaluator (`InMemoryQueryService`) works on in-process objects via LINQ. Limitations:
+`Aster.Persistence.SqliteJson` registers `SqliteJsonQueryService` as `IResourceQueryService` when `AddAsterSqliteJson()` is called after `AddAsterCore()`.
 
-- **No provider capability planner yet** — unsupported fields or value shapes fail at execution time.
-- **Sorting is intentionally small** — metadata fields and facet values are supported; provider-specific collation/index rules come later.
-- **Facet value comparison** — values are resolved through dictionaries, JSON, or POCO serialization; advanced typed/index semantics come later.
+The provider supports:
 
-These limitations will be addressed in Phase 2 (persistence backends) and Phase 3 (advanced indexing).
+- `Latest`, `AllVersions`, `Active`, and `Draft` scopes; `Active` requires `ActivationChannel`.
+- `DefinitionId` shortcut filtering.
+- metadata filtering and sorting over `ResourceId`, `Id`, `DefinitionId`, `Owner`, `Version`, and `Created`.
+- `Skip` and `Take`.
+- aspect presence checks.
+- facet `Equals`, string `Contains`, and numeric `Range`.
+- `And`, `Or`, and single-operand `Not`.
+
+Unsupported SQLite query shapes fail with `UnsupportedQueryFeatureException` instead of falling back to in-memory evaluation. Current intentional exclusions include facet sorting, unknown metadata fields, empty ranges, negative paging values, and date-like facet ranges.
+
+## Current Limitations
+
+- **No provider capability planner yet** — unsupported fields or value shapes fail when a provider translates the AST.
+- **Provider-specific semantics are explicit** — SQLite facet ranges are numeric-only in this phase.
+- **No public `IQueryable<Resource>`** — LINQ may be used inside a provider, but the public contract stays on the portable AST.
+- **Typed helper direction** — future helpers may map typed expressions into the AST, but provider execution should still consume the explicit query model rather than exposing backend-specific LINQ providers.
 
 ---
 


### PR DESCRIPTION
## Summary

- Adds a provider-backed `SqliteJsonQueryService` that translates `ResourceQuery` ASTs into parameterized SQLite SQL and JSON1 predicates.
- Registers the SQLite query service through `AddAsterSqliteJson()` so persisted resources query through the provider instead of the in-memory evaluator.
- Covers metadata filters/sorts, version scopes, paging, aspect presence, scalar facet filters, and explicit unsupported-query failures.
- Updates the provider README, querying wiki, and spec task checklist.

## Validation

- `dotnet test Aster.sln`