### PR TITLE
Add query capabilities and typed query helpers

### DIFF
--- a/.agents/skills/speckit-analyze/SKILL.md
+++ b/.agents/skills/speckit-analyze/SKILL.md
@@ -1,0 +1,255 @@
+---
+name: "speckit-analyze"
+description: "Perform a non-destructive cross-artifact consistency and quality analysis across spec.md, plan.md, and tasks.md after task generation."
+compatibility: "Requires spec-kit project structure with .specify/ directory"
+metadata:
+  author: "github-spec-kit"
+  source: "templates/commands/analyze.md"
+---
+
+
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+You **MUST** consider the user input before proceeding (if not empty).
+
+## Pre-Execution Checks
+
+**Check for extension hooks (before analysis)**:
+- Check if `.specify/extensions.yml` exists in the project root.
+- If it exists, read it and look for entries under the `hooks.before_analyze` key
+- If the YAML cannot be parsed or is invalid, skip hook checking silently and continue normally
+- Filter out hooks where `enabled` is explicitly `false`. Treat hooks without an `enabled` field as enabled by default.
+- For each remaining hook, do **not** attempt to interpret or evaluate hook `condition` expressions:
+  - If the hook has no `condition` field, or it is null/empty, treat the hook as executable
+  - If the hook defines a non-empty `condition`, skip the hook and leave condition evaluation to the HookExecutor implementation
+- For each executable hook, output the following based on its `optional` flag:
+  - **Optional hook** (`optional: true`):
+    ```
+    ## Extension Hooks
+
+    **Optional Pre-Hook**: {extension}
+    Command: `/{command}`
+    Description: {description}
+
+    Prompt: {prompt}
+    To execute: `/{command}`
+    ```
+  - **Mandatory hook** (`optional: false`):
+    ```
+    ## Extension Hooks
+
+    **Automatic Pre-Hook**: {extension}
+    Executing: `/{command}`
+    EXECUTE_COMMAND: {command}
+
+    Wait for the result of the hook command before proceeding to the Goal.
+    ```
+- If no hooks are registered or `.specify/extensions.yml` does not exist, skip silently
+
+## Goal
+
+Identify inconsistencies, duplications, ambiguities, and underspecified items across the three core artifacts (`spec.md`, `plan.md`, `tasks.md`) before implementation. This command MUST run only after `/speckit-tasks` has successfully produced a complete `tasks.md`.
+
+## Operating Constraints
+
+**STRICTLY READ-ONLY**: Do **not** modify any files. Output a structured analysis report. Offer an optional remediation plan (user must explicitly approve before any follow-up editing commands would be invoked manually).
+
+**Constitution Authority**: The project constitution (`.specify/memory/constitution.md`) is **non-negotiable** within this analysis scope. Constitution conflicts are automatically CRITICAL and require adjustment of the spec, plan, or tasks—not dilution, reinterpretation, or silent ignoring of the principle. If a principle itself needs to change, that must occur in a separate, explicit constitution update outside `/speckit-analyze`.
+
+## Execution Steps
+
+### 1. Initialize Analysis Context
+
+Run `.specify/scripts/bash/check-prerequisites.sh --json --require-tasks --include-tasks` once from repo root and parse JSON for FEATURE_DIR and AVAILABLE_DOCS. Derive absolute paths:
+
+- SPEC = FEATURE_DIR/spec.md
+- PLAN = FEATURE_DIR/plan.md
+- TASKS = FEATURE_DIR/tasks.md
+
+Abort with an error message if any required file is missing (instruct the user to run missing prerequisite command).
+For single quotes in args like "I'm Groot", use escape syntax: e.g 'I'\''m Groot' (or double-quote if possible: "I'm Groot").
+
+### 2. Load Artifacts (Progressive Disclosure)
+
+Load only the minimal necessary context from each artifact:
+
+**From spec.md:**
+
+- Overview/Context
+- Functional Requirements
+- Success Criteria (measurable outcomes — e.g., performance, security, availability, user success, business impact)
+- User Stories
+- Edge Cases (if present)
+
+**From plan.md:**
+
+- Architecture/stack choices
+- Data Model references
+- Phases
+- Technical constraints
+
+**From tasks.md:**
+
+- Task IDs
+- Descriptions
+- Phase grouping
+- Parallel markers [P]
+- Referenced file paths
+
+**From constitution:**
+
+- Load `.specify/memory/constitution.md` for principle validation
+
+### 3. Build Semantic Models
+
+Create internal representations (do not include raw artifacts in output):
+
+- **Requirements inventory**: For each Functional Requirement (FR-###) and Success Criterion (SC-###), record a stable key. Use the explicit FR-/SC- identifier as the primary key when present, and optionally also derive an imperative-phrase slug for readability (e.g., "User can upload file" → `user-can-upload-file`). Include only Success Criteria items that require buildable work (e.g., load-testing infrastructure, security audit tooling), and exclude post-launch outcome metrics and business KPIs (e.g., "Reduce support tickets by 50%").
+- **User story/action inventory**: Discrete user actions with acceptance criteria
+- **Task coverage mapping**: Map each task to one or more requirements or stories (inference by keyword / explicit reference patterns like IDs or key phrases)
+- **Constitution rule set**: Extract principle names and MUST/SHOULD normative statements
+
+### 4. Detection Passes (Token-Efficient Analysis)
+
+Focus on high-signal findings. Limit to 50 findings total; aggregate remainder in overflow summary.
+
+#### A. Duplication Detection
+
+- Identify near-duplicate requirements
+- Mark lower-quality phrasing for consolidation
+
+#### B. Ambiguity Detection
+
+- Flag vague adjectives (fast, scalable, secure, intuitive, robust) lacking measurable criteria
+- Flag unresolved placeholders (TODO, TKTK, ???, `<placeholder>`, etc.)
+
+#### C. Underspecification
+
+- Requirements with verbs but missing object or measurable outcome
+- User stories missing acceptance criteria alignment
+- Tasks referencing files or components not defined in spec/plan
+
+#### D. Constitution Alignment
+
+- Any requirement or plan element conflicting with a MUST principle
+- Missing mandated sections or quality gates from constitution
+
+#### E. Coverage Gaps
+
+- Requirements with zero associated tasks
+- Tasks with no mapped requirement/story
+- Success Criteria requiring buildable work (performance, security, availability) not reflected in tasks
+
+#### F. Inconsistency
+
+- Terminology drift (same concept named differently across files)
+- Data entities referenced in plan but absent in spec (or vice versa)
+- Task ordering contradictions (e.g., integration tasks before foundational setup tasks without dependency note)
+- Conflicting requirements (e.g., one requires Next.js while other specifies Vue)
+
+### 5. Severity Assignment
+
+Use this heuristic to prioritize findings:
+
+- **CRITICAL**: Violates constitution MUST, missing core spec artifact, or requirement with zero coverage that blocks baseline functionality
+- **HIGH**: Duplicate or conflicting requirement, ambiguous security/performance attribute, untestable acceptance criterion
+- **MEDIUM**: Terminology drift, missing non-functional task coverage, underspecified edge case
+- **LOW**: Style/wording improvements, minor redundancy not affecting execution order
+
+### 6. Produce Compact Analysis Report
+
+Output a Markdown report (no file writes) with the following structure:
+
+## Specification Analysis Report
+
+| ID | Category | Severity | Location(s) | Summary | Recommendation |
+|----|----------|----------|-------------|---------|----------------|
+| A1 | Duplication | HIGH | spec.md:L120-134 | Two similar requirements ... | Merge phrasing; keep clearer version |
+
+(Add one row per finding; generate stable IDs prefixed by category initial.)
+
+**Coverage Summary Table:**
+
+| Requirement Key | Has Task? | Task IDs | Notes |
+|-----------------|-----------|----------|-------|
+
+**Constitution Alignment Issues:** (if any)
+
+**Unmapped Tasks:** (if any)
+
+**Metrics:**
+
+- Total Requirements
+- Total Tasks
+- Coverage % (requirements with >=1 task)
+- Ambiguity Count
+- Duplication Count
+- Critical Issues Count
+
+### 7. Provide Next Actions
+
+At end of report, output a concise Next Actions block:
+
+- If CRITICAL issues exist: Recommend resolving before `/speckit-implement`
+- If only LOW/MEDIUM: User may proceed, but provide improvement suggestions
+- Provide explicit command suggestions: e.g., "Run /speckit-specify with refinement", "Run /speckit-plan to adjust architecture", "Manually edit tasks.md to add coverage for 'performance-metrics'"
+
+### 8. Offer Remediation
+
+Ask the user: "Would you like me to suggest concrete remediation edits for the top N issues?" (Do NOT apply them automatically.)
+
+### 9. Check for extension hooks
+
+After reporting, check if `.specify/extensions.yml` exists in the project root.
+- If it exists, read it and look for entries under the `hooks.after_analyze` key
+- If the YAML cannot be parsed or is invalid, skip hook checking silently and continue normally
+- Filter out hooks where `enabled` is explicitly `false`. Treat hooks without an `enabled` field as enabled by default.
+- For each remaining hook, do **not** attempt to interpret or evaluate hook `condition` expressions:
+  - If the hook has no `condition` field, or it is null/empty, treat the hook as executable
+  - If the hook defines a non-empty `condition`, skip the hook and leave condition evaluation to the HookExecutor implementation
+- For each executable hook, output the following based on its `optional` flag:
+  - **Optional hook** (`optional: true`):
+    ```
+    ## Extension Hooks
+
+    **Optional Hook**: {extension}
+    Command: `/{command}`
+    Description: {description}
+
+    Prompt: {prompt}
+    To execute: `/{command}`
+    ```
+  - **Mandatory hook** (`optional: false`):
+    ```
+    ## Extension Hooks
+
+    **Automatic Hook**: {extension}
+    Executing: `/{command}`
+    EXECUTE_COMMAND: {command}
+    ```
+- If no hooks are registered or `.specify/extensions.yml` does not exist, skip silently
+
+## Operating Principles
+
+### Context Efficiency
+
+- **Minimal high-signal tokens**: Focus on actionable findings, not exhaustive documentation
+- **Progressive disclosure**: Load artifacts incrementally; don't dump all content into analysis
+- **Token-efficient output**: Limit findings table to 50 rows; summarize overflow
+- **Deterministic results**: Rerunning without changes should produce consistent IDs and counts
+
+### Analysis Guidelines
+
+- **NEVER modify files** (this is read-only analysis)
+- **NEVER hallucinate missing sections** (if absent, report them accurately)
+- **Prioritize constitution violations** (these are always CRITICAL)
+- **Use examples over exhaustive rules** (cite specific instances, not generic patterns)
+- **Report zero issues gracefully** (emit success report with coverage statistics)
+
+## Context
+
+$ARGUMENTS

--- a/.agents/skills/speckit-checklist/SKILL.md
+++ b/.agents/skills/speckit-checklist/SKILL.md
@@ -1,0 +1,367 @@
+---
+name: "speckit-checklist"
+description: "Generate a custom checklist for the current feature based on user requirements."
+compatibility: "Requires spec-kit project structure with .specify/ directory"
+metadata:
+  author: "github-spec-kit"
+  source: "templates/commands/checklist.md"
+---
+
+
+## Checklist Purpose: "Unit Tests for English"
+
+**CRITICAL CONCEPT**: Checklists are **UNIT TESTS FOR REQUIREMENTS WRITING** - they validate the quality, clarity, and completeness of requirements in a given domain.
+
+**NOT for verification/testing**:
+
+- ❌ NOT "Verify the button clicks correctly"
+- ❌ NOT "Test error handling works"
+- ❌ NOT "Confirm the API returns 200"
+- ❌ NOT checking if code/implementation matches the spec
+
+**FOR requirements quality validation**:
+
+- ✅ "Are visual hierarchy requirements defined for all card types?" (completeness)
+- ✅ "Is 'prominent display' quantified with specific sizing/positioning?" (clarity)
+- ✅ "Are hover state requirements consistent across all interactive elements?" (consistency)
+- ✅ "Are accessibility requirements defined for keyboard navigation?" (coverage)
+- ✅ "Does the spec define what happens when logo image fails to load?" (edge cases)
+
+**Metaphor**: If your spec is code written in English, the checklist is its unit test suite. You're testing whether the requirements are well-written, complete, unambiguous, and ready for implementation - NOT whether the implementation works.
+
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+You **MUST** consider the user input before proceeding (if not empty).
+
+## Pre-Execution Checks
+
+**Check for extension hooks (before checklist generation)**:
+- Check if `.specify/extensions.yml` exists in the project root.
+- If it exists, read it and look for entries under the `hooks.before_checklist` key
+- If the YAML cannot be parsed or is invalid, skip hook checking silently and continue normally
+- Filter out hooks where `enabled` is explicitly `false`. Treat hooks without an `enabled` field as enabled by default.
+- For each remaining hook, do **not** attempt to interpret or evaluate hook `condition` expressions:
+  - If the hook has no `condition` field, or it is null/empty, treat the hook as executable
+  - If the hook defines a non-empty `condition`, skip the hook and leave condition evaluation to the HookExecutor implementation
+- For each executable hook, output the following based on its `optional` flag:
+  - **Optional hook** (`optional: true`):
+    ```
+    ## Extension Hooks
+
+    **Optional Pre-Hook**: {extension}
+    Command: `/{command}`
+    Description: {description}
+
+    Prompt: {prompt}
+    To execute: `/{command}`
+    ```
+  - **Mandatory hook** (`optional: false`):
+    ```
+    ## Extension Hooks
+
+    **Automatic Pre-Hook**: {extension}
+    Executing: `/{command}`
+    EXECUTE_COMMAND: {command}
+
+    Wait for the result of the hook command before proceeding to the Execution Steps.
+    ```
+- If no hooks are registered or `.specify/extensions.yml` does not exist, skip silently
+
+## Execution Steps
+
+1. **Setup**: Run `.specify/scripts/bash/check-prerequisites.sh --json` from repo root and parse JSON for FEATURE_DIR and AVAILABLE_DOCS list.
+   - All file paths must be absolute.
+   - For single quotes in args like "I'm Groot", use escape syntax: e.g 'I'\''m Groot' (or double-quote if possible: "I'm Groot").
+
+2. **Clarify intent (dynamic)**: Derive up to THREE initial contextual clarifying questions (no pre-baked catalog). They MUST:
+   - Be generated from the user's phrasing + extracted signals from spec/plan/tasks
+   - Only ask about information that materially changes checklist content
+   - Be skipped individually if already unambiguous in `$ARGUMENTS`
+   - Prefer precision over breadth
+
+   Generation algorithm:
+   1. Extract signals: feature domain keywords (e.g., auth, latency, UX, API), risk indicators ("critical", "must", "compliance"), stakeholder hints ("QA", "review", "security team"), and explicit deliverables ("a11y", "rollback", "contracts").
+   2. Cluster signals into candidate focus areas (max 4) ranked by relevance.
+   3. Identify probable audience & timing (author, reviewer, QA, release) if not explicit.
+   4. Detect missing dimensions: scope breadth, depth/rigor, risk emphasis, exclusion boundaries, measurable acceptance criteria.
+   5. Formulate questions chosen from these archetypes:
+      - Scope refinement (e.g., "Should this include integration touchpoints with X and Y or stay limited to local module correctness?")
+      - Risk prioritization (e.g., "Which of these potential risk areas should receive mandatory gating checks?")
+      - Depth calibration (e.g., "Is this a lightweight pre-commit sanity list or a formal release gate?")
+      - Audience framing (e.g., "Will this be used by the author only or peers during PR review?")
+      - Boundary exclusion (e.g., "Should we explicitly exclude performance tuning items this round?")
+      - Scenario class gap (e.g., "No recovery flows detected—are rollback / partial failure paths in scope?")
+
+   Question formatting rules:
+   - If presenting options, generate a compact table with columns: Option | Candidate | Why It Matters
+   - Limit to A–E options maximum; omit table if a free-form answer is clearer
+   - Never ask the user to restate what they already said
+   - Avoid speculative categories (no hallucination). If uncertain, ask explicitly: "Confirm whether X belongs in scope."
+
+   Defaults when interaction impossible:
+   - Depth: Standard
+   - Audience: Reviewer (PR) if code-related; Author otherwise
+   - Focus: Top 2 relevance clusters
+
+   Output the questions (label Q1/Q2/Q3). After answers: if ≥2 scenario classes (Alternate / Exception / Recovery / Non-Functional domain) remain unclear, you MAY ask up to TWO more targeted follow‑ups (Q4/Q5) with a one-line justification each (e.g., "Unresolved recovery path risk"). Do not exceed five total questions. Skip escalation if user explicitly declines more.
+
+3. **Understand user request**: Combine `$ARGUMENTS` + clarifying answers:
+   - Derive checklist theme (e.g., security, review, deploy, ux)
+   - Consolidate explicit must-have items mentioned by user
+   - Map focus selections to category scaffolding
+   - Infer any missing context from spec/plan/tasks (do NOT hallucinate)
+
+4. **Load feature context**: Read from FEATURE_DIR:
+   - spec.md: Feature requirements and scope
+   - plan.md (if exists): Technical details, dependencies
+   - tasks.md (if exists): Implementation tasks
+
+   **Context Loading Strategy**:
+   - Load only necessary portions relevant to active focus areas (avoid full-file dumping)
+   - Prefer summarizing long sections into concise scenario/requirement bullets
+   - Use progressive disclosure: add follow-on retrieval only if gaps detected
+   - If source docs are large, generate interim summary items instead of embedding raw text
+
+5. **Generate checklist** - Create "Unit Tests for Requirements":
+   - Create `FEATURE_DIR/checklists/` directory if it doesn't exist
+   - Generate unique checklist filename:
+     - Use short, descriptive name based on domain (e.g., `ux.md`, `api.md`, `security.md`)
+     - Format: `[domain].md`
+   - File handling behavior:
+     - If file does NOT exist: Create new file and number items starting from CHK001
+     - If file exists: Append new items to existing file, continuing from the last CHK ID (e.g., if last item is CHK015, start new items at CHK016)
+   - Never delete or replace existing checklist content - always preserve and append
+
+   **CORE PRINCIPLE - Test the Requirements, Not the Implementation**:
+   Every checklist item MUST evaluate the REQUIREMENTS THEMSELVES for:
+   - **Completeness**: Are all necessary requirements present?
+   - **Clarity**: Are requirements unambiguous and specific?
+   - **Consistency**: Do requirements align with each other?
+   - **Measurability**: Can requirements be objectively verified?
+   - **Coverage**: Are all scenarios/edge cases addressed?
+
+   **Category Structure** - Group items by requirement quality dimensions:
+   - **Requirement Completeness** (Are all necessary requirements documented?)
+   - **Requirement Clarity** (Are requirements specific and unambiguous?)
+   - **Requirement Consistency** (Do requirements align without conflicts?)
+   - **Acceptance Criteria Quality** (Are success criteria measurable?)
+   - **Scenario Coverage** (Are all flows/cases addressed?)
+   - **Edge Case Coverage** (Are boundary conditions defined?)
+   - **Non-Functional Requirements** (Performance, Security, Accessibility, etc. - are they specified?)
+   - **Dependencies & Assumptions** (Are they documented and validated?)
+   - **Ambiguities & Conflicts** (What needs clarification?)
+
+   **HOW TO WRITE CHECKLIST ITEMS - "Unit Tests for English"**:
+
+   ❌ **WRONG** (Testing implementation):
+   - "Verify landing page displays 3 episode cards"
+   - "Test hover states work on desktop"
+   - "Confirm logo click navigates home"
+
+   ✅ **CORRECT** (Testing requirements quality):
+   - "Are the exact number and layout of featured episodes specified?" [Completeness]
+   - "Is 'prominent display' quantified with specific sizing/positioning?" [Clarity]
+   - "Are hover state requirements consistent across all interactive elements?" [Consistency]
+   - "Are keyboard navigation requirements defined for all interactive UI?" [Coverage]
+   - "Is the fallback behavior specified when logo image fails to load?" [Edge Cases]
+   - "Are loading states defined for asynchronous episode data?" [Completeness]
+   - "Does the spec define visual hierarchy for competing UI elements?" [Clarity]
+
+   **ITEM STRUCTURE**:
+   Each item should follow this pattern:
+   - Question format asking about requirement quality
+   - Focus on what's WRITTEN (or not written) in the spec/plan
+   - Include quality dimension in brackets [Completeness/Clarity/Consistency/etc.]
+   - Reference spec section `[Spec §X.Y]` when checking existing requirements
+   - Use `[Gap]` marker when checking for missing requirements
+
+   **EXAMPLES BY QUALITY DIMENSION**:
+
+   Completeness:
+   - "Are error handling requirements defined for all API failure modes? [Gap]"
+   - "Are accessibility requirements specified for all interactive elements? [Completeness]"
+   - "Are mobile breakpoint requirements defined for responsive layouts? [Gap]"
+
+   Clarity:
+   - "Is 'fast loading' quantified with specific timing thresholds? [Clarity, Spec §NFR-2]"
+   - "Are 'related episodes' selection criteria explicitly defined? [Clarity, Spec §FR-5]"
+   - "Is 'prominent' defined with measurable visual properties? [Ambiguity, Spec §FR-4]"
+
+   Consistency:
+   - "Do navigation requirements align across all pages? [Consistency, Spec §FR-10]"
+   - "Are card component requirements consistent between landing and detail pages? [Consistency]"
+
+   Coverage:
+   - "Are requirements defined for zero-state scenarios (no episodes)? [Coverage, Edge Case]"
+   - "Are concurrent user interaction scenarios addressed? [Coverage, Gap]"
+   - "Are requirements specified for partial data loading failures? [Coverage, Exception Flow]"
+
+   Measurability:
+   - "Are visual hierarchy requirements measurable/testable? [Acceptance Criteria, Spec §FR-1]"
+   - "Can 'balanced visual weight' be objectively verified? [Measurability, Spec §FR-2]"
+
+   **Scenario Classification & Coverage** (Requirements Quality Focus):
+   - Check if requirements exist for: Primary, Alternate, Exception/Error, Recovery, Non-Functional scenarios
+   - For each scenario class, ask: "Are [scenario type] requirements complete, clear, and consistent?"
+   - If scenario class missing: "Are [scenario type] requirements intentionally excluded or missing? [Gap]"
+   - Include resilience/rollback when state mutation occurs: "Are rollback requirements defined for migration failures? [Gap]"
+
+   **Traceability Requirements**:
+   - MINIMUM: ≥80% of items MUST include at least one traceability reference
+   - Each item should reference: spec section `[Spec §X.Y]`, or use markers: `[Gap]`, `[Ambiguity]`, `[Conflict]`, `[Assumption]`
+   - If no ID system exists: "Is a requirement & acceptance criteria ID scheme established? [Traceability]"
+
+   **Surface & Resolve Issues** (Requirements Quality Problems):
+   Ask questions about the requirements themselves:
+   - Ambiguities: "Is the term 'fast' quantified with specific metrics? [Ambiguity, Spec §NFR-1]"
+   - Conflicts: "Do navigation requirements conflict between §FR-10 and §FR-10a? [Conflict]"
+   - Assumptions: "Is the assumption of 'always available podcast API' validated? [Assumption]"
+   - Dependencies: "Are external podcast API requirements documented? [Dependency, Gap]"
+   - Missing definitions: "Is 'visual hierarchy' defined with measurable criteria? [Gap]"
+
+   **Content Consolidation**:
+   - Soft cap: If raw candidate items > 40, prioritize by risk/impact
+   - Merge near-duplicates checking the same requirement aspect
+   - If >5 low-impact edge cases, create one item: "Are edge cases X, Y, Z addressed in requirements? [Coverage]"
+
+   **🚫 ABSOLUTELY PROHIBITED** - These make it an implementation test, not a requirements test:
+   - ❌ Any item starting with "Verify", "Test", "Confirm", "Check" + implementation behavior
+   - ❌ References to code execution, user actions, system behavior
+   - ❌ "Displays correctly", "works properly", "functions as expected"
+   - ❌ "Click", "navigate", "render", "load", "execute"
+   - ❌ Test cases, test plans, QA procedures
+   - ❌ Implementation details (frameworks, APIs, algorithms)
+
+   **✅ REQUIRED PATTERNS** - These test requirements quality:
+   - ✅ "Are [requirement type] defined/specified/documented for [scenario]?"
+   - ✅ "Is [vague term] quantified/clarified with specific criteria?"
+   - ✅ "Are requirements consistent between [section A] and [section B]?"
+   - ✅ "Can [requirement] be objectively measured/verified?"
+   - ✅ "Are [edge cases/scenarios] addressed in requirements?"
+   - ✅ "Does the spec define [missing aspect]?"
+
+6. **Structure Reference**: Generate the checklist following the canonical template in `.specify/templates/checklist-template.md` for title, meta section, category headings, and ID formatting. If template is unavailable, use: H1 title, purpose/created meta lines, `##` category sections containing `- [ ] CHK### <requirement item>` lines with globally incrementing IDs starting at CHK001.
+
+7. **Report**: Output full path to checklist file, item count, and summarize whether the run created a new file or appended to an existing one. Summarize:
+   - Focus areas selected
+   - Depth level
+   - Actor/timing
+   - Any explicit user-specified must-have items incorporated
+
+**Important**: Each `/speckit-checklist` command invocation uses a short, descriptive checklist filename and either creates a new file or appends to an existing one. This allows:
+
+- Multiple checklists of different types (e.g., `ux.md`, `test.md`, `security.md`)
+- Simple, memorable filenames that indicate checklist purpose
+- Easy identification and navigation in the `checklists/` folder
+
+To avoid clutter, use descriptive types and clean up obsolete checklists when done.
+
+## Example Checklist Types & Sample Items
+
+**UX Requirements Quality:** `ux.md`
+
+Sample items (testing the requirements, NOT the implementation):
+
+- "Are visual hierarchy requirements defined with measurable criteria? [Clarity, Spec §FR-1]"
+- "Is the number and positioning of UI elements explicitly specified? [Completeness, Spec §FR-1]"
+- "Are interaction state requirements (hover, focus, active) consistently defined? [Consistency]"
+- "Are accessibility requirements specified for all interactive elements? [Coverage, Gap]"
+- "Is fallback behavior defined when images fail to load? [Edge Case, Gap]"
+- "Can 'prominent display' be objectively measured? [Measurability, Spec §FR-4]"
+
+**API Requirements Quality:** `api.md`
+
+Sample items:
+
+- "Are error response formats specified for all failure scenarios? [Completeness]"
+- "Are rate limiting requirements quantified with specific thresholds? [Clarity]"
+- "Are authentication requirements consistent across all endpoints? [Consistency]"
+- "Are retry/timeout requirements defined for external dependencies? [Coverage, Gap]"
+- "Is versioning strategy documented in requirements? [Gap]"
+
+**Performance Requirements Quality:** `performance.md`
+
+Sample items:
+
+- "Are performance requirements quantified with specific metrics? [Clarity]"
+- "Are performance targets defined for all critical user journeys? [Coverage]"
+- "Are performance requirements under different load conditions specified? [Completeness]"
+- "Can performance requirements be objectively measured? [Measurability]"
+- "Are degradation requirements defined for high-load scenarios? [Edge Case, Gap]"
+
+**Security Requirements Quality:** `security.md`
+
+Sample items:
+
+- "Are authentication requirements specified for all protected resources? [Coverage]"
+- "Are data protection requirements defined for sensitive information? [Completeness]"
+- "Is the threat model documented and requirements aligned to it? [Traceability]"
+- "Are security requirements consistent with compliance obligations? [Consistency]"
+- "Are security failure/breach response requirements defined? [Gap, Exception Flow]"
+
+## Anti-Examples: What NOT To Do
+
+**❌ WRONG - These test implementation, not requirements:**
+
+```markdown
+- [ ] CHK001 - Verify landing page displays 3 episode cards [Spec §FR-001]
+- [ ] CHK002 - Test hover states work correctly on desktop [Spec §FR-003]
+- [ ] CHK003 - Confirm logo click navigates to home page [Spec §FR-010]
+- [ ] CHK004 - Check that related episodes section shows 3-5 items [Spec §FR-005]
+```
+
+**✅ CORRECT - These test requirements quality:**
+
+```markdown
+- [ ] CHK001 - Are the number and layout of featured episodes explicitly specified? [Completeness, Spec §FR-001]
+- [ ] CHK002 - Are hover state requirements consistently defined for all interactive elements? [Consistency, Spec §FR-003]
+- [ ] CHK003 - Are navigation requirements clear for all clickable brand elements? [Clarity, Spec §FR-010]
+- [ ] CHK004 - Is the selection criteria for related episodes documented? [Gap, Spec §FR-005]
+- [ ] CHK005 - Are loading state requirements defined for asynchronous episode data? [Gap]
+- [ ] CHK006 - Can "visual hierarchy" requirements be objectively measured? [Measurability, Spec §FR-001]
+```
+
+**Key Differences:**
+
+- Wrong: Tests if the system works correctly
+- Correct: Tests if the requirements are written correctly
+- Wrong: Verification of behavior
+- Correct: Validation of requirement quality
+- Wrong: "Does it do X?"
+- Correct: "Is X clearly specified?"
+
+## Post-Execution Checks
+
+**Check for extension hooks (after checklist generation)**:
+Check if `.specify/extensions.yml` exists in the project root.
+- If it exists, read it and look for entries under the `hooks.after_checklist` key
+- If the YAML cannot be parsed or is invalid, skip hook checking silently and continue normally
+- Filter out hooks where `enabled` is explicitly `false`. Treat hooks without an `enabled` field as enabled by default.
+- For each remaining hook, do **not** attempt to interpret or evaluate hook `condition` expressions:
+  - If the hook has no `condition` field, or it is null/empty, treat the hook as executable
+  - If the hook defines a non-empty `condition`, skip the hook and leave condition evaluation to the HookExecutor implementation
+- For each executable hook, output the following based on its `optional` flag:
+  - **Optional hook** (`optional: true`):
+    ```
+    ## Extension Hooks
+
+    **Optional Hook**: {extension}
+    Command: `/{command}`
+    Description: {description}
+
+    Prompt: {prompt}
+    To execute: `/{command}`
+    ```
+  - **Mandatory hook** (`optional: false`):
+    ```
+    ## Extension Hooks
+
+    **Automatic Hook**: {extension}
+    Executing: `/{command}`
+    EXECUTE_COMMAND: {command}
+    ```
+- If no hooks are registered or `.specify/extensions.yml` does not exist, skip silently

--- a/.agents/skills/speckit-clarify/SKILL.md
+++ b/.agents/skills/speckit-clarify/SKILL.md
@@ -1,0 +1,249 @@
+---
+name: "speckit-clarify"
+description: "Identify underspecified areas in the current feature spec by asking up to 5 highly targeted clarification questions and encoding answers back into the spec."
+compatibility: "Requires spec-kit project structure with .specify/ directory"
+metadata:
+  author: "github-spec-kit"
+  source: "templates/commands/clarify.md"
+---
+
+
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+You **MUST** consider the user input before proceeding (if not empty).
+
+## Pre-Execution Checks
+
+**Check for extension hooks (before clarification)**:
+- Check if `.specify/extensions.yml` exists in the project root.
+- If it exists, read it and look for entries under the `hooks.before_clarify` key
+- If the YAML cannot be parsed or is invalid, skip hook checking silently and continue normally
+- Filter out hooks where `enabled` is explicitly `false`. Treat hooks without an `enabled` field as enabled by default.
+- For each remaining hook, do **not** attempt to interpret or evaluate hook `condition` expressions:
+  - If the hook has no `condition` field, or it is null/empty, treat the hook as executable
+  - If the hook defines a non-empty `condition`, skip the hook and leave condition evaluation to the HookExecutor implementation
+- For each executable hook, output the following based on its `optional` flag:
+  - **Optional hook** (`optional: true`):
+    ```
+    ## Extension Hooks
+
+    **Optional Pre-Hook**: {extension}
+    Command: `/{command}`
+    Description: {description}
+
+    Prompt: {prompt}
+    To execute: `/{command}`
+    ```
+  - **Mandatory hook** (`optional: false`):
+    ```
+    ## Extension Hooks
+
+    **Automatic Pre-Hook**: {extension}
+    Executing: `/{command}`
+    EXECUTE_COMMAND: {command}
+
+    Wait for the result of the hook command before proceeding to the Outline.
+    ```
+- If no hooks are registered or `.specify/extensions.yml` does not exist, skip silently
+
+## Outline
+
+Goal: Detect and reduce ambiguity or missing decision points in the active feature specification and record the clarifications directly in the spec file.
+
+Note: This clarification workflow is expected to run (and be completed) BEFORE invoking `/speckit-plan`. If the user explicitly states they are skipping clarification (e.g., exploratory spike), you may proceed, but must warn that downstream rework risk increases.
+
+Execution steps:
+
+1. Run `.specify/scripts/bash/check-prerequisites.sh --json --paths-only` from repo root **once** (combined `--json --paths-only` mode / `-Json -PathsOnly`). Parse minimal JSON payload fields:
+   - `FEATURE_DIR`
+   - `FEATURE_SPEC`
+   - (Optionally capture `IMPL_PLAN`, `TASKS` for future chained flows.)
+   - If JSON parsing fails, abort and instruct user to re-run `/speckit-specify` or verify feature branch environment.
+   - For single quotes in args like "I'm Groot", use escape syntax: e.g 'I'\''m Groot' (or double-quote if possible: "I'm Groot").
+
+2. Load the current spec file. Perform a structured ambiguity & coverage scan using this taxonomy. For each category, mark status: Clear / Partial / Missing. Produce an internal coverage map used for prioritization (do not output raw map unless no questions will be asked).
+
+   Functional Scope & Behavior:
+   - Core user goals & success criteria
+   - Explicit out-of-scope declarations
+   - User roles / personas differentiation
+
+   Domain & Data Model:
+   - Entities, attributes, relationships
+   - Identity & uniqueness rules
+   - Lifecycle/state transitions
+   - Data volume / scale assumptions
+
+   Interaction & UX Flow:
+   - Critical user journeys / sequences
+   - Error/empty/loading states
+   - Accessibility or localization notes
+
+   Non-Functional Quality Attributes:
+   - Performance (latency, throughput targets)
+   - Scalability (horizontal/vertical, limits)
+   - Reliability & availability (uptime, recovery expectations)
+   - Observability (logging, metrics, tracing signals)
+   - Security & privacy (authN/Z, data protection, threat assumptions)
+   - Compliance / regulatory constraints (if any)
+
+   Integration & External Dependencies:
+   - External services/APIs and failure modes
+   - Data import/export formats
+   - Protocol/versioning assumptions
+
+   Edge Cases & Failure Handling:
+   - Negative scenarios
+   - Rate limiting / throttling
+   - Conflict resolution (e.g., concurrent edits)
+
+   Constraints & Tradeoffs:
+   - Technical constraints (language, storage, hosting)
+   - Explicit tradeoffs or rejected alternatives
+
+   Terminology & Consistency:
+   - Canonical glossary terms
+   - Avoided synonyms / deprecated terms
+
+   Completion Signals:
+   - Acceptance criteria testability
+   - Measurable Definition of Done style indicators
+
+   Misc / Placeholders:
+   - TODO markers / unresolved decisions
+   - Ambiguous adjectives ("robust", "intuitive") lacking quantification
+
+   For each category with Partial or Missing status, add a candidate question opportunity unless:
+   - Clarification would not materially change implementation or validation strategy
+   - Information is better deferred to planning phase (note internally)
+
+3. Generate (internally) a prioritized queue of candidate clarification questions (maximum 5). Do NOT output them all at once. Apply these constraints:
+    - Maximum of 5 total questions across the whole session.
+    - Each question must be answerable with EITHER:
+       - A short multiple‑choice selection (2–5 distinct, mutually exclusive options), OR
+       - A one-word / short‑phrase answer (explicitly constrain: "Answer in <=5 words").
+    - Only include questions whose answers materially impact architecture, data modeling, task decomposition, test design, UX behavior, operational readiness, or compliance validation.
+    - Ensure category coverage balance: attempt to cover the highest impact unresolved categories first; avoid asking two low-impact questions when a single high-impact area (e.g., security posture) is unresolved.
+    - Exclude questions already answered, trivial stylistic preferences, or plan-level execution details (unless blocking correctness).
+    - Favor clarifications that reduce downstream rework risk or prevent misaligned acceptance tests.
+    - If more than 5 categories remain unresolved, select the top 5 by (Impact * Uncertainty) heuristic.
+
+4. Sequential questioning loop (interactive):
+    - Present EXACTLY ONE question at a time.
+    - For multiple‑choice questions:
+       - **Analyze all options** and determine the **most suitable option** based on:
+          - Best practices for the project type
+          - Common patterns in similar implementations
+          - Risk reduction (security, performance, maintainability)
+          - Alignment with any explicit project goals or constraints visible in the spec
+       - Present your **recommended option prominently** at the top with clear reasoning (1-2 sentences explaining why this is the best choice).
+       - Format as: `**Recommended:** Option [X] - <reasoning>`
+       - Then render all options as a Markdown table:
+
+       | Option | Description |
+       |--------|-------------|
+       | A | <Option A description> |
+       | B | <Option B description> |
+       | C | <Option C description> (add D/E as needed up to 5) |
+       | Short | Provide a different short answer (<=5 words) (Include only if free-form alternative is appropriate) |
+
+       - After the table, add: `You can reply with the option letter (e.g., "A"), accept the recommendation by saying "yes" or "recommended", or provide your own short answer.`
+    - For short‑answer style (no meaningful discrete options):
+       - Provide your **suggested answer** based on best practices and context.
+       - Format as: `**Suggested:** <your proposed answer> - <brief reasoning>`
+       - Then output: `Format: Short answer (<=5 words). You can accept the suggestion by saying "yes" or "suggested", or provide your own answer.`
+    - After the user answers:
+       - If the user replies with "yes", "recommended", or "suggested", use your previously stated recommendation/suggestion as the answer.
+       - Otherwise, validate the answer maps to one option or fits the <=5 word constraint.
+       - If ambiguous, ask for a quick disambiguation (count still belongs to same question; do not advance).
+       - Once satisfactory, record it in working memory (do not yet write to disk) and move to the next queued question.
+    - Stop asking further questions when:
+       - All critical ambiguities resolved early (remaining queued items become unnecessary), OR
+       - User signals completion ("done", "good", "no more"), OR
+       - You reach 5 asked questions.
+    - Never reveal future queued questions in advance.
+    - If no valid questions exist at start, immediately report no critical ambiguities.
+
+5. Integration after EACH accepted answer (incremental update approach):
+    - Maintain in-memory representation of the spec (loaded once at start) plus the raw file contents.
+    - For the first integrated answer in this session:
+       - Ensure a `## Clarifications` section exists (create it just after the highest-level contextual/overview section per the spec template if missing).
+       - Under it, create (if not present) a `### Session YYYY-MM-DD` subheading for today.
+    - Append a bullet line immediately after acceptance: `- Q: <question> → A: <final answer>`.
+    - Then immediately apply the clarification to the most appropriate section(s):
+       - Functional ambiguity → Update or add a bullet in Functional Requirements.
+       - User interaction / actor distinction → Update User Stories or Actors subsection (if present) with clarified role, constraint, or scenario.
+       - Data shape / entities → Update Data Model (add fields, types, relationships) preserving ordering; note added constraints succinctly.
+       - Non-functional constraint → Add/modify measurable criteria in Success Criteria > Measurable Outcomes (convert vague adjective to metric or explicit target).
+       - Edge case / negative flow → Add a new bullet under Edge Cases / Error Handling (or create such subsection if template provides placeholder for it).
+       - Terminology conflict → Normalize term across spec; retain original only if necessary by adding `(formerly referred to as "X")` once.
+    - If the clarification invalidates an earlier ambiguous statement, replace that statement instead of duplicating; leave no obsolete contradictory text.
+    - Save the spec file AFTER each integration to minimize risk of context loss (atomic overwrite).
+    - Preserve formatting: do not reorder unrelated sections; keep heading hierarchy intact.
+    - Keep each inserted clarification minimal and testable (avoid narrative drift).
+
+6. Validation (performed after EACH write plus final pass):
+   - Clarifications session contains exactly one bullet per accepted answer (no duplicates).
+   - Total asked (accepted) questions ≤ 5.
+   - Updated sections contain no lingering vague placeholders the new answer was meant to resolve.
+   - No contradictory earlier statement remains (scan for now-invalid alternative choices removed).
+   - Markdown structure valid; only allowed new headings: `## Clarifications`, `### Session YYYY-MM-DD`.
+   - Terminology consistency: same canonical term used across all updated sections.
+
+7. Write the updated spec back to `FEATURE_SPEC`.
+
+8. Report completion (after questioning loop ends or early termination):
+   - Number of questions asked & answered.
+   - Path to updated spec.
+   - Sections touched (list names).
+   - Coverage summary table listing each taxonomy category with Status: Resolved (was Partial/Missing and addressed), Deferred (exceeds question quota or better suited for planning), Clear (already sufficient), Outstanding (still Partial/Missing but low impact).
+   - If any Outstanding or Deferred remain, recommend whether to proceed to `/speckit-plan` or run `/speckit-clarify` again later post-plan.
+   - Suggested next command.
+
+Behavior rules:
+
+- If no meaningful ambiguities found (or all potential questions would be low-impact), respond: "No critical ambiguities detected worth formal clarification." and suggest proceeding.
+- If spec file missing, instruct user to run `/speckit-specify` first (do not create a new spec here).
+- Never exceed 5 total asked questions (clarification retries for a single question do not count as new questions).
+- Avoid speculative tech stack questions unless the absence blocks functional clarity.
+- Respect user early termination signals ("stop", "done", "proceed").
+- If no questions asked due to full coverage, output a compact coverage summary (all categories Clear) then suggest advancing.
+- If quota reached with unresolved high-impact categories remaining, explicitly flag them under Deferred with rationale.
+
+Context for prioritization: $ARGUMENTS
+
+## Post-Execution Checks
+
+**Check for extension hooks (after clarification)**:
+Check if `.specify/extensions.yml` exists in the project root.
+- If it exists, read it and look for entries under the `hooks.after_clarify` key
+- If the YAML cannot be parsed or is invalid, skip hook checking silently and continue normally
+- Filter out hooks where `enabled` is explicitly `false`. Treat hooks without an `enabled` field as enabled by default.
+- For each remaining hook, do **not** attempt to interpret or evaluate hook `condition` expressions:
+  - If the hook has no `condition` field, or it is null/empty, treat the hook as executable
+  - If the hook defines a non-empty `condition`, skip the hook and leave condition evaluation to the HookExecutor implementation
+- For each executable hook, output the following based on its `optional` flag:
+  - **Optional hook** (`optional: true`):
+    ```
+    ## Extension Hooks
+
+    **Optional Hook**: {extension}
+    Command: `/{command}`
+    Description: {description}
+
+    Prompt: {prompt}
+    To execute: `/{command}`
+    ```
+  - **Mandatory hook** (`optional: false`):
+    ```
+    ## Extension Hooks
+
+    **Automatic Hook**: {extension}
+    Executing: `/{command}`
+    EXECUTE_COMMAND: {command}
+    ```
+- If no hooks are registered or `.specify/extensions.yml` does not exist, skip silently

--- a/.agents/skills/speckit-constitution/SKILL.md
+++ b/.agents/skills/speckit-constitution/SKILL.md
@@ -1,0 +1,152 @@
+---
+name: "speckit-constitution"
+description: "Create or update the project constitution from interactive or provided principle inputs, ensuring all dependent templates stay in sync."
+compatibility: "Requires spec-kit project structure with .specify/ directory"
+metadata:
+  author: "github-spec-kit"
+  source: "templates/commands/constitution.md"
+---
+
+
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+You **MUST** consider the user input before proceeding (if not empty).
+
+## Pre-Execution Checks
+
+**Check for extension hooks (before constitution update)**:
+- Check if `.specify/extensions.yml` exists in the project root.
+- If it exists, read it and look for entries under the `hooks.before_constitution` key
+- If the YAML cannot be parsed or is invalid, skip hook checking silently and continue normally
+- Filter out hooks where `enabled` is explicitly `false`. Treat hooks without an `enabled` field as enabled by default.
+- For each remaining hook, do **not** attempt to interpret or evaluate hook `condition` expressions:
+  - If the hook has no `condition` field, or it is null/empty, treat the hook as executable
+  - If the hook defines a non-empty `condition`, skip the hook and leave condition evaluation to the HookExecutor implementation
+- For each executable hook, output the following based on its `optional` flag:
+  - **Optional hook** (`optional: true`):
+    ```
+    ## Extension Hooks
+
+    **Optional Pre-Hook**: {extension}
+    Command: `/{command}`
+    Description: {description}
+
+    Prompt: {prompt}
+    To execute: `/{command}`
+    ```
+  - **Mandatory hook** (`optional: false`):
+    ```
+    ## Extension Hooks
+
+    **Automatic Pre-Hook**: {extension}
+    Executing: `/{command}`
+    EXECUTE_COMMAND: {command}
+
+    Wait for the result of the hook command before proceeding to the Outline.
+    ```
+- If no hooks are registered or `.specify/extensions.yml` does not exist, skip silently
+
+## Outline
+
+You are updating the project constitution at `.specify/memory/constitution.md`. This file is a TEMPLATE containing placeholder tokens in square brackets (e.g. `[PROJECT_NAME]`, `[PRINCIPLE_1_NAME]`). Your job is to (a) collect/derive concrete values, (b) fill the template precisely, and (c) propagate any amendments across dependent artifacts.
+
+**Note**: If `.specify/memory/constitution.md` does not exist yet, it should have been initialized from `.specify/templates/constitution-template.md` during project setup. If it's missing, copy the template first.
+
+Follow this execution flow:
+
+1. Load the existing constitution at `.specify/memory/constitution.md`.
+   - Identify every placeholder token of the form `[ALL_CAPS_IDENTIFIER]`.
+   **IMPORTANT**: The user might require less or more principles than the ones used in the template. If a number is specified, respect that - follow the general template. You will update the doc accordingly.
+
+2. Collect/derive values for placeholders:
+   - If user input (conversation) supplies a value, use it.
+   - Otherwise infer from existing repo context (README, docs, prior constitution versions if embedded).
+   - For governance dates: `RATIFICATION_DATE` is the original adoption date (if unknown ask or mark TODO), `LAST_AMENDED_DATE` is today if changes are made, otherwise keep previous.
+   - `CONSTITUTION_VERSION` must increment according to semantic versioning rules:
+     - MAJOR: Backward incompatible governance/principle removals or redefinitions.
+     - MINOR: New principle/section added or materially expanded guidance.
+     - PATCH: Clarifications, wording, typo fixes, non-semantic refinements.
+   - If version bump type ambiguous, propose reasoning before finalizing.
+
+3. Draft the updated constitution content:
+   - Replace every placeholder with concrete text (no bracketed tokens left except intentionally retained template slots that the project has chosen not to define yet—explicitly justify any left).
+   - Preserve heading hierarchy and comments can be removed once replaced unless they still add clarifying guidance.
+   - Ensure each Principle section: succinct name line, paragraph (or bullet list) capturing non‑negotiable rules, explicit rationale if not obvious.
+   - Ensure Governance section lists amendment procedure, versioning policy, and compliance review expectations.
+
+4. Consistency propagation checklist (convert prior checklist into active validations):
+   - Read `.specify/templates/plan-template.md` and ensure any "Constitution Check" or rules align with updated principles.
+   - Read `.specify/templates/spec-template.md` for scope/requirements alignment—update if constitution adds/removes mandatory sections or constraints.
+   - Read `.specify/templates/tasks-template.md` and ensure task categorization reflects new or removed principle-driven task types (e.g., observability, versioning, testing discipline).
+   - Read each command file in `.specify/templates/commands/*.md` (including this one) to verify no outdated references (agent-specific names like CLAUDE only) remain when generic guidance is required.
+   - Read any runtime guidance docs (e.g., `README.md`, `docs/quickstart.md`, or agent-specific guidance files if present). Update references to principles changed.
+
+5. Produce a Sync Impact Report (prepend as an HTML comment at top of the constitution file after update):
+   - Version change: old → new
+   - List of modified principles (old title → new title if renamed)
+   - Added sections
+   - Removed sections
+   - Templates requiring updates (✅ updated / ⚠ pending) with file paths
+   - Follow-up TODOs if any placeholders intentionally deferred.
+
+6. Validation before final output:
+   - No remaining unexplained bracket tokens.
+   - Version line matches report.
+   - Dates ISO format YYYY-MM-DD.
+   - Principles are declarative, testable, and free of vague language ("should" → replace with MUST/SHOULD rationale where appropriate).
+
+7. Write the completed constitution back to `.specify/memory/constitution.md` (overwrite).
+
+8. Output a final summary to the user with:
+   - New version and bump rationale.
+   - Any files flagged for manual follow-up.
+   - Suggested commit message (e.g., `docs: amend constitution to vX.Y.Z (principle additions + governance update)`).
+
+Formatting & Style Requirements:
+
+- Use Markdown headings exactly as in the template (do not demote/promote levels).
+- Wrap long rationale lines to keep readability (<100 chars ideally) but do not hard enforce with awkward breaks.
+- Keep a single blank line between sections.
+- Avoid trailing whitespace.
+
+If the user supplies partial updates (e.g., only one principle revision), still perform validation and version decision steps.
+
+If critical info missing (e.g., ratification date truly unknown), insert `TODO(<FIELD_NAME>): explanation` and include in the Sync Impact Report under deferred items.
+
+Do not create a new template; always operate on the existing `.specify/memory/constitution.md` file.
+
+## Post-Execution Checks
+
+**Check for extension hooks (after constitution update)**:
+Check if `.specify/extensions.yml` exists in the project root.
+- If it exists, read it and look for entries under the `hooks.after_constitution` key
+- If the YAML cannot be parsed or is invalid, skip hook checking silently and continue normally
+- Filter out hooks where `enabled` is explicitly `false`. Treat hooks without an `enabled` field as enabled by default.
+- For each remaining hook, do **not** attempt to interpret or evaluate hook `condition` expressions:
+  - If the hook has no `condition` field, or it is null/empty, treat the hook as executable
+  - If the hook defines a non-empty `condition`, skip the hook and leave condition evaluation to the HookExecutor implementation
+- For each executable hook, output the following based on its `optional` flag:
+  - **Optional hook** (`optional: true`):
+    ```
+    ## Extension Hooks
+
+    **Optional Hook**: {extension}
+    Command: `/{command}`
+    Description: {description}
+
+    Prompt: {prompt}
+    To execute: `/{command}`
+    ```
+  - **Mandatory hook** (`optional: false`):
+    ```
+    ## Extension Hooks
+
+    **Automatic Hook**: {extension}
+    Executing: `/{command}`
+    EXECUTE_COMMAND: {command}
+    ```
+- If no hooks are registered or `.specify/extensions.yml` does not exist, skip silently

--- a/.agents/skills/speckit-git-commit/SKILL.md
+++ b/.agents/skills/speckit-git-commit/SKILL.md
@@ -1,0 +1,53 @@
+---
+name: speckit-git-commit
+description: Auto-commit changes after a Spec Kit command completes
+compatibility: Requires spec-kit project structure with .specify/ directory
+metadata:
+  author: github-spec-kit
+  source: git:commands/speckit.git.commit.md
+---
+
+# Auto-Commit Changes
+
+Automatically stage and commit all changes after a Spec Kit command completes.
+
+## Behavior
+
+This command is invoked as a hook after (or before) core commands. It:
+
+1. Determines the event name from the hook context (e.g., if invoked as an `after_specify` hook, the event is `after_specify`; if `before_plan`, the event is `before_plan`)
+2. Checks `.specify/extensions/git/git-config.yml` for the `auto_commit` section
+3. Looks up the specific event key to see if auto-commit is enabled
+4. Falls back to `auto_commit.default` if no event-specific key exists
+5. Uses the per-command `message` if configured, otherwise a default message
+6. If enabled and there are uncommitted changes, runs `git add .` + `git commit`
+
+## Execution
+
+Determine the event name from the hook that triggered this command, then run the script:
+
+- **Bash**: `.specify/extensions/git/scripts/bash/auto-commit.sh <event_name>`
+- **PowerShell**: `.specify/extensions/git/scripts/powershell/auto-commit.ps1 <event_name>`
+
+Replace `<event_name>` with the actual hook event (e.g., `after_specify`, `before_plan`, `after_implement`).
+
+## Configuration
+
+In `.specify/extensions/git/git-config.yml`:
+
+```yaml
+auto_commit:
+  default: false          # Global toggle — set true to enable for all commands
+  after_specify:
+    enabled: true          # Override per-command
+    message: "[Spec Kit] Add specification"
+  after_plan:
+    enabled: false
+    message: "[Spec Kit] Add implementation plan"
+```
+
+## Graceful Degradation
+
+- If Git is not available or the current directory is not a repository: skips with a warning
+- If no config file exists: skips (disabled by default)
+- If no changes to commit: skips with a message

--- a/.agents/skills/speckit-git-feature/SKILL.md
+++ b/.agents/skills/speckit-git-feature/SKILL.md
@@ -1,0 +1,72 @@
+---
+name: speckit-git-feature
+description: Create a feature branch with sequential or timestamp numbering
+compatibility: Requires spec-kit project structure with .specify/ directory
+metadata:
+  author: github-spec-kit
+  source: git:commands/speckit.git.feature.md
+---
+
+# Create Feature Branch
+
+Create and switch to a new git feature branch for the given specification. This command handles **branch creation only** — the spec directory and files are created by the core `/speckit-specify` workflow.
+
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+You **MUST** consider the user input before proceeding (if not empty).
+
+## Environment Variable Override
+
+If the user explicitly provided `GIT_BRANCH_NAME` (e.g., via environment variable, argument, or in their request), pass it through to the script by setting the `GIT_BRANCH_NAME` environment variable before invoking the script. When `GIT_BRANCH_NAME` is set:
+- The script uses the exact value as the branch name, bypassing all prefix/suffix generation
+- `--short-name`, `--number`, and `--timestamp` flags are ignored
+- `FEATURE_NUM` is extracted from the name if it starts with a numeric prefix, otherwise set to the full branch name
+
+## Prerequisites
+
+- Verify Git is available by running `git rev-parse --is-inside-work-tree 2>/dev/null`
+- If Git is not available, warn the user and skip branch creation
+
+## Branch Numbering Mode
+
+Determine the branch numbering strategy by checking configuration in this order:
+
+1. Check `.specify/extensions/git/git-config.yml` for `branch_numbering` value
+2. Check `.specify/init-options.json` for `branch_numbering` value (backward compatibility)
+3. Default to `sequential` if neither exists
+
+## Execution
+
+Generate a concise short name (2-4 words) for the branch:
+- Analyze the feature description and extract the most meaningful keywords
+- Use action-noun format when possible (e.g., "add-user-auth", "fix-payment-bug")
+- Preserve technical terms and acronyms (OAuth2, API, JWT, etc.)
+
+Run the appropriate script based on your platform:
+
+- **Bash**: `.specify/extensions/git/scripts/bash/create-new-feature.sh --json --short-name "<short-name>" "<feature description>"`
+- **Bash (timestamp)**: `.specify/extensions/git/scripts/bash/create-new-feature.sh --json --timestamp --short-name "<short-name>" "<feature description>"`
+- **PowerShell**: `.specify/extensions/git/scripts/powershell/create-new-feature.ps1 -Json -ShortName "<short-name>" "<feature description>"`
+- **PowerShell (timestamp)**: `.specify/extensions/git/scripts/powershell/create-new-feature.ps1 -Json -Timestamp -ShortName "<short-name>" "<feature description>"`
+
+**IMPORTANT**:
+- Do NOT pass `--number` — the script determines the correct next number automatically
+- Always include the JSON flag (`--json` for Bash, `-Json` for PowerShell) so the output can be parsed reliably
+- You must only ever run this script once per feature
+- The JSON output will contain `BRANCH_NAME` and `FEATURE_NUM`
+
+## Graceful Degradation
+
+If Git is not installed or the current directory is not a Git repository:
+- Branch creation is skipped with a warning: `[specify] Warning: Git repository not detected; skipped branch creation`
+- The script still outputs `BRANCH_NAME` and `FEATURE_NUM` so the caller can reference them
+
+## Output
+
+The script outputs JSON with:
+- `BRANCH_NAME`: The branch name (e.g., `003-user-auth` or `20260319-143022-user-auth`)
+- `FEATURE_NUM`: The numeric or timestamp prefix used

--- a/.agents/skills/speckit-git-initialize/SKILL.md
+++ b/.agents/skills/speckit-git-initialize/SKILL.md
@@ -1,0 +1,54 @@
+---
+name: speckit-git-initialize
+description: Initialize a Git repository with an initial commit
+compatibility: Requires spec-kit project structure with .specify/ directory
+metadata:
+  author: github-spec-kit
+  source: git:commands/speckit.git.initialize.md
+---
+
+# Initialize Git Repository
+
+Initialize a Git repository in the current project directory if one does not already exist.
+
+## Execution
+
+Run the appropriate script from the project root:
+
+- **Bash**: `.specify/extensions/git/scripts/bash/initialize-repo.sh`
+- **PowerShell**: `.specify/extensions/git/scripts/powershell/initialize-repo.ps1`
+
+If the extension scripts are not found, fall back to:
+- **Bash**: `git init && git add . && git commit -m "Initial commit from Specify template"`
+- **PowerShell**: `git init; git add .; git commit -m "Initial commit from Specify template"`
+
+The script handles all checks internally:
+- Skips if Git is not available
+- Skips if already inside a Git repository
+- Runs `git init`, `git add .`, and `git commit` with an initial commit message
+
+## Customization
+
+Replace the script to add project-specific Git initialization steps:
+- Custom `.gitignore` templates
+- Default branch naming (`git config init.defaultBranch`)
+- Git LFS setup
+- Git hooks installation
+- Commit signing configuration
+- Git Flow initialization
+
+## Output
+
+On success:
+- `✓ Git repository initialized`
+
+## Graceful Degradation
+
+If Git is not installed:
+- Warn the user
+- Skip repository initialization
+- The project continues to function without Git (specs can still be created under `specs/`)
+
+If Git is installed but `git init`, `git add .`, or `git commit` fails:
+- Surface the error to the user
+- Stop this command rather than continuing with a partially initialized repository

--- a/.agents/skills/speckit-git-remote/SKILL.md
+++ b/.agents/skills/speckit-git-remote/SKILL.md
@@ -1,0 +1,50 @@
+---
+name: speckit-git-remote
+description: Detect Git remote URL for GitHub integration
+compatibility: Requires spec-kit project structure with .specify/ directory
+metadata:
+  author: github-spec-kit
+  source: git:commands/speckit.git.remote.md
+---
+
+# Detect Git Remote URL
+
+Detect the Git remote URL for integration with GitHub services (e.g., issue creation).
+
+## Prerequisites
+
+- Check if Git is available by running `git rev-parse --is-inside-work-tree 2>/dev/null`
+- If Git is not available, output a warning and return empty:
+  ```
+  [specify] Warning: Git repository not detected; cannot determine remote URL
+  ```
+
+## Execution
+
+Run the following command to get the remote URL:
+
+```bash
+git config --get remote.origin.url
+```
+
+## Output
+
+Parse the remote URL and determine:
+
+1. **Repository owner**: Extract from the URL (e.g., `github` from `https://github.com/github/spec-kit.git`)
+2. **Repository name**: Extract from the URL (e.g., `spec-kit` from `https://github.com/github/spec-kit.git`)
+3. **Is GitHub**: Whether the remote points to a GitHub repository
+
+Supported URL formats:
+- HTTPS: `https://github.com/<owner>/<repo>.git`
+- SSH: `git@github.com:<owner>/<repo>.git`
+
+> [!CAUTION]
+> ONLY report a GitHub repository if the remote URL actually points to github.com.
+> Do NOT assume the remote is GitHub if the URL format doesn't match.
+
+## Graceful Degradation
+
+If Git is not installed, the directory is not a Git repository, or no remote is configured:
+- Return an empty result
+- Do NOT error — other workflows should continue without Git remote information

--- a/.agents/skills/speckit-git-validate/SKILL.md
+++ b/.agents/skills/speckit-git-validate/SKILL.md
@@ -1,0 +1,54 @@
+---
+name: speckit-git-validate
+description: Validate current branch follows feature branch naming conventions
+compatibility: Requires spec-kit project structure with .specify/ directory
+metadata:
+  author: github-spec-kit
+  source: git:commands/speckit.git.validate.md
+---
+
+# Validate Feature Branch
+
+Validate that the current Git branch follows the expected feature branch naming conventions.
+
+## Prerequisites
+
+- Check if Git is available by running `git rev-parse --is-inside-work-tree 2>/dev/null`
+- If Git is not available, output a warning and skip validation:
+  ```
+  [specify] Warning: Git repository not detected; skipped branch validation
+  ```
+
+## Validation Rules
+
+Get the current branch name:
+
+```bash
+git rev-parse --abbrev-ref HEAD
+```
+
+The branch name must match one of these patterns:
+
+1. **Sequential**: `^[0-9]{3,}-` (e.g., `001-feature-name`, `042-fix-bug`, `1000-big-feature`)
+2. **Timestamp**: `^[0-9]{8}-[0-9]{6}-` (e.g., `20260319-143022-feature-name`)
+
+## Execution
+
+If on a feature branch (matches either pattern):
+- Output: `✓ On feature branch: <branch-name>`
+- Check if the corresponding spec directory exists under `specs/`:
+  - For sequential branches, look for `specs/<prefix>-*` where prefix matches the numeric portion
+  - For timestamp branches, look for `specs/<prefix>-*` where prefix matches the `YYYYMMDD-HHMMSS` portion
+- If spec directory exists: `✓ Spec directory found: <path>`
+- If spec directory missing: `⚠ No spec directory found for prefix <prefix>`
+
+If NOT on a feature branch:
+- Output: `✗ Not on a feature branch. Current branch: <branch-name>`
+- Output: `Feature branches should be named like: 001-feature-name or 20260319-143022-feature-name`
+
+## Graceful Degradation
+
+If Git is not installed or the directory is not a Git repository:
+- Check the `SPECIFY_FEATURE` environment variable as a fallback
+- If set, validate that value against the naming patterns
+- If not set, skip validation with a warning

--- a/.agents/skills/speckit-implement/SKILL.md
+++ b/.agents/skills/speckit-implement/SKILL.md
@@ -1,0 +1,205 @@
+---
+name: "speckit-implement"
+description: "Execute the implementation plan by processing and executing all tasks defined in tasks.md"
+compatibility: "Requires spec-kit project structure with .specify/ directory"
+metadata:
+  author: "github-spec-kit"
+  source: "templates/commands/implement.md"
+---
+
+
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+You **MUST** consider the user input before proceeding (if not empty).
+
+## Pre-Execution Checks
+
+**Check for extension hooks (before implementation)**:
+- Check if `.specify/extensions.yml` exists in the project root.
+- If it exists, read it and look for entries under the `hooks.before_implement` key
+- If the YAML cannot be parsed or is invalid, skip hook checking silently and continue normally
+- Filter out hooks where `enabled` is explicitly `false`. Treat hooks without an `enabled` field as enabled by default.
+- For each remaining hook, do **not** attempt to interpret or evaluate hook `condition` expressions:
+  - If the hook has no `condition` field, or it is null/empty, treat the hook as executable
+  - If the hook defines a non-empty `condition`, skip the hook and leave condition evaluation to the HookExecutor implementation
+- For each executable hook, output the following based on its `optional` flag:
+  - **Optional hook** (`optional: true`):
+    ```
+    ## Extension Hooks
+
+    **Optional Pre-Hook**: {extension}
+    Command: `/{command}`
+    Description: {description}
+
+    Prompt: {prompt}
+    To execute: `/{command}`
+    ```
+  - **Mandatory hook** (`optional: false`):
+    ```
+    ## Extension Hooks
+
+    **Automatic Pre-Hook**: {extension}
+    Executing: `/{command}`
+    EXECUTE_COMMAND: {command}
+    
+    Wait for the result of the hook command before proceeding to the Outline.
+    ```
+- If no hooks are registered or `.specify/extensions.yml` does not exist, skip silently
+
+## Outline
+
+1. Run `.specify/scripts/bash/check-prerequisites.sh --json --require-tasks --include-tasks` from repo root and parse FEATURE_DIR and AVAILABLE_DOCS list. All paths must be absolute. For single quotes in args like "I'm Groot", use escape syntax: e.g 'I'\''m Groot' (or double-quote if possible: "I'm Groot").
+
+2. **Check checklists status** (if FEATURE_DIR/checklists/ exists):
+   - Scan all checklist files in the checklists/ directory
+   - For each checklist, count:
+     - Total items: All lines matching `- [ ]` or `- [X]` or `- [x]`
+     - Completed items: Lines matching `- [X]` or `- [x]`
+     - Incomplete items: Lines matching `- [ ]`
+   - Create a status table:
+
+     ```text
+     | Checklist | Total | Completed | Incomplete | Status |
+     |-----------|-------|-----------|------------|--------|
+     | ux.md     | 12    | 12        | 0          | ✓ PASS |
+     | test.md   | 8     | 5         | 3          | ✗ FAIL |
+     | security.md | 6   | 6         | 0          | ✓ PASS |
+     ```
+
+   - Calculate overall status:
+     - **PASS**: All checklists have 0 incomplete items
+     - **FAIL**: One or more checklists have incomplete items
+
+   - **If any checklist is incomplete**:
+     - Display the table with incomplete item counts
+     - **STOP** and ask: "Some checklists are incomplete. Do you want to proceed with implementation anyway? (yes/no)"
+     - Wait for user response before continuing
+     - If user says "no" or "wait" or "stop", halt execution
+     - If user says "yes" or "proceed" or "continue", proceed to step 3
+
+   - **If all checklists are complete**:
+     - Display the table showing all checklists passed
+     - Automatically proceed to step 3
+
+3. Load and analyze the implementation context:
+   - **REQUIRED**: Read tasks.md for the complete task list and execution plan
+   - **REQUIRED**: Read plan.md for tech stack, architecture, and file structure
+   - **IF EXISTS**: Read data-model.md for entities and relationships
+   - **IF EXISTS**: Read contracts/ for API specifications and test requirements
+   - **IF EXISTS**: Read research.md for technical decisions and constraints
+   - **IF EXISTS**: Read .specify/memory/constitution.md for governance constraints
+   - **IF EXISTS**: Read quickstart.md for integration scenarios
+
+4. **Project Setup Verification**:
+   - **REQUIRED**: Create/verify ignore files based on actual project setup:
+
+   **Detection & Creation Logic**:
+   - Check if the following command succeeds to determine if the repository is a git repo (create/verify .gitignore if so):
+
+     ```sh
+     git rev-parse --git-dir 2>/dev/null
+     ```
+
+   - Check if Dockerfile* exists or Docker in plan.md → create/verify .dockerignore
+   - Check if .eslintrc* exists → create/verify .eslintignore
+   - Check if eslint.config.* exists → ensure the config's `ignores` entries cover required patterns
+   - Check if .prettierrc* exists → create/verify .prettierignore
+   - Check if .npmrc or package.json exists → create/verify .npmignore (if publishing)
+   - Check if terraform files (*.tf) exist → create/verify .terraformignore
+   - Check if .helmignore needed (helm charts present) → create/verify .helmignore
+
+   **If ignore file already exists**: Verify it contains essential patterns, append missing critical patterns only
+   **If ignore file missing**: Create with full pattern set for detected technology
+
+   **Common Patterns by Technology** (from plan.md tech stack):
+   - **Node.js/JavaScript/TypeScript**: `node_modules/`, `dist/`, `build/`, `*.log`, `.env*`
+   - **Python**: `__pycache__/`, `*.pyc`, `.venv/`, `venv/`, `dist/`, `*.egg-info/`
+   - **Java**: `target/`, `*.class`, `*.jar`, `.gradle/`, `build/`
+   - **C#/.NET**: `bin/`, `obj/`, `*.user`, `*.suo`, `packages/`
+   - **Go**: `*.exe`, `*.test`, `vendor/`, `*.out`
+   - **Ruby**: `.bundle/`, `log/`, `tmp/`, `*.gem`, `vendor/bundle/`
+   - **PHP**: `vendor/`, `*.log`, `*.cache`, `*.env`
+   - **Rust**: `target/`, `debug/`, `release/`, `*.rs.bk`, `*.rlib`, `*.prof*`, `.idea/`, `*.log`, `.env*`
+   - **Kotlin**: `build/`, `out/`, `.gradle/`, `.idea/`, `*.class`, `*.jar`, `*.iml`, `*.log`, `.env*`
+   - **C++**: `build/`, `bin/`, `obj/`, `out/`, `*.o`, `*.so`, `*.a`, `*.exe`, `*.dll`, `.idea/`, `*.log`, `.env*`
+   - **C**: `build/`, `bin/`, `obj/`, `out/`, `*.o`, `*.a`, `*.so`, `*.exe`, `*.dll`, `autom4te.cache/`, `config.status`, `config.log`, `.idea/`, `*.log`, `.env*`
+   - **Swift**: `.build/`, `DerivedData/`, `*.swiftpm/`, `Packages/`
+   - **R**: `.Rproj.user/`, `.Rhistory`, `.RData`, `.Ruserdata`, `*.Rproj`, `packrat/`, `renv/`
+   - **Universal**: `.DS_Store`, `Thumbs.db`, `*.tmp`, `*.swp`, `.vscode/`, `.idea/`
+
+   **Tool-Specific Patterns**:
+   - **Docker**: `node_modules/`, `.git/`, `Dockerfile*`, `.dockerignore`, `*.log*`, `.env*`, `coverage/`
+   - **ESLint**: `node_modules/`, `dist/`, `build/`, `coverage/`, `*.min.js`
+   - **Prettier**: `node_modules/`, `dist/`, `build/`, `coverage/`, `package-lock.json`, `yarn.lock`, `pnpm-lock.yaml`
+   - **Terraform**: `.terraform/`, `*.tfstate*`, `*.tfvars`, `.terraform.lock.hcl`
+   - **Kubernetes/k8s**: `*.secret.yaml`, `secrets/`, `.kube/`, `kubeconfig*`, `*.key`, `*.crt`
+
+5. Parse tasks.md structure and extract:
+   - **Task phases**: Setup, Tests, Core, Integration, Polish
+   - **Task dependencies**: Sequential vs parallel execution rules
+   - **Task details**: ID, description, file paths, parallel markers [P]
+   - **Execution flow**: Order and dependency requirements
+
+6. Execute implementation following the task plan:
+   - **Phase-by-phase execution**: Complete each phase before moving to the next
+   - **Respect dependencies**: Run sequential tasks in order, parallel tasks [P] can run together  
+   - **Follow TDD approach**: Execute test tasks before their corresponding implementation tasks
+   - **File-based coordination**: Tasks affecting the same files must run sequentially
+   - **Validation checkpoints**: Verify each phase completion before proceeding
+
+7. Implementation execution rules:
+   - **Setup first**: Initialize project structure, dependencies, configuration
+   - **Tests before code**: If you need to write tests for contracts, entities, and integration scenarios
+   - **Core development**: Implement models, services, CLI commands, endpoints
+   - **Integration work**: Database connections, middleware, logging, external services
+   - **Polish and validation**: Unit tests, performance optimization, documentation
+
+8. Progress tracking and error handling:
+   - Report progress after each completed task
+   - Halt execution if any non-parallel task fails
+   - For parallel tasks [P], continue with successful tasks, report failed ones
+   - Provide clear error messages with context for debugging
+   - Suggest next steps if implementation cannot proceed
+   - **IMPORTANT** For completed tasks, make sure to mark the task off as [X] in the tasks file.
+
+9. Completion validation:
+   - Verify all required tasks are completed
+   - Check that implemented features match the original specification
+   - Validate that tests pass and coverage meets requirements
+   - Confirm the implementation follows the technical plan
+   - Report final status with summary of completed work
+
+Note: This command assumes a complete task breakdown exists in tasks.md. If tasks are incomplete or missing, suggest running `/speckit-tasks` first to regenerate the task list.
+
+10. **Check for extension hooks**: After completion validation, check if `.specify/extensions.yml` exists in the project root.
+    - If it exists, read it and look for entries under the `hooks.after_implement` key
+    - If the YAML cannot be parsed or is invalid, skip hook checking silently and continue normally
+    - Filter out hooks where `enabled` is explicitly `false`. Treat hooks without an `enabled` field as enabled by default.
+    - For each remaining hook, do **not** attempt to interpret or evaluate hook `condition` expressions:
+      - If the hook has no `condition` field, or it is null/empty, treat the hook as executable
+      - If the hook defines a non-empty `condition`, skip the hook and leave condition evaluation to the HookExecutor implementation
+    - For each executable hook, output the following based on its `optional` flag:
+      - **Optional hook** (`optional: true`):
+        ```
+        ## Extension Hooks
+
+        **Optional Hook**: {extension}
+        Command: `/{command}`
+        Description: {description}
+
+        Prompt: {prompt}
+        To execute: `/{command}`
+        ```
+      - **Mandatory hook** (`optional: false`):
+        ```
+        ## Extension Hooks
+
+        **Automatic Hook**: {extension}
+        Executing: `/{command}`
+        EXECUTE_COMMAND: {command}
+        ```
+    - If no hooks are registered or `.specify/extensions.yml` does not exist, skip silently

--- a/.agents/skills/speckit-plan/SKILL.md
+++ b/.agents/skills/speckit-plan/SKILL.md
@@ -1,0 +1,147 @@
+---
+name: "speckit-plan"
+description: "Execute the implementation planning workflow using the plan template to generate design artifacts."
+compatibility: "Requires spec-kit project structure with .specify/ directory"
+metadata:
+  author: "github-spec-kit"
+  source: "templates/commands/plan.md"
+---
+
+
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+You **MUST** consider the user input before proceeding (if not empty).
+
+## Pre-Execution Checks
+
+**Check for extension hooks (before planning)**:
+- Check if `.specify/extensions.yml` exists in the project root.
+- If it exists, read it and look for entries under the `hooks.before_plan` key
+- If the YAML cannot be parsed or is invalid, skip hook checking silently and continue normally
+- Filter out hooks where `enabled` is explicitly `false`. Treat hooks without an `enabled` field as enabled by default.
+- For each remaining hook, do **not** attempt to interpret or evaluate hook `condition` expressions:
+  - If the hook has no `condition` field, or it is null/empty, treat the hook as executable
+  - If the hook defines a non-empty `condition`, skip the hook and leave condition evaluation to the HookExecutor implementation
+- For each executable hook, output the following based on its `optional` flag:
+  - **Optional hook** (`optional: true`):
+    ```
+    ## Extension Hooks
+
+    **Optional Pre-Hook**: {extension}
+    Command: `/{command}`
+    Description: {description}
+
+    Prompt: {prompt}
+    To execute: `/{command}`
+    ```
+  - **Mandatory hook** (`optional: false`):
+    ```
+    ## Extension Hooks
+
+    **Automatic Pre-Hook**: {extension}
+    Executing: `/{command}`
+    EXECUTE_COMMAND: {command}
+
+    Wait for the result of the hook command before proceeding to the Outline.
+    ```
+- If no hooks are registered or `.specify/extensions.yml` does not exist, skip silently
+
+## Outline
+
+1. **Setup**: Run `.specify/scripts/bash/setup-plan.sh --json` from repo root and parse JSON for FEATURE_SPEC, IMPL_PLAN, SPECS_DIR, BRANCH. For single quotes in args like "I'm Groot", use escape syntax: e.g 'I'\''m Groot' (or double-quote if possible: "I'm Groot").
+
+2. **Load context**: Read FEATURE_SPEC and `.specify/memory/constitution.md`. Load IMPL_PLAN template (already copied).
+
+3. **Execute plan workflow**: Follow the structure in IMPL_PLAN template to:
+   - Fill Technical Context (mark unknowns as "NEEDS CLARIFICATION")
+   - Fill Constitution Check section from constitution
+   - Evaluate gates (ERROR if violations unjustified)
+   - Phase 0: Generate research.md (resolve all NEEDS CLARIFICATION)
+   - Phase 1: Generate data-model.md, contracts/, quickstart.md
+   - Phase 1: Update agent context by running the agent script
+   - Re-evaluate Constitution Check post-design
+
+4. **Stop and report**: Command ends after Phase 2 planning. Report branch, IMPL_PLAN path, and generated artifacts.
+
+5. **Check for extension hooks**: After reporting, check if `.specify/extensions.yml` exists in the project root.
+   - If it exists, read it and look for entries under the `hooks.after_plan` key
+   - If the YAML cannot be parsed or is invalid, skip hook checking silently and continue normally
+   - Filter out hooks where `enabled` is explicitly `false`. Treat hooks without an `enabled` field as enabled by default.
+   - For each remaining hook, do **not** attempt to interpret or evaluate hook `condition` expressions:
+     - If the hook has no `condition` field, or it is null/empty, treat the hook as executable
+     - If the hook defines a non-empty `condition`, skip the hook and leave condition evaluation to the HookExecutor implementation
+   - For each executable hook, output the following based on its `optional` flag:
+     - **Optional hook** (`optional: true`):
+       ```
+       ## Extension Hooks
+
+       **Optional Hook**: {extension}
+       Command: `/{command}`
+       Description: {description}
+
+       Prompt: {prompt}
+       To execute: `/{command}`
+       ```
+     - **Mandatory hook** (`optional: false`):
+       ```
+       ## Extension Hooks
+
+       **Automatic Hook**: {extension}
+       Executing: `/{command}`
+       EXECUTE_COMMAND: {command}
+       ```
+   - If no hooks are registered or `.specify/extensions.yml` does not exist, skip silently
+
+## Phases
+
+### Phase 0: Outline & Research
+
+1. **Extract unknowns from Technical Context** above:
+   - For each NEEDS CLARIFICATION → research task
+   - For each dependency → best practices task
+   - For each integration → patterns task
+
+2. **Generate and dispatch research agents**:
+
+   ```text
+   For each unknown in Technical Context:
+     Task: "Research {unknown} for {feature context}"
+   For each technology choice:
+     Task: "Find best practices for {tech} in {domain}"
+   ```
+
+3. **Consolidate findings** in `research.md` using format:
+   - Decision: [what was chosen]
+   - Rationale: [why chosen]
+   - Alternatives considered: [what else evaluated]
+
+**Output**: research.md with all NEEDS CLARIFICATION resolved
+
+### Phase 1: Design & Contracts
+
+**Prerequisites:** `research.md` complete
+
+1. **Extract entities from feature spec** → `data-model.md`:
+   - Entity name, fields, relationships
+   - Validation rules from requirements
+   - State transitions if applicable
+
+2. **Define interface contracts** (if project has external interfaces) → `/contracts/`:
+   - Identify what interfaces the project exposes to users or other systems
+   - Document the contract format appropriate for the project type
+   - Examples: public APIs for libraries, command schemas for CLI tools, endpoints for web services, grammars for parsers, UI contracts for applications
+   - Skip if project is purely internal (build scripts, one-off tools, etc.)
+
+3. **Agent context update**:
+   - Update the plan reference between the `<!-- SPECKIT START -->` and `<!-- SPECKIT END -->` markers in `AGENTS.md` to point to the plan file created in step 1 (the IMPL_PLAN path)
+
+**Output**: data-model.md, /contracts/*, quickstart.md, updated agent context file
+
+## Key rules
+
+- Use absolute paths for filesystem operations; use project-relative paths for references in documentation and agent context files
+- ERROR on gate failures or unresolved clarifications

--- a/.agents/skills/speckit-specify/SKILL.md
+++ b/.agents/skills/speckit-specify/SKILL.md
@@ -1,0 +1,325 @@
+---
+name: "speckit-specify"
+description: "Create or update the feature specification from a natural language feature description."
+compatibility: "Requires spec-kit project structure with .specify/ directory"
+metadata:
+  author: "github-spec-kit"
+  source: "templates/commands/specify.md"
+---
+
+
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+You **MUST** consider the user input before proceeding (if not empty).
+
+## Pre-Execution Checks
+
+**Check for extension hooks (before specification)**:
+- Check if `.specify/extensions.yml` exists in the project root.
+- If it exists, read it and look for entries under the `hooks.before_specify` key
+- If the YAML cannot be parsed or is invalid, skip hook checking silently and continue normally
+- Filter out hooks where `enabled` is explicitly `false`. Treat hooks without an `enabled` field as enabled by default.
+- For each remaining hook, do **not** attempt to interpret or evaluate hook `condition` expressions:
+  - If the hook has no `condition` field, or it is null/empty, treat the hook as executable
+  - If the hook defines a non-empty `condition`, skip the hook and leave condition evaluation to the HookExecutor implementation
+- For each executable hook, output the following based on its `optional` flag:
+  - **Optional hook** (`optional: true`):
+    ```
+    ## Extension Hooks
+
+    **Optional Pre-Hook**: {extension}
+    Command: `/{command}`
+    Description: {description}
+
+    Prompt: {prompt}
+    To execute: `/{command}`
+    ```
+  - **Mandatory hook** (`optional: false`):
+    ```
+    ## Extension Hooks
+
+    **Automatic Pre-Hook**: {extension}
+    Executing: `/{command}`
+    EXECUTE_COMMAND: {command}
+
+    Wait for the result of the hook command before proceeding to the Outline.
+    ```
+- If no hooks are registered or `.specify/extensions.yml` does not exist, skip silently
+
+## Outline
+
+The text the user typed after `/speckit-specify` in the triggering message **is** the feature description. Assume you always have it available in this conversation even if `$ARGUMENTS` appears literally below. Do not ask the user to repeat it unless they provided an empty command.
+
+Given that feature description, do this:
+
+1. **Generate a concise short name** (2-4 words) for the feature:
+   - Analyze the feature description and extract the most meaningful keywords
+   - Create a 2-4 word short name that captures the essence of the feature
+   - Use action-noun format when possible (e.g., "add-user-auth", "fix-payment-bug")
+   - Preserve technical terms and acronyms (OAuth2, API, JWT, etc.)
+   - Keep it concise but descriptive enough to understand the feature at a glance
+   - Examples:
+     - "I want to add user authentication" → "user-auth"
+     - "Implement OAuth2 integration for the API" → "oauth2-api-integration"
+     - "Create a dashboard for analytics" → "analytics-dashboard"
+     - "Fix payment processing timeout bug" → "fix-payment-timeout"
+
+2. **Branch creation** (optional, via hook):
+
+   If a `before_specify` hook ran successfully in the Pre-Execution Checks above, it will have created/switched to a git branch and output JSON containing `BRANCH_NAME` and `FEATURE_NUM`. Note these values for reference, but the branch name does **not** dictate the spec directory name.
+
+   If the user explicitly provided `GIT_BRANCH_NAME`, pass it through to the hook so the branch script uses the exact value as the branch name (bypassing all prefix/suffix generation).
+
+3. **Create the spec feature directory**:
+
+   Specs live under the default `specs/` directory unless the user explicitly provides `SPECIFY_FEATURE_DIRECTORY`.
+
+   **Resolution order for `SPECIFY_FEATURE_DIRECTORY`**:
+   1. If the user explicitly provided `SPECIFY_FEATURE_DIRECTORY` (e.g., via environment variable, argument, or configuration), use it as-is
+   2. Otherwise, auto-generate it under `specs/`:
+      - Check `.specify/init-options.json` for `branch_numbering`
+      - If `"timestamp"`: prefix is `YYYYMMDD-HHMMSS` (current timestamp)
+      - If `"sequential"` or absent: prefix is `NNN` (next available 3-digit number after scanning existing directories in `specs/`)
+      - Construct the directory name: `<prefix>-<short-name>` (e.g., `003-user-auth` or `20260319-143022-user-auth`)
+      - Set `SPECIFY_FEATURE_DIRECTORY` to `specs/<directory-name>`
+
+   **Create the directory and spec file**:
+   - `mkdir -p SPECIFY_FEATURE_DIRECTORY`
+   - Copy `.specify/templates/spec-template.md` to `SPECIFY_FEATURE_DIRECTORY/spec.md` as the starting point
+   - Set `SPEC_FILE` to `SPECIFY_FEATURE_DIRECTORY/spec.md`
+   - Persist the resolved path to `.specify/feature.json`:
+     ```json
+     {
+       "feature_directory": "<resolved feature dir>"
+     }
+     ```
+     Write the actual resolved directory path value (for example, `specs/003-user-auth`), not the literal string `SPECIFY_FEATURE_DIRECTORY`.
+     This allows downstream commands (`/speckit-plan`, `/speckit-tasks`, etc.) to locate the feature directory without relying on git branch name conventions.
+
+   **IMPORTANT**:
+   - You must only create one feature per `/speckit-specify` invocation
+   - The spec directory name and the git branch name are independent — they may be the same but that is the user's choice
+   - The spec directory and file are always created by this command, never by the hook
+
+4. Load `.specify/templates/spec-template.md` to understand required sections.
+
+5. Follow this execution flow:
+    1. Parse user description from arguments
+       If empty: ERROR "No feature description provided"
+    2. Extract key concepts from description
+       Identify: actors, actions, data, constraints
+    3. For unclear aspects:
+       - Make informed guesses based on context and industry standards
+       - Only mark with [NEEDS CLARIFICATION: specific question] if:
+         - The choice significantly impacts feature scope or user experience
+         - Multiple reasonable interpretations exist with different implications
+         - No reasonable default exists
+       - **LIMIT: Maximum 3 [NEEDS CLARIFICATION] markers total**
+       - Prioritize clarifications by impact: scope > security/privacy > user experience > technical details
+    4. Fill User Scenarios & Testing section
+       If no clear user flow: ERROR "Cannot determine user scenarios"
+    5. Generate Functional Requirements
+       Each requirement must be testable
+       Use reasonable defaults for unspecified details (document assumptions in Assumptions section)
+    6. Define Success Criteria
+       Create measurable, technology-agnostic outcomes
+       Include both quantitative metrics (time, performance, volume) and qualitative measures (user satisfaction, task completion)
+       Each criterion must be verifiable without implementation details
+    7. Identify Key Entities (if data involved)
+    8. Return: SUCCESS (spec ready for planning)
+
+6. Write the specification to SPEC_FILE using the template structure, replacing placeholders with concrete details derived from the feature description (arguments) while preserving section order and headings.
+
+7. **Specification Quality Validation**: After writing the initial spec, validate it against quality criteria:
+
+   a. **Create Spec Quality Checklist**: Generate a checklist file at `SPECIFY_FEATURE_DIRECTORY/checklists/requirements.md` using the checklist template structure with these validation items:
+
+      ```markdown
+      # Specification Quality Checklist: [FEATURE NAME]
+      
+      **Purpose**: Validate specification completeness and quality before proceeding to planning
+      **Created**: [DATE]
+      **Feature**: [Link to spec.md]
+      
+      ## Content Quality
+      
+      - [ ] No implementation details (languages, frameworks, APIs)
+      - [ ] Focused on user value and business needs
+      - [ ] Written for non-technical stakeholders
+      - [ ] All mandatory sections completed
+      
+      ## Requirement Completeness
+      
+      - [ ] No [NEEDS CLARIFICATION] markers remain
+      - [ ] Requirements are testable and unambiguous
+      - [ ] Success criteria are measurable
+      - [ ] Success criteria are technology-agnostic (no implementation details)
+      - [ ] All acceptance scenarios are defined
+      - [ ] Edge cases are identified
+      - [ ] Scope is clearly bounded
+      - [ ] Dependencies and assumptions identified
+      
+      ## Feature Readiness
+      
+      - [ ] All functional requirements have clear acceptance criteria
+      - [ ] User scenarios cover primary flows
+      - [ ] Feature meets measurable outcomes defined in Success Criteria
+      - [ ] No implementation details leak into specification
+      
+      ## Notes
+      
+      - Items marked incomplete require spec updates before `/speckit-clarify` or `/speckit-plan`
+      ```
+
+   b. **Run Validation Check**: Review the spec against each checklist item:
+      - For each item, determine if it passes or fails
+      - Document specific issues found (quote relevant spec sections)
+
+   c. **Handle Validation Results**:
+
+      - **If all items pass**: Mark checklist complete and proceed to step 8
+
+      - **If items fail (excluding [NEEDS CLARIFICATION])**:
+        1. List the failing items and specific issues
+        2. Update the spec to address each issue
+        3. Re-run validation until all items pass (max 3 iterations)
+        4. If still failing after 3 iterations, document remaining issues in checklist notes and warn user
+
+      - **If [NEEDS CLARIFICATION] markers remain**:
+        1. Extract all [NEEDS CLARIFICATION: ...] markers from the spec
+        2. **LIMIT CHECK**: If more than 3 markers exist, keep only the 3 most critical (by scope/security/UX impact) and make informed guesses for the rest
+        3. For each clarification needed (max 3), present options to user in this format:
+
+           ```markdown
+           ## Question [N]: [Topic]
+           
+           **Context**: [Quote relevant spec section]
+           
+           **What we need to know**: [Specific question from NEEDS CLARIFICATION marker]
+           
+           **Suggested Answers**:
+           
+           | Option | Answer | Implications |
+           |--------|--------|--------------|
+           | A      | [First suggested answer] | [What this means for the feature] |
+           | B      | [Second suggested answer] | [What this means for the feature] |
+           | C      | [Third suggested answer] | [What this means for the feature] |
+           | Custom | Provide your own answer | [Explain how to provide custom input] |
+           
+           **Your choice**: _[Wait for user response]_
+           ```
+
+        4. **CRITICAL - Table Formatting**: Ensure markdown tables are properly formatted:
+           - Use consistent spacing with pipes aligned
+           - Each cell should have spaces around content: `| Content |` not `|Content|`
+           - Header separator must have at least 3 dashes: `|--------|`
+           - Test that the table renders correctly in markdown preview
+        5. Number questions sequentially (Q1, Q2, Q3 - max 3 total)
+        6. Present all questions together before waiting for responses
+        7. Wait for user to respond with their choices for all questions (e.g., "Q1: A, Q2: Custom - [details], Q3: B")
+        8. Update the spec by replacing each [NEEDS CLARIFICATION] marker with the user's selected or provided answer
+        9. Re-run validation after all clarifications are resolved
+
+   d. **Update Checklist**: After each validation iteration, update the checklist file with current pass/fail status
+
+8. **Report completion** to the user with:
+   - `SPECIFY_FEATURE_DIRECTORY` — the feature directory path
+   - `SPEC_FILE` — the spec file path
+   - Checklist results summary
+   - Readiness for the next phase (`/speckit-clarify` or `/speckit-plan`)
+
+9. **Check for extension hooks**: After reporting completion, check if `.specify/extensions.yml` exists in the project root.
+   - If it exists, read it and look for entries under the `hooks.after_specify` key
+   - If the YAML cannot be parsed or is invalid, skip hook checking silently and continue normally
+   - Filter out hooks where `enabled` is explicitly `false`. Treat hooks without an `enabled` field as enabled by default.
+   - For each remaining hook, do **not** attempt to interpret or evaluate hook `condition` expressions:
+     - If the hook has no `condition` field, or it is null/empty, treat the hook as executable
+     - If the hook defines a non-empty `condition`, skip the hook and leave condition evaluation to the HookExecutor implementation
+   - For each executable hook, output the following based on its `optional` flag:
+     - **Optional hook** (`optional: true`):
+       ```
+       ## Extension Hooks
+
+       **Optional Hook**: {extension}
+       Command: `/{command}`
+       Description: {description}
+
+       Prompt: {prompt}
+       To execute: `/{command}`
+       ```
+     - **Mandatory hook** (`optional: false`):
+       ```
+       ## Extension Hooks
+
+       **Automatic Hook**: {extension}
+       Executing: `/{command}`
+       EXECUTE_COMMAND: {command}
+       ```
+   - If no hooks are registered or `.specify/extensions.yml` does not exist, skip silently
+
+**NOTE:** Branch creation is handled by the `before_specify` hook (git extension). Spec directory and file creation are always handled by this core command.
+
+## Quick Guidelines
+
+- Focus on **WHAT** users need and **WHY**.
+- Avoid HOW to implement (no tech stack, APIs, code structure).
+- Written for business stakeholders, not developers.
+- DO NOT create any checklists that are embedded in the spec. That will be a separate command.
+
+### Section Requirements
+
+- **Mandatory sections**: Must be completed for every feature
+- **Optional sections**: Include only when relevant to the feature
+- When a section doesn't apply, remove it entirely (don't leave as "N/A")
+
+### For AI Generation
+
+When creating this spec from a user prompt:
+
+1. **Make informed guesses**: Use context, industry standards, and common patterns to fill gaps
+2. **Document assumptions**: Record reasonable defaults in the Assumptions section
+3. **Limit clarifications**: Maximum 3 [NEEDS CLARIFICATION] markers - use only for critical decisions that:
+   - Significantly impact feature scope or user experience
+   - Have multiple reasonable interpretations with different implications
+   - Lack any reasonable default
+4. **Prioritize clarifications**: scope > security/privacy > user experience > technical details
+5. **Think like a tester**: Every vague requirement should fail the "testable and unambiguous" checklist item
+6. **Common areas needing clarification** (only if no reasonable default exists):
+   - Feature scope and boundaries (include/exclude specific use cases)
+   - User types and permissions (if multiple conflicting interpretations possible)
+   - Security/compliance requirements (when legally/financially significant)
+
+**Examples of reasonable defaults** (don't ask about these):
+
+- Data retention: Industry-standard practices for the domain
+- Performance targets: Standard web/mobile app expectations unless specified
+- Error handling: User-friendly messages with appropriate fallbacks
+- Authentication method: Standard session-based or OAuth2 for web apps
+- Integration patterns: Use project-appropriate patterns (REST/GraphQL for web services, function calls for libraries, CLI args for tools, etc.)
+
+### Success Criteria Guidelines
+
+Success criteria must be:
+
+1. **Measurable**: Include specific metrics (time, percentage, count, rate)
+2. **Technology-agnostic**: No mention of frameworks, languages, databases, or tools
+3. **User-focused**: Describe outcomes from user/business perspective, not system internals
+4. **Verifiable**: Can be tested/validated without knowing implementation details
+
+**Good examples**:
+
+- "Users can complete checkout in under 3 minutes"
+- "System supports 10,000 concurrent users"
+- "95% of searches return results in under 1 second"
+- "Task completion rate improves by 40%"
+
+**Bad examples** (implementation-focused):
+
+- "API response time is under 200ms" (too technical, use "Users see results instantly")
+- "Database can handle 1000 TPS" (implementation detail, use user-facing metric)
+- "React components render efficiently" (framework-specific)
+- "Redis cache hit rate above 80%" (technology-specific)

--- a/.agents/skills/speckit-tasks/SKILL.md
+++ b/.agents/skills/speckit-tasks/SKILL.md
@@ -1,0 +1,197 @@
+---
+name: "speckit-tasks"
+description: "Generate an actionable, dependency-ordered tasks.md for the feature based on available design artifacts."
+compatibility: "Requires spec-kit project structure with .specify/ directory"
+metadata:
+  author: "github-spec-kit"
+  source: "templates/commands/tasks.md"
+---
+
+
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+You **MUST** consider the user input before proceeding (if not empty).
+
+## Pre-Execution Checks
+
+**Check for extension hooks (before tasks generation)**:
+- Check if `.specify/extensions.yml` exists in the project root.
+- If it exists, read it and look for entries under the `hooks.before_tasks` key
+- If the YAML cannot be parsed or is invalid, skip hook checking silently and continue normally
+- Filter out hooks where `enabled` is explicitly `false`. Treat hooks without an `enabled` field as enabled by default.
+- For each remaining hook, do **not** attempt to interpret or evaluate hook `condition` expressions:
+  - If the hook has no `condition` field, or it is null/empty, treat the hook as executable
+  - If the hook defines a non-empty `condition`, skip the hook and leave condition evaluation to the HookExecutor implementation
+- For each executable hook, output the following based on its `optional` flag:
+  - **Optional hook** (`optional: true`):
+    ```
+    ## Extension Hooks
+
+    **Optional Pre-Hook**: {extension}
+    Command: `/{command}`
+    Description: {description}
+
+    Prompt: {prompt}
+    To execute: `/{command}`
+    ```
+  - **Mandatory hook** (`optional: false`):
+    ```
+    ## Extension Hooks
+
+    **Automatic Pre-Hook**: {extension}
+    Executing: `/{command}`
+    EXECUTE_COMMAND: {command}
+    
+    Wait for the result of the hook command before proceeding to the Outline.
+    ```
+- If no hooks are registered or `.specify/extensions.yml` does not exist, skip silently
+
+## Outline
+
+1. **Setup**: Run `.specify/scripts/bash/setup-tasks.sh --json` from repo root and parse FEATURE_DIR, TASKS_TEMPLATE, and AVAILABLE_DOCS list. `FEATURE_DIR` and `TASKS_TEMPLATE` must be absolute paths when provided. `AVAILABLE_DOCS` is a list of document names/relative paths available under `FEATURE_DIR` (for example `research.md` or `contracts/`). For single quotes in args like "I'm Groot", use escape syntax: e.g 'I'\''m Groot' (or double-quote if possible: "I'm Groot").
+
+2. **Load design documents**: Read from FEATURE_DIR:
+   - **Required**: plan.md (tech stack, libraries, structure), spec.md (user stories with priorities)
+   - **Optional**: data-model.md (entities), contracts/ (interface contracts), research.md (decisions), quickstart.md (test scenarios)
+   - Note: Not all projects have all documents. Generate tasks based on what's available.
+
+3. **Execute task generation workflow**:
+   - Load plan.md and extract tech stack, libraries, project structure
+   - Load spec.md and extract user stories with their priorities (P1, P2, P3, etc.)
+   - If data-model.md exists: Extract entities and map to user stories
+   - If contracts/ exists: Map interface contracts to user stories
+   - If research.md exists: Extract decisions for setup tasks
+   - Generate tasks organized by user story (see Task Generation Rules below)
+   - Generate dependency graph showing user story completion order
+   - Create parallel execution examples per user story
+   - Validate task completeness (each user story has all needed tasks, independently testable)
+
+4. **Generate tasks.md**: Read the tasks template from TASKS_TEMPLATE (from the JSON output above) and use it as structure. If TASKS_TEMPLATE is empty, fall back to `.specify/templates/tasks-template.md`. Fill with:
+   - Correct feature name from plan.md
+   - Phase 1: Setup tasks (project initialization)
+   - Phase 2: Foundational tasks (blocking prerequisites for all user stories)
+   - Phase 3+: One phase per user story (in priority order from spec.md)
+   - Each phase includes: story goal, independent test criteria, tests (if requested), implementation tasks
+   - Final Phase: Polish & cross-cutting concerns
+   - All tasks must follow the strict checklist format (see Task Generation Rules below)
+   - Clear file paths for each task
+   - Dependencies section showing story completion order
+   - Parallel execution examples per story
+   - Implementation strategy section (MVP first, incremental delivery)
+
+5. **Report**: Output path to generated tasks.md and summary:
+   - Total task count
+   - Task count per user story
+   - Parallel opportunities identified
+   - Independent test criteria for each story
+   - Suggested MVP scope (typically just User Story 1)
+   - Format validation: Confirm ALL tasks follow the checklist format (checkbox, ID, labels, file paths)
+
+6. **Check for extension hooks**: After tasks.md is generated, check if `.specify/extensions.yml` exists in the project root.
+   - If it exists, read it and look for entries under the `hooks.after_tasks` key
+   - If the YAML cannot be parsed or is invalid, skip hook checking silently and continue normally
+   - Filter out hooks where `enabled` is explicitly `false`. Treat hooks without an `enabled` field as enabled by default.
+   - For each remaining hook, do **not** attempt to interpret or evaluate hook `condition` expressions:
+     - If the hook has no `condition` field, or it is null/empty, treat the hook as executable
+     - If the hook defines a non-empty `condition`, skip the hook and leave condition evaluation to the HookExecutor implementation
+   - For each executable hook, output the following based on its `optional` flag:
+     - **Optional hook** (`optional: true`):
+       ```
+       ## Extension Hooks
+
+       **Optional Hook**: {extension}
+       Command: `/{command}`
+       Description: {description}
+
+       Prompt: {prompt}
+       To execute: `/{command}`
+       ```
+     - **Mandatory hook** (`optional: false`):
+       ```
+       ## Extension Hooks
+
+       **Automatic Hook**: {extension}
+       Executing: `/{command}`
+       EXECUTE_COMMAND: {command}
+       ```
+   - If no hooks are registered or `.specify/extensions.yml` does not exist, skip silently
+
+Context for task generation: $ARGUMENTS
+
+The tasks.md should be immediately executable - each task must be specific enough that an LLM can complete it without additional context.
+
+## Task Generation Rules
+
+**CRITICAL**: Tasks MUST be organized by user story to enable independent implementation and testing.
+
+**Tests are OPTIONAL**: Only generate test tasks if explicitly requested in the feature specification or if user requests TDD approach.
+
+### Checklist Format (REQUIRED)
+
+Every task MUST strictly follow this format:
+
+```text
+- [ ] [TaskID] [P?] [Story?] Description with file path
+```
+
+**Format Components**:
+
+1. **Checkbox**: ALWAYS start with `- [ ]` (markdown checkbox)
+2. **Task ID**: Sequential number (T001, T002, T003...) in execution order
+3. **[P] marker**: Include ONLY if task is parallelizable (different files, no dependencies on incomplete tasks)
+4. **[Story] label**: REQUIRED for user story phase tasks only
+   - Format: [US1], [US2], [US3], etc. (maps to user stories from spec.md)
+   - Setup phase: NO story label
+   - Foundational phase: NO story label  
+   - User Story phases: MUST have story label
+   - Polish phase: NO story label
+5. **Description**: Clear action with exact file path
+
+**Examples**:
+
+- ✅ CORRECT: `- [ ] T001 Create project structure per implementation plan`
+- ✅ CORRECT: `- [ ] T005 [P] Implement authentication middleware in src/middleware/auth.py`
+- ✅ CORRECT: `- [ ] T012 [P] [US1] Create User model in src/models/user.py`
+- ✅ CORRECT: `- [ ] T014 [US1] Implement UserService in src/services/user_service.py`
+- ❌ WRONG: `- [ ] Create User model` (missing ID and Story label)
+- ❌ WRONG: `T001 [US1] Create model` (missing checkbox)
+- ❌ WRONG: `- [ ] [US1] Create User model` (missing Task ID)
+- ❌ WRONG: `- [ ] T001 [US1] Create model` (missing file path)
+
+### Task Organization
+
+1. **From User Stories (spec.md)** - PRIMARY ORGANIZATION:
+   - Each user story (P1, P2, P3...) gets its own phase
+   - Map all related components to their story:
+     - Models needed for that story
+     - Services needed for that story
+     - Interfaces/UI needed for that story
+     - If tests requested: Tests specific to that story
+   - Mark story dependencies (most stories should be independent)
+
+2. **From Contracts**:
+   - Map each interface contract → to the user story it serves
+   - If tests requested: Each interface contract → contract test task [P] before implementation in that story's phase
+
+3. **From Data Model**:
+   - Map each entity to the user story(ies) that need it
+   - If entity serves multiple stories: Put in earliest story or Setup phase
+   - Relationships → service layer tasks in appropriate story phase
+
+4. **From Setup/Infrastructure**:
+   - Shared infrastructure → Setup phase (Phase 1)
+   - Foundational/blocking tasks → Foundational phase (Phase 2)
+   - Story-specific setup → within that story's phase
+
+### Phase Structure
+
+- **Phase 1**: Setup (project initialization)
+- **Phase 2**: Foundational (blocking prerequisites - MUST complete before user stories)
+- **Phase 3+**: User Stories in priority order (P1, P2, P3...)
+  - Within each story: Tests (if requested) → Models → Services → Endpoints → Integration
+  - Each phase should be a complete, independently testable increment
+- **Final Phase**: Polish & Cross-Cutting Concerns

--- a/.agents/skills/speckit-taskstoissues/SKILL.md
+++ b/.agents/skills/speckit-taskstoissues/SKILL.md
@@ -1,0 +1,101 @@
+---
+name: "speckit-taskstoissues"
+description: "Convert existing tasks into actionable, dependency-ordered GitHub issues for the feature based on available design artifacts."
+compatibility: "Requires spec-kit project structure with .specify/ directory"
+metadata:
+  author: "github-spec-kit"
+  source: "templates/commands/taskstoissues.md"
+---
+
+
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+You **MUST** consider the user input before proceeding (if not empty).
+
+## Pre-Execution Checks
+
+**Check for extension hooks (before tasks-to-issues conversion)**:
+- Check if `.specify/extensions.yml` exists in the project root.
+- If it exists, read it and look for entries under the `hooks.before_taskstoissues` key
+- If the YAML cannot be parsed or is invalid, skip hook checking silently and continue normally
+- Filter out hooks where `enabled` is explicitly `false`. Treat hooks without an `enabled` field as enabled by default.
+- For each remaining hook, do **not** attempt to interpret or evaluate hook `condition` expressions:
+  - If the hook has no `condition` field, or it is null/empty, treat the hook as executable
+  - If the hook defines a non-empty `condition`, skip the hook and leave condition evaluation to the HookExecutor implementation
+- For each executable hook, output the following based on its `optional` flag:
+  - **Optional hook** (`optional: true`):
+    ```
+    ## Extension Hooks
+
+    **Optional Pre-Hook**: {extension}
+    Command: `/{command}`
+    Description: {description}
+
+    Prompt: {prompt}
+    To execute: `/{command}`
+    ```
+  - **Mandatory hook** (`optional: false`):
+    ```
+    ## Extension Hooks
+
+    **Automatic Pre-Hook**: {extension}
+    Executing: `/{command}`
+    EXECUTE_COMMAND: {command}
+
+    Wait for the result of the hook command before proceeding to the Outline.
+    ```
+- If no hooks are registered or `.specify/extensions.yml` does not exist, skip silently
+
+## Outline
+
+1. Run `.specify/scripts/bash/check-prerequisites.sh --json --require-tasks --include-tasks` from repo root and parse FEATURE_DIR and AVAILABLE_DOCS list. All paths must be absolute. For single quotes in args like "I'm Groot", use escape syntax: e.g 'I'\''m Groot' (or double-quote if possible: "I'm Groot").
+1. From the executed script, extract the path to **tasks**.
+1. Get the Git remote by running:
+
+```bash
+git config --get remote.origin.url
+```
+
+> [!CAUTION]
+> ONLY PROCEED TO NEXT STEPS IF THE REMOTE IS A GITHUB URL
+
+1. For each task in the list, use the GitHub MCP server to create a new issue in the repository that is representative of the Git remote.
+
+> [!CAUTION]
+> UNDER NO CIRCUMSTANCES EVER CREATE ISSUES IN REPOSITORIES THAT DO NOT MATCH THE REMOTE URL
+
+## Post-Execution Checks
+
+**Check for extension hooks (after tasks-to-issues conversion)**:
+Check if `.specify/extensions.yml` exists in the project root.
+- If it exists, read it and look for entries under the `hooks.after_taskstoissues` key
+- If the YAML cannot be parsed or is invalid, skip hook checking silently and continue normally
+- Filter out hooks where `enabled` is explicitly `false`. Treat hooks without an `enabled` field as enabled by default.
+- For each remaining hook, do **not** attempt to interpret or evaluate hook `condition` expressions:
+  - If the hook has no `condition` field, or it is null/empty, treat the hook as executable
+  - If the hook defines a non-empty `condition`, skip the hook and leave condition evaluation to the HookExecutor implementation
+- For each executable hook, output the following based on its `optional` flag:
+  - **Optional hook** (`optional: true`):
+    ```
+    ## Extension Hooks
+
+    **Optional Hook**: {extension}
+    Command: `/{command}`
+    Description: {description}
+
+    Prompt: {prompt}
+    To execute: `/{command}`
+    ```
+  - **Mandatory hook** (`optional: false`):
+    ```
+    ## Extension Hooks
+
+    **Automatic Hook**: {extension}
+    Executing: `/{command}`
+    EXECUTE_COMMAND: {command}
+    ```
+- If no hooks are registered or `.specify/extensions.yml` does not exist, skip silently

--- a/.github/agents/copilot-instructions.md
+++ b/.github/agents/copilot-instructions.md
@@ -3,6 +3,8 @@
 Auto-generated from all feature plans. Last updated: 2026-03-04
 
 ## Active Technologies
+- C# latest, .NET 8.0 / 9.0 / 10.0 multi-targeting + Existing `Microsoft.Extensions.DependencyInjection.Abstractions`, `Microsoft.Extensions.Logging.Abstractions`; SQLite provider keeps existing `Microsoft.Data.Sqlite` (003-query-capabilities-typed)
+- No new storage; existing in-memory and SQLite JSON providers declare query capabilities (003-query-capabilities-typed)
 
 - C# / .NET 9.0 (Standard 2.0/2.1 compatible ideally, but targeted for net9.0) + Microsoft.Extensions.DependencyInjection, Microsoft.Extensions.Logging (001-core-sdk-foundation)
 
@@ -22,6 +24,7 @@ tests/
 C# / .NET 9.0 (Standard 2.0/2.1 compatible ideally, but targeted for net9.0): Follow standard conventions
 
 ## Recent Changes
+- 003-query-capabilities-typed: Added C# latest, .NET 8.0 / 9.0 / 10.0 multi-targeting + Existing `Microsoft.Extensions.DependencyInjection.Abstractions`, `Microsoft.Extensions.Logging.Abstractions`; SQLite provider keeps existing `Microsoft.Data.Sqlite`
 
 - 001-core-sdk-foundation: Added C# / .NET 9.0 (Standard 2.0/2.1 compatible ideally, but targeted for net9.0) + Microsoft.Extensions.DependencyInjection, Microsoft.Extensions.Logging
 

--- a/.github/agents/speckit.git.commit.agent.md
+++ b/.github/agents/speckit.git.commit.agent.md
@@ -1,0 +1,51 @@
+---
+description: Auto-commit changes after a Spec Kit command completes
+---
+
+
+<!-- Extension: git -->
+<!-- Config: .specify/extensions/git/ -->
+# Auto-Commit Changes
+
+Automatically stage and commit all changes after a Spec Kit command completes.
+
+## Behavior
+
+This command is invoked as a hook after (or before) core commands. It:
+
+1. Determines the event name from the hook context (e.g., if invoked as an `after_specify` hook, the event is `after_specify`; if `before_plan`, the event is `before_plan`)
+2. Checks `.specify/extensions/git/git-config.yml` for the `auto_commit` section
+3. Looks up the specific event key to see if auto-commit is enabled
+4. Falls back to `auto_commit.default` if no event-specific key exists
+5. Uses the per-command `message` if configured, otherwise a default message
+6. If enabled and there are uncommitted changes, runs `git add .` + `git commit`
+
+## Execution
+
+Determine the event name from the hook that triggered this command, then run the script:
+
+- **Bash**: `.specify/extensions/git/scripts/bash/auto-commit.sh <event_name>`
+- **PowerShell**: `.specify/extensions/git/scripts/powershell/auto-commit.ps1 <event_name>`
+
+Replace `<event_name>` with the actual hook event (e.g., `after_specify`, `before_plan`, `after_implement`).
+
+## Configuration
+
+In `.specify/extensions/git/git-config.yml`:
+
+```yaml
+auto_commit:
+  default: false          # Global toggle — set true to enable for all commands
+  after_specify:
+    enabled: true          # Override per-command
+    message: "[Spec Kit] Add specification"
+  after_plan:
+    enabled: false
+    message: "[Spec Kit] Add implementation plan"
+```
+
+## Graceful Degradation
+
+- If Git is not available or the current directory is not a repository: skips with a warning
+- If no config file exists: skips (disabled by default)
+- If no changes to commit: skips with a message

--- a/.github/agents/speckit.git.feature.agent.md
+++ b/.github/agents/speckit.git.feature.agent.md
@@ -1,0 +1,70 @@
+---
+description: Create a feature branch with sequential or timestamp numbering
+---
+
+
+<!-- Extension: git -->
+<!-- Config: .specify/extensions/git/ -->
+# Create Feature Branch
+
+Create and switch to a new git feature branch for the given specification. This command handles **branch creation only** — the spec directory and files are created by the core `/speckit.specify` workflow.
+
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+You **MUST** consider the user input before proceeding (if not empty).
+
+## Environment Variable Override
+
+If the user explicitly provided `GIT_BRANCH_NAME` (e.g., via environment variable, argument, or in their request), pass it through to the script by setting the `GIT_BRANCH_NAME` environment variable before invoking the script. When `GIT_BRANCH_NAME` is set:
+- The script uses the exact value as the branch name, bypassing all prefix/suffix generation
+- `--short-name`, `--number`, and `--timestamp` flags are ignored
+- `FEATURE_NUM` is extracted from the name if it starts with a numeric prefix, otherwise set to the full branch name
+
+## Prerequisites
+
+- Verify Git is available by running `git rev-parse --is-inside-work-tree 2>/dev/null`
+- If Git is not available, warn the user and skip branch creation
+
+## Branch Numbering Mode
+
+Determine the branch numbering strategy by checking configuration in this order:
+
+1. Check `.specify/extensions/git/git-config.yml` for `branch_numbering` value
+2. Check `.specify/init-options.json` for `branch_numbering` value (backward compatibility)
+3. Default to `sequential` if neither exists
+
+## Execution
+
+Generate a concise short name (2-4 words) for the branch:
+- Analyze the feature description and extract the most meaningful keywords
+- Use action-noun format when possible (e.g., "add-user-auth", "fix-payment-bug")
+- Preserve technical terms and acronyms (OAuth2, API, JWT, etc.)
+
+Run the appropriate script based on your platform:
+
+- **Bash**: `.specify/extensions/git/scripts/bash/create-new-feature.sh --json --short-name "<short-name>" "<feature description>"`
+- **Bash (timestamp)**: `.specify/extensions/git/scripts/bash/create-new-feature.sh --json --timestamp --short-name "<short-name>" "<feature description>"`
+- **PowerShell**: `.specify/extensions/git/scripts/powershell/create-new-feature.ps1 -Json -ShortName "<short-name>" "<feature description>"`
+- **PowerShell (timestamp)**: `.specify/extensions/git/scripts/powershell/create-new-feature.ps1 -Json -Timestamp -ShortName "<short-name>" "<feature description>"`
+
+**IMPORTANT**:
+- Do NOT pass `--number` — the script determines the correct next number automatically
+- Always include the JSON flag (`--json` for Bash, `-Json` for PowerShell) so the output can be parsed reliably
+- You must only ever run this script once per feature
+- The JSON output will contain `BRANCH_NAME` and `FEATURE_NUM`
+
+## Graceful Degradation
+
+If Git is not installed or the current directory is not a Git repository:
+- Branch creation is skipped with a warning: `[specify] Warning: Git repository not detected; skipped branch creation`
+- The script still outputs `BRANCH_NAME` and `FEATURE_NUM` so the caller can reference them
+
+## Output
+
+The script outputs JSON with:
+- `BRANCH_NAME`: The branch name (e.g., `003-user-auth` or `20260319-143022-user-auth`)
+- `FEATURE_NUM`: The numeric or timestamp prefix used

--- a/.github/agents/speckit.git.initialize.agent.md
+++ b/.github/agents/speckit.git.initialize.agent.md
@@ -1,0 +1,52 @@
+---
+description: Initialize a Git repository with an initial commit
+---
+
+
+<!-- Extension: git -->
+<!-- Config: .specify/extensions/git/ -->
+# Initialize Git Repository
+
+Initialize a Git repository in the current project directory if one does not already exist.
+
+## Execution
+
+Run the appropriate script from the project root:
+
+- **Bash**: `.specify/extensions/git/scripts/bash/initialize-repo.sh`
+- **PowerShell**: `.specify/extensions/git/scripts/powershell/initialize-repo.ps1`
+
+If the extension scripts are not found, fall back to:
+- **Bash**: `git init && git add . && git commit -m "Initial commit from Specify template"`
+- **PowerShell**: `git init; git add .; git commit -m "Initial commit from Specify template"`
+
+The script handles all checks internally:
+- Skips if Git is not available
+- Skips if already inside a Git repository
+- Runs `git init`, `git add .`, and `git commit` with an initial commit message
+
+## Customization
+
+Replace the script to add project-specific Git initialization steps:
+- Custom `.gitignore` templates
+- Default branch naming (`git config init.defaultBranch`)
+- Git LFS setup
+- Git hooks installation
+- Commit signing configuration
+- Git Flow initialization
+
+## Output
+
+On success:
+- `✓ Git repository initialized`
+
+## Graceful Degradation
+
+If Git is not installed:
+- Warn the user
+- Skip repository initialization
+- The project continues to function without Git (specs can still be created under `specs/`)
+
+If Git is installed but `git init`, `git add .`, or `git commit` fails:
+- Surface the error to the user
+- Stop this command rather than continuing with a partially initialized repository

--- a/.github/agents/speckit.git.remote.agent.md
+++ b/.github/agents/speckit.git.remote.agent.md
@@ -1,0 +1,48 @@
+---
+description: Detect Git remote URL for GitHub integration
+---
+
+
+<!-- Extension: git -->
+<!-- Config: .specify/extensions/git/ -->
+# Detect Git Remote URL
+
+Detect the Git remote URL for integration with GitHub services (e.g., issue creation).
+
+## Prerequisites
+
+- Check if Git is available by running `git rev-parse --is-inside-work-tree 2>/dev/null`
+- If Git is not available, output a warning and return empty:
+  ```
+  [specify] Warning: Git repository not detected; cannot determine remote URL
+  ```
+
+## Execution
+
+Run the following command to get the remote URL:
+
+```bash
+git config --get remote.origin.url
+```
+
+## Output
+
+Parse the remote URL and determine:
+
+1. **Repository owner**: Extract from the URL (e.g., `github` from `https://github.com/github/spec-kit.git`)
+2. **Repository name**: Extract from the URL (e.g., `spec-kit` from `https://github.com/github/spec-kit.git`)
+3. **Is GitHub**: Whether the remote points to a GitHub repository
+
+Supported URL formats:
+- HTTPS: `https://github.com/<owner>/<repo>.git`
+- SSH: `git@github.com:<owner>/<repo>.git`
+
+> [!CAUTION]
+> ONLY report a GitHub repository if the remote URL actually points to github.com.
+> Do NOT assume the remote is GitHub if the URL format doesn't match.
+
+## Graceful Degradation
+
+If Git is not installed, the directory is not a Git repository, or no remote is configured:
+- Return an empty result
+- Do NOT error — other workflows should continue without Git remote information

--- a/.github/agents/speckit.git.validate.agent.md
+++ b/.github/agents/speckit.git.validate.agent.md
@@ -1,0 +1,52 @@
+---
+description: Validate current branch follows feature branch naming conventions
+---
+
+
+<!-- Extension: git -->
+<!-- Config: .specify/extensions/git/ -->
+# Validate Feature Branch
+
+Validate that the current Git branch follows the expected feature branch naming conventions.
+
+## Prerequisites
+
+- Check if Git is available by running `git rev-parse --is-inside-work-tree 2>/dev/null`
+- If Git is not available, output a warning and skip validation:
+  ```
+  [specify] Warning: Git repository not detected; skipped branch validation
+  ```
+
+## Validation Rules
+
+Get the current branch name:
+
+```bash
+git rev-parse --abbrev-ref HEAD
+```
+
+The branch name must match one of these patterns:
+
+1. **Sequential**: `^[0-9]{3,}-` (e.g., `001-feature-name`, `042-fix-bug`, `1000-big-feature`)
+2. **Timestamp**: `^[0-9]{8}-[0-9]{6}-` (e.g., `20260319-143022-feature-name`)
+
+## Execution
+
+If on a feature branch (matches either pattern):
+- Output: `✓ On feature branch: <branch-name>`
+- Check if the corresponding spec directory exists under `specs/`:
+  - For sequential branches, look for `specs/<prefix>-*` where prefix matches the numeric portion
+  - For timestamp branches, look for `specs/<prefix>-*` where prefix matches the `YYYYMMDD-HHMMSS` portion
+- If spec directory exists: `✓ Spec directory found: <path>`
+- If spec directory missing: `⚠ No spec directory found for prefix <prefix>`
+
+If NOT on a feature branch:
+- Output: `✗ Not on a feature branch. Current branch: <branch-name>`
+- Output: `Feature branches should be named like: 001-feature-name or 20260319-143022-feature-name`
+
+## Graceful Degradation
+
+If Git is not installed or the directory is not a Git repository:
+- Check the `SPECIFY_FEATURE` environment variable as a fallback
+- If set, validate that value against the naming patterns
+- If not set, skip validation with a warning

--- a/.github/prompts/speckit.git.commit.prompt.md
+++ b/.github/prompts/speckit.git.commit.prompt.md
@@ -1,0 +1,3 @@
+---
+agent: speckit.git.commit
+---

--- a/.github/prompts/speckit.git.feature.prompt.md
+++ b/.github/prompts/speckit.git.feature.prompt.md
@@ -1,0 +1,3 @@
+---
+agent: speckit.git.feature
+---

--- a/.github/prompts/speckit.git.initialize.prompt.md
+++ b/.github/prompts/speckit.git.initialize.prompt.md
@@ -1,0 +1,3 @@
+---
+agent: speckit.git.initialize
+---

--- a/.github/prompts/speckit.git.remote.prompt.md
+++ b/.github/prompts/speckit.git.remote.prompt.md
@@ -1,0 +1,3 @@
+---
+agent: speckit.git.remote
+---

--- a/.github/prompts/speckit.git.validate.prompt.md
+++ b/.github/prompts/speckit.git.validate.prompt.md
@@ -1,0 +1,3 @@
+---
+agent: speckit.git.validate
+---

--- a/.gitignore
+++ b/.gitignore
@@ -96,6 +96,7 @@ StyleCopReport.xml
 *.tmp_proj
 *_wpftmp.csproj
 *.log
+*.lscache
 *.tlog
 *.vspscc
 *.vssscc

--- a/.specify/extensions.yml
+++ b/.specify/extensions.yml
@@ -1,0 +1,148 @@
+installed: []
+settings:
+  auto_execute_hooks: true
+hooks:
+  before_constitution:
+  - extension: git
+    command: speckit.git.initialize
+    enabled: true
+    optional: false
+    prompt: Execute speckit.git.initialize?
+    description: Initialize Git repository before constitution setup
+    condition: null
+  before_specify:
+  - extension: git
+    command: speckit.git.feature
+    enabled: true
+    optional: false
+    prompt: Execute speckit.git.feature?
+    description: Create feature branch before specification
+    condition: null
+  before_clarify:
+  - extension: git
+    command: speckit.git.commit
+    enabled: true
+    optional: true
+    prompt: Commit outstanding changes before clarification?
+    description: Auto-commit before spec clarification
+    condition: null
+  before_plan:
+  - extension: git
+    command: speckit.git.commit
+    enabled: true
+    optional: true
+    prompt: Commit outstanding changes before planning?
+    description: Auto-commit before implementation planning
+    condition: null
+  before_tasks:
+  - extension: git
+    command: speckit.git.commit
+    enabled: true
+    optional: true
+    prompt: Commit outstanding changes before task generation?
+    description: Auto-commit before task generation
+    condition: null
+  before_implement:
+  - extension: git
+    command: speckit.git.commit
+    enabled: true
+    optional: true
+    prompt: Commit outstanding changes before implementation?
+    description: Auto-commit before implementation
+    condition: null
+  before_checklist:
+  - extension: git
+    command: speckit.git.commit
+    enabled: true
+    optional: true
+    prompt: Commit outstanding changes before checklist?
+    description: Auto-commit before checklist generation
+    condition: null
+  before_analyze:
+  - extension: git
+    command: speckit.git.commit
+    enabled: true
+    optional: true
+    prompt: Commit outstanding changes before analysis?
+    description: Auto-commit before analysis
+    condition: null
+  before_taskstoissues:
+  - extension: git
+    command: speckit.git.commit
+    enabled: true
+    optional: true
+    prompt: Commit outstanding changes before issue sync?
+    description: Auto-commit before tasks-to-issues conversion
+    condition: null
+  after_constitution:
+  - extension: git
+    command: speckit.git.commit
+    enabled: true
+    optional: true
+    prompt: Commit constitution changes?
+    description: Auto-commit after constitution update
+    condition: null
+  after_specify:
+  - extension: git
+    command: speckit.git.commit
+    enabled: true
+    optional: true
+    prompt: Commit specification changes?
+    description: Auto-commit after specification
+    condition: null
+  after_clarify:
+  - extension: git
+    command: speckit.git.commit
+    enabled: true
+    optional: true
+    prompt: Commit clarification changes?
+    description: Auto-commit after spec clarification
+    condition: null
+  after_plan:
+  - extension: git
+    command: speckit.git.commit
+    enabled: true
+    optional: true
+    prompt: Commit plan changes?
+    description: Auto-commit after implementation planning
+    condition: null
+  after_tasks:
+  - extension: git
+    command: speckit.git.commit
+    enabled: true
+    optional: true
+    prompt: Commit task changes?
+    description: Auto-commit after task generation
+    condition: null
+  after_implement:
+  - extension: git
+    command: speckit.git.commit
+    enabled: true
+    optional: true
+    prompt: Commit implementation changes?
+    description: Auto-commit after implementation
+    condition: null
+  after_checklist:
+  - extension: git
+    command: speckit.git.commit
+    enabled: true
+    optional: true
+    prompt: Commit checklist changes?
+    description: Auto-commit after checklist generation
+    condition: null
+  after_analyze:
+  - extension: git
+    command: speckit.git.commit
+    enabled: true
+    optional: true
+    prompt: Commit analysis results?
+    description: Auto-commit after analysis
+    condition: null
+  after_taskstoissues:
+  - extension: git
+    command: speckit.git.commit
+    enabled: true
+    optional: true
+    prompt: Commit after syncing issues?
+    description: Auto-commit after tasks-to-issues conversion
+    condition: null

--- a/.specify/extensions/.registry
+++ b/.specify/extensions/.registry
@@ -1,0 +1,37 @@
+{
+  "schema_version": "1.0",
+  "extensions": {
+    "git": {
+      "version": "1.0.0",
+      "source": "local",
+      "manifest_hash": "sha256:9731aa8143a72fbebfdb440f155038ab42642517c2b2bdbbf67c8fdbe076ed79",
+      "enabled": true,
+      "priority": 10,
+      "registered_commands": {
+        "agy": [
+          "speckit.git.feature",
+          "speckit.git.validate",
+          "speckit.git.remote",
+          "speckit.git.initialize",
+          "speckit.git.commit"
+        ],
+        "codex": [
+          "speckit.git.feature",
+          "speckit.git.validate",
+          "speckit.git.remote",
+          "speckit.git.initialize",
+          "speckit.git.commit"
+        ],
+        "copilot": [
+          "speckit.git.feature",
+          "speckit.git.validate",
+          "speckit.git.remote",
+          "speckit.git.initialize",
+          "speckit.git.commit"
+        ]
+      },
+      "registered_skills": [],
+      "installed_at": "2026-05-15T11:27:53.678987+00:00"
+    }
+  }
+}

--- a/.specify/extensions/git/README.md
+++ b/.specify/extensions/git/README.md
@@ -1,0 +1,100 @@
+# Git Branching Workflow Extension
+
+Git repository initialization, feature branch creation, numbering (sequential/timestamp), validation, remote detection, and auto-commit for Spec Kit.
+
+## Overview
+
+This extension provides Git operations as an optional, self-contained module. It manages:
+
+- **Repository initialization** with configurable commit messages
+- **Feature branch creation** with sequential (`001-feature-name`) or timestamp (`20260319-143022-feature-name`) numbering
+- **Branch validation** to ensure branches follow naming conventions
+- **Git remote detection** for GitHub integration (e.g., issue creation)
+- **Auto-commit** after core commands (configurable per-command with custom messages)
+
+## Commands
+
+| Command | Description |
+|---------|-------------|
+| `speckit.git.initialize` | Initialize a Git repository with a configurable commit message |
+| `speckit.git.feature` | Create a feature branch with sequential or timestamp numbering |
+| `speckit.git.validate` | Validate current branch follows feature branch naming conventions |
+| `speckit.git.remote` | Detect Git remote URL for GitHub integration |
+| `speckit.git.commit` | Auto-commit changes (configurable per-command enable/disable and messages) |
+
+## Hooks
+
+| Event | Command | Optional | Description |
+|-------|---------|----------|-------------|
+| `before_constitution` | `speckit.git.initialize` | No | Init git repo before constitution |
+| `before_specify` | `speckit.git.feature` | No | Create feature branch before specification |
+| `before_clarify` | `speckit.git.commit` | Yes | Commit outstanding changes before clarification |
+| `before_plan` | `speckit.git.commit` | Yes | Commit outstanding changes before planning |
+| `before_tasks` | `speckit.git.commit` | Yes | Commit outstanding changes before task generation |
+| `before_implement` | `speckit.git.commit` | Yes | Commit outstanding changes before implementation |
+| `before_checklist` | `speckit.git.commit` | Yes | Commit outstanding changes before checklist |
+| `before_analyze` | `speckit.git.commit` | Yes | Commit outstanding changes before analysis |
+| `before_taskstoissues` | `speckit.git.commit` | Yes | Commit outstanding changes before issue sync |
+| `after_constitution` | `speckit.git.commit` | Yes | Auto-commit after constitution update |
+| `after_specify` | `speckit.git.commit` | Yes | Auto-commit after specification |
+| `after_clarify` | `speckit.git.commit` | Yes | Auto-commit after clarification |
+| `after_plan` | `speckit.git.commit` | Yes | Auto-commit after planning |
+| `after_tasks` | `speckit.git.commit` | Yes | Auto-commit after task generation |
+| `after_implement` | `speckit.git.commit` | Yes | Auto-commit after implementation |
+| `after_checklist` | `speckit.git.commit` | Yes | Auto-commit after checklist |
+| `after_analyze` | `speckit.git.commit` | Yes | Auto-commit after analysis |
+| `after_taskstoissues` | `speckit.git.commit` | Yes | Auto-commit after issue sync |
+
+## Configuration
+
+Configuration is stored in `.specify/extensions/git/git-config.yml`:
+
+```yaml
+# Branch numbering strategy: "sequential" or "timestamp"
+branch_numbering: sequential
+
+# Custom commit message for git init
+init_commit_message: "[Spec Kit] Initial commit"
+
+# Auto-commit per command (all disabled by default)
+# Example: enable auto-commit after specify
+auto_commit:
+  default: false
+  after_specify:
+    enabled: true
+    message: "[Spec Kit] Add specification"
+```
+
+## Installation
+
+```bash
+# Install the bundled git extension (no network required)
+specify extension add git
+```
+
+## Disabling
+
+```bash
+# Disable the git extension (spec creation continues without branching)
+specify extension disable git
+
+# Re-enable it
+specify extension enable git
+```
+
+## Graceful Degradation
+
+When Git is not installed or the directory is not a Git repository:
+- Spec directories are still created under `specs/`
+- Branch creation is skipped with a warning
+- Branch validation is skipped with a warning
+- Remote detection returns empty results
+
+## Scripts
+
+The extension bundles cross-platform scripts:
+
+- `scripts/bash/create-new-feature.sh` — Bash implementation
+- `scripts/bash/git-common.sh` — Shared Git utilities (Bash)
+- `scripts/powershell/create-new-feature.ps1` — PowerShell implementation
+- `scripts/powershell/git-common.ps1` — Shared Git utilities (PowerShell)

--- a/.specify/extensions/git/commands/speckit.git.commit.md
+++ b/.specify/extensions/git/commands/speckit.git.commit.md
@@ -1,0 +1,48 @@
+---
+description: "Auto-commit changes after a Spec Kit command completes"
+---
+
+# Auto-Commit Changes
+
+Automatically stage and commit all changes after a Spec Kit command completes.
+
+## Behavior
+
+This command is invoked as a hook after (or before) core commands. It:
+
+1. Determines the event name from the hook context (e.g., if invoked as an `after_specify` hook, the event is `after_specify`; if `before_plan`, the event is `before_plan`)
+2. Checks `.specify/extensions/git/git-config.yml` for the `auto_commit` section
+3. Looks up the specific event key to see if auto-commit is enabled
+4. Falls back to `auto_commit.default` if no event-specific key exists
+5. Uses the per-command `message` if configured, otherwise a default message
+6. If enabled and there are uncommitted changes, runs `git add .` + `git commit`
+
+## Execution
+
+Determine the event name from the hook that triggered this command, then run the script:
+
+- **Bash**: `.specify/extensions/git/scripts/bash/auto-commit.sh <event_name>`
+- **PowerShell**: `.specify/extensions/git/scripts/powershell/auto-commit.ps1 <event_name>`
+
+Replace `<event_name>` with the actual hook event (e.g., `after_specify`, `before_plan`, `after_implement`).
+
+## Configuration
+
+In `.specify/extensions/git/git-config.yml`:
+
+```yaml
+auto_commit:
+  default: false          # Global toggle — set true to enable for all commands
+  after_specify:
+    enabled: true          # Override per-command
+    message: "[Spec Kit] Add specification"
+  after_plan:
+    enabled: false
+    message: "[Spec Kit] Add implementation plan"
+```
+
+## Graceful Degradation
+
+- If Git is not available or the current directory is not a repository: skips with a warning
+- If no config file exists: skips (disabled by default)
+- If no changes to commit: skips with a message

--- a/.specify/extensions/git/commands/speckit.git.feature.md
+++ b/.specify/extensions/git/commands/speckit.git.feature.md
@@ -1,0 +1,67 @@
+---
+description: "Create a feature branch with sequential or timestamp numbering"
+---
+
+# Create Feature Branch
+
+Create and switch to a new git feature branch for the given specification. This command handles **branch creation only** — the spec directory and files are created by the core `__SPECKIT_COMMAND_SPECIFY__` workflow.
+
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+You **MUST** consider the user input before proceeding (if not empty).
+
+## Environment Variable Override
+
+If the user explicitly provided `GIT_BRANCH_NAME` (e.g., via environment variable, argument, or in their request), pass it through to the script by setting the `GIT_BRANCH_NAME` environment variable before invoking the script. When `GIT_BRANCH_NAME` is set:
+- The script uses the exact value as the branch name, bypassing all prefix/suffix generation
+- `--short-name`, `--number`, and `--timestamp` flags are ignored
+- `FEATURE_NUM` is extracted from the name if it starts with a numeric prefix, otherwise set to the full branch name
+
+## Prerequisites
+
+- Verify Git is available by running `git rev-parse --is-inside-work-tree 2>/dev/null`
+- If Git is not available, warn the user and skip branch creation
+
+## Branch Numbering Mode
+
+Determine the branch numbering strategy by checking configuration in this order:
+
+1. Check `.specify/extensions/git/git-config.yml` for `branch_numbering` value
+2. Check `.specify/init-options.json` for `branch_numbering` value (backward compatibility)
+3. Default to `sequential` if neither exists
+
+## Execution
+
+Generate a concise short name (2-4 words) for the branch:
+- Analyze the feature description and extract the most meaningful keywords
+- Use action-noun format when possible (e.g., "add-user-auth", "fix-payment-bug")
+- Preserve technical terms and acronyms (OAuth2, API, JWT, etc.)
+
+Run the appropriate script based on your platform:
+
+- **Bash**: `.specify/extensions/git/scripts/bash/create-new-feature.sh --json --short-name "<short-name>" "<feature description>"`
+- **Bash (timestamp)**: `.specify/extensions/git/scripts/bash/create-new-feature.sh --json --timestamp --short-name "<short-name>" "<feature description>"`
+- **PowerShell**: `.specify/extensions/git/scripts/powershell/create-new-feature.ps1 -Json -ShortName "<short-name>" "<feature description>"`
+- **PowerShell (timestamp)**: `.specify/extensions/git/scripts/powershell/create-new-feature.ps1 -Json -Timestamp -ShortName "<short-name>" "<feature description>"`
+
+**IMPORTANT**:
+- Do NOT pass `--number` — the script determines the correct next number automatically
+- Always include the JSON flag (`--json` for Bash, `-Json` for PowerShell) so the output can be parsed reliably
+- You must only ever run this script once per feature
+- The JSON output will contain `BRANCH_NAME` and `FEATURE_NUM`
+
+## Graceful Degradation
+
+If Git is not installed or the current directory is not a Git repository:
+- Branch creation is skipped with a warning: `[specify] Warning: Git repository not detected; skipped branch creation`
+- The script still outputs `BRANCH_NAME` and `FEATURE_NUM` so the caller can reference them
+
+## Output
+
+The script outputs JSON with:
+- `BRANCH_NAME`: The branch name (e.g., `003-user-auth` or `20260319-143022-user-auth`)
+- `FEATURE_NUM`: The numeric or timestamp prefix used

--- a/.specify/extensions/git/commands/speckit.git.initialize.md
+++ b/.specify/extensions/git/commands/speckit.git.initialize.md
@@ -1,0 +1,49 @@
+---
+description: "Initialize a Git repository with an initial commit"
+---
+
+# Initialize Git Repository
+
+Initialize a Git repository in the current project directory if one does not already exist.
+
+## Execution
+
+Run the appropriate script from the project root:
+
+- **Bash**: `.specify/extensions/git/scripts/bash/initialize-repo.sh`
+- **PowerShell**: `.specify/extensions/git/scripts/powershell/initialize-repo.ps1`
+
+If the extension scripts are not found, fall back to:
+- **Bash**: `git init && git add . && git commit -m "Initial commit from Specify template"`
+- **PowerShell**: `git init; git add .; git commit -m "Initial commit from Specify template"`
+
+The script handles all checks internally:
+- Skips if Git is not available
+- Skips if already inside a Git repository
+- Runs `git init`, `git add .`, and `git commit` with an initial commit message
+
+## Customization
+
+Replace the script to add project-specific Git initialization steps:
+- Custom `.gitignore` templates
+- Default branch naming (`git config init.defaultBranch`)
+- Git LFS setup
+- Git hooks installation
+- Commit signing configuration
+- Git Flow initialization
+
+## Output
+
+On success:
+- `✓ Git repository initialized`
+
+## Graceful Degradation
+
+If Git is not installed:
+- Warn the user
+- Skip repository initialization
+- The project continues to function without Git (specs can still be created under `specs/`)
+
+If Git is installed but `git init`, `git add .`, or `git commit` fails:
+- Surface the error to the user
+- Stop this command rather than continuing with a partially initialized repository

--- a/.specify/extensions/git/commands/speckit.git.remote.md
+++ b/.specify/extensions/git/commands/speckit.git.remote.md
@@ -1,0 +1,45 @@
+---
+description: "Detect Git remote URL for GitHub integration"
+---
+
+# Detect Git Remote URL
+
+Detect the Git remote URL for integration with GitHub services (e.g., issue creation).
+
+## Prerequisites
+
+- Check if Git is available by running `git rev-parse --is-inside-work-tree 2>/dev/null`
+- If Git is not available, output a warning and return empty:
+  ```
+  [specify] Warning: Git repository not detected; cannot determine remote URL
+  ```
+
+## Execution
+
+Run the following command to get the remote URL:
+
+```bash
+git config --get remote.origin.url
+```
+
+## Output
+
+Parse the remote URL and determine:
+
+1. **Repository owner**: Extract from the URL (e.g., `github` from `https://github.com/github/spec-kit.git`)
+2. **Repository name**: Extract from the URL (e.g., `spec-kit` from `https://github.com/github/spec-kit.git`)
+3. **Is GitHub**: Whether the remote points to a GitHub repository
+
+Supported URL formats:
+- HTTPS: `https://github.com/<owner>/<repo>.git`
+- SSH: `git@github.com:<owner>/<repo>.git`
+
+> [!CAUTION]
+> ONLY report a GitHub repository if the remote URL actually points to github.com.
+> Do NOT assume the remote is GitHub if the URL format doesn't match.
+
+## Graceful Degradation
+
+If Git is not installed, the directory is not a Git repository, or no remote is configured:
+- Return an empty result
+- Do NOT error — other workflows should continue without Git remote information

--- a/.specify/extensions/git/commands/speckit.git.validate.md
+++ b/.specify/extensions/git/commands/speckit.git.validate.md
@@ -1,0 +1,49 @@
+---
+description: "Validate current branch follows feature branch naming conventions"
+---
+
+# Validate Feature Branch
+
+Validate that the current Git branch follows the expected feature branch naming conventions.
+
+## Prerequisites
+
+- Check if Git is available by running `git rev-parse --is-inside-work-tree 2>/dev/null`
+- If Git is not available, output a warning and skip validation:
+  ```
+  [specify] Warning: Git repository not detected; skipped branch validation
+  ```
+
+## Validation Rules
+
+Get the current branch name:
+
+```bash
+git rev-parse --abbrev-ref HEAD
+```
+
+The branch name must match one of these patterns:
+
+1. **Sequential**: `^[0-9]{3,}-` (e.g., `001-feature-name`, `042-fix-bug`, `1000-big-feature`)
+2. **Timestamp**: `^[0-9]{8}-[0-9]{6}-` (e.g., `20260319-143022-feature-name`)
+
+## Execution
+
+If on a feature branch (matches either pattern):
+- Output: `✓ On feature branch: <branch-name>`
+- Check if the corresponding spec directory exists under `specs/`:
+  - For sequential branches, look for `specs/<prefix>-*` where prefix matches the numeric portion
+  - For timestamp branches, look for `specs/<prefix>-*` where prefix matches the `YYYYMMDD-HHMMSS` portion
+- If spec directory exists: `✓ Spec directory found: <path>`
+- If spec directory missing: `⚠ No spec directory found for prefix <prefix>`
+
+If NOT on a feature branch:
+- Output: `✗ Not on a feature branch. Current branch: <branch-name>`
+- Output: `Feature branches should be named like: 001-feature-name or 20260319-143022-feature-name`
+
+## Graceful Degradation
+
+If Git is not installed or the directory is not a Git repository:
+- Check the `SPECIFY_FEATURE` environment variable as a fallback
+- If set, validate that value against the naming patterns
+- If not set, skip validation with a warning

--- a/.specify/extensions/git/config-template.yml
+++ b/.specify/extensions/git/config-template.yml
@@ -1,0 +1,62 @@
+# Git Branching Workflow Extension Configuration
+# Copied to .specify/extensions/git/git-config.yml on install
+
+# Branch numbering strategy: "sequential" (001, 002, ...) or "timestamp" (YYYYMMDD-HHMMSS)
+branch_numbering: sequential
+
+# Commit message used by `git commit` during repository initialization
+init_commit_message: "[Spec Kit] Initial commit"
+
+# Auto-commit before/after core commands.
+# Set "default" to enable for all commands, then override per-command.
+# Each key can be true/false. Message is customizable per-command.
+auto_commit:
+  default: false
+  before_clarify:
+    enabled: false
+    message: "[Spec Kit] Save progress before clarification"
+  before_plan:
+    enabled: false
+    message: "[Spec Kit] Save progress before planning"
+  before_tasks:
+    enabled: false
+    message: "[Spec Kit] Save progress before task generation"
+  before_implement:
+    enabled: false
+    message: "[Spec Kit] Save progress before implementation"
+  before_checklist:
+    enabled: false
+    message: "[Spec Kit] Save progress before checklist"
+  before_analyze:
+    enabled: false
+    message: "[Spec Kit] Save progress before analysis"
+  before_taskstoissues:
+    enabled: false
+    message: "[Spec Kit] Save progress before issue sync"
+  after_constitution:
+    enabled: false
+    message: "[Spec Kit] Add project constitution"
+  after_specify:
+    enabled: false
+    message: "[Spec Kit] Add specification"
+  after_clarify:
+    enabled: false
+    message: "[Spec Kit] Clarify specification"
+  after_plan:
+    enabled: false
+    message: "[Spec Kit] Add implementation plan"
+  after_tasks:
+    enabled: false
+    message: "[Spec Kit] Add tasks"
+  after_implement:
+    enabled: false
+    message: "[Spec Kit] Implementation progress"
+  after_checklist:
+    enabled: false
+    message: "[Spec Kit] Add checklist"
+  after_analyze:
+    enabled: false
+    message: "[Spec Kit] Add analysis report"
+  after_taskstoissues:
+    enabled: false
+    message: "[Spec Kit] Sync tasks to issues"

--- a/.specify/extensions/git/extension.yml
+++ b/.specify/extensions/git/extension.yml
@@ -1,0 +1,140 @@
+schema_version: "1.0"
+
+extension:
+  id: git
+  name: "Git Branching Workflow"
+  version: "1.0.0"
+  description: "Feature branch creation, numbering (sequential/timestamp), validation, and Git remote detection"
+  author: spec-kit-core
+  repository: https://github.com/github/spec-kit
+  license: MIT
+
+requires:
+  speckit_version: ">=0.2.0"
+  tools:
+    - name: git
+      required: false
+
+provides:
+  commands:
+    - name: speckit.git.feature
+      file: commands/speckit.git.feature.md
+      description: "Create a feature branch with sequential or timestamp numbering"
+    - name: speckit.git.validate
+      file: commands/speckit.git.validate.md
+      description: "Validate current branch follows feature branch naming conventions"
+    - name: speckit.git.remote
+      file: commands/speckit.git.remote.md
+      description: "Detect Git remote URL for GitHub integration"
+    - name: speckit.git.initialize
+      file: commands/speckit.git.initialize.md
+      description: "Initialize a Git repository with an initial commit"
+    - name: speckit.git.commit
+      file: commands/speckit.git.commit.md
+      description: "Auto-commit changes after a Spec Kit command completes"
+
+  config:
+    - name: "git-config.yml"
+      template: "config-template.yml"
+      description: "Git branching configuration"
+      required: false
+
+hooks:
+  before_constitution:
+    command: speckit.git.initialize
+    optional: false
+    description: "Initialize Git repository before constitution setup"
+  before_specify:
+    command: speckit.git.feature
+    optional: false
+    description: "Create feature branch before specification"
+  before_clarify:
+    command: speckit.git.commit
+    optional: true
+    prompt: "Commit outstanding changes before clarification?"
+    description: "Auto-commit before spec clarification"
+  before_plan:
+    command: speckit.git.commit
+    optional: true
+    prompt: "Commit outstanding changes before planning?"
+    description: "Auto-commit before implementation planning"
+  before_tasks:
+    command: speckit.git.commit
+    optional: true
+    prompt: "Commit outstanding changes before task generation?"
+    description: "Auto-commit before task generation"
+  before_implement:
+    command: speckit.git.commit
+    optional: true
+    prompt: "Commit outstanding changes before implementation?"
+    description: "Auto-commit before implementation"
+  before_checklist:
+    command: speckit.git.commit
+    optional: true
+    prompt: "Commit outstanding changes before checklist?"
+    description: "Auto-commit before checklist generation"
+  before_analyze:
+    command: speckit.git.commit
+    optional: true
+    prompt: "Commit outstanding changes before analysis?"
+    description: "Auto-commit before analysis"
+  before_taskstoissues:
+    command: speckit.git.commit
+    optional: true
+    prompt: "Commit outstanding changes before issue sync?"
+    description: "Auto-commit before tasks-to-issues conversion"
+  after_constitution:
+    command: speckit.git.commit
+    optional: true
+    prompt: "Commit constitution changes?"
+    description: "Auto-commit after constitution update"
+  after_specify:
+    command: speckit.git.commit
+    optional: true
+    prompt: "Commit specification changes?"
+    description: "Auto-commit after specification"
+  after_clarify:
+    command: speckit.git.commit
+    optional: true
+    prompt: "Commit clarification changes?"
+    description: "Auto-commit after spec clarification"
+  after_plan:
+    command: speckit.git.commit
+    optional: true
+    prompt: "Commit plan changes?"
+    description: "Auto-commit after implementation planning"
+  after_tasks:
+    command: speckit.git.commit
+    optional: true
+    prompt: "Commit task changes?"
+    description: "Auto-commit after task generation"
+  after_implement:
+    command: speckit.git.commit
+    optional: true
+    prompt: "Commit implementation changes?"
+    description: "Auto-commit after implementation"
+  after_checklist:
+    command: speckit.git.commit
+    optional: true
+    prompt: "Commit checklist changes?"
+    description: "Auto-commit after checklist generation"
+  after_analyze:
+    command: speckit.git.commit
+    optional: true
+    prompt: "Commit analysis results?"
+    description: "Auto-commit after analysis"
+  after_taskstoissues:
+    command: speckit.git.commit
+    optional: true
+    prompt: "Commit after syncing issues?"
+    description: "Auto-commit after tasks-to-issues conversion"
+
+tags:
+  - "git"
+  - "branching"
+  - "workflow"
+
+config:
+  defaults:
+    branch_numbering: sequential
+    init_commit_message: "[Spec Kit] Initial commit"

--- a/.specify/extensions/git/git-config.yml
+++ b/.specify/extensions/git/git-config.yml
@@ -1,0 +1,62 @@
+# Git Branching Workflow Extension Configuration
+# Copied to .specify/extensions/git/git-config.yml on install
+
+# Branch numbering strategy: "sequential" (001, 002, ...) or "timestamp" (YYYYMMDD-HHMMSS)
+branch_numbering: sequential
+
+# Commit message used by `git commit` during repository initialization
+init_commit_message: "[Spec Kit] Initial commit"
+
+# Auto-commit before/after core commands.
+# Set "default" to enable for all commands, then override per-command.
+# Each key can be true/false. Message is customizable per-command.
+auto_commit:
+  default: false
+  before_clarify:
+    enabled: false
+    message: "[Spec Kit] Save progress before clarification"
+  before_plan:
+    enabled: false
+    message: "[Spec Kit] Save progress before planning"
+  before_tasks:
+    enabled: false
+    message: "[Spec Kit] Save progress before task generation"
+  before_implement:
+    enabled: false
+    message: "[Spec Kit] Save progress before implementation"
+  before_checklist:
+    enabled: false
+    message: "[Spec Kit] Save progress before checklist"
+  before_analyze:
+    enabled: false
+    message: "[Spec Kit] Save progress before analysis"
+  before_taskstoissues:
+    enabled: false
+    message: "[Spec Kit] Save progress before issue sync"
+  after_constitution:
+    enabled: false
+    message: "[Spec Kit] Add project constitution"
+  after_specify:
+    enabled: false
+    message: "[Spec Kit] Add specification"
+  after_clarify:
+    enabled: false
+    message: "[Spec Kit] Clarify specification"
+  after_plan:
+    enabled: false
+    message: "[Spec Kit] Add implementation plan"
+  after_tasks:
+    enabled: false
+    message: "[Spec Kit] Add tasks"
+  after_implement:
+    enabled: false
+    message: "[Spec Kit] Implementation progress"
+  after_checklist:
+    enabled: false
+    message: "[Spec Kit] Add checklist"
+  after_analyze:
+    enabled: false
+    message: "[Spec Kit] Add analysis report"
+  after_taskstoissues:
+    enabled: false
+    message: "[Spec Kit] Sync tasks to issues"

--- a/.specify/extensions/git/scripts/bash/auto-commit.sh
+++ b/.specify/extensions/git/scripts/bash/auto-commit.sh
@@ -1,0 +1,140 @@
+#!/usr/bin/env bash
+# Git extension: auto-commit.sh
+# Automatically commit changes after a Spec Kit command completes.
+# Checks per-command config keys in git-config.yml before committing.
+#
+# Usage: auto-commit.sh <event_name>
+#   e.g.: auto-commit.sh after_specify
+
+set -e
+
+EVENT_NAME="${1:-}"
+if [ -z "$EVENT_NAME" ]; then
+    echo "Usage: $0 <event_name>" >&2
+    exit 1
+fi
+
+SCRIPT_DIR="$(CDPATH="" cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+_find_project_root() {
+    local dir="$1"
+    while [ "$dir" != "/" ]; do
+        if [ -d "$dir/.specify" ] || [ -d "$dir/.git" ]; then
+            echo "$dir"
+            return 0
+        fi
+        dir="$(dirname "$dir")"
+    done
+    return 1
+}
+
+REPO_ROOT=$(_find_project_root "$SCRIPT_DIR") || REPO_ROOT="$(pwd)"
+cd "$REPO_ROOT"
+
+# Check if git is available
+if ! command -v git >/dev/null 2>&1; then
+    echo "[specify] Warning: Git not found; skipped auto-commit" >&2
+    exit 0
+fi
+
+if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+    echo "[specify] Warning: Not a Git repository; skipped auto-commit" >&2
+    exit 0
+fi
+
+# Read per-command config from git-config.yml
+_config_file="$REPO_ROOT/.specify/extensions/git/git-config.yml"
+_enabled=false
+_commit_msg=""
+
+if [ -f "$_config_file" ]; then
+    # Parse the auto_commit section for this event.
+    # Look for auto_commit.<event_name>.enabled and .message
+    # Also check auto_commit.default as fallback.
+    _in_auto_commit=false
+    _in_event=false
+    _default_enabled=false
+
+    while IFS= read -r _line; do
+        # Detect auto_commit: section
+        if echo "$_line" | grep -q '^auto_commit:'; then
+            _in_auto_commit=true
+            _in_event=false
+            continue
+        fi
+
+        # Exit auto_commit section on next top-level key
+        if $_in_auto_commit && echo "$_line" | grep -Eq '^[a-z]'; then
+            break
+        fi
+
+        if $_in_auto_commit; then
+            # Check default key
+            if echo "$_line" | grep -Eq "^[[:space:]]+default:[[:space:]]"; then
+                _val=$(echo "$_line" | sed 's/^[^:]*:[[:space:]]*//' | tr -d '[:space:]' | tr '[:upper:]' '[:lower:]')
+                [ "$_val" = "true" ] && _default_enabled=true
+            fi
+
+            # Detect our event subsection
+            if echo "$_line" | grep -Eq "^[[:space:]]+${EVENT_NAME}:"; then
+                _in_event=true
+                continue
+            fi
+
+            # Inside our event subsection
+            if $_in_event; then
+                # Exit on next sibling key (same indent level as event name)
+                if echo "$_line" | grep -Eq '^[[:space:]]{2}[a-z]' && ! echo "$_line" | grep -Eq '^[[:space:]]{4}'; then
+                    _in_event=false
+                    continue
+                fi
+                if echo "$_line" | grep -Eq '[[:space:]]+enabled:'; then
+                    _val=$(echo "$_line" | sed 's/^[^:]*:[[:space:]]*//' | tr -d '[:space:]' | tr '[:upper:]' '[:lower:]')
+                    [ "$_val" = "true" ] && _enabled=true
+                    [ "$_val" = "false" ] && _enabled=false
+                fi
+                if echo "$_line" | grep -Eq '[[:space:]]+message:'; then
+                    _commit_msg=$(echo "$_line" | sed 's/^[^:]*:[[:space:]]*//' | sed 's/^["'\'']//' | sed 's/["'\'']*$//')
+                fi
+            fi
+        fi
+    done < "$_config_file"
+
+    # If event-specific key not found, use default
+    if [ "$_enabled" = "false" ] && [ "$_default_enabled" = "true" ]; then
+        # Only use default if the event wasn't explicitly set to false
+        # Check if event section existed at all
+        if ! grep -q "^[[:space:]]*${EVENT_NAME}:" "$_config_file" 2>/dev/null; then
+            _enabled=true
+        fi
+    fi
+else
+    # No config file — auto-commit disabled by default
+    exit 0
+fi
+
+if [ "$_enabled" != "true" ]; then
+    exit 0
+fi
+
+# Check if there are changes to commit
+if git diff --quiet HEAD 2>/dev/null && git diff --cached --quiet 2>/dev/null && [ -z "$(git ls-files --others --exclude-standard 2>/dev/null)" ]; then
+    echo "[specify] No changes to commit after $EVENT_NAME" >&2
+    exit 0
+fi
+
+# Derive a human-readable command name from the event
+# e.g., after_specify -> specify, before_plan -> plan
+_command_name=$(echo "$EVENT_NAME" | sed 's/^after_//' | sed 's/^before_//')
+_phase=$(echo "$EVENT_NAME" | grep -q '^before_' && echo 'before' || echo 'after')
+
+# Use custom message if configured, otherwise default
+if [ -z "$_commit_msg" ]; then
+    _commit_msg="[Spec Kit] Auto-commit ${_phase} ${_command_name}"
+fi
+
+# Stage and commit
+_git_out=$(git add . 2>&1) || { echo "[specify] Error: git add failed: $_git_out" >&2; exit 1; }
+_git_out=$(git commit -q -m "$_commit_msg" 2>&1) || { echo "[specify] Error: git commit failed: $_git_out" >&2; exit 1; }
+
+echo "[OK] Changes committed ${_phase} ${_command_name}" >&2

--- a/.specify/extensions/git/scripts/bash/create-new-feature.sh
+++ b/.specify/extensions/git/scripts/bash/create-new-feature.sh
@@ -1,0 +1,453 @@
+#!/usr/bin/env bash
+# Git extension: create-new-feature.sh
+# Adapted from core scripts/bash/create-new-feature.sh for extension layout.
+# Sources common.sh from the project's installed scripts, falling back to
+# git-common.sh for minimal git helpers.
+
+set -e
+
+JSON_MODE=false
+DRY_RUN=false
+ALLOW_EXISTING=false
+SHORT_NAME=""
+BRANCH_NUMBER=""
+USE_TIMESTAMP=false
+ARGS=()
+i=1
+while [ $i -le $# ]; do
+    arg="${!i}"
+    case "$arg" in
+        --json)
+            JSON_MODE=true
+            ;;
+        --dry-run)
+            DRY_RUN=true
+            ;;
+        --allow-existing-branch)
+            ALLOW_EXISTING=true
+            ;;
+        --short-name)
+            if [ $((i + 1)) -gt $# ]; then
+                echo 'Error: --short-name requires a value' >&2
+                exit 1
+            fi
+            i=$((i + 1))
+            next_arg="${!i}"
+            if [[ "$next_arg" == --* ]]; then
+                echo 'Error: --short-name requires a value' >&2
+                exit 1
+            fi
+            SHORT_NAME="$next_arg"
+            ;;
+        --number)
+            if [ $((i + 1)) -gt $# ]; then
+                echo 'Error: --number requires a value' >&2
+                exit 1
+            fi
+            i=$((i + 1))
+            next_arg="${!i}"
+            if [[ "$next_arg" == --* ]]; then
+                echo 'Error: --number requires a value' >&2
+                exit 1
+            fi
+            BRANCH_NUMBER="$next_arg"
+            if [[ ! "$BRANCH_NUMBER" =~ ^[0-9]+$ ]]; then
+                echo 'Error: --number must be a non-negative integer' >&2
+                exit 1
+            fi
+            ;;
+        --timestamp)
+            USE_TIMESTAMP=true
+            ;;
+        --help|-h)
+            echo "Usage: $0 [--json] [--dry-run] [--allow-existing-branch] [--short-name <name>] [--number N] [--timestamp] <feature_description>"
+            echo ""
+            echo "Options:"
+            echo "  --json              Output in JSON format"
+            echo "  --dry-run           Compute branch name without creating the branch"
+            echo "  --allow-existing-branch  Switch to branch if it already exists instead of failing"
+            echo "  --short-name <name> Provide a custom short name (2-4 words) for the branch"
+            echo "  --number N          Specify branch number manually (overrides auto-detection)"
+            echo "  --timestamp         Use timestamp prefix (YYYYMMDD-HHMMSS) instead of sequential numbering"
+            echo "  --help, -h          Show this help message"
+            echo ""
+            echo "Environment variables:"
+            echo "  GIT_BRANCH_NAME     Use this exact branch name, bypassing all prefix/suffix generation"
+            echo ""
+            echo "Examples:"
+            echo "  $0 'Add user authentication system' --short-name 'user-auth'"
+            echo "  $0 'Implement OAuth2 integration for API' --number 5"
+            echo "  $0 --timestamp --short-name 'user-auth' 'Add user authentication'"
+            echo "  GIT_BRANCH_NAME=my-branch $0 'feature description'"
+            exit 0
+            ;;
+        *)
+            ARGS+=("$arg")
+            ;;
+    esac
+    i=$((i + 1))
+done
+
+FEATURE_DESCRIPTION="${ARGS[*]}"
+if [ -z "$FEATURE_DESCRIPTION" ]; then
+    echo "Usage: $0 [--json] [--dry-run] [--allow-existing-branch] [--short-name <name>] [--number N] [--timestamp] <feature_description>" >&2
+    exit 1
+fi
+
+# Trim whitespace and validate description is not empty
+FEATURE_DESCRIPTION=$(echo "$FEATURE_DESCRIPTION" | sed -E 's/^[[:space:]]+|[[:space:]]+$//g')
+if [ -z "$FEATURE_DESCRIPTION" ]; then
+    echo "Error: Feature description cannot be empty or contain only whitespace" >&2
+    exit 1
+fi
+
+# Function to get highest number from specs directory
+get_highest_from_specs() {
+    local specs_dir="$1"
+    local highest=0
+
+    if [ -d "$specs_dir" ]; then
+        for dir in "$specs_dir"/*; do
+            [ -d "$dir" ] || continue
+            dirname=$(basename "$dir")
+            # Match sequential prefixes (>=3 digits), but skip timestamp dirs.
+            if echo "$dirname" | grep -Eq '^[0-9]{3,}-' && ! echo "$dirname" | grep -Eq '^[0-9]{8}-[0-9]{6}-'; then
+                number=$(echo "$dirname" | grep -Eo '^[0-9]+')
+                number=$((10#$number))
+                if [ "$number" -gt "$highest" ]; then
+                    highest=$number
+                fi
+            fi
+        done
+    fi
+
+    echo "$highest"
+}
+
+# Function to get highest number from git branches
+get_highest_from_branches() {
+    git branch -a 2>/dev/null | sed 's/^[* ]*//; s|^remotes/[^/]*/||' | _extract_highest_number
+}
+
+# Extract the highest sequential feature number from a list of ref names (one per line).
+_extract_highest_number() {
+    local highest=0
+    while IFS= read -r name; do
+        [ -z "$name" ] && continue
+        if echo "$name" | grep -Eq '^[0-9]{3,}-' && ! echo "$name" | grep -Eq '^[0-9]{8}-[0-9]{6}-'; then
+            number=$(echo "$name" | grep -Eo '^[0-9]+' || echo "0")
+            number=$((10#$number))
+            if [ "$number" -gt "$highest" ]; then
+                highest=$number
+            fi
+        fi
+    done
+    echo "$highest"
+}
+
+# Function to get highest number from remote branches without fetching (side-effect-free)
+get_highest_from_remote_refs() {
+    local highest=0
+
+    for remote in $(git remote 2>/dev/null); do
+        local remote_highest
+        remote_highest=$(GIT_TERMINAL_PROMPT=0 git ls-remote --heads "$remote" 2>/dev/null | sed 's|.*refs/heads/||' | _extract_highest_number)
+        if [ "$remote_highest" -gt "$highest" ]; then
+            highest=$remote_highest
+        fi
+    done
+
+    echo "$highest"
+}
+
+# Function to check existing branches and return next available number.
+check_existing_branches() {
+    local specs_dir="$1"
+    local skip_fetch="${2:-false}"
+
+    if [ "$skip_fetch" = true ]; then
+        local highest_remote=$(get_highest_from_remote_refs)
+        local highest_branch=$(get_highest_from_branches)
+        if [ "$highest_remote" -gt "$highest_branch" ]; then
+            highest_branch=$highest_remote
+        fi
+    else
+        git fetch --all --prune >/dev/null 2>&1 || true
+        local highest_branch=$(get_highest_from_branches)
+    fi
+
+    local highest_spec=$(get_highest_from_specs "$specs_dir")
+
+    local max_num=$highest_branch
+    if [ "$highest_spec" -gt "$max_num" ]; then
+        max_num=$highest_spec
+    fi
+
+    echo $((max_num + 1))
+}
+
+# Function to clean and format a branch name
+clean_branch_name() {
+    local name="$1"
+    echo "$name" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9]/-/g' | sed 's/-\+/-/g' | sed 's/^-//' | sed 's/-$//'
+}
+
+# ---------------------------------------------------------------------------
+# Source common.sh for resolve_template, json_escape, get_repo_root, has_git.
+#
+# Search locations in priority order:
+#  1. .specify/scripts/bash/common.sh under the project root (installed project)
+#  2. scripts/bash/common.sh under the project root (source checkout fallback)
+#  3. git-common.sh next to this script (minimal fallback — lacks resolve_template)
+# ---------------------------------------------------------------------------
+SCRIPT_DIR="$(CDPATH="" cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Find project root by walking up from the script location
+_find_project_root() {
+    local dir="$1"
+    while [ "$dir" != "/" ]; do
+        if [ -d "$dir/.specify" ] || [ -d "$dir/.git" ]; then
+            echo "$dir"
+            return 0
+        fi
+        dir="$(dirname "$dir")"
+    done
+    return 1
+}
+
+_common_loaded=false
+_PROJECT_ROOT=$(_find_project_root "$SCRIPT_DIR") || true
+
+if [ -n "$_PROJECT_ROOT" ] && [ -f "$_PROJECT_ROOT/.specify/scripts/bash/common.sh" ]; then
+    source "$_PROJECT_ROOT/.specify/scripts/bash/common.sh"
+    _common_loaded=true
+elif [ -n "$_PROJECT_ROOT" ] && [ -f "$_PROJECT_ROOT/scripts/bash/common.sh" ]; then
+    source "$_PROJECT_ROOT/scripts/bash/common.sh"
+    _common_loaded=true
+elif [ -f "$SCRIPT_DIR/git-common.sh" ]; then
+    source "$SCRIPT_DIR/git-common.sh"
+    _common_loaded=true
+fi
+
+if [ "$_common_loaded" != "true" ]; then
+    echo "Error: Could not locate common.sh or git-common.sh. Please ensure the Specify core scripts are installed." >&2
+    exit 1
+fi
+
+# Resolve repository root
+if type get_repo_root >/dev/null 2>&1; then
+    REPO_ROOT=$(get_repo_root)
+elif git rev-parse --show-toplevel >/dev/null 2>&1; then
+    REPO_ROOT=$(git rev-parse --show-toplevel)
+elif [ -n "$_PROJECT_ROOT" ]; then
+    REPO_ROOT="$_PROJECT_ROOT"
+else
+    echo "Error: Could not determine repository root." >&2
+    exit 1
+fi
+
+# Check if git is available at this repo root
+if type has_git >/dev/null 2>&1; then
+    if has_git "$REPO_ROOT"; then
+        HAS_GIT=true
+    else
+        HAS_GIT=false
+    fi
+elif git -C "$REPO_ROOT" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+    HAS_GIT=true
+else
+    HAS_GIT=false
+fi
+
+cd "$REPO_ROOT"
+
+SPECS_DIR="$REPO_ROOT/specs"
+
+# Function to generate branch name with stop word filtering
+generate_branch_name() {
+    local description="$1"
+
+    local stop_words="^(i|a|an|the|to|for|of|in|on|at|by|with|from|is|are|was|were|be|been|being|have|has|had|do|does|did|will|would|should|could|can|may|might|must|shall|this|that|these|those|my|your|our|their|want|need|add|get|set)$"
+
+    local clean_name=$(echo "$description" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9]/ /g')
+
+    local meaningful_words=()
+    for word in $clean_name; do
+        [ -z "$word" ] && continue
+        if ! echo "$word" | grep -qiE "$stop_words"; then
+            if [ ${#word} -ge 3 ]; then
+                meaningful_words+=("$word")
+            elif echo "$description" | grep -qw -- "${word^^}"; then
+                meaningful_words+=("$word")
+            fi
+        fi
+    done
+
+    if [ ${#meaningful_words[@]} -gt 0 ]; then
+        local max_words=3
+        if [ ${#meaningful_words[@]} -eq 4 ]; then max_words=4; fi
+
+        local result=""
+        local count=0
+        for word in "${meaningful_words[@]}"; do
+            if [ $count -ge $max_words ]; then break; fi
+            if [ -n "$result" ]; then result="$result-"; fi
+            result="$result$word"
+            count=$((count + 1))
+        done
+        echo "$result"
+    else
+        local cleaned=$(clean_branch_name "$description")
+        echo "$cleaned" | tr '-' '\n' | grep -v '^$' | head -3 | tr '\n' '-' | sed 's/-$//'
+    fi
+}
+
+# Check for GIT_BRANCH_NAME env var override (exact branch name, no prefix/suffix)
+if [ -n "${GIT_BRANCH_NAME:-}" ]; then
+    BRANCH_NAME="$GIT_BRANCH_NAME"
+    # Extract FEATURE_NUM from the branch name if it starts with a numeric prefix
+    # Check timestamp pattern first (YYYYMMDD-HHMMSS-) since it also matches the simpler ^[0-9]+ pattern
+    if echo "$BRANCH_NAME" | grep -Eq '^[0-9]{8}-[0-9]{6}-'; then
+        FEATURE_NUM=$(echo "$BRANCH_NAME" | grep -Eo '^[0-9]{8}-[0-9]{6}')
+        BRANCH_SUFFIX="${BRANCH_NAME#${FEATURE_NUM}-}"
+    elif echo "$BRANCH_NAME" | grep -Eq '^[0-9]+-'; then
+        FEATURE_NUM=$(echo "$BRANCH_NAME" | grep -Eo '^[0-9]+')
+        BRANCH_SUFFIX="${BRANCH_NAME#${FEATURE_NUM}-}"
+    else
+        FEATURE_NUM="$BRANCH_NAME"
+        BRANCH_SUFFIX="$BRANCH_NAME"
+    fi
+else
+    # Generate branch name
+    if [ -n "$SHORT_NAME" ]; then
+        BRANCH_SUFFIX=$(clean_branch_name "$SHORT_NAME")
+    else
+        BRANCH_SUFFIX=$(generate_branch_name "$FEATURE_DESCRIPTION")
+    fi
+
+    # Warn if --number and --timestamp are both specified
+    if [ "$USE_TIMESTAMP" = true ] && [ -n "$BRANCH_NUMBER" ]; then
+        >&2 echo "[specify] Warning: --number is ignored when --timestamp is used"
+        BRANCH_NUMBER=""
+    fi
+
+    # Determine branch prefix
+    if [ "$USE_TIMESTAMP" = true ]; then
+        FEATURE_NUM=$(date +%Y%m%d-%H%M%S)
+        BRANCH_NAME="${FEATURE_NUM}-${BRANCH_SUFFIX}"
+    else
+        if [ -z "$BRANCH_NUMBER" ]; then
+            if [ "$DRY_RUN" = true ] && [ "$HAS_GIT" = true ]; then
+                BRANCH_NUMBER=$(check_existing_branches "$SPECS_DIR" true)
+            elif [ "$DRY_RUN" = true ]; then
+                HIGHEST=$(get_highest_from_specs "$SPECS_DIR")
+                BRANCH_NUMBER=$((HIGHEST + 1))
+            elif [ "$HAS_GIT" = true ]; then
+                BRANCH_NUMBER=$(check_existing_branches "$SPECS_DIR")
+            else
+                HIGHEST=$(get_highest_from_specs "$SPECS_DIR")
+                BRANCH_NUMBER=$((HIGHEST + 1))
+            fi
+        fi
+
+        FEATURE_NUM=$(printf "%03d" "$((10#$BRANCH_NUMBER))")
+        BRANCH_NAME="${FEATURE_NUM}-${BRANCH_SUFFIX}"
+    fi
+fi
+
+# GitHub enforces a 244-byte limit on branch names
+MAX_BRANCH_LENGTH=244
+_byte_length() { printf '%s' "$1" | LC_ALL=C wc -c | tr -d ' '; }
+BRANCH_BYTE_LEN=$(_byte_length "$BRANCH_NAME")
+if [ -n "${GIT_BRANCH_NAME:-}" ] && [ "$BRANCH_BYTE_LEN" -gt $MAX_BRANCH_LENGTH ]; then
+    >&2 echo "Error: GIT_BRANCH_NAME must be 244 bytes or fewer in UTF-8. Provided value is ${BRANCH_BYTE_LEN} bytes."
+    exit 1
+elif [ "$BRANCH_BYTE_LEN" -gt $MAX_BRANCH_LENGTH ]; then
+    PREFIX_LENGTH=$(( ${#FEATURE_NUM} + 1 ))
+    MAX_SUFFIX_LENGTH=$((MAX_BRANCH_LENGTH - PREFIX_LENGTH))
+
+    TRUNCATED_SUFFIX=$(echo "$BRANCH_SUFFIX" | cut -c1-$MAX_SUFFIX_LENGTH)
+    TRUNCATED_SUFFIX=$(echo "$TRUNCATED_SUFFIX" | sed 's/-$//')
+
+    ORIGINAL_BRANCH_NAME="$BRANCH_NAME"
+    BRANCH_NAME="${FEATURE_NUM}-${TRUNCATED_SUFFIX}"
+
+    >&2 echo "[specify] Warning: Branch name exceeded GitHub's 244-byte limit"
+    >&2 echo "[specify] Original: $ORIGINAL_BRANCH_NAME (${#ORIGINAL_BRANCH_NAME} bytes)"
+    >&2 echo "[specify] Truncated to: $BRANCH_NAME (${#BRANCH_NAME} bytes)"
+fi
+
+if [ "$DRY_RUN" != true ]; then
+    if [ "$HAS_GIT" = true ]; then
+        branch_create_error=""
+        if ! branch_create_error=$(git checkout -q -b "$BRANCH_NAME" 2>&1); then
+            current_branch="$(git rev-parse --abbrev-ref HEAD 2>/dev/null || true)"
+            if git branch --list "$BRANCH_NAME" | grep -q .; then
+                if [ "$ALLOW_EXISTING" = true ]; then
+                    if [ "$current_branch" = "$BRANCH_NAME" ]; then
+                        :
+                    elif ! switch_branch_error=$(git checkout -q "$BRANCH_NAME" 2>&1); then
+                        >&2 echo "Error: Failed to switch to existing branch '$BRANCH_NAME'. Please resolve any local changes or conflicts and try again."
+                        if [ -n "$switch_branch_error" ]; then
+                            >&2 printf '%s\n' "$switch_branch_error"
+                        fi
+                        exit 1
+                    fi
+                elif [ "$USE_TIMESTAMP" = true ]; then
+                    >&2 echo "Error: Branch '$BRANCH_NAME' already exists. Rerun to get a new timestamp or use a different --short-name."
+                    exit 1
+                else
+                    >&2 echo "Error: Branch '$BRANCH_NAME' already exists. Please use a different feature name or specify a different number with --number."
+                    exit 1
+                fi
+            else
+                >&2 echo "Error: Failed to create git branch '$BRANCH_NAME'."
+                if [ -n "$branch_create_error" ]; then
+                    >&2 printf '%s\n' "$branch_create_error"
+                else
+                    >&2 echo "Please check your git configuration and try again."
+                fi
+                exit 1
+            fi
+        fi
+    else
+        >&2 echo "[specify] Warning: Git repository not detected; skipped branch creation for $BRANCH_NAME"
+    fi
+
+    printf '# To persist: export SPECIFY_FEATURE=%q\n' "$BRANCH_NAME" >&2
+fi
+
+if $JSON_MODE; then
+    if command -v jq >/dev/null 2>&1; then
+        if [ "$DRY_RUN" = true ]; then
+            jq -cn \
+                --arg branch_name "$BRANCH_NAME" \
+                --arg feature_num "$FEATURE_NUM" \
+                '{BRANCH_NAME:$branch_name,FEATURE_NUM:$feature_num,DRY_RUN:true}'
+        else
+            jq -cn \
+                --arg branch_name "$BRANCH_NAME" \
+                --arg feature_num "$FEATURE_NUM" \
+                '{BRANCH_NAME:$branch_name,FEATURE_NUM:$feature_num}'
+        fi
+    else
+        if type json_escape >/dev/null 2>&1; then
+            _je_branch=$(json_escape "$BRANCH_NAME")
+            _je_num=$(json_escape "$FEATURE_NUM")
+        else
+            _je_branch="$BRANCH_NAME"
+            _je_num="$FEATURE_NUM"
+        fi
+        if [ "$DRY_RUN" = true ]; then
+            printf '{"BRANCH_NAME":"%s","FEATURE_NUM":"%s","DRY_RUN":true}\n' "$_je_branch" "$_je_num"
+        else
+            printf '{"BRANCH_NAME":"%s","FEATURE_NUM":"%s"}\n' "$_je_branch" "$_je_num"
+        fi
+    fi
+else
+    echo "BRANCH_NAME: $BRANCH_NAME"
+    echo "FEATURE_NUM: $FEATURE_NUM"
+    if [ "$DRY_RUN" != true ]; then
+        printf '# To persist in your shell: export SPECIFY_FEATURE=%q\n' "$BRANCH_NAME"
+    fi
+fi

--- a/.specify/extensions/git/scripts/bash/git-common.sh
+++ b/.specify/extensions/git/scripts/bash/git-common.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# Git-specific common functions for the git extension.
+# Extracted from scripts/bash/common.sh — contains only git-specific
+# branch validation and detection logic.
+
+# Check if we have git available at the repo root
+has_git() {
+    local repo_root="${1:-$(pwd)}"
+    { [ -d "$repo_root/.git" ] || [ -f "$repo_root/.git" ]; } && \
+        command -v git >/dev/null 2>&1 && \
+        git -C "$repo_root" rev-parse --is-inside-work-tree >/dev/null 2>&1
+}
+
+# Strip a single optional path segment (e.g. gitflow "feat/004-name" -> "004-name").
+# Only when the full name is exactly two slash-free segments; otherwise returns the raw name.
+spec_kit_effective_branch_name() {
+    local raw="$1"
+    if [[ "$raw" =~ ^([^/]+)/([^/]+)$ ]]; then
+        printf '%s\n' "${BASH_REMATCH[2]}"
+    else
+        printf '%s\n' "$raw"
+    fi
+}
+
+# Validate that a branch name matches the expected feature branch pattern.
+# Accepts sequential (###-* with >=3 digits) or timestamp (YYYYMMDD-HHMMSS-*) formats.
+# Logic aligned with scripts/bash/common.sh check_feature_branch after effective-name normalization.
+check_feature_branch() {
+    local raw="$1"
+    local has_git_repo="$2"
+
+    # For non-git repos, we can't enforce branch naming but still provide output
+    if [[ "$has_git_repo" != "true" ]]; then
+        echo "[specify] Warning: Git repository not detected; skipped branch validation" >&2
+        return 0
+    fi
+
+    local branch
+    branch=$(spec_kit_effective_branch_name "$raw")
+
+    # Accept sequential prefix (3+ digits) but exclude malformed timestamps
+    # Malformed: 7-or-8 digit date + 6-digit time with no trailing slug (e.g. "2026031-143022" or "20260319-143022")
+    local is_sequential=false
+    if [[ "$branch" =~ ^[0-9]{3,}- ]] && [[ ! "$branch" =~ ^[0-9]{7}-[0-9]{6}- ]] && [[ ! "$branch" =~ ^[0-9]{7,8}-[0-9]{6}$ ]]; then
+        is_sequential=true
+    fi
+    if [[ "$is_sequential" != "true" ]] && [[ ! "$branch" =~ ^[0-9]{8}-[0-9]{6}- ]]; then
+        echo "ERROR: Not on a feature branch. Current branch: $raw" >&2
+        echo "Feature branches should be named like: 001-feature-name, 1234-feature-name, or 20260319-143022-feature-name" >&2
+        return 1
+    fi
+
+    return 0
+}

--- a/.specify/extensions/git/scripts/bash/initialize-repo.sh
+++ b/.specify/extensions/git/scripts/bash/initialize-repo.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# Git extension: initialize-repo.sh
+# Initialize a Git repository with an initial commit.
+# Customizable — replace this script to add .gitignore templates,
+# default branch config, git-flow, LFS, signing, etc.
+
+set -e
+
+SCRIPT_DIR="$(CDPATH="" cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Find project root
+_find_project_root() {
+    local dir="$1"
+    while [ "$dir" != "/" ]; do
+        if [ -d "$dir/.specify" ] || [ -d "$dir/.git" ]; then
+            echo "$dir"
+            return 0
+        fi
+        dir="$(dirname "$dir")"
+    done
+    return 1
+}
+
+REPO_ROOT=$(_find_project_root "$SCRIPT_DIR") || REPO_ROOT="$(pwd)"
+cd "$REPO_ROOT"
+
+# Read commit message from extension config, fall back to default
+COMMIT_MSG="[Spec Kit] Initial commit"
+_config_file="$REPO_ROOT/.specify/extensions/git/git-config.yml"
+if [ -f "$_config_file" ]; then
+    _msg=$(grep '^init_commit_message:' "$_config_file" 2>/dev/null | sed 's/^init_commit_message:[[:space:]]*//' | sed 's/^["'\'']//' | sed 's/["'\'']*$//')
+    if [ -n "$_msg" ]; then
+        COMMIT_MSG="$_msg"
+    fi
+fi
+
+# Check if git is available
+if ! command -v git >/dev/null 2>&1; then
+    echo "[specify] Warning: Git not found; skipped repository initialization" >&2
+    exit 0
+fi
+
+# Check if already a git repo
+if git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+    echo "[specify] Git repository already initialized; skipping" >&2
+    exit 0
+fi
+
+# Initialize
+_git_out=$(git init -q 2>&1) || { echo "[specify] Error: git init failed: $_git_out" >&2; exit 1; }
+_git_out=$(git add . 2>&1) || { echo "[specify] Error: git add failed: $_git_out" >&2; exit 1; }
+_git_out=$(git commit --allow-empty -q -m "$COMMIT_MSG" 2>&1) || { echo "[specify] Error: git commit failed: $_git_out" >&2; exit 1; }
+
+echo "✓ Git repository initialized" >&2

--- a/.specify/extensions/git/scripts/powershell/auto-commit.ps1
+++ b/.specify/extensions/git/scripts/powershell/auto-commit.ps1
@@ -1,0 +1,169 @@
+#!/usr/bin/env pwsh
+# Git extension: auto-commit.ps1
+# Automatically commit changes after a Spec Kit command completes.
+# Checks per-command config keys in git-config.yml before committing.
+#
+# Usage: auto-commit.ps1 <event_name>
+#   e.g.: auto-commit.ps1 after_specify
+param(
+    [Parameter(Position = 0, Mandatory = $true)]
+    [string]$EventName
+)
+$ErrorActionPreference = 'Stop'
+
+function Find-ProjectRoot {
+    param([string]$StartDir)
+    $current = Resolve-Path $StartDir
+    while ($true) {
+        foreach ($marker in @('.specify', '.git')) {
+            if (Test-Path (Join-Path $current $marker)) {
+                return $current
+            }
+        }
+        $parent = Split-Path $current -Parent
+        if ($parent -eq $current) { return $null }
+        $current = $parent
+    }
+}
+
+$repoRoot = Find-ProjectRoot -StartDir $PSScriptRoot
+if (-not $repoRoot) { $repoRoot = Get-Location }
+Set-Location $repoRoot
+
+# Check if git is available
+if (-not (Get-Command git -ErrorAction SilentlyContinue)) {
+    Write-Warning "[specify] Warning: Git not found; skipped auto-commit"
+    exit 0
+}
+
+# Temporarily relax ErrorActionPreference so git stderr warnings
+# (e.g. CRLF notices on Windows) do not become terminating errors.
+$savedEAP = $ErrorActionPreference
+$ErrorActionPreference = 'Continue'
+try {
+    git rev-parse --is-inside-work-tree 2>$null | Out-Null
+    $isRepo = $LASTEXITCODE -eq 0
+} finally {
+    $ErrorActionPreference = $savedEAP
+}
+if (-not $isRepo) {
+    Write-Warning "[specify] Warning: Not a Git repository; skipped auto-commit"
+    exit 0
+}
+
+# Read per-command config from git-config.yml
+$configFile = Join-Path $repoRoot ".specify/extensions/git/git-config.yml"
+$enabled = $false
+$commitMsg = ""
+
+if (Test-Path $configFile) {
+    # Parse YAML to find auto_commit section
+    $inAutoCommit = $false
+    $inEvent = $false
+    $defaultEnabled = $false
+
+    foreach ($line in Get-Content $configFile) {
+        # Detect auto_commit: section
+        if ($line -match '^auto_commit:') {
+            $inAutoCommit = $true
+            $inEvent = $false
+            continue
+        }
+
+        # Exit auto_commit section on next top-level key
+        if ($inAutoCommit -and $line -match '^[a-z]') {
+            break
+        }
+
+        if ($inAutoCommit) {
+            # Check default key
+            if ($line -match '^\s+default:\s*(.+)$') {
+                $val = $matches[1].Trim().ToLower()
+                if ($val -eq 'true') { $defaultEnabled = $true }
+            }
+
+            # Detect our event subsection
+            if ($line -match "^\s+${EventName}:") {
+                $inEvent = $true
+                continue
+            }
+
+            # Inside our event subsection
+            if ($inEvent) {
+                # Exit on next sibling key (2-space indent, not 4+)
+                if ($line -match '^\s{2}[a-z]' -and $line -notmatch '^\s{4}') {
+                    $inEvent = $false
+                    continue
+                }
+                if ($line -match '\s+enabled:\s*(.+)$') {
+                    $val = $matches[1].Trim().ToLower()
+                    if ($val -eq 'true') { $enabled = $true }
+                    if ($val -eq 'false') { $enabled = $false }
+                }
+                if ($line -match '\s+message:\s*(.+)$') {
+                    $commitMsg = $matches[1].Trim() -replace '^["'']' -replace '["'']$'
+                }
+            }
+        }
+    }
+
+    # If event-specific key not found, use default
+    if (-not $enabled -and $defaultEnabled) {
+        $hasEventKey = Select-String -Path $configFile -Pattern "^\s*${EventName}:" -Quiet
+        if (-not $hasEventKey) {
+            $enabled = $true
+        }
+    }
+} else {
+    # No config file — auto-commit disabled by default
+    exit 0
+}
+
+if (-not $enabled) {
+    exit 0
+}
+
+# Check if there are changes to commit
+# Relax ErrorActionPreference so CRLF warnings on stderr do not terminate.
+$savedEAP = $ErrorActionPreference
+$ErrorActionPreference = 'Continue'
+try {
+    git diff --quiet HEAD 2>$null; $d1 = $LASTEXITCODE
+    git diff --cached --quiet 2>$null; $d2 = $LASTEXITCODE
+    $untracked = git ls-files --others --exclude-standard 2>$null
+} finally {
+    $ErrorActionPreference = $savedEAP
+}
+
+if ($d1 -eq 0 -and $d2 -eq 0 -and -not $untracked) {
+    Write-Host "[specify] No changes to commit after $EventName" -ForegroundColor DarkGray
+    exit 0
+}
+
+# Derive a human-readable command name from the event
+$commandName = $EventName -replace '^after_', '' -replace '^before_', ''
+$phase = if ($EventName -match '^before_') { 'before' } else { 'after' }
+
+# Use custom message if configured, otherwise default
+if (-not $commitMsg) {
+    $commitMsg = "[Spec Kit] Auto-commit $phase $commandName"
+}
+
+# Stage and commit
+# Relax ErrorActionPreference so CRLF warnings on stderr do not terminate,
+# while still allowing redirected error output to be captured for diagnostics.
+$savedEAP = $ErrorActionPreference
+$ErrorActionPreference = 'Continue'
+try {
+    $out = git add . 2>&1 | Out-String
+    if ($LASTEXITCODE -ne 0) { throw "git add failed: $out" }
+    $out = git commit -q -m $commitMsg 2>&1 | Out-String
+    if ($LASTEXITCODE -ne 0) { throw "git commit failed: $out" }
+} catch {
+    Write-Warning "[specify] Error: $_"
+    exit 1
+} finally {
+    $ErrorActionPreference = $savedEAP
+}
+
+Write-Host "[OK] Changes committed $phase $commandName"

--- a/.specify/extensions/git/scripts/powershell/create-new-feature.ps1
+++ b/.specify/extensions/git/scripts/powershell/create-new-feature.ps1
@@ -1,0 +1,403 @@
+#!/usr/bin/env pwsh
+# Git extension: create-new-feature.ps1
+# Adapted from core scripts/powershell/create-new-feature.ps1 for extension layout.
+# Sources common.ps1 from the project's installed scripts, falling back to
+# git-common.ps1 for minimal git helpers.
+[CmdletBinding()]
+param(
+    [switch]$Json,
+    [switch]$AllowExistingBranch,
+    [switch]$DryRun,
+    [string]$ShortName,
+    [Parameter()]
+    [long]$Number = 0,
+    [switch]$Timestamp,
+    [switch]$Help,
+    [Parameter(Position = 0, ValueFromRemainingArguments = $true)]
+    [string[]]$FeatureDescription
+)
+$ErrorActionPreference = 'Stop'
+
+if ($Help) {
+    Write-Host "Usage: ./create-new-feature.ps1 [-Json] [-DryRun] [-AllowExistingBranch] [-ShortName <name>] [-Number N] [-Timestamp] <feature description>"
+    Write-Host ""
+    Write-Host "Options:"
+    Write-Host "  -Json               Output in JSON format"
+    Write-Host "  -DryRun             Compute branch name without creating the branch"
+    Write-Host "  -AllowExistingBranch  Switch to branch if it already exists instead of failing"
+    Write-Host "  -ShortName <name>   Provide a custom short name (2-4 words) for the branch"
+    Write-Host "  -Number N           Specify branch number manually (overrides auto-detection)"
+    Write-Host "  -Timestamp          Use timestamp prefix (YYYYMMDD-HHMMSS) instead of sequential numbering"
+    Write-Host "  -Help               Show this help message"
+    Write-Host ""
+    Write-Host "Environment variables:"
+    Write-Host "  GIT_BRANCH_NAME     Use this exact branch name, bypassing all prefix/suffix generation"
+    Write-Host ""
+    exit 0
+}
+
+if (-not $FeatureDescription -or $FeatureDescription.Count -eq 0) {
+    Write-Error "Usage: ./create-new-feature.ps1 [-Json] [-DryRun] [-AllowExistingBranch] [-ShortName <name>] [-Number N] [-Timestamp] <feature description>"
+    exit 1
+}
+
+$featureDesc = ($FeatureDescription -join ' ').Trim()
+
+if ([string]::IsNullOrWhiteSpace($featureDesc)) {
+    Write-Error "Error: Feature description cannot be empty or contain only whitespace"
+    exit 1
+}
+
+function Get-HighestNumberFromSpecs {
+    param([string]$SpecsDir)
+
+    [long]$highest = 0
+    if (Test-Path $SpecsDir) {
+        Get-ChildItem -Path $SpecsDir -Directory | ForEach-Object {
+            if ($_.Name -match '^(\d{3,})-' -and $_.Name -notmatch '^\d{8}-\d{6}-') {
+                [long]$num = 0
+                if ([long]::TryParse($matches[1], [ref]$num) -and $num -gt $highest) {
+                    $highest = $num
+                }
+            }
+        }
+    }
+    return $highest
+}
+
+function Get-HighestNumberFromNames {
+    param([string[]]$Names)
+
+    [long]$highest = 0
+    foreach ($name in $Names) {
+        if ($name -match '^(\d{3,})-' -and $name -notmatch '^\d{8}-\d{6}-') {
+            [long]$num = 0
+            if ([long]::TryParse($matches[1], [ref]$num) -and $num -gt $highest) {
+                $highest = $num
+            }
+        }
+    }
+    return $highest
+}
+
+function Get-HighestNumberFromBranches {
+    param()
+
+    try {
+        $branches = git branch -a 2>$null
+        if ($LASTEXITCODE -eq 0 -and $branches) {
+            $cleanNames = $branches | ForEach-Object {
+                $_.Trim() -replace '^\*?\s+', '' -replace '^remotes/[^/]+/', ''
+            }
+            return Get-HighestNumberFromNames -Names $cleanNames
+        }
+    } catch {
+        Write-Verbose "Could not check Git branches: $_"
+    }
+    return 0
+}
+
+function Get-HighestNumberFromRemoteRefs {
+    [long]$highest = 0
+    try {
+        $remotes = git remote 2>$null
+        if ($remotes) {
+            foreach ($remote in $remotes) {
+                $env:GIT_TERMINAL_PROMPT = '0'
+                $refs = git ls-remote --heads $remote 2>$null
+                $env:GIT_TERMINAL_PROMPT = $null
+                if ($LASTEXITCODE -eq 0 -and $refs) {
+                    $refNames = $refs | ForEach-Object {
+                        if ($_ -match 'refs/heads/(.+)$') { $matches[1] }
+                    } | Where-Object { $_ }
+                    $remoteHighest = Get-HighestNumberFromNames -Names $refNames
+                    if ($remoteHighest -gt $highest) { $highest = $remoteHighest }
+                }
+            }
+        }
+    } catch {
+        Write-Verbose "Could not query remote refs: $_"
+    }
+    return $highest
+}
+
+function Get-NextBranchNumber {
+    param(
+        [string]$SpecsDir,
+        [switch]$SkipFetch
+    )
+
+    if ($SkipFetch) {
+        $highestBranch = Get-HighestNumberFromBranches
+        $highestRemote = Get-HighestNumberFromRemoteRefs
+        $highestBranch = [Math]::Max($highestBranch, $highestRemote)
+    } else {
+        try {
+            git fetch --all --prune 2>$null | Out-Null
+        } catch { }
+        $highestBranch = Get-HighestNumberFromBranches
+    }
+
+    $highestSpec = Get-HighestNumberFromSpecs -SpecsDir $SpecsDir
+    $maxNum = [Math]::Max($highestBranch, $highestSpec)
+    return $maxNum + 1
+}
+
+function ConvertTo-CleanBranchName {
+    param([string]$Name)
+    return $Name.ToLower() -replace '[^a-z0-9]', '-' -replace '-{2,}', '-' -replace '^-', '' -replace '-$', ''
+}
+
+# ---------------------------------------------------------------------------
+# Source common.ps1 from the project's installed scripts.
+# Search locations in priority order:
+#  1. .specify/scripts/powershell/common.ps1 under the project root
+#  2. scripts/powershell/common.ps1 under the project root (source checkout)
+#  3. git-common.ps1 next to this script (minimal fallback)
+# ---------------------------------------------------------------------------
+function Find-ProjectRoot {
+    param([string]$StartDir)
+    $current = Resolve-Path $StartDir
+    while ($true) {
+        foreach ($marker in @('.specify', '.git')) {
+            if (Test-Path (Join-Path $current $marker)) {
+                return $current
+            }
+        }
+        $parent = Split-Path $current -Parent
+        if ($parent -eq $current) { return $null }
+        $current = $parent
+    }
+}
+
+$projectRoot = Find-ProjectRoot -StartDir $PSScriptRoot
+$commonLoaded = $false
+
+if ($projectRoot) {
+    $candidates = @(
+        (Join-Path $projectRoot ".specify/scripts/powershell/common.ps1"),
+        (Join-Path $projectRoot "scripts/powershell/common.ps1")
+    )
+    foreach ($candidate in $candidates) {
+        if (Test-Path $candidate) {
+            . $candidate
+            $commonLoaded = $true
+            break
+        }
+    }
+}
+
+if (-not $commonLoaded -and (Test-Path "$PSScriptRoot/git-common.ps1")) {
+    . "$PSScriptRoot/git-common.ps1"
+    $commonLoaded = $true
+}
+
+if (-not $commonLoaded) {
+    throw "Unable to locate common script file. Please ensure the Specify core scripts are installed."
+}
+
+# Resolve repository root
+if (Get-Command Get-RepoRoot -ErrorAction SilentlyContinue) {
+    $repoRoot = Get-RepoRoot
+} elseif ($projectRoot) {
+    $repoRoot = $projectRoot
+} else {
+    throw "Could not determine repository root."
+}
+
+# Check if git is available
+if (Get-Command Test-HasGit -ErrorAction SilentlyContinue) {
+    # Call without parameters for compatibility with core common.ps1 (no -RepoRoot param)
+    # and git-common.ps1 (has -RepoRoot param with default).
+    $hasGit = Test-HasGit
+} else {
+    try {
+        git -C $repoRoot rev-parse --is-inside-work-tree 2>$null | Out-Null
+        $hasGit = ($LASTEXITCODE -eq 0)
+    } catch {
+        $hasGit = $false
+    }
+}
+
+Set-Location $repoRoot
+
+$specsDir = Join-Path $repoRoot 'specs'
+
+function Get-BranchName {
+    param([string]$Description)
+
+    $stopWords = @(
+        'i', 'a', 'an', 'the', 'to', 'for', 'of', 'in', 'on', 'at', 'by', 'with', 'from',
+        'is', 'are', 'was', 'were', 'be', 'been', 'being', 'have', 'has', 'had',
+        'do', 'does', 'did', 'will', 'would', 'should', 'could', 'can', 'may', 'might', 'must', 'shall',
+        'this', 'that', 'these', 'those', 'my', 'your', 'our', 'their',
+        'want', 'need', 'add', 'get', 'set'
+    )
+
+    $cleanName = $Description.ToLower() -replace '[^a-z0-9\s]', ' '
+    $words = $cleanName -split '\s+' | Where-Object { $_ }
+
+    $meaningfulWords = @()
+    foreach ($word in $words) {
+        if ($stopWords -contains $word) { continue }
+        if ($word.Length -ge 3) {
+            $meaningfulWords += $word
+        } elseif ($Description -match "\b$($word.ToUpper())\b") {
+            $meaningfulWords += $word
+        }
+    }
+
+    if ($meaningfulWords.Count -gt 0) {
+        $maxWords = if ($meaningfulWords.Count -eq 4) { 4 } else { 3 }
+        $result = ($meaningfulWords | Select-Object -First $maxWords) -join '-'
+        return $result
+    } else {
+        $result = ConvertTo-CleanBranchName -Name $Description
+        $fallbackWords = ($result -split '-') | Where-Object { $_ } | Select-Object -First 3
+        return [string]::Join('-', $fallbackWords)
+    }
+}
+
+# Check for GIT_BRANCH_NAME env var override (exact branch name, no prefix/suffix)
+if ($env:GIT_BRANCH_NAME) {
+    $branchName = $env:GIT_BRANCH_NAME
+    # Check 244-byte limit (UTF-8) for override names
+    $branchNameUtf8ByteCount = [System.Text.Encoding]::UTF8.GetByteCount($branchName)
+    if ($branchNameUtf8ByteCount -gt 244) {
+        throw "GIT_BRANCH_NAME must be 244 bytes or fewer in UTF-8. Provided value is $branchNameUtf8ByteCount bytes; please supply a shorter override branch name."
+    }
+    # Extract FEATURE_NUM from the branch name if it starts with a numeric prefix
+    # Check timestamp pattern first (YYYYMMDD-HHMMSS-) since it also matches the simpler ^\d+ pattern
+    if ($branchName -match '^(\d{8}-\d{6})-') {
+        $featureNum = $matches[1]
+    } elseif ($branchName -match '^(\d+)-') {
+        $featureNum = $matches[1]
+    } else {
+        $featureNum = $branchName
+    }
+} else {
+    if ($ShortName) {
+        $branchSuffix = ConvertTo-CleanBranchName -Name $ShortName
+    } else {
+        $branchSuffix = Get-BranchName -Description $featureDesc
+    }
+
+    if ($Timestamp -and $Number -ne 0) {
+        Write-Warning "[specify] Warning: -Number is ignored when -Timestamp is used"
+        $Number = 0
+    }
+
+    if ($Timestamp) {
+        $featureNum = Get-Date -Format 'yyyyMMdd-HHmmss'
+        $branchName = "$featureNum-$branchSuffix"
+    } else {
+        if ($Number -eq 0) {
+            if ($DryRun -and $hasGit) {
+                $Number = Get-NextBranchNumber -SpecsDir $specsDir -SkipFetch
+            } elseif ($DryRun) {
+                $Number = (Get-HighestNumberFromSpecs -SpecsDir $specsDir) + 1
+            } elseif ($hasGit) {
+                $Number = Get-NextBranchNumber -SpecsDir $specsDir
+            } else {
+                $Number = (Get-HighestNumberFromSpecs -SpecsDir $specsDir) + 1
+            }
+        }
+
+        $featureNum = ('{0:000}' -f $Number)
+        $branchName = "$featureNum-$branchSuffix"
+    }
+}
+
+$maxBranchLength = 244
+if ($branchName.Length -gt $maxBranchLength) {
+    $prefixLength = $featureNum.Length + 1
+    $maxSuffixLength = $maxBranchLength - $prefixLength
+
+    $truncatedSuffix = $branchSuffix.Substring(0, [Math]::Min($branchSuffix.Length, $maxSuffixLength))
+    $truncatedSuffix = $truncatedSuffix -replace '-$', ''
+
+    $originalBranchName = $branchName
+    $branchName = "$featureNum-$truncatedSuffix"
+
+    Write-Warning "[specify] Branch name exceeded GitHub's 244-byte limit"
+    Write-Warning "[specify] Original: $originalBranchName ($($originalBranchName.Length) bytes)"
+    Write-Warning "[specify] Truncated to: $branchName ($($branchName.Length) bytes)"
+}
+
+if (-not $DryRun) {
+    if ($hasGit) {
+        $branchCreated = $false
+        $branchCreateError = ''
+        try {
+            $branchCreateError = git checkout -q -b $branchName 2>&1 | Out-String
+            if ($LASTEXITCODE -eq 0) {
+                $branchCreated = $true
+            }
+        } catch {
+            $branchCreateError = $_.Exception.Message
+        }
+
+        if (-not $branchCreated) {
+            $currentBranch = ''
+            try { $currentBranch = (git rev-parse --abbrev-ref HEAD 2>$null).Trim() } catch {}
+            $existingBranch = git branch --list $branchName 2>$null
+            if ($existingBranch) {
+                if ($AllowExistingBranch) {
+                    if ($currentBranch -eq $branchName) {
+                        # Already on the target branch
+                    } else {
+                        $switchBranchError = git checkout -q $branchName 2>&1 | Out-String
+                        if ($LASTEXITCODE -ne 0) {
+                            if ($switchBranchError) {
+                                Write-Error "Error: Branch '$branchName' exists but could not be checked out.`n$($switchBranchError.Trim())"
+                            } else {
+                                Write-Error "Error: Branch '$branchName' exists but could not be checked out. Resolve any uncommitted changes or conflicts and try again."
+                            }
+                            exit 1
+                        }
+                    }
+                } elseif ($Timestamp) {
+                    Write-Error "Error: Branch '$branchName' already exists. Rerun to get a new timestamp or use a different -ShortName."
+                    exit 1
+                } else {
+                    Write-Error "Error: Branch '$branchName' already exists. Please use a different feature name or specify a different number with -Number."
+                    exit 1
+                }
+            } else {
+                if ($branchCreateError) {
+                    Write-Error "Error: Failed to create git branch '$branchName'.`n$($branchCreateError.Trim())"
+                } else {
+                    Write-Error "Error: Failed to create git branch '$branchName'. Please check your git configuration and try again."
+                }
+                exit 1
+            }
+        }
+    } else {
+        if ($Json) {
+            [Console]::Error.WriteLine("[specify] Warning: Git repository not detected; skipped branch creation for $branchName")
+        } else {
+            Write-Warning "[specify] Warning: Git repository not detected; skipped branch creation for $branchName"
+        }
+    }
+
+    $env:SPECIFY_FEATURE = $branchName
+}
+
+if ($Json) {
+    $obj = [PSCustomObject]@{
+        BRANCH_NAME = $branchName
+        FEATURE_NUM = $featureNum
+        HAS_GIT = $hasGit
+    }
+    if ($DryRun) {
+        $obj | Add-Member -NotePropertyName 'DRY_RUN' -NotePropertyValue $true
+    }
+    $obj | ConvertTo-Json -Compress
+} else {
+    Write-Output "BRANCH_NAME: $branchName"
+    Write-Output "FEATURE_NUM: $featureNum"
+    Write-Output "HAS_GIT: $hasGit"
+    if (-not $DryRun) {
+        Write-Output "SPECIFY_FEATURE environment variable set to: $branchName"
+    }
+}

--- a/.specify/extensions/git/scripts/powershell/git-common.ps1
+++ b/.specify/extensions/git/scripts/powershell/git-common.ps1
@@ -1,0 +1,51 @@
+#!/usr/bin/env pwsh
+# Git-specific common functions for the git extension.
+# Extracted from scripts/powershell/common.ps1 — contains only git-specific
+# branch validation and detection logic.
+
+function Test-HasGit {
+    param([string]$RepoRoot = (Get-Location))
+    try {
+        if (-not (Test-Path (Join-Path $RepoRoot '.git'))) { return $false }
+        if (-not (Get-Command git -ErrorAction SilentlyContinue)) { return $false }
+        git -C $RepoRoot rev-parse --is-inside-work-tree 2>$null | Out-Null
+        return ($LASTEXITCODE -eq 0)
+    } catch {
+        return $false
+    }
+}
+
+function Get-SpecKitEffectiveBranchName {
+    param([string]$Branch)
+    if ($Branch -match '^([^/]+)/([^/]+)$') {
+        return $Matches[2]
+    }
+    return $Branch
+}
+
+function Test-FeatureBranch {
+    param(
+        [string]$Branch,
+        [bool]$HasGit = $true
+    )
+
+    # For non-git repos, we can't enforce branch naming but still provide output
+    if (-not $HasGit) {
+        Write-Warning "[specify] Warning: Git repository not detected; skipped branch validation"
+        return $true
+    }
+
+    $raw = $Branch
+    $Branch = Get-SpecKitEffectiveBranchName $raw
+
+    # Accept sequential prefix (3+ digits) but exclude malformed timestamps
+    # Malformed: 7-or-8 digit date + 6-digit time with no trailing slug (e.g. "2026031-143022" or "20260319-143022")
+    $hasMalformedTimestamp = ($Branch -match '^[0-9]{7}-[0-9]{6}-') -or ($Branch -match '^(?:\d{7}|\d{8})-\d{6}$')
+    $isSequential = ($Branch -match '^[0-9]{3,}-') -and (-not $hasMalformedTimestamp)
+    if (-not $isSequential -and $Branch -notmatch '^\d{8}-\d{6}-') {
+        [Console]::Error.WriteLine("ERROR: Not on a feature branch. Current branch: $raw")
+        [Console]::Error.WriteLine("Feature branches should be named like: 001-feature-name, 1234-feature-name, or 20260319-143022-feature-name")
+        return $false
+    }
+    return $true
+}

--- a/.specify/extensions/git/scripts/powershell/initialize-repo.ps1
+++ b/.specify/extensions/git/scripts/powershell/initialize-repo.ps1
@@ -1,0 +1,69 @@
+#!/usr/bin/env pwsh
+# Git extension: initialize-repo.ps1
+# Initialize a Git repository with an initial commit.
+# Customizable — replace this script to add .gitignore templates,
+# default branch config, git-flow, LFS, signing, etc.
+$ErrorActionPreference = 'Stop'
+
+# Find project root
+function Find-ProjectRoot {
+    param([string]$StartDir)
+    $current = Resolve-Path $StartDir
+    while ($true) {
+        foreach ($marker in @('.specify', '.git')) {
+            if (Test-Path (Join-Path $current $marker)) {
+                return $current
+            }
+        }
+        $parent = Split-Path $current -Parent
+        if ($parent -eq $current) { return $null }
+        $current = $parent
+    }
+}
+
+$repoRoot = Find-ProjectRoot -StartDir $PSScriptRoot
+if (-not $repoRoot) { $repoRoot = Get-Location }
+Set-Location $repoRoot
+
+# Read commit message from extension config, fall back to default
+$commitMsg = "[Spec Kit] Initial commit"
+$configFile = Join-Path $repoRoot ".specify/extensions/git/git-config.yml"
+if (Test-Path $configFile) {
+    foreach ($line in Get-Content $configFile) {
+        if ($line -match '^init_commit_message:\s*(.+)$') {
+            $val = $matches[1].Trim() -replace '^["'']' -replace '["'']$'
+            if ($val) { $commitMsg = $val }
+            break
+        }
+    }
+}
+
+# Check if git is available
+if (-not (Get-Command git -ErrorAction SilentlyContinue)) {
+    Write-Warning "[specify] Warning: Git not found; skipped repository initialization"
+    exit 0
+}
+
+# Check if already a git repo
+try {
+    git rev-parse --is-inside-work-tree 2>$null | Out-Null
+    if ($LASTEXITCODE -eq 0) {
+        Write-Warning "[specify] Git repository already initialized; skipping"
+        exit 0
+    }
+} catch { }
+
+# Initialize
+try {
+    $out = git init -q 2>&1 | Out-String
+    if ($LASTEXITCODE -ne 0) { throw "git init failed: $out" }
+    $out = git add . 2>&1 | Out-String
+    if ($LASTEXITCODE -ne 0) { throw "git add failed: $out" }
+    $out = git commit --allow-empty -q -m $commitMsg 2>&1 | Out-String
+    if ($LASTEXITCODE -ne 0) { throw "git commit failed: $out" }
+} catch {
+    Write-Warning "[specify] Error: $_"
+    exit 1
+}
+
+Write-Host "✓ Git repository initialized"

--- a/.specify/init-options.json
+++ b/.specify/init-options.json
@@ -1,0 +1,10 @@
+{
+  "ai": "codex",
+  "ai_skills": true,
+  "branch_numbering": "sequential",
+  "context_file": "AGENTS.md",
+  "here": true,
+  "integration": "codex",
+  "script": "sh",
+  "speckit_version": "0.8.9"
+}

--- a/.specify/integration.json
+++ b/.specify/integration.json
@@ -1,0 +1,15 @@
+{
+  "version": "0.8.9",
+  "integration_state_schema": 1,
+  "installed_integrations": [
+    "codex"
+  ],
+  "integration_settings": {
+    "codex": {
+      "script": "sh",
+      "invoke_separator": "-"
+    }
+  },
+  "integration": "codex",
+  "default_integration": "codex"
+}

--- a/.specify/integrations/codex.manifest.json
+++ b/.specify/integrations/codex.manifest.json
@@ -1,0 +1,16 @@
+{
+  "integration": "codex",
+  "version": "0.8.9",
+  "installed_at": "2026-05-15T11:27:53.061396+00:00",
+  "files": {
+    ".agents/skills/speckit-analyze/SKILL.md": "23d10a774acad3a26e5ab01041eb65a39e627aadee6e0e366d79713ad054fdf6",
+    ".agents/skills/speckit-checklist/SKILL.md": "2db3121cd5d97ca2c0902be413d39d9ec0d9323932a976330eefa208e72a483a",
+    ".agents/skills/speckit-clarify/SKILL.md": "a429d1af7bf00c65c6be2766a11c2571e9d18ede2b77ec4fd538db4d5ec242d1",
+    ".agents/skills/speckit-constitution/SKILL.md": "7310adee465ee6a439a689518e6c133ce851d808c7a6e64d66f659ad8b4bd56e",
+    ".agents/skills/speckit-implement/SKILL.md": "b39c4de2e794a96302cd36cc7b6796711aee0f3bcedba0d0c01ccf3b1036f898",
+    ".agents/skills/speckit-plan/SKILL.md": "1cd13274eb35a18d87e6f43bc69801910437ce9543286b13f87c4e3cbc33b9d8",
+    ".agents/skills/speckit-specify/SKILL.md": "164542c78d6415ea9e16bb063652e989e14524a9a273176273e6c9b5ffa0b942",
+    ".agents/skills/speckit-tasks/SKILL.md": "0b36b19eb61347406afea1953c1e5983f084931eaa34d1b10c6c6e67f828f29f",
+    ".agents/skills/speckit-taskstoissues/SKILL.md": "32d8ee0f0482a7b2b9e6bee4dfd6947465754f2f82c404bfc7ef64f4a3b63bdd"
+  }
+}

--- a/.specify/integrations/speckit.manifest.json
+++ b/.specify/integrations/speckit.manifest.json
@@ -1,0 +1,8 @@
+{
+  "integration": "speckit",
+  "version": "0.8.9",
+  "installed_at": "2026-05-15T11:27:53.152062+00:00",
+  "files": {
+    ".specify/scripts/bash/setup-tasks.sh": "e8d050c63c5afb664a8b671b0b0155513fb9cab0567b335e16b9eb035482aad2"
+  }
+}

--- a/.specify/memory/constitution.md
+++ b/.specify/memory/constitution.md
@@ -1,17 +1,24 @@
 <!--
 SYNC IMPACT REPORT
-Version Change: 1.0.0 -> 1.1.0
+Version Change: 1.1.0 -> 1.1.1
 Modified Principles:
-- II. Immutable Versioning (clarified Resource snapshot terminology)
-- V. Provider Agnostic (updated persistence abstraction names)
+- 16. Simplicity First (added rationale)
+- 17. Modern C# Idioms (added rationale)
+- 18. Readability Over Cleverness (added rationale)
+- 19. Explicitness Over Magic (added rationale)
+- 20. Abstractions Must Earn Their Existence (added rationale)
+- 21. Optimize For Deletion (added rationale)
+- 22. Favor Composition Over Inheritance (added rationale)
+- 23. Dependencies Should Remain Intentional (added rationale)
+- 24. Operational Simplicity Matters (added rationale)
 Added Sections:
-- Engineering Principles (16. Simplicity First through 24. Operational Simplicity Matters)
+- None
 Removed Sections:
 - None
 Templates Requiring Updates:
-- ✅ .specify/templates/plan-template.md
-- ✅ .specify/templates/spec-template.md
-- ✅ .specify/templates/tasks-template.md
+- ✅ .specify/templates/plan-template.md (no changes required)
+- ✅ .specify/templates/spec-template.md (no changes required)
+- ✅ .specify/templates/tasks-template.md (no changes required)
 Follow-up TODOs:
 - None
 -->
@@ -55,46 +62,55 @@ Follow-up TODOs:
 **Solutions SHOULD prefer the simplest architecture and implementation that correctly satisfies current requirements.**
 - Avoid speculative abstractions, premature generalization, and unnecessary infrastructure.
 - A simpler direct implementation SHOULD be preferred until a real use case proves it insufficient.
+- Rationale: Simpler designs reduce review burden, make provider behavior easier to reason about, and leave room to evolve once requirements are proven.
 
 ### 17. Modern C# Idioms
 **Code SHOULD use modern C# and .NET features when they improve clarity, correctness, and conciseness.**
 - Appropriate idioms include records, primary constructors, collection expressions, pattern matching, async streams, minimal APIs, and nullable reference types.
 - Modern language features SHOULD NOT be used when they make behavior harder to understand for experienced .NET developers.
+- Rationale: Modern C# can express immutable data, async workflows, and domain intent clearly, but language features are tools rather than goals.
 
 ### 18. Readability Over Cleverness
 **Code MUST optimize for maintainability and clarity by experienced .NET developers.**
 - Cleverness, excessive indirection, unnecessary metaprogramming, and obscure control flow SHOULD be avoided.
 - Names, boundaries, and behavior SHOULD make the code easy to review and change.
+- Rationale: Aster is SDK infrastructure; maintainers and consumers need predictable code paths more than compact tricks.
 
 ### 19. Explicitness Over Magic
 **Behavior SHOULD be discoverable through code and configuration rather than hidden conventions.**
 - Runtime scanning, implicit side effects, and convention-only behavior SHOULD be avoided unless they are clearly documented and justified.
 - Configuration and registration paths SHOULD make provider choices and operational behavior explicit.
+- Rationale: Explicit behavior makes provider selection, persistence semantics, and query support visible during development and debugging.
 
 ### 20. Abstractions Must Earn Their Existence
 **Interfaces, layers, generic pipelines, and extension points SHOULD only be introduced when they solve a demonstrated need.**
 - Avoid designing hypothetical frameworks inside the product.
 - New abstractions SHOULD identify the current duplication, provider boundary, test seam, or lifecycle need they address.
+- Rationale: Every abstraction becomes part of the SDK's maintenance and learning surface, so it must pay for itself in present product value.
 
 ### 21. Optimize For Deletion
 **The architecture SHOULD make it easy to remove, replace, or simplify components later.**
 - Small composable modules are preferred over deeply intertwined systems.
 - Features SHOULD avoid broad coupling and global side effects that make later deletion expensive.
+- Rationale: Early-stage architecture changes often reveal simpler paths; replaceable components let the project adapt without large rewrites.
 
 ### 22. Favor Composition Over Inheritance
 **Composition, explicit contracts, and data-oriented design SHOULD generally be preferred over deep inheritance hierarchies.**
 - Inheritance SHOULD be shallow and purposeful when used.
 - Reusable behavior SHOULD usually be expressed through services, records, functions, and explicit collaborators.
+- Rationale: Composition keeps provider behavior and lifecycle rules local, testable, and easier to recombine across host scenarios.
 
 ### 23. Dependencies Should Remain Intentional
 **The solution SHOULD minimize unnecessary third-party dependencies.**
 - Prefer platform capabilities before introducing additional frameworks.
 - New dependencies MUST be justified by clear product value, operational value, or meaningful risk reduction.
+- Rationale: Dependencies affect consumers, deployment, security review, versioning, and long-term portability.
 
 ### 24. Operational Simplicity Matters
 **Deployment, debugging, local development, and observability SHOULD remain straightforward.**
 - Operational complexity MUST be justified by clear product value.
 - Provider setup, migrations/provisioning, logs, and local test workflows SHOULD be understandable without specialized infrastructure.
+- Rationale: A headless SDK should be easy to embed and diagnose in many host applications, including small local and test environments.
 
 ## Governance
 
@@ -120,4 +136,4 @@ Follow-up TODOs:
 - The Constitution Check MUST explicitly consider simplicity, abstraction justification, dependency justification, provider boundaries, operational impact, and testability.
 - If a feature intentionally violates a SHOULD-level principle, the plan MUST explain why and identify the simpler alternative that was rejected.
 
-**Version**: 1.1.0 | **Ratified**: 2026-03-04 | **Last Amended**: 2026-05-14
+**Version**: 1.1.1 | **Ratified**: 2026-03-04 | **Last Amended**: 2026-05-15

--- a/.specify/scripts/bash/common.sh
+++ b/.specify/scripts/bash/common.sh
@@ -154,3 +154,54 @@ EOF
 check_file() { [[ -f "$1" ]] && echo "  ✓ $2" || echo "  ✗ $2"; }
 check_dir() { [[ -d "$1" && -n $(ls -A "$1" 2>/dev/null) ]] && echo "  ✓ $2" || echo "  ✗ $2"; }
 
+has_jq() {
+    command -v jq >/dev/null 2>&1
+}
+
+json_escape() {
+    local value="$1"
+    value=${value//\\/\\\\}
+    value=${value//\"/\\\"}
+    value=${value//$'\n'/\\n}
+    value=${value//$'\r'/\\r}
+    value=${value//$'\t'/\\t}
+    printf '%s' "$value"
+}
+
+feature_json_matches_feature_dir() {
+    local repo_root="$1"
+    local feature_dir="$2"
+    local feature_json="$repo_root/.specify/feature.json"
+
+    [[ -f "$feature_json" ]] || return 1
+
+    if has_jq; then
+        local configured
+        configured=$(jq -r '.featureDir // .FEATURE_DIR // empty' "$feature_json" 2>/dev/null || true)
+        [[ -n "$configured" ]] || return 1
+        [[ "$configured" = /* ]] || configured="$repo_root/$configured"
+        [[ "$configured" == "$feature_dir" ]]
+        return
+    fi
+
+    return 1
+}
+
+resolve_template() {
+    local template_name="$1"
+    local repo_root="$2"
+    local template_file="$template_name.md"
+    local candidates=(
+        "$repo_root/.specify/templates/overrides/$template_file"
+        "$repo_root/.specify/templates/$template_file"
+    )
+
+    for candidate in "${candidates[@]}"; do
+        if [[ -f "$candidate" ]]; then
+            echo "$candidate"
+            return 0
+        fi
+    done
+
+    return 1
+}

--- a/.specify/scripts/bash/setup-tasks.sh
+++ b/.specify/scripts/bash/setup-tasks.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+
+set -e
+
+# Parse command line arguments
+JSON_MODE=false
+
+for arg in "$@"; do
+    case "$arg" in
+        --json) JSON_MODE=true ;;
+        --help|-h)
+            echo "Usage: $0 [--json]"
+            echo "  --json    Output results in JSON format"
+            echo "  --help    Show this help message"
+            exit 0
+            ;;
+        *) echo "ERROR: Unknown option '$arg'" >&2; exit 1 ;;
+    esac
+done
+
+# Source common functions
+SCRIPT_DIR="$(CDPATH="" cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/common.sh"
+
+# Get feature paths
+_paths_output=$(get_feature_paths) || { echo "ERROR: Failed to resolve feature paths" >&2; exit 1; }
+eval "$_paths_output"
+unset _paths_output
+
+# Validate branch
+# If feature.json pins an existing feature directory, branch naming is not required.
+if ! feature_json_matches_feature_dir "$REPO_ROOT" "$FEATURE_DIR"; then
+    check_feature_branch "$CURRENT_BRANCH" "$HAS_GIT" || exit 1
+fi
+
+if [[ ! -f "$IMPL_PLAN" ]]; then
+    echo "ERROR: plan.md not found in $FEATURE_DIR" >&2
+    echo "Run /speckit.plan first to create the implementation plan." >&2
+    exit 1
+fi
+
+if [[ ! -f "$FEATURE_SPEC" ]]; then
+    echo "ERROR: spec.md not found in $FEATURE_DIR" >&2
+    echo "Run /speckit.specify first to create the feature structure." >&2
+    exit 1
+fi
+
+# Build available docs list
+docs=()
+[[ -f "$RESEARCH" ]] && docs+=("research.md")
+[[ -f "$DATA_MODEL" ]] && docs+=("data-model.md")
+if [[ -d "$CONTRACTS_DIR" ]] && [[ -n "$(ls -A "$CONTRACTS_DIR" 2>/dev/null)" ]]; then
+    docs+=("contracts/")
+fi
+[[ -f "$QUICKSTART" ]] && docs+=("quickstart.md")
+
+# Resolve tasks template through override stack
+TASKS_TEMPLATE=$(resolve_template "tasks-template" "$REPO_ROOT") || true
+if [[ -z "$TASKS_TEMPLATE" ]] || [[ ! -f "$TASKS_TEMPLATE" ]]; then
+    echo "ERROR: Could not resolve required tasks-template from the template override stack for $REPO_ROOT" >&2
+    echo "Template 'tasks-template' was not found in any supported location (overrides, presets, extensions, or shared core). Add an override at .specify/templates/overrides/tasks-template.md, or run 'specify init' / reinstall shared infra to restore the core .specify/templates/tasks-template.md template." >&2
+    exit 1
+fi
+
+# Output results
+if $JSON_MODE; then
+    if has_jq; then
+        if [[ ${#docs[@]} -eq 0 ]]; then
+            json_docs="[]"
+        else
+            json_docs=$(printf '%s\n' "${docs[@]}" | jq -R . | jq -s .)
+        fi
+        jq -cn \
+            --arg feature_dir "$FEATURE_DIR" \
+            --argjson docs "$json_docs" \
+            --arg tasks_template "${TASKS_TEMPLATE:-}" \
+            '{FEATURE_DIR:$feature_dir,AVAILABLE_DOCS:$docs,TASKS_TEMPLATE:$tasks_template}'
+    else
+        if [[ ${#docs[@]} -eq 0 ]]; then
+            json_docs="[]"
+        else
+            json_docs=$(for d in "${docs[@]}"; do printf '"%s",' "$(json_escape "$d")"; done)
+            json_docs="[${json_docs%,}]"
+        fi
+        printf '{"FEATURE_DIR":"%s","AVAILABLE_DOCS":%s,"TASKS_TEMPLATE":"%s"}\n' \
+            "$(json_escape "$FEATURE_DIR")" "$json_docs" "$(json_escape "${TASKS_TEMPLATE:-}")"
+    fi
+else
+    echo "FEATURE_DIR: $FEATURE_DIR"
+    echo "TASKS_TEMPLATE: ${TASKS_TEMPLATE:-not found}"
+    echo "AVAILABLE_DOCS:"
+    check_file "$RESEARCH" "research.md"
+    check_file "$DATA_MODEL" "data-model.md"
+    check_dir "$CONTRACTS_DIR" "contracts/"
+    check_file "$QUICKSTART" "quickstart.md"
+fi

--- a/.specify/workflows/speckit/workflow.yml
+++ b/.specify/workflows/speckit/workflow.yml
@@ -1,0 +1,63 @@
+schema_version: "1.0"
+workflow:
+  id: "speckit"
+  name: "Full SDD Cycle"
+  version: "1.0.0"
+  author: "GitHub"
+  description: "Runs specify → plan → tasks → implement with review gates"
+
+requires:
+  speckit_version: ">=0.7.2"
+  integrations:
+    any: ["copilot", "claude", "gemini"]
+
+inputs:
+  spec:
+    type: string
+    required: true
+    prompt: "Describe what you want to build"
+  integration:
+    type: string
+    default: "copilot"
+    prompt: "Integration to use (e.g. claude, copilot, gemini)"
+  scope:
+    type: string
+    default: "full"
+    enum: ["full", "backend-only", "frontend-only"]
+
+steps:
+  - id: specify
+    command: speckit.specify
+    integration: "{{ inputs.integration }}"
+    input:
+      args: "{{ inputs.spec }}"
+
+  - id: review-spec
+    type: gate
+    message: "Review the generated spec before planning."
+    options: [approve, reject]
+    on_reject: abort
+
+  - id: plan
+    command: speckit.plan
+    integration: "{{ inputs.integration }}"
+    input:
+      args: "{{ inputs.spec }}"
+
+  - id: review-plan
+    type: gate
+    message: "Review the plan before generating tasks."
+    options: [approve, reject]
+    on_reject: abort
+
+  - id: tasks
+    command: speckit.tasks
+    integration: "{{ inputs.integration }}"
+    input:
+      args: "{{ inputs.spec }}"
+
+  - id: implement
+    command: speckit.implement
+    integration: "{{ inputs.integration }}"
+    input:
+      args: "{{ inputs.spec }}"

--- a/.specify/workflows/workflow-registry.json
+++ b/.specify/workflows/workflow-registry.json
@@ -1,0 +1,13 @@
+{
+  "schema_version": "1.0",
+  "workflows": {
+    "speckit": {
+      "name": "Full SDD Cycle",
+      "version": "1.0.0",
+      "description": "Runs specify \u2192 plan \u2192 tasks \u2192 implement with review gates",
+      "source": "bundled",
+      "installed_at": "2026-05-15T11:27:53.768893+00:00",
+      "updated_at": "2026-05-15T11:27:53.768917+00:00"
+    }
+  }
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,4 @@
+<!-- SPECKIT START -->
+For additional context about technologies to be used, project structure,
+shell commands, and other important information, read the current plan
+<!-- SPECKIT END -->

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 It provides a headless, backend-agnostic foundation for attaching reusable, cross-cutting capabilities (Tags, Owner, RBAC, Scheduling, …) to any resource type — without hard-coding every entity from scratch.
 
-> **Status:** Phase 2A complete — Core SDK, in-memory engine, and SQLite JSON persistence/querying are available. Next focus: query capabilities and typed query helpers. See [Roadmap](#roadmap) for future phases.
+> **Status:** Phase 3 in progress — Core SDK, in-memory engine, SQLite JSON persistence/querying, query capability discovery, preflight validation, and typed query helpers are available. See [Roadmap](#roadmap) for future phases.
 
 ---
 
@@ -135,6 +135,8 @@ Console.WriteLine(title?.Title); // "Super Gadget Pro"
 | `IResourceVersionWriter` | `InMemoryResourceStore` |
 | `IResourceVersionReader` | `InMemoryResourceStore` |
 | `IResourceQueryService` | `InMemoryQueryService` |
+| `IResourceQueryCapabilitiesProvider` | `InMemoryQueryCapabilitiesProvider` |
+| `IResourceQueryValidator` | `ResourceQueryValidator` |
 | `ITypedAspectBinder` | `SystemTextJsonAspectBinder` |
 | `ITypedFacetBinder` | `SystemTextJsonFacetBinder` |
 | `IIdentityGenerator` | `GuidIdentityGenerator` |
@@ -148,19 +150,36 @@ All services are registered as **singletons** — the in-memory store is the sin
 Use `IResourceQueryService` with a portable `ResourceQuery` AST:
 
 ```csharp
-var results = await queryService.QueryAsync(new ResourceQuery
+var query = new ResourceQuery
 {
     DefinitionId = "Product",
     Filter = new FacetValueFilter("TitleAspect", "Title", "Gadget", ComparisonOperator.Contains),
     Sorts = [new SortExpression("Created", SortDirection.Descending)],
     Skip = 0,
     Take = 20,
-});
+};
+
+var results = await queryService.QueryAsync(query);
 ```
 
 The in-memory evaluator supports `Equals`, `Contains`, and `Range`, plus latest/all/active/draft version scopes.
 
 The SQLite JSON provider executes the same `ResourceQuery` AST in SQLite for its supported subset: metadata filters/sorts, version scopes, paging, aspect presence, scalar facet `Equals`/`Contains`, and numeric facet `Range`. Unsupported provider query shapes throw `UnsupportedQueryFeatureException`.
+
+Inspect provider support and validate before execution:
+
+```csharp
+var capabilities = serviceProvider.GetRequiredService<IResourceQueryCapabilitiesProvider>().Capabilities;
+var validation = serviceProvider.GetRequiredService<IResourceQueryValidator>().Validate(query);
+```
+
+Typed helpers build the same portable query model without repeating common aspect/facet strings:
+
+```csharp
+var filter = TypedQuery.For<TitleAspect>()
+    .Facet(x => x.Title)
+    .Contains("Gadget");
+```
 
 ---
 
@@ -247,7 +266,7 @@ specs/                       ← Feature specs (001-core-sdk-foundation, …)
 |---|---|---|
 | **1** | Core SDK & In-Memory Engine | ✅ Complete |
 | **2A** | SQLite JSON Persistence & Querying | ✅ Complete |
-| **3** | Query Capabilities & Typed Querying | 🔜 Next |
+| **3** | Query Capabilities & Typed Querying | 🚧 In Progress |
 | **4** | Portability & Integration Hooks | 📋 Planned |
 | **5** | Multi-tenancy, Policies, Advanced Versioning | 📋 Planned |
 | **6** | Operational Hardening (concurrency, perf, migrations) | 📋 Planned |

--- a/specs/003-query-capabilities-typed/checklists/requirements.md
+++ b/specs/003-query-capabilities-typed/checklists/requirements.md
@@ -1,0 +1,35 @@
+# Specification Quality Checklist: Query Capabilities & Typed Query Helpers
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-05-15
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Validation pass completed on 2026-05-15.
+- The spec intentionally keeps execution on the existing portable query model and excludes public queryable provider exposure.

--- a/specs/003-query-capabilities-typed/contracts/query-capabilities.md
+++ b/specs/003-query-capabilities-typed/contracts/query-capabilities.md
@@ -72,7 +72,7 @@ FilterExpression hasTitle = TypedQuery.HasAspect<TitleAspect>();
 // Equality / contains / range
 FilterExpression titleEquals = TypedQuery.For<TitleAspect>()
     .Facet(x => x.Title)
-    .Equals("Gadget");
+    .EqualTo("Gadget");
 
 FilterExpression titleContains = TypedQuery.For<TitleAspect>()
     .Facet(x => x.Title)
@@ -90,7 +90,7 @@ FilterExpression namedPrice = TypedQuery.For<PriceAspect>(aspectKey: "PriceAspec
 
 ### Expected Behavior
 
-- Helpers return `FilterExpression` or `ResourceQuery` objects.
+- Helpers return `FilterExpression` objects that callers place into `ResourceQuery`.
 - Generated aspect keys and facet identifiers remain visible in the produced query records.
 - Helpers do not expose or return `IQueryable<Resource>`.
 - Invalid member selection fails clearly before execution.

--- a/specs/003-query-capabilities-typed/contracts/query-capabilities.md
+++ b/specs/003-query-capabilities-typed/contracts/query-capabilities.md
@@ -1,0 +1,96 @@
+# Contract: Query Capabilities & Typed Query Helpers
+
+This contract describes the public SDK surface expected by the feature. Names are provisional for planning, but behavior is normative.
+
+## Capability Discovery
+
+### Provider Capability Source
+
+Providers expose a query capability description for the active query provider.
+
+```csharp
+public interface IResourceQueryCapabilitiesProvider
+{
+    QueryCapabilityDescription Capabilities { get; }
+}
+```
+
+### Expected Behavior
+
+- The default in-memory provider exposes capabilities matching in-memory query execution.
+- The SQLite JSON provider exposes capabilities matching SQLite JSON query execution.
+- If no capability provider is registered for the active query provider, validation fails closed with a capabilities-not-declared failure.
+
+## Query Validation
+
+### Validator
+
+```csharp
+public interface IResourceQueryValidator
+{
+    QueryValidationResult Validate(ResourceQuery query);
+}
+```
+
+### Result Shape
+
+```csharp
+public sealed record QueryValidationResult(
+    bool IsValid,
+    IReadOnlyList<QueryValidationFailure> Failures);
+
+public sealed record QueryValidationFailure(
+    string Code,
+    string Message,
+    string? Path = null,
+    string? Feature = null);
+```
+
+### Expected Behavior
+
+- Supported queries return `IsValid == true` and no failures.
+- Unsupported queries return `IsValid == false` and all detectable failures.
+- Validation does not mutate the supplied query.
+- Execution still rejects unsupported shapes even when callers skip validation.
+
+## Typed Query Helpers
+
+Typed helpers construct existing portable query model records.
+
+### Convention
+
+- Default aspect key: typed aspect CLR type name.
+- Default facet identifier: selected member name.
+- Per-query overrides may replace aspect key and/or facet identifier.
+
+### Expected Helper Forms
+
+```csharp
+// Presence
+FilterExpression hasTitle = TypedQuery.HasAspect<TitleAspect>();
+
+// Equality / contains / range
+FilterExpression titleEquals = TypedQuery.For<TitleAspect>()
+    .Facet(x => x.Title)
+    .Equals("Gadget");
+
+FilterExpression titleContains = TypedQuery.For<TitleAspect>()
+    .Facet(x => x.Title)
+    .Contains("Gadget");
+
+FilterExpression priceRange = TypedQuery.For<PriceAspect>()
+    .Facet(x => x.Amount)
+    .Range(min: 10m, max: 100m);
+
+// Per-query override for named aspects or non-conventional facet identifiers
+FilterExpression namedPrice = TypedQuery.For<PriceAspect>(aspectKey: "PriceAspect:Sale")
+    .Facet(x => x.Amount, facetIdentifier: "Amount")
+    .Range(min: 10m, max: 100m);
+```
+
+### Expected Behavior
+
+- Helpers return `FilterExpression` or `ResourceQuery` objects.
+- Generated aspect keys and facet identifiers remain visible in the produced query records.
+- Helpers do not expose or return `IQueryable<Resource>`.
+- Invalid member selection fails clearly before execution.

--- a/specs/003-query-capabilities-typed/data-model.md
+++ b/specs/003-query-capabilities-typed/data-model.md
@@ -87,13 +87,12 @@ The portable query object produced by typed helper construction.
 
 - `AspectPresenceFilter` for typed aspect presence.
 - `FacetValueFilter` for typed facet comparisons.
-- `ResourceQuery` when helper composition creates a full query.
 
 ### Validation Rules
 
 - Output must be inspectable as existing query model records.
 - Output must not depend on provider-specific state.
-- Output must be accepted by the shared validator like any manually built query.
+- Output must be accepted by the shared validator when placed into a manually built query.
 
 ## State Transitions
 

--- a/specs/003-query-capabilities-typed/data-model.md
+++ b/specs/003-query-capabilities-typed/data-model.md
@@ -1,0 +1,116 @@
+# Data Model: Query Capabilities & Typed Query Helpers
+
+## Query Capability Description
+
+Describes what a query provider can execute.
+
+### Fields
+
+- `ProviderName`: Human-readable provider identifier.
+- `SupportedScopes`: Set of supported resource version scopes.
+- `RequiresActivationChannelForActiveScope`: Whether active scope requires a channel.
+- `SupportedFilterTypes`: Set of supported filter expression categories.
+- `SupportedLogicalOperators`: Set of supported logical operators.
+- `SupportedComparisonOperators`: Set of supported comparison operators by filter category.
+- `SupportedMetadataFields`: Set of metadata fields accepted for filtering and/or sorting.
+- `SupportsMetadataSorting`: Whether metadata sort expressions are supported.
+- `SupportsFacetSorting`: Whether facet sort expressions are supported.
+- `SupportsSkip`: Whether skip paging is supported.
+- `SupportsTake`: Whether take paging is supported.
+- `FacetRangeSupport`: Supported facet range value shapes, initially numeric scalar for SQLite JSON and numeric/date-like comparison for in-memory behavior.
+- `UnsupportedFeatures`: Human-readable exclusions for discoverability and documentation.
+
+### Validation Rules
+
+- Provider name must be non-empty.
+- Supported collections must be empty rather than null.
+- Missing provider capabilities are treated as validation failure by consumers.
+- SQLite JSON capabilities must declare facet sorting unsupported.
+- Capability declarations must match provider execution behavior.
+
+## Query Validation Result
+
+Represents the result of validating a resource query against a provider's capabilities.
+
+### Fields
+
+- `IsValid`: True when no validation failures exist.
+- `Failures`: Collection of query validation failures.
+
+### Validation Rules
+
+- `IsValid` must be equivalent to `Failures.Count == 0`.
+- Validation must not mutate the query being validated.
+- Validation should include all detectable failures where practical.
+
+## Query Validation Failure
+
+Represents one unsupported or invalid query shape.
+
+### Fields
+
+- `Code`: Stable failure code suitable for tests and documentation.
+- `Message`: Human-readable actionable explanation.
+- `Path`: Optional location within the query shape, such as `Filter.Operands[1]` or `Sorts[0]`.
+- `Feature`: The unsupported feature category, such as scope, metadata field, facet sort, comparison operator, value shape, or capabilities missing.
+
+### Validation Rules
+
+- Code and message must be non-empty.
+- Message must identify what is unsupported and, where possible, the active provider.
+- Path should be included when the failure can be tied to a specific predicate or sort.
+
+## Typed Query Mapping
+
+Represents how typed helper input maps to portable query identifiers.
+
+### Fields
+
+- `AspectType`: Typed aspect CLR type.
+- `MemberName`: Selected typed aspect member name.
+- `AspectKey`: Generated or overridden aspect key.
+- `FacetIdentifier`: Generated or overridden facet identifier.
+
+### Validation Rules
+
+- Default `AspectKey` is the typed aspect CLR type name.
+- Default `FacetIdentifier` is the selected member name.
+- Per-query overrides may replace aspect key and/or facet identifier.
+- Aspect key and facet identifier must be non-empty after convention and overrides are applied.
+- Member selection must identify a single readable member.
+
+## Typed Query Helper Output
+
+The portable query object produced by typed helper construction.
+
+### Forms
+
+- `AspectPresenceFilter` for typed aspect presence.
+- `FacetValueFilter` for typed facet comparisons.
+- `ResourceQuery` when helper composition creates a full query.
+
+### Validation Rules
+
+- Output must be inspectable as existing query model records.
+- Output must not depend on provider-specific state.
+- Output must be accepted by the shared validator like any manually built query.
+
+## State Transitions
+
+### Query Validation Result
+
+```text
+Unvalidated ResourceQuery
+  ├─ validate with declared capabilities and no failures → Valid result
+  ├─ validate with declared capabilities and failures → Invalid result with failures
+  └─ validate without declared capabilities → Invalid result with capabilities-not-declared failure
+```
+
+### Typed Helper Construction
+
+```text
+Typed aspect + member selector
+  ├─ apply default convention
+  ├─ apply per-query overrides, if any
+  └─ emit portable query/filter record
+```

--- a/specs/003-query-capabilities-typed/plan.md
+++ b/specs/003-query-capabilities-typed/plan.md
@@ -1,0 +1,126 @@
+# Implementation Plan: Query Capabilities & Typed Query Helpers
+
+**Branch**: `003-query-capabilities-typed` | **Date**: 2026-05-15 | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from `/specs/003-query-capabilities-typed/spec.md`
+
+**Note**: This template is filled in by the `/speckit.plan` command. See `.specify/templates/plan-template.md` for the execution workflow.
+
+## Summary
+
+Add explicit query capability discovery, structured query preflight validation, and typed query helper APIs that continue to produce the existing portable `ResourceQuery` AST. The design keeps provider differences visible, fails closed when provider capabilities are missing, and avoids introducing a public `IQueryable<Resource>` or provider-specific execution surface.
+
+## Technical Context
+
+**Language/Version**: C# latest, .NET 8.0 / 9.0 / 10.0 multi-targeting  
+**Primary Dependencies**: Existing `Microsoft.Extensions.DependencyInjection.Abstractions`, `Microsoft.Extensions.Logging.Abstractions`; SQLite provider keeps existing `Microsoft.Data.Sqlite`  
+**Storage**: N/A for core capability models; existing in-memory and SQLite JSON providers declare their current behavior  
+**Testing**: xUnit via `dotnet test Aster.sln`  
+**Target Platform**: .NET library usable from Generic Host / ASP.NET Core hosts  
+**Project Type**: SDK/library with provider package  
+**Performance Goals**: Query validation should run in-memory over a `ResourceQuery` AST and complete in negligible time for typical query trees; typed helper construction should allocate only the resulting query/filter records and small mapping metadata  
+**Constraints**: No public `IQueryable<Resource>` contract; no silent provider fallback; no new third-party dependencies expected; behavior must remain host-agnostic  
+**Scale/Scope**: Current scope covers existing in-memory and SQLite JSON providers, current query AST shapes, common scalar typed aspect members, and per-query typed mapping overrides
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+- **SDK-first/headless**: PASS — Adds library contracts and helpers only; no UI/CMS coupling.
+- **Immutable versioning**: PASS — Feature validates/builds queries only and does not alter resource mutation semantics.
+- **Channel activation**: PASS — Capabilities and validation must describe existing active/draft scope behavior without moving activation into payloads.
+- **Typed/queryable**: PASS — Preserves typed aspects and portable `ResourceQuery`; explicitly forbids public `IQueryable` leakage.
+- **Provider agnostic**: PASS — Core capability/validation contracts describe provider behavior without depending on database-specific frameworks.
+- **Simplicity first**: PASS — Use direct capability records, a shared validator, and typed helper construction; defer query planner/indexing.
+- **Modern C# idioms**: PASS — Records, collection expressions, and expression pattern matching may be used where they clarify immutable query data.
+- **Readability over cleverness**: PASS — Avoid expression-tree translation beyond member-name extraction for typed helper mapping.
+- **Explicitness over magic**: PASS — Conventions are documented, generated `ResourceQuery` is inspectable, and per-query overrides are explicit.
+- **Abstractions justified**: PASS — Capability provider and validator solve current multi-provider discoverability and preflight requirements.
+- **Optimize for deletion**: PASS — Capability declarations, validator, and typed helpers can be removed independently of provider execution.
+- **Composition over inheritance**: PASS — Prefer records/services/static helpers over inheritance hierarchies.
+- **Intentional dependencies**: PASS — No new third-party dependencies expected.
+- **Operational simplicity**: PASS — No new infrastructure; debugging improves through structured validation results.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/003-query-capabilities-typed/
+├── plan.md
+├── research.md
+├── data-model.md
+├── quickstart.md
+├── contracts/
+│   └── query-capabilities.md
+└── tasks.md
+```
+
+### Source Code (repository root)
+
+```text
+src/
+├── core/
+│   └── Aster.Core/
+│       ├── Abstractions/
+│       │   ├── IResourceQueryCapabilitiesProvider.cs
+│       │   └── IResourceQueryValidator.cs
+│       ├── Extensions/
+│       │   └── TypedQuery.cs
+│       ├── InMemory/
+│       │   └── InMemoryQueryCapabilitiesProvider.cs
+│       ├── Models/
+│       │   └── Querying/
+│       │       ├── QueryCapabilityDescription.cs
+│       │       ├── QueryValidationFailure.cs
+│       │       ├── QueryValidationResult.cs
+│       │       └── TypedQueryOptions.cs
+│       └── Services/
+│           └── ResourceQueryValidator.cs
+├── persistence/
+│   └── Aster.Persistence.SqliteJson/
+│       └── SqliteJsonQueryCapabilitiesProvider.cs
+test/
+└── Aster.Tests/
+    ├── Querying/
+    │   ├── ResourceQueryValidatorTests.cs
+    │   └── TypedQueryHelperTests.cs
+    ├── InMemory/
+    │   └── InMemoryQueryCapabilityTests.cs
+    └── SqliteJson/
+        └── SqliteJsonQueryCapabilityTests.cs
+```
+
+**Structure Decision**: Keep capability models, validator, and typed helper construction in `Aster.Core` because they are provider-agnostic public SDK surface. Provider-specific capability declarations live beside each provider. Tests are split between core query behavior and provider-specific declarations.
+
+## Phase 0: Research
+
+Completed in [research.md](research.md).
+
+## Phase 1: Design & Contracts
+
+Completed artifacts:
+
+- [data-model.md](data-model.md)
+- [contracts/query-capabilities.md](contracts/query-capabilities.md)
+- [quickstart.md](quickstart.md)
+
+## Post-Design Constitution Check
+
+- **SDK-first/headless**: PASS — Public surface remains SDK contracts and helpers.
+- **Immutable versioning**: PASS — No persistence mutation changes introduced.
+- **Channel activation**: PASS — Active/draft behavior remains represented as query scope capability.
+- **Typed/queryable**: PASS — Typed helpers output `ResourceQuery`; no public `IQueryable<Resource>`.
+- **Provider agnostic**: PASS — Providers describe capabilities; core validator consumes descriptions.
+- **Simplicity first**: PASS — Direct records and one validator are sufficient for the current provider set.
+- **Modern C# idioms**: PASS — Plan favors immutable records and concise typed helper APIs.
+- **Readability over cleverness**: PASS — Expression use is limited to member selection, not general expression translation.
+- **Explicitness over magic**: PASS — Convention, overrides, and produced query records remain inspectable.
+- **Abstractions justified**: PASS — New abstractions map directly to spec entities and multi-provider requirements.
+- **Optimize for deletion**: PASS — Typed helpers are additive over existing manual `ResourceQuery` construction.
+- **Composition over inheritance**: PASS — No inheritance hierarchy planned.
+- **Intentional dependencies**: PASS — No new third-party dependencies.
+- **Operational simplicity**: PASS — No deployment/runtime infrastructure changes.
+
+## Complexity Tracking
+
+No constitution violations identified.

--- a/specs/003-query-capabilities-typed/quickstart.md
+++ b/specs/003-query-capabilities-typed/quickstart.md
@@ -1,0 +1,98 @@
+# Quickstart: Query Capabilities & Typed Query Helpers
+
+## Discover Provider Capabilities
+
+```csharp
+var capabilities = serviceProvider
+    .GetRequiredService<IResourceQueryCapabilitiesProvider>()
+    .Capabilities;
+
+Console.WriteLine(capabilities.ProviderName);
+
+foreach (var unsupported in capabilities.UnsupportedFeatures)
+    Console.WriteLine(unsupported);
+```
+
+## Validate Before Execution
+
+```csharp
+var query = new ResourceQuery
+{
+    DefinitionId = "Product",
+    Filter = new FacetValueFilter(
+        "TitleAspect",
+        "Title",
+        "Gadget",
+        ComparisonOperator.Contains),
+    Sorts = [new SortExpression("Created", SortDirection.Descending)],
+    Take = 20,
+};
+
+var validator = serviceProvider.GetRequiredService<IResourceQueryValidator>();
+var validation = validator.Validate(query);
+
+if (!validation.IsValid)
+{
+    foreach (var failure in validation.Failures)
+        Console.WriteLine($"{failure.Code}: {failure.Message}");
+
+    return;
+}
+
+var queryService = serviceProvider.GetRequiredService<IResourceQueryService>();
+var results = await queryService.QueryAsync(query);
+```
+
+## Build Query Filters With Typed Helpers
+
+```csharp
+public sealed record TitleAspect(string Title);
+public sealed record PriceAspect(decimal Amount, string Currency);
+
+var filter = new LogicalExpression(LogicalOperator.And, [
+    TypedQuery.For<TitleAspect>()
+        .Facet(x => x.Title)
+        .Contains("Gadget"),
+    TypedQuery.For<PriceAspect>()
+        .Facet(x => x.Amount)
+        .Range(min: 10m, max: 100m),
+]);
+
+var query = new ResourceQuery
+{
+    DefinitionId = "Product",
+    Filter = filter,
+};
+```
+
+## Override Convention Per Query
+
+By default, typed helpers use:
+
+- aspect key = typed aspect CLR type name
+- facet identifier = selected member name
+
+Use an explicit override for named aspects or non-conventional identifiers:
+
+```csharp
+var salePriceFilter = TypedQuery.For<PriceAspect>(aspectKey: "PriceAspect:Sale")
+    .Facet(x => x.Amount, facetIdentifier: "Amount")
+    .Range(min: 10m, max: 100m);
+```
+
+The generated output is still a normal `FacetValueFilter` and can be inspected or validated before execution.
+
+## Provider Differences
+
+SQLite JSON supports metadata sorting but not facet sorting:
+
+```csharp
+var unsupportedForSqlite = new ResourceQuery
+{
+    Sorts = [new SortExpression("Title", AspectKey: "TitleAspect")],
+};
+
+var validation = validator.Validate(unsupportedForSqlite);
+// validation.IsValid == false
+// failure message identifies facet sorting as unsupported by SQLite JSON
+```

--- a/specs/003-query-capabilities-typed/research.md
+++ b/specs/003-query-capabilities-typed/research.md
@@ -1,0 +1,92 @@
+# Research: Query Capabilities & Typed Query Helpers
+
+## Decision 1: Represent provider support as explicit immutable capability descriptions
+
+**Decision**: Add a provider-owned query capability description that lists supported scopes, filters, logical operators, comparison operators, sort categories, paging support, supported metadata fields, and provider-specific exclusions.
+
+**Rationale**: The current in-memory and SQLite JSON providers intentionally support different query subsets. A single immutable description makes those differences discoverable without executing a query and keeps provider support explicit.
+
+**Alternatives considered**:
+
+- Infer capabilities by probing providers with sample queries. Rejected because it is brittle, slow, and operationally surprising.
+- Encode capabilities only in documentation. Rejected because validation and tests need machine-readable provider behavior.
+- Use a free-form dictionary. Rejected because it would be harder to validate, document, and evolve safely.
+
+## Decision 2: Fail closed when a provider has no declared capabilities
+
+**Decision**: Query validation returns an invalid structured result with a "capabilities not declared" failure when the active provider lacks a capability description.
+
+**Rationale**: Unknown provider support should not be treated as full support. Failing closed aligns with explicitness and avoids accidental reliance on fallback behavior.
+
+**Alternatives considered**:
+
+- Allow execution to decide. Rejected because it weakens preflight and makes validation unreliable.
+- Assume the smallest portable baseline. Rejected because the baseline is still provider-specific in practice.
+
+## Decision 3: Use a shared validator that returns structured results
+
+**Decision**: Add a shared query validator that consumes a `ResourceQuery` plus capabilities and returns a structured validation result containing `IsValid` and all detectable failures.
+
+**Rationale**: Validation is expected product behavior, not an exceptional control path. A structured result supports UI/reporting, tests, and multiple failures in one pass.
+
+**Alternatives considered**:
+
+- Throw for preflight validation. Rejected because preflight failures are expected user feedback.
+- Return only the first failure. Rejected because the spec requires all detectable failures where practical.
+- Duplicate validation inside each provider. Rejected because common query AST traversal would drift.
+
+## Decision 4: Execution still enforces unsupported shapes
+
+**Decision**: Provider query services continue to reject unsupported query shapes explicitly during execution. They may reuse the shared validator, but execution failures remain typed/actionable and no silent fallback is introduced.
+
+**Rationale**: Preflight validation is advisory and may be skipped. Execution must remain safe and consistent.
+
+**Alternatives considered**:
+
+- Make validation mandatory before execution. Rejected because it complicates existing call sites and duplicates work for known-supported queries.
+- Fall back to in-memory execution. Rejected because it violates provider semantics and can cause large hidden materialization.
+
+## Decision 5: Typed helpers compile to the existing `ResourceQuery` AST
+
+**Decision**: Typed query helpers create `ResourceQuery` or `FilterExpression` records and never introduce a public query provider abstraction.
+
+**Rationale**: This preserves provider portability and the existing query contract while reducing stringly-typed query construction.
+
+**Alternatives considered**:
+
+- Public `IQueryable<Resource>`. Rejected by constitution and prior design decision.
+- Provider-specific typed helper APIs. Rejected because they would fragment query construction.
+- Full expression-to-query translation. Rejected as too broad for this slice.
+
+## Decision 6: Typed helper mapping uses convention with per-query overrides
+
+**Decision**: By default, aspect key is the typed aspect CLR type name and facet identifier is the selected member name. Helpers also allow explicit per-query overrides for aspect key and/or facet identifier.
+
+**Rationale**: The convention matches existing examples and keeps common cases concise. Overrides support named aspects and non-conventional facet identifiers without global mapping infrastructure.
+
+**Alternatives considered**:
+
+- Convention only. Rejected because named aspects and legacy identifiers would be awkward.
+- Global registration-time mapping. Rejected as a larger mapping framework better deferred until schema metadata matures.
+- Require explicit aspect key and facet identifier every time. Rejected because it does not meaningfully reduce stringly-typed usage.
+
+## Decision 7: Expression handling is limited to member selection
+
+**Decision**: Typed helper APIs may accept member selectors only to identify a single typed aspect member. They do not parse arbitrary predicates or translate expression bodies.
+
+**Rationale**: Member selection is sufficient to get type/member names safely. General expression translation would resemble a LINQ provider and introduce complexity this feature explicitly avoids.
+
+**Alternatives considered**:
+
+- Parse arbitrary boolean expressions. Rejected as premature and close to an `IQueryable` provider.
+- Require member names as strings. Rejected because it fails the typed-helper ergonomics goal.
+
+## Decision 8: No new third-party dependencies
+
+**Decision**: Implement capability declarations, validation, and typed helper construction with platform capabilities and existing project dependencies.
+
+**Rationale**: The feature is mostly records, AST traversal, and member metadata. Additional packages would not materially reduce risk.
+
+**Alternatives considered**:
+
+- Add expression parsing or mapper libraries. Rejected because current requirements need only simple member selection and explicit overrides.

--- a/specs/003-query-capabilities-typed/spec.md
+++ b/specs/003-query-capabilities-typed/spec.md
@@ -1,0 +1,156 @@
+# Feature Specification: Query Capabilities & Typed Query Helpers
+
+**Feature Branch**: `003-query-capabilities-typed`  
+**Created**: 2026-05-15  
+**Status**: Draft  
+**Input**: User description: "Add provider query capability discovery, query preflight validation, and typed query helper APIs that compile into the existing ResourceQuery AST while keeping ResourceQuery as the public execution contract and avoiding IQueryable exposure."
+
+## Clarifications
+
+### Session 2026-05-15
+
+- Q: How should typed helpers determine aspect keys and facet identifiers? → A: Infer both aspect key and facet/member name from the aspect type by convention.
+- Q: How should validation behave when the active provider has no declared capabilities? → A: Validation fails with “capabilities not declared”.
+- Q: Should typed helper convention mapping allow overrides? → A: Convention by default, with explicit per-query override for aspect key and/or facet identifier.
+- Q: What shape should query preflight validation use? → A: Validation returns a structured result with IsValid and a collection of failures.
+- Q: What exact typed helper naming convention should be used? → A: Aspect key = typed aspect CLR type name; facet identifier = selected member name.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Discover Provider Query Support (Priority: P1)
+
+As an application developer choosing a query shape, I want to know what the active query provider supports before I rely on it, so that unsupported filters, sorts, scopes, and comparisons are visible during development instead of surprising users at runtime.
+
+**Why this priority**: Capability discovery is the safety rail for every later query improvement. Without it, typed helpers can produce query shapes that a provider cannot execute.
+
+**Independent Test**: Can be fully tested by resolving the active query provider capabilities and confirming they describe the supported scopes, filter types, comparison operators, sort targets, facet range behavior, and unsupported features for both the in-memory and SQLite JSON providers.
+
+**Acceptance Scenarios**:
+
+1. **Given** an application configured with the default in-memory provider, **When** a developer inspects query capabilities, **Then** the system reports supported version scopes, metadata filtering, aspect presence filtering, facet value filtering, logical expressions, metadata sorting, and facet sorting as provider-supported where applicable.
+2. **Given** an application configured with SQLite JSON persistence, **When** a developer inspects query capabilities, **Then** the system reports the SQLite-supported subset including metadata filters/sorts, version scopes, paging, aspect presence, scalar facet equality, string containment, and numeric facet ranges.
+3. **Given** a provider does not support a query behavior, **When** capabilities are inspected, **Then** the unsupported behavior is discoverable without executing a query.
+
+---
+
+### User Story 2 - Validate Queries Before Execution (Priority: P1)
+
+As an application developer, I want to validate a resource query against the active provider before execution, so that users get clear and actionable feedback when a query cannot be served by that provider.
+
+**Why this priority**: Preflight validation turns provider limitations into explicit product behavior and prevents typed helpers from obscuring unsupported query shapes.
+
+**Independent Test**: Can be fully tested by building supported and unsupported resource queries, validating them against each provider, and verifying success results for supported queries and actionable validation failures for unsupported queries.
+
+**Acceptance Scenarios**:
+
+1. **Given** a query that uses only provider-supported predicates, scopes, sorts, and paging, **When** the query is validated, **Then** validation succeeds without changing the query.
+2. **Given** a SQLite-backed application and a query that requests facet sorting, **When** the query is validated, **Then** validation fails with a message identifying facet sorting as unsupported by the active provider.
+3. **Given** a query with multiple unsupported features, **When** the query is validated, **Then** validation returns a structured result showing the query is invalid and listing all detectable unsupported features rather than stopping at the first one.
+4. **Given** a query fails preflight validation, **When** the same query is executed through the standard query service, **Then** execution fails with the same category of actionable feedback rather than silently falling back to another provider.
+
+---
+
+### User Story 3 - Build Queries With Typed Helpers (Priority: P2)
+
+As an application developer using typed aspects, I want typed query helpers that produce the existing portable query model, so that I can write less stringly-typed query construction while preserving the same provider-agnostic execution contract.
+
+**Why this priority**: Typed helpers improve developer experience after capability discovery and validation establish safe boundaries.
+
+**Independent Test**: Can be fully tested by constructing queries with typed helpers, verifying the produced portable query model, and executing the produced query against supported providers.
+
+**Acceptance Scenarios**:
+
+1. **Given** a typed aspect with scalar properties, **When** a developer builds an equality or contains predicate through typed helpers, **Then** the helper produces an equivalent portable query using convention-derived aspect key and facet identifier values.
+2. **Given** a typed numeric facet, **When** a developer builds a range predicate through typed helpers, **Then** the helper produces an equivalent portable range query.
+3. **Given** a typed helper needs to target a named aspect or non-conventional facet identifier, **When** the developer provides a per-query override, **Then** the produced portable query uses the override values and remains inspectable.
+4. **Given** a typed helper produces a query unsupported by the active provider, **When** the query is validated or executed, **Then** the same provider capability failure is reported.
+5. **Given** a developer uses typed helpers, **When** the query is executed, **Then** execution still uses the portable resource query contract rather than a public provider-specific query abstraction.
+
+---
+
+### User Story 4 - Preserve Provider-Agnostic Query Semantics (Priority: P3)
+
+As a library maintainer, I want typed helpers and capability checks to reinforce the existing query architecture, so that Aster remains portable across in-memory, SQLite, and future providers.
+
+**Why this priority**: This protects the architecture while the developer-facing query experience becomes more ergonomic.
+
+**Independent Test**: Can be fully tested by confirming typed helpers output the portable query model, no public queryable provider contract is introduced, and provider-specific differences remain declared through capabilities and validation.
+
+**Acceptance Scenarios**:
+
+1. **Given** a query built with typed helpers, **When** the application inspects it, **Then** it is represented as the same portable query model used by manually built queries.
+2. **Given** a provider-specific limitation, **When** developers inspect capabilities or validation failures, **Then** the limitation is described explicitly rather than hidden behind conventions.
+3. **Given** future providers are added, **When** they expose their capabilities, **Then** they can participate in validation without changing the portable query model.
+
+---
+
+### Edge Cases
+
+- A query contains nested logical expressions with both supported and unsupported child predicates.
+- A query requests a supported filter over an unsupported metadata or facet field shape.
+- A query requests an unsupported sort while all predicates are supported.
+- A typed helper references a property that cannot be mapped to a queryable facet.
+- A provider has no declared capabilities; validation fails closed with an actionable "capabilities not declared" result.
+- A provider supports a feature only for specific value shapes, such as numeric ranges but not date-like ranges.
+- A query validates successfully before provider configuration changes, then is executed after the active provider changes.
+
+### Constitution Alignment *(mandatory)*
+
+- **Simplicity**: The simplest acceptable behavior is capability discovery, validation, and typed helper output over the existing portable query model. A full query planner, public queryable provider, advanced indexing engine, and cross-provider optimization are intentionally out of scope.
+- **Explicitness**: Provider support must be visible through declared capabilities and validation results. Typed helper conventions must be documented and the generated portable query must remain inspectable rather than hidden behind provider-specific behavior.
+- **Dependencies**: None expected. The feature should use existing platform and project capabilities unless a later plan identifies a concrete need.
+- **Operational Impact**: No new service infrastructure should be required. Local development and debugging should remain straightforward: developers can inspect capabilities, validate queries, and see actionable failure messages.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The system MUST expose a query capability description for the active query provider.
+- **FR-002**: Query capabilities MUST describe supported version scopes, filter expression types, comparison operators, logical operators, sort categories, paging support, and provider-specific exclusions.
+- **FR-003**: Query capabilities MUST distinguish metadata sorting from facet sorting.
+- **FR-004**: Query capabilities MUST distinguish scalar facet equality, string containment, and numeric range support from unsupported range value shapes.
+- **FR-005**: The system MUST provide a way to validate a resource query against provider capabilities before execution.
+- **FR-006**: Query validation MUST return success for supported queries without mutating the query being validated.
+- **FR-007**: Query validation MUST return a structured result containing an overall validity indicator and a collection of validation failures.
+- **FR-008**: Query validation MUST return actionable failures for unsupported scopes, predicates, comparison operators, sorts, paging values, and value shapes.
+- **FR-009**: Query validation MUST report all detectable unsupported features in a query where practical.
+- **FR-010**: Query validation MUST fail closed with an actionable "capabilities not declared" result when the active provider has no capability description.
+- **FR-011**: Query execution MUST continue to reject unsupported provider query shapes explicitly; validation must not introduce silent in-memory fallback behavior.
+- **FR-012**: The in-memory provider MUST declare capabilities matching its currently supported query behavior.
+- **FR-013**: The SQLite JSON provider MUST declare capabilities matching its currently supported query behavior.
+- **FR-014**: Typed query helpers MUST produce the existing portable resource query model rather than a provider-specific execution contract.
+- **FR-015**: Typed query helpers MUST support typed construction of aspect presence, facet equality, string containment, and numeric range predicates for convention-mapped typed aspects.
+- **FR-016**: Typed query helpers MUST infer both the aspect key and facet identifier from the typed aspect and selected member by documented convention.
+- **FR-017**: Typed query helpers MUST allow explicit per-query overrides for aspect key and/or facet identifier.
+- **FR-018**: Typed query helpers MUST keep generated aspect keys and facet identifiers visible in the produced portable query so generated queries are inspectable and debuggable.
+- **FR-019**: Typed query helpers MUST surface a clear failure when a typed member cannot be mapped to a queryable facet by convention or explicit override.
+- **FR-020**: The public query execution contract MUST remain the portable resource query model; the feature MUST NOT expose a public queryable resource provider contract.
+- **FR-021**: Documentation MUST explain provider capability discovery, validation behavior, typed helper output, current provider differences, typed mapping conventions, and per-query override behavior.
+
+### Key Entities *(include if feature involves data)*
+
+- **Query Capability Description**: Declares what a provider can execute, including scopes, filters, comparisons, sorting, paging, and known exclusions.
+- **Query Validation Result**: Represents whether a query is supported by a provider, including an overall validity indicator and, when unsupported, a collection of actionable failures.
+- **Query Validation Failure**: A single unsupported query feature with a location or category, a human-readable explanation, and the affected query shape.
+- **Typed Query Mapping**: The convention-derived or per-query overridden association between a typed aspect type/member and the aspect key plus facet identifier used in the portable query model. By default, the aspect key is the typed aspect CLR type name and the facet identifier is the selected member name.
+- **Typed Query Helper Output**: A portable resource query or filter expression produced from typed aspect-oriented construction.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Developers can determine whether a provider supports a given query shape before execution in 100% of supported-provider configurations.
+- **SC-002**: Validation reports actionable structured failures for unsupported query shapes in at least 95% of detectable cases covered by the current query model.
+- **SC-003**: Typed helpers reduce manually typed aspect/facet identifier usage for common typed aspect queries by at least 50% in documented examples.
+- **SC-004**: All typed helper-generated queries can be inspected as the portable query model before execution.
+- **SC-005**: No public queryable resource provider contract is introduced.
+- **SC-006**: Existing manually built resource queries continue to behave as before unless validation is explicitly requested or execution already rejects an unsupported shape.
+
+## Assumptions
+
+- The active providers for this feature are the existing in-memory and SQLite JSON providers.
+- Capability discovery describes the provider's current behavior; it does not promise advanced indexing, full-text search, or future provider optimizations.
+- Typed helpers target common scalar typed aspect members first.
+- Typed helper naming conventions are part of the user-visible contract: by default, aspect key equals the typed aspect CLR type name and facet identifier equals the selected member name.
+- Provider capability validation is advisory before execution but execution must continue to enforce unsupported behavior.
+- Advanced indexing, provider capability negotiation across multiple simultaneous providers, and versioned definition schema upgrades are future work.

--- a/specs/003-query-capabilities-typed/tasks.md
+++ b/specs/003-query-capabilities-typed/tasks.md
@@ -1,0 +1,234 @@
+# Tasks: Query Capabilities & Typed Query Helpers
+
+**Input**: Design documents from `/specs/003-query-capabilities-typed/`
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/, quickstart.md
+
+**Tests**: Tests are required because this feature changes public SDK contracts, provider capability declarations, validation behavior, and typed query construction.
+
+**Organization**: Tasks are grouped by user story to enable independent implementation and testing.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (US1, US2, US3, US4)
+- Include exact file paths in descriptions
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Confirm project state and prepare shared query capability surface.
+
+- [X] T001 Confirm Constitution Check gates in `specs/003-query-capabilities-typed/plan.md` still pass before implementation begins
+- [X] T002 Create shared query capability model files in `src/core/Aster.Core/Models/Querying/`
+- [X] T003 Create shared query capability abstraction files in `src/core/Aster.Core/Abstractions/`
+- [X] T004 Create test file placeholders in `test/Aster.Tests/Querying/`
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Core data shapes and contracts that all user stories depend on.
+
+**CRITICAL**: No user story work can begin until this phase is complete.
+
+- [X] T005 Implement `QueryCapabilityDescription` in `src/core/Aster.Core/Models/Querying/QueryCapabilityDescription.cs`
+- [X] T006 [P] Implement `QueryValidationResult` in `src/core/Aster.Core/Models/Querying/QueryValidationResult.cs`
+- [X] T007 [P] Implement `QueryValidationFailure` in `src/core/Aster.Core/Models/Querying/QueryValidationFailure.cs`
+- [X] T008 [P] Implement query capability category/value-shape supporting enums or records in `src/core/Aster.Core/Models/Querying/QueryCapabilityDescription.cs`
+- [X] T009 Implement `IResourceQueryCapabilitiesProvider` in `src/core/Aster.Core/Abstractions/IResourceQueryCapabilitiesProvider.cs`
+- [X] T010 Implement `IResourceQueryValidator` in `src/core/Aster.Core/Abstractions/IResourceQueryValidator.cs`
+- [X] T011 Register the shared query validator in `src/core/Aster.Core/Extensions/AsterCoreServiceCollectionExtensions.cs`
+- [X] T012 Document why the new abstractions are required by current multi-provider validation needs in `specs/003-query-capabilities-typed/plan.md`
+
+**Checkpoint**: Shared capability and validation contracts compile and are ready for provider/story work.
+
+---
+
+## Phase 3: User Story 1 - Discover Provider Query Support (Priority: P1) MVP
+
+**Goal**: Developers can inspect the active provider's supported query scopes, filters, operators, sorts, paging, value shapes, and exclusions.
+
+**Independent Test**: Resolve the active capability provider for in-memory and SQLite JSON configurations and verify each reports its real supported query subset without executing a query.
+
+### Tests for User Story 1
+
+- [X] T013 [P] [US1] Add in-memory capability declaration tests in `test/Aster.Tests/InMemory/InMemoryQueryCapabilityTests.cs`
+- [X] T014 [P] [US1] Add SQLite JSON capability declaration tests in `test/Aster.Tests/SqliteJson/SqliteJsonQueryCapabilityTests.cs`
+- [X] T015 [P] [US1] Add capability discovery DI tests in `test/Aster.Tests/Querying/QueryCapabilityDiscoveryTests.cs`
+
+### Implementation for User Story 1
+
+- [X] T016 [US1] Implement `InMemoryQueryCapabilitiesProvider` in `src/core/Aster.Core/InMemory/InMemoryQueryCapabilitiesProvider.cs`
+- [X] T017 [US1] Register `InMemoryQueryCapabilitiesProvider` as `IResourceQueryCapabilitiesProvider` in `src/core/Aster.Core/Extensions/AsterCoreServiceCollectionExtensions.cs`
+- [X] T018 [US1] Implement `SqliteJsonQueryCapabilitiesProvider` in `src/persistence/Aster.Persistence.SqliteJson/SqliteJsonQueryCapabilitiesProvider.cs`
+- [X] T019 [US1] Register `SqliteJsonQueryCapabilitiesProvider` as `IResourceQueryCapabilitiesProvider` in `src/persistence/Aster.Persistence.SqliteJson/SqliteJsonAsterServiceCollectionExtensions.cs`
+- [X] T020 [US1] Ensure in-memory capabilities include facet sorting and date-like range behavior matching `src/core/Aster.Core/InMemory/InMemoryQueryService.cs`
+- [X] T021 [US1] Ensure SQLite JSON capabilities exclude facet sorting and date-like facet ranges matching `src/persistence/Aster.Persistence.SqliteJson/SqliteJsonQueryService.cs`
+
+**Checkpoint**: User Story 1 is independently functional and provider support is discoverable without query execution.
+
+---
+
+## Phase 4: User Story 2 - Validate Queries Before Execution (Priority: P1)
+
+**Goal**: Developers can preflight a `ResourceQuery` against the active provider and receive a structured result with all detectable failures.
+
+**Independent Test**: Validate supported and unsupported queries against declared in-memory and SQLite JSON capabilities, including missing capabilities, multiple failures, and unsupported facet sorting.
+
+### Tests for User Story 2
+
+- [X] T022 [P] [US2] Add validator success and non-mutating query tests in `test/Aster.Tests/Querying/ResourceQueryValidatorTests.cs`
+- [X] T023 [P] [US2] Add validator multiple-failure aggregation tests in `test/Aster.Tests/Querying/ResourceQueryValidatorTests.cs`
+- [X] T024 [P] [US2] Add missing-capabilities fail-closed tests in `test/Aster.Tests/Querying/ResourceQueryValidatorTests.cs`
+- [X] T025 [P] [US2] Add SQLite unsupported facet sorting validation tests in `test/Aster.Tests/SqliteJson/SqliteJsonQueryCapabilityTests.cs`
+- [X] T026 [P] [US2] Add validation/execution consistency tests for unsupported SQLite shapes in `test/Aster.Tests/SqliteJson/SqliteJsonQueryServiceTests.cs`
+- [X] T060 [P] [US2] Add validation-before-provider-change execution enforcement tests in `test/Aster.Tests/SqliteJson/SqliteJsonQueryServiceTests.cs`
+
+### Implementation for User Story 2
+
+- [X] T027 [US2] Implement `ResourceQueryValidator` in `src/core/Aster.Core/Services/ResourceQueryValidator.cs`
+- [X] T028 [US2] Implement validation traversal for `ResourceQuery.Scope`, `ActivationChannel`, `Skip`, and `Take` in `src/core/Aster.Core/Services/ResourceQueryValidator.cs`
+- [X] T029 [US2] Implement validation traversal for `MetadataFilter`, `AspectPresenceFilter`, `FacetValueFilter`, and `LogicalExpression` in `src/core/Aster.Core/Services/ResourceQueryValidator.cs`
+- [X] T030 [US2] Implement validation traversal for metadata and facet `SortExpression` values in `src/core/Aster.Core/Services/ResourceQueryValidator.cs`
+- [X] T031 [US2] Implement value-shape validation for `RangeValue` and numeric facet ranges in `src/core/Aster.Core/Services/ResourceQueryValidator.cs`
+- [X] T032 [US2] Implement stable failure codes, messages, paths, and feature categories in `src/core/Aster.Core/Services/ResourceQueryValidator.cs`
+- [X] T033 [US2] Ensure `SqliteJsonQueryService` unsupported execution behavior remains explicit in `src/persistence/Aster.Persistence.SqliteJson/SqliteJsonQueryService.cs`
+
+**Checkpoint**: User Story 2 is independently functional and unsupported query shapes can be preflighted before execution.
+
+---
+
+## Phase 5: User Story 3 - Build Queries With Typed Helpers (Priority: P2)
+
+**Goal**: Developers can construct common typed aspect queries without manually typing aspect keys and facet identifiers, while still producing inspectable `ResourceQuery`/`FilterExpression` records.
+
+**Independent Test**: Build typed filters for presence, equality, contains, numeric range, and per-query overrides; inspect the generated query model and validate/execute it with supported providers.
+
+### Tests for User Story 3
+
+- [X] T034 [P] [US3] Add typed helper convention mapping tests in `test/Aster.Tests/Querying/TypedQueryHelperTests.cs`
+- [X] T035 [P] [US3] Add typed helper per-query override tests in `test/Aster.Tests/Querying/TypedQueryHelperTests.cs`
+- [X] T036 [P] [US3] Add typed helper invalid member selection tests in `test/Aster.Tests/Querying/TypedQueryHelperTests.cs`
+- [X] T037 [P] [US3] Add typed helper validation integration tests in `test/Aster.Tests/Querying/TypedQueryHelperTests.cs`
+- [X] T061 [P] [US3] Add typed helper generated-query execution tests against a supported provider in `test/Aster.Tests/Querying/TypedQueryHelperTests.cs`
+
+### Implementation for User Story 3
+
+- [X] T038 [US3] Implement `TypedQueryOptions` in `src/core/Aster.Core/Models/Querying/TypedQueryOptions.cs`
+- [X] T039 [US3] Implement `TypedQuery` entry points in `src/core/Aster.Core/Extensions/TypedQuery.cs`
+- [X] T040 [US3] Implement typed aspect presence helper outputting `AspectPresenceFilter` in `src/core/Aster.Core/Extensions/TypedQuery.cs`
+- [X] T041 [US3] Implement typed facet member selection with CLR type-name/member-name convention in `src/core/Aster.Core/Extensions/TypedQuery.cs`
+- [X] T042 [US3] Implement typed equality, contains, and numeric range helper outputting `FacetValueFilter` in `src/core/Aster.Core/Extensions/TypedQuery.cs`
+- [X] T043 [US3] Implement per-query aspect key and facet identifier override support in `src/core/Aster.Core/Extensions/TypedQuery.cs`
+- [X] T044 [US3] Implement clear failure behavior for unsupported or non-member selector expressions in `src/core/Aster.Core/Extensions/TypedQuery.cs`
+
+**Checkpoint**: User Story 3 is independently functional and typed helpers produce inspectable portable query records.
+
+---
+
+## Phase 6: User Story 4 - Preserve Provider-Agnostic Query Semantics (Priority: P3)
+
+**Goal**: The new helper and capability APIs reinforce the portable query model and do not introduce a public provider-specific query contract.
+
+**Independent Test**: Confirm helper output is `ResourceQuery`/`FilterExpression`, no public `IQueryable<Resource>` provider surface exists, and provider-specific differences are expressed through capabilities and validation.
+
+### Tests for User Story 4
+
+- [X] T045 [P] [US4] Add no public `IQueryable<Resource>` API regression tests in `test/Aster.Tests/Querying/TypedQueryHelperTests.cs`
+- [X] T046 [P] [US4] Add provider difference tests comparing in-memory and SQLite capabilities in `test/Aster.Tests/Querying/QueryCapabilityDiscoveryTests.cs`
+- [X] T047 [P] [US4] Add manual query compatibility tests in `test/Aster.Tests/Querying/ResourceQueryValidatorTests.cs`
+
+### Implementation for User Story 4
+
+- [X] T048 [US4] Review public query APIs for absence of `IQueryable<Resource>` exposure in `src/core/Aster.Core/Abstractions/`
+- [X] T049 [US4] Ensure manually built `ResourceQuery` usage remains unchanged in `src/core/Aster.Core/Models/Querying/ResourceQuery.cs`
+- [X] T050 [US4] Ensure provider-specific differences are represented only through capabilities and validation in `src/core/Aster.Core/Models/Querying/QueryCapabilityDescription.cs`
+
+**Checkpoint**: User Story 4 is independently functional and the provider-agnostic query architecture is preserved.
+
+---
+
+## Phase 7: Polish & Cross-Cutting Concerns
+
+**Purpose**: Documentation, cleanup, and final verification across all stories.
+
+- [X] T051 [P] Update querying documentation with capabilities, validation, and typed helper examples in `wiki/Querying.md`
+- [X] T052 [P] Update DI documentation with capability provider and validator registrations in `wiki/DI-Registration.md`
+- [X] T053 [P] Update root README query examples with typed helper and validation snippets in `README.md`
+- [X] T054 [P] Update `src/core/Aster.Core/README.md` with typed helper and validation quick examples
+- [X] T055 [P] Update SQLite provider README with declared capability subset in `src/persistence/Aster.Persistence.SqliteJson/README.md`
+- [X] T056 Run quickstart validation from `specs/003-query-capabilities-typed/quickstart.md`
+- [X] T057 Re-run Constitution Check and remove unnecessary abstractions/dependencies before final verification in `specs/003-query-capabilities-typed/plan.md`
+- [X] T058 Run `dotnet test Aster.sln`
+- [X] T059 Review capability declarations against provider execution behavior in `src/core/Aster.Core/InMemory/InMemoryQueryService.cs` and `src/persistence/Aster.Persistence.SqliteJson/SqliteJsonQueryService.cs`
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies.
+- **Foundational (Phase 2)**: Depends on Setup completion and blocks all user stories.
+- **US1 Discover Provider Query Support (Phase 3)**: Depends on Foundational and is the MVP.
+- **US2 Validate Queries Before Execution (Phase 4)**: Depends on Foundational and capability declarations from US1.
+- **US3 Build Queries With Typed Helpers (Phase 5)**: Depends on Foundational; validation integration depends on US2.
+- **US4 Preserve Provider-Agnostic Query Semantics (Phase 6)**: Depends on US1-US3 surfaces being present.
+- **Polish (Phase 7)**: Depends on desired user stories being complete.
+
+### User Story Dependencies
+
+- **User Story 1 (P1)**: Can start after Foundational; no dependencies on other stories.
+- **User Story 2 (P1)**: Requires capability declarations from US1 to validate real providers.
+- **User Story 3 (P2)**: Can start after Foundational for helper output; validation integration requires US2.
+- **User Story 4 (P3)**: Requires public surfaces from US1-US3 to verify architecture preservation.
+
+### Parallel Opportunities
+
+- T006-T008 can run in parallel after T005 starts.
+- T013-T015 can run in parallel.
+- T016 and T018 can run in parallel after foundational contracts exist.
+- T022-T026 and T060 can run in parallel.
+- T034-T037 and T061 can run in parallel.
+- T045-T047 can run in parallel.
+- T051-T055 can run in parallel after implementation stabilizes.
+
+## Parallel Example: User Story 1
+
+```text
+Task: "Add in-memory capability declaration tests in test/Aster.Tests/InMemory/InMemoryQueryCapabilityTests.cs"
+Task: "Add SQLite JSON capability declaration tests in test/Aster.Tests/SqliteJson/SqliteJsonQueryCapabilityTests.cs"
+Task: "Add capability discovery DI tests in test/Aster.Tests/Querying/QueryCapabilityDiscoveryTests.cs"
+```
+
+## Parallel Example: User Story 3
+
+```text
+Task: "Add typed helper convention mapping tests in test/Aster.Tests/Querying/TypedQueryHelperTests.cs"
+Task: "Add typed helper per-query override tests in test/Aster.Tests/Querying/TypedQueryHelperTests.cs"
+Task: "Add typed helper invalid member selection tests in test/Aster.Tests/Querying/TypedQueryHelperTests.cs"
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 Only)
+
+1. Complete Setup and Foundational phases.
+2. Complete US1 capability declarations and DI registration.
+3. Run provider capability tests.
+4. Validate that developers can inspect in-memory and SQLite JSON support before executing a query.
+
+### Incremental Delivery
+
+1. US1: Provider capabilities are discoverable.
+2. US2: Queries can be validated against capabilities.
+3. US3: Typed helpers produce inspectable portable query records.
+4. US4: Architecture guardrails and compatibility are verified.
+5. Polish: Documentation and quickstart validation.
+
+### Quality Gates
+
+- Each story must pass its story-specific tests before moving to the next dependent story.
+- `dotnet test Aster.sln` must pass before implementation is considered complete.
+- No task should introduce a public `IQueryable<Resource>` execution surface.

--- a/src/core/Aster.Core/Abstractions/IResourceQueryCapabilitiesProvider.cs
+++ b/src/core/Aster.Core/Abstractions/IResourceQueryCapabilitiesProvider.cs
@@ -1,0 +1,14 @@
+using Aster.Core.Models.Querying;
+
+namespace Aster.Core.Abstractions;
+
+/// <summary>
+/// Exposes the query capabilities of an active resource query provider.
+/// </summary>
+public interface IResourceQueryCapabilitiesProvider
+{
+    /// <summary>
+    /// Gets the provider's supported query surface.
+    /// </summary>
+    QueryCapabilityDescription Capabilities { get; }
+}

--- a/src/core/Aster.Core/Abstractions/IResourceQueryValidator.cs
+++ b/src/core/Aster.Core/Abstractions/IResourceQueryValidator.cs
@@ -1,0 +1,16 @@
+using Aster.Core.Models.Querying;
+
+namespace Aster.Core.Abstractions;
+
+/// <summary>
+/// Validates resource queries against the active provider's declared capabilities.
+/// </summary>
+public interface IResourceQueryValidator
+{
+    /// <summary>
+    /// Validates a query without mutating it.
+    /// </summary>
+    /// <param name="query">The resource query to validate.</param>
+    /// <returns>A structured validation result.</returns>
+    QueryValidationResult Validate(ResourceQuery query);
+}

--- a/src/core/Aster.Core/Extensions/AsterCoreServiceCollectionExtensions.cs
+++ b/src/core/Aster.Core/Extensions/AsterCoreServiceCollectionExtensions.cs
@@ -48,6 +48,9 @@ public static class AsterCoreServiceCollectionExtensions
         // Query service
         services.AddSingleton<InMemoryQueryService>();
         services.AddSingleton<IResourceQueryService>(sp => sp.GetRequiredService<InMemoryQueryService>());
+        services.AddSingleton<InMemoryQueryCapabilitiesProvider>();
+        services.AddSingleton<IResourceQueryCapabilitiesProvider>(sp => sp.GetRequiredService<InMemoryQueryCapabilitiesProvider>());
+        services.AddSingleton<IResourceQueryValidator, ResourceQueryValidator>();
 
         // Typed binders
         services.AddSingleton<SystemTextJsonAspectBinder>();

--- a/src/core/Aster.Core/Extensions/TypedQuery.cs
+++ b/src/core/Aster.Core/Extensions/TypedQuery.cs
@@ -1,4 +1,5 @@
 using System.Linq.Expressions;
+using System.Reflection;
 using Aster.Core.Models.Querying;
 
 namespace Aster.Core.Extensions;
@@ -49,9 +50,14 @@ public static class TypedQuery
             ? unary.Operand
             : selector.Body;
 
-        return expression is MemberExpression { Member.Name.Length: > 0 } member
-            ? member.Member.Name
-            : throw new ArgumentException("Typed query selectors must identify a single readable member.", nameof(selector));
+        if (expression is not MemberExpression { Member.Name.Length: > 0 } member
+            || !ReferenceEquals(member.Expression, selector.Parameters[0])
+            || !IsReadableMember(member.Member))
+        {
+            throw new ArgumentException("Typed query selectors must identify a single readable member on the typed aspect.", nameof(selector));
+        }
+
+        return member.Member.Name;
     }
 
     internal static string ResolveFacetIdentifier<TAspect, TValue>(
@@ -59,15 +65,23 @@ public static class TypedQuery
         string? facetIdentifier,
         string? defaultFacetIdentifier)
     {
+        var memberName = ResolveMemberName(selector);
         var resolved = NonEmpty(facetIdentifier)
             ?? NonEmpty(defaultFacetIdentifier)
-            ?? ResolveMemberName(selector);
+            ?? memberName;
 
         return resolved;
     }
 
     private static string? NonEmpty(string? value) =>
         string.IsNullOrWhiteSpace(value) ? null : value;
+
+    private static bool IsReadableMember(MemberInfo member) => member switch
+    {
+        PropertyInfo { CanRead: true } => true,
+        FieldInfo => true,
+        _ => false,
+    };
 }
 
 /// <summary>
@@ -153,8 +167,8 @@ public sealed class TypedFacetQuery<TValue>
     /// <param name="includeMax">Whether the upper bound is inclusive.</param>
     /// <returns>A portable facet value filter.</returns>
     public FilterExpression Range(
-        TValue? min = default,
-        TValue? max = default,
+        object? min = null,
+        object? max = null,
         bool includeMin = true,
         bool includeMax = true) =>
         new FacetValueFilter(

--- a/src/core/Aster.Core/Extensions/TypedQuery.cs
+++ b/src/core/Aster.Core/Extensions/TypedQuery.cs
@@ -135,6 +135,12 @@ public sealed class TypedFacetQuery<TValue>
     /// </summary>
     /// <param name="value">The substring to match.</param>
     /// <returns>A portable facet value filter.</returns>
+    /// <remarks>
+    /// Containment is a string-oriented predicate. Using this on non-string typed facets produces
+    /// a syntactically valid AST node, but execution depends on how the active provider serializes
+    /// the facet value. Prefer <see cref="EqualTo"/> or <see cref="Range"/> for strongly typed
+    /// non-string comparisons.
+    /// </remarks>
     public FilterExpression Contains(string value) =>
         new FacetValueFilter(aspectKey, facetIdentifier, value, ComparisonOperator.Contains);
 

--- a/src/core/Aster.Core/Extensions/TypedQuery.cs
+++ b/src/core/Aster.Core/Extensions/TypedQuery.cs
@@ -1,0 +1,159 @@
+using System.Linq.Expressions;
+using Aster.Core.Models.Querying;
+
+namespace Aster.Core.Extensions;
+
+/// <summary>
+/// Factory methods for building portable query filters from typed aspect members.
+/// </summary>
+public static class TypedQuery
+{
+    /// <summary>
+    /// Creates an aspect presence filter using the aspect type name as the aspect key.
+    /// </summary>
+    /// <typeparam name="TAspect">The typed aspect.</typeparam>
+    /// <param name="aspectKey">Optional aspect key override.</param>
+    /// <returns>An aspect presence filter.</returns>
+    public static FilterExpression HasAspect<TAspect>(string? aspectKey = null) =>
+        new AspectPresenceFilter(ResolveAspectKey<TAspect>(aspectKey));
+
+    /// <summary>
+    /// Starts a typed query helper chain for an aspect.
+    /// </summary>
+    /// <typeparam name="TAspect">The typed aspect.</typeparam>
+    /// <param name="aspectKey">Optional aspect key override.</param>
+    /// <returns>A typed aspect query builder.</returns>
+    public static TypedAspectQuery<TAspect> For<TAspect>(string? aspectKey = null) =>
+        new(ResolveAspectKey<TAspect>(aspectKey));
+
+    /// <summary>
+    /// Starts a typed query helper chain for an aspect.
+    /// </summary>
+    /// <typeparam name="TAspect">The typed aspect.</typeparam>
+    /// <param name="options">Per-query mapping overrides.</param>
+    /// <returns>A typed aspect query builder.</returns>
+    public static TypedAspectQuery<TAspect> For<TAspect>(TypedQueryOptions options)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+        return new(ResolveAspectKey<TAspect>(options.AspectKey), options.FacetIdentifier);
+    }
+
+    internal static string ResolveAspectKey<TAspect>(string? aspectKey) =>
+        NonEmpty(aspectKey) ?? typeof(TAspect).Name;
+
+    internal static string ResolveMemberName<TAspect, TValue>(Expression<Func<TAspect, TValue>> selector)
+    {
+        ArgumentNullException.ThrowIfNull(selector);
+
+        var expression = selector.Body is UnaryExpression { NodeType: ExpressionType.Convert or ExpressionType.ConvertChecked } unary
+            ? unary.Operand
+            : selector.Body;
+
+        return expression is MemberExpression { Member.Name.Length: > 0 } member
+            ? member.Member.Name
+            : throw new ArgumentException("Typed query selectors must identify a single readable member.", nameof(selector));
+    }
+
+    internal static string ResolveFacetIdentifier<TAspect, TValue>(
+        Expression<Func<TAspect, TValue>> selector,
+        string? facetIdentifier,
+        string? defaultFacetIdentifier)
+    {
+        var resolved = NonEmpty(facetIdentifier)
+            ?? NonEmpty(defaultFacetIdentifier)
+            ?? ResolveMemberName(selector);
+
+        return resolved;
+    }
+
+    private static string? NonEmpty(string? value) =>
+        string.IsNullOrWhiteSpace(value) ? null : value;
+}
+
+/// <summary>
+/// Builder for typed filters targeting a specific aspect.
+/// </summary>
+/// <typeparam name="TAspect">The typed aspect.</typeparam>
+public sealed class TypedAspectQuery<TAspect>
+{
+    private readonly string aspectKey;
+    private readonly string? defaultFacetIdentifier;
+
+    internal TypedAspectQuery(string aspectKey, string? defaultFacetIdentifier = null)
+    {
+        this.aspectKey = aspectKey;
+        this.defaultFacetIdentifier = defaultFacetIdentifier;
+    }
+
+    /// <summary>
+    /// Creates an aspect presence filter for the current aspect.
+    /// </summary>
+    /// <returns>An aspect presence filter.</returns>
+    public FilterExpression HasAspect() => new AspectPresenceFilter(aspectKey);
+
+    /// <summary>
+    /// Selects a facet member for typed comparison helpers.
+    /// </summary>
+    /// <typeparam name="TValue">The selected member value type.</typeparam>
+    /// <param name="selector">Expression selecting a single readable member.</param>
+    /// <param name="facetIdentifier">Optional facet identifier override.</param>
+    /// <returns>A typed facet query builder.</returns>
+    public TypedFacetQuery<TValue> Facet<TValue>(
+        Expression<Func<TAspect, TValue>> selector,
+        string? facetIdentifier = null)
+    {
+        var resolvedFacetIdentifier = TypedQuery.ResolveFacetIdentifier(selector, facetIdentifier, defaultFacetIdentifier);
+        return new(aspectKey, resolvedFacetIdentifier);
+    }
+}
+
+/// <summary>
+/// Builder for typed filters targeting a specific facet.
+/// </summary>
+/// <typeparam name="TValue">The facet value type.</typeparam>
+public sealed class TypedFacetQuery<TValue>
+{
+    private readonly string aspectKey;
+    private readonly string facetIdentifier;
+
+    internal TypedFacetQuery(string aspectKey, string facetIdentifier)
+    {
+        this.aspectKey = aspectKey;
+        this.facetIdentifier = facetIdentifier;
+    }
+
+    /// <summary>
+    /// Creates an equality facet filter.
+    /// </summary>
+    /// <param name="value">The expected value.</param>
+    /// <returns>A portable facet value filter.</returns>
+    public FilterExpression EqualTo(TValue value) =>
+        new FacetValueFilter(aspectKey, facetIdentifier, value!, ComparisonOperator.Equals);
+
+    /// <summary>
+    /// Creates a string containment facet filter.
+    /// </summary>
+    /// <param name="value">The substring to match.</param>
+    /// <returns>A portable facet value filter.</returns>
+    public FilterExpression Contains(string value) =>
+        new FacetValueFilter(aspectKey, facetIdentifier, value, ComparisonOperator.Contains);
+
+    /// <summary>
+    /// Creates a range facet filter.
+    /// </summary>
+    /// <param name="min">The lower bound.</param>
+    /// <param name="max">The upper bound.</param>
+    /// <param name="includeMin">Whether the lower bound is inclusive.</param>
+    /// <param name="includeMax">Whether the upper bound is inclusive.</param>
+    /// <returns>A portable facet value filter.</returns>
+    public FilterExpression Range(
+        TValue? min = default,
+        TValue? max = default,
+        bool includeMin = true,
+        bool includeMax = true) =>
+        new FacetValueFilter(
+            aspectKey,
+            facetIdentifier,
+            new RangeValue(min, max, includeMin, includeMax),
+            ComparisonOperator.Range);
+}

--- a/src/core/Aster.Core/InMemory/InMemoryQueryCapabilitiesProvider.cs
+++ b/src/core/Aster.Core/InMemory/InMemoryQueryCapabilitiesProvider.cs
@@ -38,7 +38,6 @@ public sealed class InMemoryQueryCapabilitiesProvider : IResourceQueryCapabiliti
             {
                 ComparisonOperator.Equals,
                 ComparisonOperator.Contains,
-                ComparisonOperator.Range,
             },
             [QueryFilterType.FacetValue] = new HashSet<ComparisonOperator>
             {
@@ -48,6 +47,15 @@ public sealed class InMemoryQueryCapabilitiesProvider : IResourceQueryCapabiliti
             },
         },
         SupportedMetadataFields: new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+        {
+            "ResourceId",
+            "Id",
+            "DefinitionId",
+            "Owner",
+            "Version",
+            "Created",
+        },
+        MetadataContainsFields: new HashSet<string>(StringComparer.OrdinalIgnoreCase)
         {
             "ResourceId",
             "Id",

--- a/src/core/Aster.Core/InMemory/InMemoryQueryCapabilitiesProvider.cs
+++ b/src/core/Aster.Core/InMemory/InMemoryQueryCapabilitiesProvider.cs
@@ -1,0 +1,69 @@
+using Aster.Core.Abstractions;
+using Aster.Core.Models.Querying;
+
+namespace Aster.Core.InMemory;
+
+/// <summary>
+/// Query capability declaration for the in-memory query provider.
+/// </summary>
+public sealed class InMemoryQueryCapabilitiesProvider : IResourceQueryCapabilitiesProvider
+{
+    /// <inheritdoc />
+    public QueryCapabilityDescription Capabilities { get; } = new(
+        ProviderName: "In-memory",
+        SupportedScopes: new HashSet<ResourceVersionScope>
+        {
+            ResourceVersionScope.Latest,
+            ResourceVersionScope.AllVersions,
+            ResourceVersionScope.Active,
+            ResourceVersionScope.Draft,
+        },
+        RequiresActivationChannelForActiveScope: true,
+        SupportedFilterTypes: new HashSet<QueryFilterType>
+        {
+            QueryFilterType.Metadata,
+            QueryFilterType.AspectPresence,
+            QueryFilterType.FacetValue,
+            QueryFilterType.Logical,
+        },
+        SupportedLogicalOperators: new HashSet<LogicalOperator>
+        {
+            LogicalOperator.And,
+            LogicalOperator.Or,
+            LogicalOperator.Not,
+        },
+        SupportedComparisonOperators: new Dictionary<QueryFilterType, IReadOnlySet<ComparisonOperator>>
+        {
+            [QueryFilterType.Metadata] = new HashSet<ComparisonOperator>
+            {
+                ComparisonOperator.Equals,
+                ComparisonOperator.Contains,
+                ComparisonOperator.Range,
+            },
+            [QueryFilterType.FacetValue] = new HashSet<ComparisonOperator>
+            {
+                ComparisonOperator.Equals,
+                ComparisonOperator.Contains,
+                ComparisonOperator.Range,
+            },
+        },
+        SupportedMetadataFields: new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+        {
+            "ResourceId",
+            "Id",
+            "DefinitionId",
+            "Owner",
+            "Version",
+            "Created",
+        },
+        SupportsMetadataSorting: true,
+        SupportsFacetSorting: true,
+        SupportsSkip: true,
+        SupportsTake: true,
+        FacetRangeSupport: new HashSet<QueryValueShape>
+        {
+            QueryValueShape.Numeric,
+            QueryValueShape.DateTime,
+        },
+        UnsupportedFeatures: []);
+}

--- a/src/core/Aster.Core/Models/Querying/QueryCapabilityDescription.cs
+++ b/src/core/Aster.Core/Models/Querying/QueryCapabilityDescription.cs
@@ -1,0 +1,76 @@
+namespace Aster.Core.Models.Querying;
+
+/// <summary>
+/// Describes the query shapes a resource query provider can execute.
+/// </summary>
+/// <param name="ProviderName">Human-readable provider name.</param>
+/// <param name="SupportedScopes">Resource version scopes supported by the provider.</param>
+/// <param name="RequiresActivationChannelForActiveScope">Whether active scope requires an activation channel.</param>
+/// <param name="SupportedFilterTypes">Filter expression categories supported by the provider.</param>
+/// <param name="SupportedLogicalOperators">Logical operators supported by the provider.</param>
+/// <param name="SupportedComparisonOperators">Comparison operators supported for each filter category.</param>
+/// <param name="SupportedMetadataFields">Metadata fields supported for filtering and sorting.</param>
+/// <param name="SupportsMetadataSorting">Whether metadata sort expressions are supported.</param>
+/// <param name="SupportsFacetSorting">Whether facet sort expressions are supported.</param>
+/// <param name="SupportsSkip">Whether skip paging is supported.</param>
+/// <param name="SupportsTake">Whether take paging is supported.</param>
+/// <param name="FacetRangeSupport">Facet range value shapes supported by the provider.</param>
+/// <param name="UnsupportedFeatures">Known unsupported features, for discovery and documentation.</param>
+public sealed record QueryCapabilityDescription(
+    string ProviderName,
+    IReadOnlySet<ResourceVersionScope> SupportedScopes,
+    bool RequiresActivationChannelForActiveScope,
+    IReadOnlySet<QueryFilterType> SupportedFilterTypes,
+    IReadOnlySet<LogicalOperator> SupportedLogicalOperators,
+    IReadOnlyDictionary<QueryFilterType, IReadOnlySet<ComparisonOperator>> SupportedComparisonOperators,
+    IReadOnlySet<string> SupportedMetadataFields,
+    bool SupportsMetadataSorting,
+    bool SupportsFacetSorting,
+    bool SupportsSkip,
+    bool SupportsTake,
+    IReadOnlySet<QueryValueShape> FacetRangeSupport,
+    IReadOnlyList<string> UnsupportedFeatures)
+{
+    /// <summary>
+    /// Returns whether the provider supports the supplied comparison operator for the filter type.
+    /// </summary>
+    /// <param name="filterType">The filter category.</param>
+    /// <param name="comparisonOperator">The comparison operator.</param>
+    /// <returns><see langword="true"/> when the operator is supported for the filter category.</returns>
+    public bool SupportsComparison(QueryFilterType filterType, ComparisonOperator comparisonOperator) =>
+        SupportedComparisonOperators.TryGetValue(filterType, out var operators)
+        && operators.Contains(comparisonOperator);
+}
+
+/// <summary>
+/// Query filter expression categories used by provider capability descriptions.
+/// </summary>
+public enum QueryFilterType
+{
+    /// <summary>Metadata field filter.</summary>
+    Metadata,
+
+    /// <summary>Aspect presence filter.</summary>
+    AspectPresence,
+
+    /// <summary>Facet value filter.</summary>
+    FacetValue,
+
+    /// <summary>Logical filter expression.</summary>
+    Logical,
+}
+
+/// <summary>
+/// Value shapes relevant to query provider capability checks.
+/// </summary>
+public enum QueryValueShape
+{
+    /// <summary>String or string-like scalar values.</summary>
+    String,
+
+    /// <summary>Numeric scalar values.</summary>
+    Numeric,
+
+    /// <summary>Date or date-like scalar values.</summary>
+    DateTime,
+}

--- a/src/core/Aster.Core/Models/Querying/QueryCapabilityDescription.cs
+++ b/src/core/Aster.Core/Models/Querying/QueryCapabilityDescription.cs
@@ -10,6 +10,7 @@ namespace Aster.Core.Models.Querying;
 /// <param name="SupportedLogicalOperators">Logical operators supported by the provider.</param>
 /// <param name="SupportedComparisonOperators">Comparison operators supported for each filter category.</param>
 /// <param name="SupportedMetadataFields">Metadata fields supported for filtering and sorting.</param>
+/// <param name="MetadataContainsFields">Metadata fields that support containment filtering.</param>
 /// <param name="SupportsMetadataSorting">Whether metadata sort expressions are supported.</param>
 /// <param name="SupportsFacetSorting">Whether facet sort expressions are supported.</param>
 /// <param name="SupportsSkip">Whether skip paging is supported.</param>
@@ -24,6 +25,7 @@ public sealed record QueryCapabilityDescription(
     IReadOnlySet<LogicalOperator> SupportedLogicalOperators,
     IReadOnlyDictionary<QueryFilterType, IReadOnlySet<ComparisonOperator>> SupportedComparisonOperators,
     IReadOnlySet<string> SupportedMetadataFields,
+    IReadOnlySet<string> MetadataContainsFields,
     bool SupportsMetadataSorting,
     bool SupportsFacetSorting,
     bool SupportsSkip,

--- a/src/core/Aster.Core/Models/Querying/QueryValidationFailure.cs
+++ b/src/core/Aster.Core/Models/Querying/QueryValidationFailure.cs
@@ -1,0 +1,14 @@
+namespace Aster.Core.Models.Querying;
+
+/// <summary>
+/// Represents a single unsupported or invalid query feature found during validation.
+/// </summary>
+/// <param name="Code">Stable failure code suitable for tests and documentation.</param>
+/// <param name="Message">Human-readable actionable explanation.</param>
+/// <param name="Path">Optional location within the query shape.</param>
+/// <param name="Feature">Optional unsupported feature category.</param>
+public sealed record QueryValidationFailure(
+    string Code,
+    string Message,
+    string? Path = null,
+    string? Feature = null);

--- a/src/core/Aster.Core/Models/Querying/QueryValidationResult.cs
+++ b/src/core/Aster.Core/Models/Querying/QueryValidationResult.cs
@@ -1,0 +1,18 @@
+namespace Aster.Core.Models.Querying;
+
+/// <summary>
+/// Represents the result of validating a <see cref="ResourceQuery"/> against provider capabilities.
+/// </summary>
+/// <param name="Failures">Validation failures found in the query.</param>
+public sealed record QueryValidationResult(IReadOnlyList<QueryValidationFailure> Failures)
+{
+    /// <summary>
+    /// Gets a value indicating whether the query is valid for the provider.
+    /// </summary>
+    public bool IsValid => Failures.Count == 0;
+
+    /// <summary>
+    /// Creates a successful validation result.
+    /// </summary>
+    public static QueryValidationResult Success { get; } = new([]);
+}

--- a/src/core/Aster.Core/Models/Querying/TypedQueryOptions.cs
+++ b/src/core/Aster.Core/Models/Querying/TypedQueryOptions.cs
@@ -1,0 +1,8 @@
+namespace Aster.Core.Models.Querying;
+
+/// <summary>
+/// Overrides convention-based typed query mapping for a single helper chain.
+/// </summary>
+/// <param name="AspectKey">Optional aspect key override.</param>
+/// <param name="FacetIdentifier">Optional facet identifier override.</param>
+public sealed record TypedQueryOptions(string? AspectKey = null, string? FacetIdentifier = null);

--- a/src/core/Aster.Core/README.md
+++ b/src/core/Aster.Core/README.md
@@ -38,6 +38,8 @@ builder.Services.AddAsterCore();
 | `InMemoryResourceStore` | `IResourceVersionReader`, `IResourceVersionWriter` |
 | `DefaultResourceManager` | `IResourceManager` |
 | `InMemoryQueryService` | `IResourceQueryService` |
+| `InMemoryQueryCapabilitiesProvider` | `IResourceQueryCapabilitiesProvider` |
+| `ResourceQueryValidator` | `IResourceQueryValidator` |
 | `GuidIdentityGenerator` | `IIdentityGenerator` |
 | `SystemTextJsonAspectBinder` | `ITypedAspectBinder` |
 | `SystemTextJsonFacetBinder` | `ITypedFacetBinder` |
@@ -116,13 +118,29 @@ var active = await manager.GetActiveVersionsAsync(resource.ResourceId, "Publishe
 
 ```csharp
 var queryService = serviceProvider.GetRequiredService<IResourceQueryService>();
-
-var results = await queryService.QueryAsync(new ResourceQuery
+var query = new ResourceQuery
 {
     DefinitionId = "Product",
     Filter = new FacetValueFilter("Title", "Title", "Super Gadget Pro", ComparisonOperator.Equals),
     Take = 10,
-});
+};
+
+var results = await queryService.QueryAsync(query);
+```
+
+Preflight the query against the active provider:
+
+```csharp
+var validator = serviceProvider.GetRequiredService<IResourceQueryValidator>();
+var validation = validator.Validate(query);
+```
+
+Or build common typed aspect filters without repeating convention-based identifiers:
+
+```csharp
+var filter = TypedQuery.For<TitleAspect>()
+    .Facet(x => x.Title)
+    .Contains("Gadget");
 ```
 
 ---
@@ -135,6 +153,8 @@ IResourceManager              — provider-backed create / update / activate orc
 IResourceVersionWriter           — low-level version/activation persistence hook
 IResourceVersionReader           — low-level read hook for query candidate version sets
 IResourceQueryService         — portable query service; default is LINQ-based in-memory
+IResourceQueryCapabilitiesProvider — declares active provider query support
+IResourceQueryValidator        — preflights ResourceQuery against provider capabilities
 ITypedAspectBinder            — serialise/deserialise full aspects (System.Text.Json)
 ITypedFacetBinder             — serialise/deserialise individual facet values
 IIdentityGenerator            — pluggable ID strategy (default: Guid)

--- a/src/core/Aster.Core/Services/ResourceQueryValidator.cs
+++ b/src/core/Aster.Core/Services/ResourceQueryValidator.cs
@@ -21,6 +21,23 @@ public sealed class ResourceQueryValidator : IResourceQueryValidator
         capabilities = capabilityProviders.LastOrDefault()?.Capabilities;
     }
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ResourceQueryValidator"/> class.
+    /// </summary>
+    /// <param name="capabilityProviders">Registered provider capability declarations.</param>
+    /// <param name="queryService">The active query service.</param>
+    public ResourceQueryValidator(
+        IEnumerable<IResourceQueryCapabilitiesProvider> capabilityProviders,
+        IResourceQueryService queryService)
+    {
+        ArgumentNullException.ThrowIfNull(capabilityProviders);
+        ArgumentNullException.ThrowIfNull(queryService);
+
+        capabilities = capabilityProviders
+            .LastOrDefault(provider => IsCapabilityProviderForQueryService(provider, queryService))
+            ?.Capabilities;
+    }
+
     /// <inheritdoc />
     public QueryValidationResult Validate(ResourceQuery query)
     {
@@ -153,6 +170,16 @@ public sealed class ResourceQueryValidator : IResourceQueryValidator
         }
 
         ValidateComparison(QueryFilterType.Metadata, filter.Operator, $"{path}.Operator", failures);
+
+        if (filter.Operator == ComparisonOperator.Contains
+            && !capabilities.MetadataContainsFields.Contains(filter.Field))
+        {
+            failures.Add(Failure(
+                "unsupported-metadata-contains-field",
+                $"Metadata field '{filter.Field}' does not support containment filtering in {capabilities.ProviderName}.",
+                $"{path}.Field",
+                "metadata field"));
+        }
     }
 
     private void ValidateFacetValueFilter(FacetValueFilter filter, string path, List<QueryValidationFailure> failures)
@@ -208,6 +235,15 @@ public sealed class ResourceQueryValidator : IResourceQueryValidator
         {
             var sort = sorts[index];
             var path = $"Sorts[{index}]";
+
+            if (!Enum.IsDefined(sort.Direction))
+            {
+                failures.Add(Failure(
+                    "unsupported-sort-direction",
+                    $"Sort direction '{sort.Direction}' is not supported by {capabilities!.ProviderName}.",
+                    $"{path}.Direction",
+                    "sort direction"));
+            }
 
             if (string.IsNullOrWhiteSpace(sort.AspectKey))
             {
@@ -314,7 +350,7 @@ public sealed class ResourceQueryValidator : IResourceQueryValidator
 
     private static QueryValueShape? ResolveValueShape(object value)
     {
-        if (value is DateTime or DateTimeOffset or DateOnly)
+        if (value is DateTime or DateTimeOffset)
             return QueryValueShape.DateTime;
 
         if (value is string stringValue)
@@ -340,4 +376,19 @@ public sealed class ResourceQueryValidator : IResourceQueryValidator
         string? path = null,
         string? feature = null) =>
         new(code, message, path, feature);
+
+    private static bool IsCapabilityProviderForQueryService(
+        IResourceQueryCapabilitiesProvider provider,
+        IResourceQueryService queryService)
+    {
+        var providerName = NormalizeProviderTypeName(provider.GetType().Name);
+        var queryServiceName = NormalizeProviderTypeName(queryService.GetType().Name);
+
+        return queryServiceName.StartsWith(providerName, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static string NormalizeProviderTypeName(string typeName) =>
+        typeName
+            .Replace("QueryCapabilitiesProvider", string.Empty, StringComparison.Ordinal)
+            .Replace("QueryService", string.Empty, StringComparison.Ordinal);
 }

--- a/src/core/Aster.Core/Services/ResourceQueryValidator.cs
+++ b/src/core/Aster.Core/Services/ResourceQueryValidator.cs
@@ -1,0 +1,343 @@
+using System.Globalization;
+using Aster.Core.Abstractions;
+using Aster.Core.Models.Querying;
+
+namespace Aster.Core.Services;
+
+/// <summary>
+/// Default <see cref="IResourceQueryValidator"/> implementation.
+/// </summary>
+public sealed class ResourceQueryValidator : IResourceQueryValidator
+{
+    private readonly QueryCapabilityDescription? capabilities;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ResourceQueryValidator"/> class.
+    /// </summary>
+    /// <param name="capabilityProviders">Registered provider capability declarations.</param>
+    public ResourceQueryValidator(IEnumerable<IResourceQueryCapabilitiesProvider> capabilityProviders)
+    {
+        ArgumentNullException.ThrowIfNull(capabilityProviders);
+        capabilities = capabilityProviders.LastOrDefault()?.Capabilities;
+    }
+
+    /// <inheritdoc />
+    public QueryValidationResult Validate(ResourceQuery query)
+    {
+        ArgumentNullException.ThrowIfNull(query);
+
+        if (capabilities is null)
+        {
+            return new([
+                Failure(
+                    "capabilities-not-declared",
+                    "Query capabilities are not declared for the active provider.",
+                    feature: "capabilities missing"),
+            ]);
+        }
+
+        var failures = new List<QueryValidationFailure>();
+        ValidateScope(query, failures);
+        ValidatePaging(query, failures);
+
+        if (query.Filter is not null)
+            ValidateFilter(query.Filter, "Filter", failures);
+
+        ValidateSorts(query.Sorts, failures);
+
+        return failures.Count == 0
+            ? QueryValidationResult.Success
+            : new(failures);
+    }
+
+    private void ValidateScope(ResourceQuery query, List<QueryValidationFailure> failures)
+    {
+        var providerCapabilities = capabilities!;
+
+        if (!Enum.IsDefined(query.Scope) || !providerCapabilities.SupportedScopes.Contains(query.Scope))
+        {
+            failures.Add(Failure(
+                "unsupported-scope",
+                $"Scope '{query.Scope}' is not supported by {providerCapabilities.ProviderName}.",
+                "Scope",
+                "scope"));
+        }
+
+        if (query.Scope == ResourceVersionScope.Active
+            && providerCapabilities.RequiresActivationChannelForActiveScope
+            && string.IsNullOrWhiteSpace(query.ActivationChannel))
+        {
+            failures.Add(Failure(
+                "activation-channel-required",
+                $"Active scope requires an activation channel for {providerCapabilities.ProviderName}.",
+                "ActivationChannel",
+                "scope"));
+        }
+    }
+
+    private void ValidatePaging(ResourceQuery query, List<QueryValidationFailure> failures)
+    {
+        if (query.Skip is < 0)
+        {
+            failures.Add(Failure(
+                "negative-skip",
+                "Skip must be zero or greater.",
+                "Skip",
+                "paging"));
+        }
+        else if (query.Skip.HasValue && !capabilities!.SupportsSkip)
+        {
+            failures.Add(Failure(
+                "unsupported-skip",
+                $"Skip paging is not supported by {capabilities.ProviderName}.",
+                "Skip",
+                "paging"));
+        }
+
+        if (query.Take is < 0)
+        {
+            failures.Add(Failure(
+                "negative-take",
+                "Take must be zero or greater.",
+                "Take",
+                "paging"));
+        }
+        else if (query.Take.HasValue && !capabilities!.SupportsTake)
+        {
+            failures.Add(Failure(
+                "unsupported-take",
+                $"Take paging is not supported by {capabilities.ProviderName}.",
+                "Take",
+                "paging"));
+        }
+    }
+
+    private void ValidateFilter(FilterExpression expression, string path, List<QueryValidationFailure> failures)
+    {
+        switch (expression)
+        {
+            case MetadataFilter metadata:
+                ValidateMetadataFilter(metadata, path, failures);
+                break;
+            case AspectPresenceFilter:
+                ValidateFilterType(QueryFilterType.AspectPresence, path, failures);
+                break;
+            case FacetValueFilter facet:
+                ValidateFacetValueFilter(facet, path, failures);
+                break;
+            case LogicalExpression logical:
+                ValidateLogicalExpression(logical, path, failures);
+                break;
+            default:
+                failures.Add(Failure(
+                    "unsupported-filter-type",
+                    $"Filter expression '{expression.GetType().Name}' is not supported by {capabilities!.ProviderName}.",
+                    path,
+                    "predicate"));
+                break;
+        }
+    }
+
+    private void ValidateMetadataFilter(MetadataFilter filter, string path, List<QueryValidationFailure> failures)
+    {
+        if (!ValidateFilterType(QueryFilterType.Metadata, path, failures))
+            return;
+
+        if (!capabilities!.SupportedMetadataFields.Contains(filter.Field))
+        {
+            failures.Add(Failure(
+                "unsupported-metadata-field",
+                $"Metadata field '{filter.Field}' is not supported by {capabilities.ProviderName}.",
+                $"{path}.Field",
+                "metadata field"));
+        }
+
+        ValidateComparison(QueryFilterType.Metadata, filter.Operator, $"{path}.Operator", failures);
+    }
+
+    private void ValidateFacetValueFilter(FacetValueFilter filter, string path, List<QueryValidationFailure> failures)
+    {
+        if (!ValidateFilterType(QueryFilterType.FacetValue, path, failures))
+            return;
+
+        ValidateComparison(QueryFilterType.FacetValue, filter.Operator, $"{path}.Operator", failures);
+
+        if (filter.Operator == ComparisonOperator.Range)
+            ValidateRangeValue(filter.Value, $"{path}.Value", failures);
+    }
+
+    private void ValidateLogicalExpression(LogicalExpression expression, string path, List<QueryValidationFailure> failures)
+    {
+        if (!ValidateFilterType(QueryFilterType.Logical, path, failures))
+            return;
+
+        if (!capabilities!.SupportedLogicalOperators.Contains(expression.Operator))
+        {
+            failures.Add(Failure(
+                "unsupported-logical-operator",
+                $"Logical operator '{expression.Operator}' is not supported by {capabilities.ProviderName}.",
+                $"{path}.Operator",
+                "logical operator"));
+        }
+
+        if (expression.Operator == LogicalOperator.Not && expression.Operands.Count != 1)
+        {
+            failures.Add(Failure(
+                "invalid-not-operands",
+                "NOT logical expressions require exactly one operand.",
+                $"{path}.Operands",
+                "logical expression"));
+        }
+
+        if (expression.Operator is LogicalOperator.And or LogicalOperator.Or && expression.Operands.Count == 0)
+        {
+            failures.Add(Failure(
+                "empty-logical-operands",
+                $"{expression.Operator} logical expressions require at least one operand.",
+                $"{path}.Operands",
+                "logical expression"));
+        }
+
+        for (var index = 0; index < expression.Operands.Count; index++)
+            ValidateFilter(expression.Operands[index], $"{path}.Operands[{index}]", failures);
+    }
+
+    private void ValidateSorts(IReadOnlyList<SortExpression> sorts, List<QueryValidationFailure> failures)
+    {
+        for (var index = 0; index < sorts.Count; index++)
+        {
+            var sort = sorts[index];
+            var path = $"Sorts[{index}]";
+
+            if (string.IsNullOrWhiteSpace(sort.AspectKey))
+            {
+                if (!capabilities!.SupportsMetadataSorting)
+                {
+                    failures.Add(Failure(
+                        "unsupported-metadata-sort",
+                        $"Metadata sorting is not supported by {capabilities.ProviderName}.",
+                        path,
+                        "sort"));
+                }
+
+                if (!capabilities.SupportedMetadataFields.Contains(sort.Field))
+                {
+                    failures.Add(Failure(
+                        "unsupported-metadata-sort-field",
+                        $"Metadata sort field '{sort.Field}' is not supported by {capabilities.ProviderName}.",
+                        $"{path}.Field",
+                        "metadata field"));
+                }
+            }
+            else if (!capabilities!.SupportsFacetSorting)
+            {
+                failures.Add(Failure(
+                    "unsupported-facet-sort",
+                    $"Facet sorting is not supported by {capabilities.ProviderName}.",
+                    path,
+                    "sort"));
+            }
+        }
+    }
+
+    private bool ValidateFilterType(QueryFilterType filterType, string path, List<QueryValidationFailure> failures)
+    {
+        if (capabilities!.SupportedFilterTypes.Contains(filterType))
+            return true;
+
+        failures.Add(Failure(
+            "unsupported-filter-type",
+            $"Filter type '{filterType}' is not supported by {capabilities.ProviderName}.",
+            path,
+            "predicate"));
+        return false;
+    }
+
+    private void ValidateComparison(
+        QueryFilterType filterType,
+        ComparisonOperator comparisonOperator,
+        string path,
+        List<QueryValidationFailure> failures)
+    {
+        if (Enum.IsDefined(comparisonOperator)
+            && capabilities!.SupportsComparison(filterType, comparisonOperator))
+            return;
+
+        failures.Add(Failure(
+            "unsupported-comparison-operator",
+            $"Comparison operator '{comparisonOperator}' is not supported for {filterType} filters by {capabilities!.ProviderName}.",
+            path,
+            "comparison operator"));
+    }
+
+    private void ValidateRangeValue(object value, string path, List<QueryValidationFailure> failures)
+    {
+        if (value is not RangeValue range)
+        {
+            failures.Add(Failure(
+                "range-value-required",
+                "Range predicates require a RangeValue.",
+                path,
+                "value shape"));
+            return;
+        }
+
+        if (range.Min is null && range.Max is null)
+        {
+            failures.Add(Failure(
+                "empty-range",
+                "Range predicates require at least one bound.",
+                path,
+                "value shape"));
+            return;
+        }
+
+        ValidateRangeBound(range.Min, $"{path}.Min", failures);
+        ValidateRangeBound(range.Max, $"{path}.Max", failures);
+    }
+
+    private void ValidateRangeBound(object? value, string path, List<QueryValidationFailure> failures)
+    {
+        if (value is null)
+            return;
+
+        var shape = ResolveValueShape(value);
+        if (shape is not null && capabilities!.FacetRangeSupport.Contains(shape.Value))
+            return;
+
+        failures.Add(Failure(
+            "unsupported-range-value-shape",
+            $"Range value shape '{shape?.ToString() ?? value.GetType().Name}' is not supported by {capabilities!.ProviderName}.",
+            path,
+            "value shape"));
+    }
+
+    private static QueryValueShape? ResolveValueShape(object value)
+    {
+        if (value is DateTime or DateTimeOffset or DateOnly)
+            return QueryValueShape.DateTime;
+
+        if (value is string stringValue)
+        {
+            if (decimal.TryParse(stringValue, NumberStyles.Number, CultureInfo.InvariantCulture, out _))
+                return QueryValueShape.Numeric;
+
+            if (DateTime.TryParse(stringValue, CultureInfo.InvariantCulture, DateTimeStyles.AdjustToUniversal, out _))
+                return QueryValueShape.DateTime;
+
+            return QueryValueShape.String;
+        }
+
+        if (value is byte or sbyte or short or ushort or int or uint or long or ulong or float or double or decimal)
+            return QueryValueShape.Numeric;
+
+        return null;
+    }
+
+    private static QueryValidationFailure Failure(
+        string code,
+        string message,
+        string? path = null,
+        string? feature = null) =>
+        new(code, message, path, feature);
+}

--- a/src/persistence/Aster.Persistence.SqliteJson/README.md
+++ b/src/persistence/Aster.Persistence.SqliteJson/README.md
@@ -10,6 +10,7 @@ This package currently provides:
 - `IResourceVersionReader`
 - `IResourceVersionWriter`
 - `IResourceQueryService`
+- `IResourceQueryCapabilitiesProvider`
 
 It persists resource definitions, resource version snapshots, and activation state using SQLite tables with JSON payload columns.
 Query execution is provider-backed: `ResourceQuery` ASTs are translated to parameterized SQLite SQL and JSON1 expressions instead of materializing the full store in memory.
@@ -35,3 +36,5 @@ Supported query shapes:
 - `And`, `Or`, and single-operand `Not`
 
 Unsupported query shapes throw `UnsupportedQueryFeatureException` with an actionable message. Facet sorting, unknown metadata fields, empty ranges, negative paging values, and date-like facet ranges are intentionally out of scope for this phase.
+
+The provider also declares this support through `SqliteJsonQueryCapabilitiesProvider`, so callers can inspect capabilities or use `IResourceQueryValidator` before execution. Validation reports unsupported SQLite shapes, such as facet sorting or date-like facet ranges, without falling back to the in-memory provider.

--- a/src/persistence/Aster.Persistence.SqliteJson/SqliteJsonAsterServiceCollectionExtensions.cs
+++ b/src/persistence/Aster.Persistence.SqliteJson/SqliteJsonAsterServiceCollectionExtensions.cs
@@ -27,10 +27,12 @@ public static class SqliteJsonAsterServiceCollectionExtensions
         services.AddSingleton(options);
         services.AddSingleton<SqliteJsonResourceStore>();
         services.AddSingleton<SqliteJsonQueryService>();
+        services.AddSingleton<SqliteJsonQueryCapabilitiesProvider>();
         services.AddSingleton<IResourceDefinitionStore>(sp => sp.GetRequiredService<SqliteJsonResourceStore>());
         services.AddSingleton<IResourceVersionReader>(sp => sp.GetRequiredService<SqliteJsonResourceStore>());
         services.AddSingleton<IResourceVersionWriter>(sp => sp.GetRequiredService<SqliteJsonResourceStore>());
         services.AddSingleton<IResourceQueryService>(sp => sp.GetRequiredService<SqliteJsonQueryService>());
+        services.AddSingleton<IResourceQueryCapabilitiesProvider>(sp => sp.GetRequiredService<SqliteJsonQueryCapabilitiesProvider>());
 
         return services;
     }

--- a/src/persistence/Aster.Persistence.SqliteJson/SqliteJsonQueryCapabilitiesProvider.cs
+++ b/src/persistence/Aster.Persistence.SqliteJson/SqliteJsonQueryCapabilitiesProvider.cs
@@ -55,6 +55,14 @@ public sealed class SqliteJsonQueryCapabilitiesProvider : IResourceQueryCapabili
             "Version",
             "Created",
         },
+        MetadataContainsFields: new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+        {
+            "ResourceId",
+            "Id",
+            "DefinitionId",
+            "Owner",
+            "Created",
+        },
         SupportsMetadataSorting: true,
         SupportsFacetSorting: false,
         SupportsSkip: true,

--- a/src/persistence/Aster.Persistence.SqliteJson/SqliteJsonQueryCapabilitiesProvider.cs
+++ b/src/persistence/Aster.Persistence.SqliteJson/SqliteJsonQueryCapabilitiesProvider.cs
@@ -1,0 +1,69 @@
+using Aster.Core.Abstractions;
+using Aster.Core.Models.Querying;
+
+namespace Aster.Persistence.SqliteJson;
+
+/// <summary>
+/// Query capability declaration for the SQLite JSON query provider.
+/// </summary>
+public sealed class SqliteJsonQueryCapabilitiesProvider : IResourceQueryCapabilitiesProvider
+{
+    /// <inheritdoc />
+    public QueryCapabilityDescription Capabilities { get; } = new(
+        ProviderName: "SQLite JSON",
+        SupportedScopes: new HashSet<ResourceVersionScope>
+        {
+            ResourceVersionScope.Latest,
+            ResourceVersionScope.AllVersions,
+            ResourceVersionScope.Active,
+            ResourceVersionScope.Draft,
+        },
+        RequiresActivationChannelForActiveScope: true,
+        SupportedFilterTypes: new HashSet<QueryFilterType>
+        {
+            QueryFilterType.Metadata,
+            QueryFilterType.AspectPresence,
+            QueryFilterType.FacetValue,
+            QueryFilterType.Logical,
+        },
+        SupportedLogicalOperators: new HashSet<LogicalOperator>
+        {
+            LogicalOperator.And,
+            LogicalOperator.Or,
+            LogicalOperator.Not,
+        },
+        SupportedComparisonOperators: new Dictionary<QueryFilterType, IReadOnlySet<ComparisonOperator>>
+        {
+            [QueryFilterType.Metadata] = new HashSet<ComparisonOperator>
+            {
+                ComparisonOperator.Equals,
+                ComparisonOperator.Contains,
+            },
+            [QueryFilterType.FacetValue] = new HashSet<ComparisonOperator>
+            {
+                ComparisonOperator.Equals,
+                ComparisonOperator.Contains,
+                ComparisonOperator.Range,
+            },
+        },
+        SupportedMetadataFields: new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+        {
+            "ResourceId",
+            "Id",
+            "DefinitionId",
+            "Owner",
+            "Version",
+            "Created",
+        },
+        SupportsMetadataSorting: true,
+        SupportsFacetSorting: false,
+        SupportsSkip: true,
+        SupportsTake: true,
+        FacetRangeSupport: new HashSet<QueryValueShape> { QueryValueShape.Numeric },
+        UnsupportedFeatures:
+        [
+            "Facet sorting",
+            "Metadata range filters",
+            "Date-like facet ranges",
+        ]);
+}

--- a/test/Aster.Tests/InMemory/InMemoryQueryCapabilityTests.cs
+++ b/test/Aster.Tests/InMemory/InMemoryQueryCapabilityTests.cs
@@ -1,0 +1,39 @@
+using Aster.Core.InMemory;
+using Aster.Core.Models.Querying;
+
+namespace Aster.Tests.InMemory;
+
+public sealed class InMemoryQueryCapabilityTests
+{
+    private readonly QueryCapabilityDescription capabilities = new InMemoryQueryCapabilitiesProvider().Capabilities;
+
+    [Fact]
+    public void Capabilities_DeclareCurrentInMemoryQuerySurface()
+    {
+        Assert.Equal("In-memory", capabilities.ProviderName);
+        Assert.True(capabilities.RequiresActivationChannelForActiveScope);
+        Assert.True(capabilities.SupportsMetadataSorting);
+        Assert.True(capabilities.SupportsFacetSorting);
+        Assert.True(capabilities.SupportsSkip);
+        Assert.True(capabilities.SupportsTake);
+
+        Assert.Contains(ResourceVersionScope.Latest, capabilities.SupportedScopes);
+        Assert.Contains(ResourceVersionScope.AllVersions, capabilities.SupportedScopes);
+        Assert.Contains(ResourceVersionScope.Active, capabilities.SupportedScopes);
+        Assert.Contains(ResourceVersionScope.Draft, capabilities.SupportedScopes);
+
+        Assert.Contains(QueryFilterType.Metadata, capabilities.SupportedFilterTypes);
+        Assert.Contains(QueryFilterType.AspectPresence, capabilities.SupportedFilterTypes);
+        Assert.Contains(QueryFilterType.FacetValue, capabilities.SupportedFilterTypes);
+        Assert.Contains(QueryFilterType.Logical, capabilities.SupportedFilterTypes);
+    }
+
+    [Fact]
+    public void Capabilities_IncludeFacetSortingAndDateLikeFacetRanges()
+    {
+        Assert.True(capabilities.SupportsFacetSorting);
+        Assert.Contains(QueryValueShape.Numeric, capabilities.FacetRangeSupport);
+        Assert.Contains(QueryValueShape.DateTime, capabilities.FacetRangeSupport);
+        Assert.True(capabilities.SupportsComparison(QueryFilterType.FacetValue, ComparisonOperator.Range));
+    }
+}

--- a/test/Aster.Tests/Querying/QueryCapabilityDiscoveryTests.cs
+++ b/test/Aster.Tests/Querying/QueryCapabilityDiscoveryTests.cs
@@ -1,0 +1,58 @@
+using Aster.Core.Abstractions;
+using Aster.Core.Extensions;
+using Aster.Core.Models.Querying;
+using Aster.Persistence.SqliteJson;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Aster.Tests.Querying;
+
+public sealed class QueryCapabilityDiscoveryTests
+{
+    [Fact]
+    public void AddAsterCore_RegistersInMemoryCapabilities()
+    {
+        using var provider = new ServiceCollection()
+            .AddAsterCore()
+            .BuildServiceProvider();
+
+        var capabilities = provider.GetRequiredService<IResourceQueryCapabilitiesProvider>().Capabilities;
+
+        Assert.Equal("In-memory", capabilities.ProviderName);
+        Assert.True(capabilities.SupportsFacetSorting);
+    }
+
+    [Fact]
+    public void AddAsterSqliteJson_RegistersSqliteCapabilitiesAsActiveProvider()
+    {
+        using var provider = new ServiceCollection()
+            .AddAsterCore()
+            .AddAsterSqliteJson(options =>
+            {
+                options.ConnectionString = "Data Source=:memory:";
+                options.InitializeSchema = false;
+            })
+            .BuildServiceProvider();
+
+        var capabilities = provider.GetRequiredService<IResourceQueryCapabilitiesProvider>().Capabilities;
+        var validator = provider.GetRequiredService<IResourceQueryValidator>();
+
+        Assert.Equal("SQLite JSON", capabilities.ProviderName);
+        Assert.False(capabilities.SupportsFacetSorting);
+        Assert.False(validator.Validate(new ResourceQuery
+        {
+            Sorts = [new SortExpression("Title", AspectKey: "TitleAspect")],
+        }).IsValid);
+    }
+
+    [Fact]
+    public void Capabilities_ExposeProviderDifferences()
+    {
+        var inMemory = new Core.InMemory.InMemoryQueryCapabilitiesProvider().Capabilities;
+        var sqlite = new SqliteJsonQueryCapabilitiesProvider().Capabilities;
+
+        Assert.True(inMemory.SupportsFacetSorting);
+        Assert.False(sqlite.SupportsFacetSorting);
+        Assert.Contains(QueryValueShape.DateTime, inMemory.FacetRangeSupport);
+        Assert.DoesNotContain(QueryValueShape.DateTime, sqlite.FacetRangeSupport);
+    }
+}

--- a/test/Aster.Tests/Querying/ResourceQueryValidatorTests.cs
+++ b/test/Aster.Tests/Querying/ResourceQueryValidatorTests.cs
@@ -1,8 +1,10 @@
 using Aster.Core.Abstractions;
 using Aster.Core.InMemory;
+using Aster.Core.Models.Instances;
 using Aster.Core.Models.Querying;
 using Aster.Core.Services;
 using Aster.Persistence.SqliteJson;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace Aster.Tests.Querying;
 
@@ -23,12 +25,23 @@ public sealed class ResourceQueryValidatorTests
             Take = 10,
         };
 
-        var before = query;
+        var expected = new ResourceQuery
+        {
+            Scope = ResourceVersionScope.Latest,
+            Filter = new FacetValueFilter("Title", "Title", "Gadget", ComparisonOperator.Contains),
+            Sorts = [new SortExpression("Created", SortDirection.Descending)],
+            Skip = 1,
+            Take = 10,
+        };
         var result = sqliteValidator.Validate(query);
 
         Assert.True(result.IsValid);
         Assert.Empty(result.Failures);
-        Assert.Equal(before, query);
+        Assert.Equal(expected.Scope, query.Scope);
+        Assert.Equal(expected.Filter, query.Filter);
+        Assert.Equal(expected.Sorts, query.Sorts);
+        Assert.Equal(expected.Skip, query.Skip);
+        Assert.Equal(expected.Take, query.Take);
     }
 
     [Fact]
@@ -110,6 +123,67 @@ public sealed class ResourceQueryValidatorTests
         Assert.Contains(sqliteResult.Failures, failure => failure.Code == "unsupported-facet-sort");
     }
 
+    [Fact]
+    public void Validate_MetadataCapabilitiesMatchProviderExecution()
+    {
+        var sqliteMetadataContains = sqliteValidator.Validate(new ResourceQuery
+        {
+            Filter = new MetadataFilter("Version", "1", ComparisonOperator.Contains),
+        });
+        var inMemoryMetadataRange = inMemoryValidator.Validate(new ResourceQuery
+        {
+            Filter = new MetadataFilter("Created", "2026-01-01", ComparisonOperator.Range),
+        });
+
+        Assert.False(sqliteMetadataContains.IsValid);
+        Assert.Contains(sqliteMetadataContains.Failures, failure => failure.Code == "unsupported-metadata-contains-field");
+        Assert.False(inMemoryMetadataRange.IsValid);
+        Assert.Contains(inMemoryMetadataRange.Failures, failure => failure.Code == "unsupported-comparison-operator");
+    }
+
+    [Fact]
+    public void Validate_RejectsInvalidSortDirection()
+    {
+        var result = sqliteValidator.Validate(new ResourceQuery
+        {
+            Sorts = [new SortExpression("Created", (SortDirection)999)],
+        });
+
+        Assert.False(result.IsValid);
+        Assert.Contains(result.Failures, failure => failure.Code == "unsupported-sort-direction");
+    }
+
+    [Fact]
+    public void Validate_RejectsDateOnlyRangeBounds()
+    {
+        var result = inMemoryValidator.Validate(new ResourceQuery
+        {
+            Filter = new FacetValueFilter(
+                "Schedule",
+                "StartsOn",
+                new RangeValue(DateOnly.FromDateTime(DateTime.UtcNow), null),
+                ComparisonOperator.Range),
+        });
+
+        Assert.False(result.IsValid);
+        Assert.Contains(result.Failures, failure => failure.Code == "unsupported-range-value-shape");
+    }
+
+    [Fact]
+    public void Validate_WhenActiveQueryServiceHasNoMatchingCapabilities_FailsClosed()
+    {
+        using var provider = new ServiceCollection()
+            .AddSingleton<IResourceQueryCapabilitiesProvider, InMemoryQueryCapabilitiesProvider>()
+            .AddSingleton<IResourceQueryService, CustomQueryService>()
+            .AddSingleton<IResourceQueryValidator, ResourceQueryValidator>()
+            .BuildServiceProvider();
+
+        var result = provider.GetRequiredService<IResourceQueryValidator>().Validate(new ResourceQuery());
+
+        Assert.False(result.IsValid);
+        Assert.Contains(result.Failures, failure => failure.Code == "capabilities-not-declared");
+    }
+
     private sealed class EmptyCapabilitiesProvider : IResourceQueryCapabilitiesProvider
     {
         public QueryCapabilityDescription Capabilities { get; } = new(
@@ -120,11 +194,20 @@ public sealed class ResourceQueryValidatorTests
             SupportedLogicalOperators: new HashSet<LogicalOperator>(),
             SupportedComparisonOperators: new Dictionary<QueryFilterType, IReadOnlySet<ComparisonOperator>>(),
             SupportedMetadataFields: new HashSet<string>(),
+            MetadataContainsFields: new HashSet<string>(),
             SupportsMetadataSorting: false,
             SupportsFacetSorting: false,
             SupportsSkip: false,
             SupportsTake: false,
             FacetRangeSupport: new HashSet<QueryValueShape>(),
             UnsupportedFeatures: []);
+    }
+
+    private sealed class CustomQueryService : IResourceQueryService
+    {
+        public ValueTask<IEnumerable<Resource>> QueryAsync(
+            ResourceQuery query,
+            CancellationToken cancellationToken = default) =>
+            new([]);
     }
 }

--- a/test/Aster.Tests/Querying/ResourceQueryValidatorTests.cs
+++ b/test/Aster.Tests/Querying/ResourceQueryValidatorTests.cs
@@ -1,0 +1,130 @@
+using Aster.Core.Abstractions;
+using Aster.Core.InMemory;
+using Aster.Core.Models.Querying;
+using Aster.Core.Services;
+using Aster.Persistence.SqliteJson;
+
+namespace Aster.Tests.Querying;
+
+public sealed class ResourceQueryValidatorTests
+{
+    private readonly ResourceQueryValidator inMemoryValidator = new([new InMemoryQueryCapabilitiesProvider()]);
+    private readonly ResourceQueryValidator sqliteValidator = new([new SqliteJsonQueryCapabilitiesProvider()]);
+
+    [Fact]
+    public void Validate_WithSupportedQuery_ReturnsSuccessWithoutMutatingQuery()
+    {
+        var query = new ResourceQuery
+        {
+            Scope = ResourceVersionScope.Latest,
+            Filter = new FacetValueFilter("Title", "Title", "Gadget", ComparisonOperator.Contains),
+            Sorts = [new SortExpression("Created", SortDirection.Descending)],
+            Skip = 1,
+            Take = 10,
+        };
+
+        var before = query;
+        var result = sqliteValidator.Validate(query);
+
+        Assert.True(result.IsValid);
+        Assert.Empty(result.Failures);
+        Assert.Equal(before, query);
+    }
+
+    [Fact]
+    public void Validate_WithMultipleUnsupportedFeatures_ReturnsAllDetectableFailures()
+    {
+        var result = sqliteValidator.Validate(new ResourceQuery
+        {
+            Scope = ResourceVersionScope.Active,
+            Skip = -1,
+            Take = -1,
+            Filter = new LogicalExpression(LogicalOperator.And, [
+                new MetadataFilter("Unknown", "value", ComparisonOperator.Range),
+                new FacetValueFilter(
+                    "Price",
+                    "Amount",
+                    new RangeValue(DateTime.UtcNow.AddDays(-1), DateTime.UtcNow),
+                    ComparisonOperator.Range),
+            ]),
+            Sorts = [new SortExpression("Title", AspectKey: "Title")],
+        });
+
+        Assert.False(result.IsValid);
+        Assert.Contains(result.Failures, failure => failure.Code == "activation-channel-required");
+        Assert.Contains(result.Failures, failure => failure.Code == "negative-skip");
+        Assert.Contains(result.Failures, failure => failure.Code == "negative-take");
+        Assert.Contains(result.Failures, failure => failure.Code == "unsupported-metadata-field");
+        Assert.Contains(result.Failures, failure => failure.Code == "unsupported-comparison-operator");
+        Assert.Contains(result.Failures, failure => failure.Code == "unsupported-range-value-shape");
+        Assert.Contains(result.Failures, failure => failure.Code == "unsupported-facet-sort");
+    }
+
+    [Fact]
+    public void Validate_WithoutCapabilities_FailsClosed()
+    {
+        var result = new ResourceQueryValidator([]).Validate(new ResourceQuery());
+
+        Assert.False(result.IsValid);
+        var failure = Assert.Single(result.Failures);
+        Assert.Equal("capabilities-not-declared", failure.Code);
+        Assert.Contains("not declared", failure.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Validate_ManualResourceQueriesRemainSupported()
+    {
+        var query = new ResourceQuery
+        {
+            DefinitionId = "Product",
+            Filter = new LogicalExpression(LogicalOperator.And, [
+                new AspectPresenceFilter("Title"),
+                new FacetValueFilter("Title", "Title", "Gadget", ComparisonOperator.Contains),
+            ]),
+        };
+
+        var result = inMemoryValidator.Validate(query);
+
+        Assert.True(result.IsValid);
+    }
+
+    [Fact]
+    public void Validate_InMemoryAndSqliteReflectProviderDifferences()
+    {
+        var dateRangeQuery = new ResourceQuery
+        {
+            Filter = new FacetValueFilter(
+                "Schedule",
+                "StartsAt",
+                new RangeValue(DateTime.UtcNow.AddDays(-1), DateTime.UtcNow),
+                ComparisonOperator.Range),
+            Sorts = [new SortExpression("StartsAt", AspectKey: "Schedule")],
+        };
+
+        Assert.True(inMemoryValidator.Validate(dateRangeQuery).IsValid);
+
+        var sqliteResult = sqliteValidator.Validate(dateRangeQuery);
+
+        Assert.False(sqliteResult.IsValid);
+        Assert.Contains(sqliteResult.Failures, failure => failure.Code == "unsupported-range-value-shape");
+        Assert.Contains(sqliteResult.Failures, failure => failure.Code == "unsupported-facet-sort");
+    }
+
+    private sealed class EmptyCapabilitiesProvider : IResourceQueryCapabilitiesProvider
+    {
+        public QueryCapabilityDescription Capabilities { get; } = new(
+            ProviderName: "Empty",
+            SupportedScopes: new HashSet<ResourceVersionScope>(),
+            RequiresActivationChannelForActiveScope: false,
+            SupportedFilterTypes: new HashSet<QueryFilterType>(),
+            SupportedLogicalOperators: new HashSet<LogicalOperator>(),
+            SupportedComparisonOperators: new Dictionary<QueryFilterType, IReadOnlySet<ComparisonOperator>>(),
+            SupportedMetadataFields: new HashSet<string>(),
+            SupportsMetadataSorting: false,
+            SupportsFacetSorting: false,
+            SupportsSkip: false,
+            SupportsTake: false,
+            FacetRangeSupport: new HashSet<QueryValueShape>(),
+            UnsupportedFeatures: []);
+    }
+}

--- a/test/Aster.Tests/Querying/TypedQueryHelperTests.cs
+++ b/test/Aster.Tests/Querying/TypedQueryHelperTests.cs
@@ -10,6 +10,9 @@ public sealed class TypedQueryHelperTests
 {
     private sealed record TitleAspect(string Title);
     private sealed record PriceAspect(decimal Amount);
+    private sealed record NestedAspect(TitleAspect Nested);
+
+    private static string StaticTitle => "Static";
 
     [Fact]
     public void HasAspect_UsesAspectTypeNameByConvention()
@@ -36,6 +39,18 @@ public sealed class TypedQueryHelperTests
         Assert.Equal(("TitleAspect", "Title", ComparisonOperator.Contains), (contains.AspectKey, contains.FacetDefinitionId, contains.Operator));
         Assert.Equal(("PriceAspect", "Amount", ComparisonOperator.Range), (range.AspectKey, range.FacetDefinitionId, range.Operator));
         Assert.Equal(new RangeValue(10m, 20m), range.Value);
+    }
+
+    [Fact]
+    public void Range_WithOnlyMaxBound_LeavesMinimumUnbounded()
+    {
+        var filter = Assert.IsType<FacetValueFilter>(TypedQuery.For<PriceAspect>()
+            .Facet(aspect => aspect.Amount)
+            .Range(max: 100m));
+
+        var range = Assert.IsType<RangeValue>(filter.Value);
+        Assert.Null(range.Min);
+        Assert.Equal(100m, range.Max);
     }
 
     [Fact]
@@ -71,6 +86,25 @@ public sealed class TypedQueryHelperTests
             .Facet(aspect => aspect.Title.ToUpperInvariant()));
 
         Assert.Contains("single readable member", exception.Message);
+    }
+
+    [Fact]
+    public void Facet_WithOverrideStillValidatesSelector()
+    {
+        var exception = Assert.Throws<ArgumentException>(() => TypedQuery.For<TitleAspect>()
+            .Facet(aspect => aspect.Title.ToUpperInvariant(), facetIdentifier: "Title"));
+
+        Assert.Contains("single readable member", exception.Message);
+    }
+
+    [Fact]
+    public void Facet_WithNonDirectMemberSelector_FailsClearly()
+    {
+        Assert.Throws<ArgumentException>(() => TypedQuery.For<NestedAspect>()
+            .Facet(aspect => aspect.Nested.Title));
+
+        Assert.Throws<ArgumentException>(() => TypedQuery.For<TitleAspect>()
+            .Facet(_ => StaticTitle));
     }
 
     [Fact]

--- a/test/Aster.Tests/Querying/TypedQueryHelperTests.cs
+++ b/test/Aster.Tests/Querying/TypedQueryHelperTests.cs
@@ -1,0 +1,132 @@
+using Aster.Core.Abstractions;
+using Aster.Core.Extensions;
+using Aster.Core.Models.Instances;
+using Aster.Core.Models.Querying;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Aster.Tests.Querying;
+
+public sealed class TypedQueryHelperTests
+{
+    private sealed record TitleAspect(string Title);
+    private sealed record PriceAspect(decimal Amount);
+
+    [Fact]
+    public void HasAspect_UsesAspectTypeNameByConvention()
+    {
+        var filter = Assert.IsType<AspectPresenceFilter>(TypedQuery.HasAspect<TitleAspect>());
+
+        Assert.Equal("TitleAspect", filter.AspectKey);
+    }
+
+    [Fact]
+    public void FacetHelpers_UseAspectAndMemberNamesByConvention()
+    {
+        var equality = Assert.IsType<FacetValueFilter>(TypedQuery.For<TitleAspect>()
+            .Facet(aspect => aspect.Title)
+            .EqualTo("Gadget"));
+        var contains = Assert.IsType<FacetValueFilter>(TypedQuery.For<TitleAspect>()
+            .Facet(aspect => aspect.Title)
+            .Contains("Gadget"));
+        var range = Assert.IsType<FacetValueFilter>(TypedQuery.For<PriceAspect>()
+            .Facet(aspect => aspect.Amount)
+            .Range(10m, 20m));
+
+        Assert.Equal(("TitleAspect", "Title", ComparisonOperator.Equals), (equality.AspectKey, equality.FacetDefinitionId, equality.Operator));
+        Assert.Equal(("TitleAspect", "Title", ComparisonOperator.Contains), (contains.AspectKey, contains.FacetDefinitionId, contains.Operator));
+        Assert.Equal(("PriceAspect", "Amount", ComparisonOperator.Range), (range.AspectKey, range.FacetDefinitionId, range.Operator));
+        Assert.Equal(new RangeValue(10m, 20m), range.Value);
+    }
+
+    [Fact]
+    public void FacetHelpers_UsePerQueryOverrides()
+    {
+        var filter = Assert.IsType<FacetValueFilter>(TypedQuery.For<PriceAspect>(aspectKey: "PriceAspect:Sale")
+            .Facet(aspect => aspect.Amount, facetIdentifier: "sale_amount")
+            .Range(10m, 100m));
+
+        Assert.Equal("PriceAspect:Sale", filter.AspectKey);
+        Assert.Equal("sale_amount", filter.FacetDefinitionId);
+    }
+
+    [Fact]
+    public void FacetHelpers_UseOptionsOverrides()
+    {
+        var options = new TypedQueryOptions(
+            AspectKey: "PriceAspect:Wholesale",
+            FacetIdentifier: "wholesale_amount");
+
+        var filter = Assert.IsType<FacetValueFilter>(TypedQuery.For<PriceAspect>(options)
+            .Facet(aspect => aspect.Amount)
+            .Range(10m, 100m));
+
+        Assert.Equal("PriceAspect:Wholesale", filter.AspectKey);
+        Assert.Equal("wholesale_amount", filter.FacetDefinitionId);
+    }
+
+    [Fact]
+    public void Facet_WithNonMemberSelector_FailsClearly()
+    {
+        var exception = Assert.Throws<ArgumentException>(() => TypedQuery.For<TitleAspect>()
+            .Facet(aspect => aspect.Title.ToUpperInvariant()));
+
+        Assert.Contains("single readable member", exception.Message);
+    }
+
+    [Fact]
+    public void TypedHelperOutput_ValidatesLikeManualQuery()
+    {
+        using var provider = new ServiceCollection()
+            .AddAsterCore()
+            .BuildServiceProvider();
+        var validator = provider.GetRequiredService<IResourceQueryValidator>();
+
+        var result = validator.Validate(new ResourceQuery
+        {
+            Filter = TypedQuery.For<TitleAspect>()
+                .Facet(aspect => aspect.Title)
+                .Contains("Gadget"),
+        });
+
+        Assert.True(result.IsValid);
+    }
+
+    [Fact]
+    public async Task TypedHelperGeneratedQuery_ExecutesAgainstSupportedProvider()
+    {
+        using var provider = new ServiceCollection()
+            .AddAsterCore()
+            .BuildServiceProvider();
+        var manager = provider.GetRequiredService<IResourceManager>();
+        var query = provider.GetRequiredService<IResourceQueryService>();
+
+        await manager.CreateAsync("Product", new CreateResourceRequest
+        {
+            InitialAspects = new() { ["TitleAspect"] = new TitleAspect("Super Gadget") },
+        });
+        await manager.CreateAsync("Product", new CreateResourceRequest
+        {
+            InitialAspects = new() { ["TitleAspect"] = new TitleAspect("Regular Widget") },
+        });
+
+        var results = (await query.QueryAsync(new ResourceQuery
+        {
+            Filter = TypedQuery.For<TitleAspect>()
+                .Facet(aspect => aspect.Title)
+                .Contains("Gadget"),
+        })).ToList();
+
+        Assert.Single(results);
+        Assert.Equal("Product", results[0].DefinitionId);
+    }
+
+    [Fact]
+    public void PublicAbstractions_DoNotExposeQueryableResourceProvider()
+    {
+        var publicTypes = typeof(IResourceQueryService).Assembly
+            .GetTypes()
+            .Where(type => type.IsPublic && type.Namespace == "Aster.Core.Abstractions");
+
+        Assert.DoesNotContain(publicTypes, type => typeof(IQueryable<Resource>).IsAssignableFrom(type));
+    }
+}

--- a/test/Aster.Tests/SqliteJson/SqliteJsonQueryCapabilityTests.cs
+++ b/test/Aster.Tests/SqliteJson/SqliteJsonQueryCapabilityTests.cs
@@ -1,0 +1,60 @@
+using Aster.Core.Abstractions;
+using Aster.Core.Extensions;
+using Aster.Core.Models.Querying;
+using Aster.Persistence.SqliteJson;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Aster.Tests.SqliteJson;
+
+public sealed class SqliteJsonQueryCapabilityTests
+{
+    private readonly QueryCapabilityDescription capabilities = new SqliteJsonQueryCapabilitiesProvider().Capabilities;
+
+    [Fact]
+    public void Capabilities_DeclareCurrentSqliteQuerySurface()
+    {
+        Assert.Equal("SQLite JSON", capabilities.ProviderName);
+        Assert.True(capabilities.RequiresActivationChannelForActiveScope);
+        Assert.True(capabilities.SupportsMetadataSorting);
+        Assert.False(capabilities.SupportsFacetSorting);
+        Assert.True(capabilities.SupportsSkip);
+        Assert.True(capabilities.SupportsTake);
+
+        Assert.Contains(ResourceVersionScope.Latest, capabilities.SupportedScopes);
+        Assert.Contains(ResourceVersionScope.AllVersions, capabilities.SupportedScopes);
+        Assert.Contains(ResourceVersionScope.Active, capabilities.SupportedScopes);
+        Assert.Contains(ResourceVersionScope.Draft, capabilities.SupportedScopes);
+    }
+
+    [Fact]
+    public void Capabilities_ExcludeFacetSortingAndDateLikeFacetRanges()
+    {
+        Assert.False(capabilities.SupportsFacetSorting);
+        Assert.Contains("Facet sorting", capabilities.UnsupportedFeatures);
+        Assert.Contains(QueryValueShape.Numeric, capabilities.FacetRangeSupport);
+        Assert.DoesNotContain(QueryValueShape.DateTime, capabilities.FacetRangeSupport);
+        Assert.True(capabilities.SupportsComparison(QueryFilterType.FacetValue, ComparisonOperator.Range));
+    }
+
+    [Fact]
+    public void Validator_RejectsFacetSortingForSqliteCapabilities()
+    {
+        var validator = new ServiceCollection()
+            .AddAsterCore()
+            .AddAsterSqliteJson(options =>
+            {
+                options.ConnectionString = "Data Source=:memory:";
+                options.InitializeSchema = false;
+            })
+            .BuildServiceProvider()
+            .GetRequiredService<IResourceQueryValidator>();
+
+        var result = validator.Validate(new ResourceQuery
+        {
+            Sorts = [new SortExpression("Title", AspectKey: "TitleAspect")],
+        });
+
+        Assert.False(result.IsValid);
+        Assert.Contains(result.Failures, failure => failure.Code == "unsupported-facet-sort");
+    }
+}

--- a/test/Aster.Tests/SqliteJson/SqliteJsonQueryServiceTests.cs
+++ b/test/Aster.Tests/SqliteJson/SqliteJsonQueryServiceTests.cs
@@ -2,8 +2,10 @@ using System.Linq;
 using Aster.Core.Abstractions;
 using Aster.Core.Exceptions;
 using Aster.Core.Extensions;
+using Aster.Core.InMemory;
 using Aster.Core.Models.Instances;
 using Aster.Core.Models.Querying;
+using Aster.Core.Services;
 using Aster.Persistence.SqliteJson;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -388,6 +390,23 @@ public sealed class SqliteJsonQueryServiceTests : IDisposable
 
         Assert.Single(results);
         Assert.Equal("product-a", results[0].ResourceId);
+    }
+
+    [Fact]
+    public async Task QueryAsync_AfterValidationAgainstDifferentProvider_StillEnforcesSqliteCapabilities()
+    {
+        var queryShape = new ResourceQuery
+        {
+            Sorts = [new SortExpression("Title", AspectKey: "Title")],
+        };
+        var inMemoryValidation = new ResourceQueryValidator([new InMemoryQueryCapabilitiesProvider()])
+            .Validate(queryShape);
+        await using var provider = CreateServiceProvider();
+        var query = provider.GetRequiredService<IResourceQueryService>();
+
+        Assert.True(inMemoryValidation.IsValid);
+        await Assert.ThrowsAsync<UnsupportedQueryFeatureException>(() =>
+            query.QueryAsync(queryShape).AsTask());
     }
 
     [Fact]

--- a/wiki/Architecture-Overview.md
+++ b/wiki/Architecture-Overview.md
@@ -138,7 +138,7 @@ Aster.Abstractions       -- interfaces only
 Aster.Definitions        -- builder API
 Aster.Runtime            -- services, lifecycle, versioning pipelines
 Aster.Querying           -- ResourceQuery AST + IResourceQueryService
-Aster.Indexing           -- index field model, IQueryCapabilities, query planner
+Aster.Indexing           -- index field model, provider capabilities, query planner
 Aster.Persistence.X      -- provider: SqliteJson, PostgresJsonb, Mongo, ...
 Aster.Hosting            -- AddAsterCore() and DI glue
 Aster.Recipes            -- optional: export/import recipe execution

--- a/wiki/DI-Registration.md
+++ b/wiki/DI-Registration.md
@@ -24,6 +24,8 @@ All services are registered as **singletons**.
 | `IResourceVersionWriter` | `InMemoryResourceStore` | Version/activation write primitive |
 | `IResourceVersionReader` | `InMemoryResourceStore` | Query/read candidate version primitive |
 | `IResourceQueryService` | `InMemoryQueryService` | LINQ-based query evaluator |
+| `IResourceQueryCapabilitiesProvider` | `InMemoryQueryCapabilitiesProvider` | Declares in-memory query support |
+| `IResourceQueryValidator` | `ResourceQueryValidator` | Preflights `ResourceQuery` against active provider capabilities |
 | `ITypedAspectBinder` | `SystemTextJsonAspectBinder` | Aspect POCO ↔ raw storage via `System.Text.Json` |
 | `ITypedFacetBinder` | `SystemTextJsonFacetBinder` | Facet value POCO ↔ raw storage via `System.Text.Json` |
 
@@ -54,8 +56,9 @@ builder.Services.AddAsterSqliteJson(options =>
 | `IResourceVersionWriter` | `SqliteJsonResourceStore` | Persists resource versions and activation state |
 | `IResourceVersionReader` | `SqliteJsonResourceStore` | Reads persisted version sets |
 | `IResourceQueryService` | `SqliteJsonQueryService` | Translates supported `ResourceQuery` ASTs to SQLite SQL/JSON queries |
+| `IResourceQueryCapabilitiesProvider` | `SqliteJsonQueryCapabilitiesProvider` | Declares SQLite JSON query support |
 
-`AddAsterSqliteJson()` should be called after `AddAsterCore()` so the provider registrations become the resolved implementations for the shared interfaces.
+`AddAsterSqliteJson()` should be called after `AddAsterCore()` so the provider registrations become the resolved implementations for the shared interfaces. The shared `IResourceQueryValidator` uses the active provider's capability declaration when preflighting queries.
 
 ---
 

--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -4,7 +4,7 @@ Welcome to the Aster documentation wiki.
 
 **Aster** is a .NET SDK for defining, versioning, and querying composable resources using a **Resource → Aspect → Facet** model. It provides a headless, backend-agnostic foundation for attaching reusable, cross-cutting capabilities to any resource type.
 
-> **Current Status:** Phase 2A complete — Core SDK, in-memory engine, and SQLite JSON persistence/querying are available. Next focus: query capabilities and typed query helpers.
+> **Current Status:** Phase 3 in progress — Core SDK, in-memory engine, SQLite JSON persistence/querying, query capability discovery, preflight validation, and typed query helpers are available.
 
 ---
 
@@ -16,7 +16,7 @@ Welcome to the Aster documentation wiki.
 | [Getting Started](Getting-Started) | Install, register, define, create, update, and activate resources |
 | [Versioning & Activation](Versioning-and-Activation) | Immutable versions, optimistic concurrency, channel-based activation |
 | [Typed Aspects & Facets](Typed-Aspects-and-Facets) | Working with C# POCOs instead of raw dictionaries |
-| [Querying](Querying) | The portable `ResourceQuery` AST, in-memory evaluator, and SQLite JSON provider subset |
+| [Querying](Querying) | The portable `ResourceQuery` AST, capability discovery, validation, typed helpers, and provider behavior |
 | [DI Registration & Configuration](DI-Registration) | Service registrations and extension points |
 | [Exception Reference](Exception-Reference) | All typed exceptions, when they are thrown, and how to handle them |
 | [Architecture Overview](Architecture-Overview) | Layered design, package layout, key design decisions |

--- a/wiki/Querying.md
+++ b/wiki/Querying.md
@@ -121,6 +121,69 @@ foreach (var resource in results)
 
 ---
 
+## Capability Discovery
+
+Providers expose their supported query surface through `IResourceQueryCapabilitiesProvider`:
+
+```csharp
+var capabilities = serviceProvider
+    .GetRequiredService<IResourceQueryCapabilitiesProvider>()
+    .Capabilities;
+
+Console.WriteLine(capabilities.ProviderName);
+Console.WriteLine(capabilities.SupportsFacetSorting);
+```
+
+Capabilities describe supported scopes, filter categories, comparison operators, logical operators, metadata fields, sort categories, paging, facet range value shapes, and known exclusions. The in-memory provider currently declares facet sorting and numeric/date-like facet ranges; SQLite JSON declares metadata sorting, numeric facet ranges, and no facet sorting.
+
+## Preflight Validation
+
+Use `IResourceQueryValidator` to validate a query before execution:
+
+```csharp
+var validation = validator.Validate(query);
+
+if (!validation.IsValid)
+{
+    foreach (var failure in validation.Failures)
+        Console.WriteLine($"{failure.Code}: {failure.Message}");
+
+    return;
+}
+```
+
+Validation returns a structured `QueryValidationResult` and does not mutate the query. If no capability provider is declared for the active provider, validation fails closed with `capabilities-not-declared`. Execution still rejects unsupported shapes even when validation is skipped.
+
+## Typed Query Helpers
+
+Typed helpers reduce repeated aspect/facet strings while still producing the same portable AST:
+
+```csharp
+public sealed record TitleAspect(string Title);
+public sealed record PriceAspect(decimal Amount);
+
+var filter = new LogicalExpression(LogicalOperator.And, [
+    TypedQuery.For<TitleAspect>()
+        .Facet(x => x.Title)
+        .Contains("Gadget"),
+    TypedQuery.For<PriceAspect>()
+        .Facet(x => x.Amount)
+        .Range(min: 10m, max: 100m),
+]);
+```
+
+By default, the aspect key is the CLR type name and the facet identifier is the selected member name. Override either value per query when targeting named aspects or non-conventional identifiers:
+
+```csharp
+var filter = TypedQuery.For<PriceAspect>(aspectKey: "PriceAspect:Sale")
+    .Facet(x => x.Amount, facetIdentifier: "sale_amount")
+    .Range(min: 10m, max: 100m);
+```
+
+The generated `AspectPresenceFilter`, `FacetValueFilter`, or `ResourceQuery` remains inspectable before validation or execution.
+
+---
+
 ## Compound Query Example
 
 Find all Products with "Pro" in the title **and** a price under $100:
@@ -162,10 +225,9 @@ Unsupported SQLite query shapes fail with `UnsupportedQueryFeatureException` ins
 
 ## Current Limitations
 
-- **No provider capability planner yet** — unsupported fields or value shapes fail when a provider translates the AST.
+- **No provider capability planner yet** — capabilities and validation describe what a provider can execute; they do not rewrite queries.
 - **Provider-specific semantics are explicit** — SQLite facet ranges are numeric-only in this phase.
 - **No public `IQueryable<Resource>`** — LINQ may be used inside a provider, but the public contract stays on the portable AST.
-- **Typed helper direction** — future helpers may map typed expressions into the AST, but provider execution should still consume the explicit query model rather than exposing backend-specific LINQ providers.
 
 ---
 
@@ -174,7 +236,7 @@ Unsupported SQLite query shapes fail with `UnsupportedQueryFeatureException` ins
 The `ResourceQuery` AST was designed early (Phase 1) to avoid painting future persistence backends into a corner. Key design decisions:
 
 - **No `IQueryable<T>`** as the public abstraction — `IQueryable` is fine within a single backend but breaks when crossing provider boundaries.
-- **Explicit operator set** — providers advertise what they support via `IQueryCapabilities` (Phase 3).
+- **Explicit operator set** — providers advertise what they support via `IResourceQueryCapabilitiesProvider`.
 - **Portable semantics** — `NormalizedText` fields for deterministic substring matching across backends; `Text` fields for provider-specific full-text search. (Phase 3+)
 
 ---

--- a/wiki/Querying.md
+++ b/wiki/Querying.md
@@ -180,7 +180,7 @@ var filter = TypedQuery.For<PriceAspect>(aspectKey: "PriceAspect:Sale")
     .Range(min: 10m, max: 100m);
 ```
 
-The generated `AspectPresenceFilter`, `FacetValueFilter`, or `ResourceQuery` remains inspectable before validation or execution.
+The generated `AspectPresenceFilter` or `FacetValueFilter` remains inspectable before validation or execution.
 
 ---
 

--- a/wiki/Roadmap.md
+++ b/wiki/Roadmap.md
@@ -2,7 +2,7 @@
 
 Aster is delivered in six phases. Each phase builds on the last, with clean extension points so earlier work is not thrown away.
 
-> **Current status:** Phase 2A complete — Core SDK, in-memory engine, and SQLite JSON persistence/querying are available. Next focus: query capabilities and typed query helpers.
+> **Current status:** Phase 3 in progress — Core SDK, in-memory engine, SQLite JSON persistence/querying, query capability discovery, preflight validation, and typed query helpers are available.
 
 ---
 
@@ -12,7 +12,7 @@ Aster is delivered in six phases. Each phase builds on the last, with clean exte
 |---|---|---|
 | **1** | Core SDK & In-Memory Engine | Complete |
 | **2A** | SQLite JSON Persistence & Querying | Complete |
-| **3** | Query Capabilities & Typed Querying | Next |
+| **3** | Query Capabilities & Typed Querying | In Progress |
 | **4** | Portability & Integration Hooks | Planned |
 | **5** | Multi-tenancy, Policies, Advanced Versioning | Planned |
 | **6** | Operational Hardening | Planned |
@@ -67,8 +67,8 @@ Completed implementation note: `Aster.Persistence.SqliteJson` provides the SQLit
 
 | Epic | Description |
 |---|---|
-| **3.1** | Query capabilities (`IQueryCapabilities`) and provider preflight validation |
-| **3.2** | Typed aspect querying — `WhereAspect<TAspect>(...)` compiles to `ResourceQuery` predicates via mapping metadata |
+| **3.1** | Query capabilities (`IResourceQueryCapabilitiesProvider`) and provider preflight validation |
+| **3.2** | Typed aspect querying — `TypedQuery.For<TAspect>()` builds portable `ResourceQuery` predicates via convention and per-query overrides |
 | **3.3** | Advanced indexing logic; portable index field types such as `Keyword`, `Text`, `NormalizedText`, `Boolean`, `Integer`, `Decimal`, `DateTime`, `Guid`, `KeywordArray` |
 | **3.4** | Versioned definition schemas — `ResourceDefinitionVersion` model; resources reference a definition version; upgrade API |
 


### PR DESCRIPTION
## Summary

- Add provider query capability discovery and structured preflight validation for `ResourceQuery`.
- Add in-memory and SQLite JSON capability declarations with DI registration.
- Add typed query helper APIs that emit the existing portable query AST.
- Update Spec Kit constitution/spec artifacts, workflow support files, README/wiki/provider docs, and ignore local `.lscache` files.

## Validation

- `dotnet test Aster.sln`
- `dotnet test Aster.sln --no-build`
- `git diff --check`
