### PR TITLE
[codex] Align provider validation and execution

### DIFF
--- a/.github/agents/copilot-instructions.md
+++ b/.github/agents/copilot-instructions.md
@@ -5,6 +5,7 @@ Auto-generated from all feature plans. Last updated: 2026-03-04
 ## Active Technologies
 - C# latest, .NET 8.0 / 9.0 / 10.0 multi-targeting + Existing `Microsoft.Extensions.DependencyInjection.Abstractions`, `Microsoft.Extensions.Logging.Abstractions`; SQLite provider keeps existing `Microsoft.Data.Sqlite` (003-query-capabilities-typed)
 - No new storage; existing in-memory and SQLite JSON providers declare query capabilities (003-query-capabilities-typed)
+- N/A for core validation/failure contracts; existing in-memory and SQLite JSON providers keep current persistence behavior (004-provider-validation-execution)
 
 - C# / .NET 9.0 (Standard 2.0/2.1 compatible ideally, but targeted for net9.0) + Microsoft.Extensions.DependencyInjection, Microsoft.Extensions.Logging (001-core-sdk-foundation)
 
@@ -24,6 +25,7 @@ tests/
 C# / .NET 9.0 (Standard 2.0/2.1 compatible ideally, but targeted for net9.0): Follow standard conventions
 
 ## Recent Changes
+- 004-provider-validation-execution: Added C# latest, .NET 8.0 / 9.0 / 10.0 multi-targeting + Existing `Microsoft.Extensions.DependencyInjection.Abstractions`, `Microsoft.Extensions.Logging.Abstractions`; SQLite provider keeps existing `Microsoft.Data.Sqlite`
 - 003-query-capabilities-typed: Added C# latest, .NET 8.0 / 9.0 / 10.0 multi-targeting + Existing `Microsoft.Extensions.DependencyInjection.Abstractions`, `Microsoft.Extensions.Logging.Abstractions`; SQLite provider keeps existing `Microsoft.Data.Sqlite`
 
 - 001-core-sdk-foundation: Added C# / .NET 9.0 (Standard 2.0/2.1 compatible ideally, but targeted for net9.0) + Microsoft.Extensions.DependencyInjection, Microsoft.Extensions.Logging

--- a/specs/004-provider-validation-execution/checklists/requirements.md
+++ b/specs/004-provider-validation-execution/checklists/requirements.md
@@ -1,0 +1,34 @@
+# Specification Quality Checklist: Provider Validation Execution Alignment
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-05-15
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [X] No implementation details (languages, frameworks, APIs)
+- [X] Focused on user value and business needs
+- [X] Written for non-technical stakeholders
+- [X] All mandatory sections completed
+
+## Requirement Completeness
+
+- [X] No [NEEDS CLARIFICATION] markers remain
+- [X] Requirements are testable and unambiguous
+- [X] Success criteria are measurable
+- [X] Success criteria are technology-agnostic (no implementation details)
+- [X] All acceptance scenarios are defined
+- [X] Edge cases are identified
+- [X] Scope is clearly bounded
+- [X] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [X] All functional requirements have clear acceptance criteria
+- [X] User scenarios cover primary flows
+- [X] Feature meets measurable outcomes defined in Success Criteria
+- [X] No implementation details leak into specification
+
+## Notes
+
+- Initial validation passed. The spec intentionally names existing product concepts such as resource queries, providers, capabilities, validation, and execution failures because those are the user-facing SDK concepts under specification.

--- a/specs/004-provider-validation-execution/contracts/provider-validation-execution.md
+++ b/specs/004-provider-validation-execution/contracts/provider-validation-execution.md
@@ -1,0 +1,95 @@
+# Contract: Provider Validation Execution Alignment
+
+This contract describes the public SDK behavior expected by the feature. Names are provisional for planning, but behavior is normative.
+
+## Provider Identity
+
+Query providers expose an explicit provider key used to match capability declarations.
+
+```csharp
+public interface IResourceQueryProviderIdentity
+{
+    string ProviderKey { get; }
+}
+```
+
+Expected behavior:
+
+- The in-memory query provider uses a stable key such as `in-memory`.
+- The SQLite JSON query provider uses a stable key such as `sqlite-json`.
+- Capability declarations expose the same key as the provider they describe.
+
+## Capability Declaration
+
+Capability descriptions include provider identity.
+
+```csharp
+public sealed record QueryCapabilityDescription(
+    string ProviderKey,
+    string ProviderName,
+    /* existing capability fields */);
+```
+
+Expected behavior:
+
+- Validation selects capabilities by matching the active provider key.
+- Validation fails closed when no capability declaration matches the active provider key.
+- Capability matching does not depend on registration order or type-name convention.
+
+## Query Validation
+
+Preflight validation remains non-throwing.
+
+```csharp
+public interface IResourceQueryValidator
+{
+    QueryValidationResult Validate(ResourceQuery query);
+}
+```
+
+Expected behavior:
+
+- Supported queries return `IsValid == true`.
+- Unsupported queries return structured failures.
+- Missing matching capabilities return a `capabilities-not-declared` failure.
+
+## Unsupported Execution Failure
+
+Execution raises structured unsupported-query exceptions when a provider cannot execute a query.
+
+```csharp
+public sealed class UnsupportedQueryFeatureException : Exception
+{
+    public string Code { get; }
+    public string Feature { get; }
+    public string? Path { get; }
+}
+```
+
+Expected behavior:
+
+- Code and feature are stable enough for tests and caller handling.
+- Message remains actionable for humans.
+- When execution fails for a shape validation can detect, code/category should match the validation failure.
+- Execution may stop at the first blocking failure.
+
+## Provider Execution Flow
+
+Providers run validation before translation/execution and keep provider-specific checks.
+
+```csharp
+public async ValueTask<IEnumerable<Resource>> QueryAsync(
+    ResourceQuery query,
+    CancellationToken cancellationToken = default)
+{
+    // Validate with active provider capabilities.
+    // Throw structured unsupported execution failure for the first blocking validation failure.
+    // Continue with provider-specific translation/execution checks.
+}
+```
+
+Expected behavior:
+
+- Skipping caller preflight does not bypass unsupported-query safeguards.
+- Provider-specific checks remain authoritative.
+- Supported query behavior remains unchanged.

--- a/specs/004-provider-validation-execution/data-model.md
+++ b/specs/004-provider-validation-execution/data-model.md
@@ -1,0 +1,102 @@
+# Data Model: Provider Validation Execution Alignment
+
+## Query Provider Key
+
+Identifies the active query provider and links it to its capability declaration.
+
+### Fields
+
+- `Value`: Stable non-empty provider identifier, such as `in-memory` or `sqlite-json`.
+
+### Validation Rules
+
+- Provider key must be non-empty.
+- The active query provider and matching capability declaration must use the same key.
+- Provider key matching is exact and deterministic.
+
+## Provider Capability Declaration
+
+Extends the existing query capability description with provider identity.
+
+### Fields
+
+- `ProviderKey`: Stable provider key used for matching.
+- `ProviderName`: Human-readable provider name.
+- Existing capability fields for scopes, filters, comparisons, sorts, paging, value shapes, and exclusions.
+
+### Validation Rules
+
+- `ProviderKey` and `ProviderName` must be non-empty.
+- Capability declaration must match provider execution behavior.
+- If no declaration matches the active provider key, validation fails closed.
+
+## Query Validation Failure
+
+Existing preflight failure result for unsupported query features.
+
+### Fields
+
+- `Code`: Stable failure code.
+- `Feature`: Unsupported feature category.
+- `Message`: Actionable explanation.
+- `Path`: Optional query location.
+
+### Validation Rules
+
+- Code and message must be non-empty.
+- Feature should be present for unsupported provider capabilities.
+- Paths should be included when failures map to a specific predicate, sort, scope, or paging property.
+
+## Unsupported Query Execution Failure
+
+Execution-time failure for unsupported query shapes.
+
+### Fields
+
+- `Code`: Stable failure code aligned with validation when applicable.
+- `Feature`: Unsupported feature category.
+- `Message`: Actionable explanation.
+- `Path`: Optional query location.
+
+### Validation Rules
+
+- Code, feature, and message must be available to callers.
+- Execution may report the first blocking unsupported feature.
+- Provider-specific failures should use the same code/category as validation when both paths detect the same shape.
+
+## Provider Consistency Case
+
+Test scenario that compares validation and execution behavior.
+
+### Fields
+
+- `ProviderKey`: Provider under test.
+- `QueryShape`: Query scenario being validated and executed.
+- `ExpectedValidation`: Expected validation result category/code.
+- `ExpectedExecution`: Expected execution failure category/code or success.
+
+### Validation Rules
+
+- Each provider must include at least one supported query consistency case.
+- Each provider must include unsupported cases that cover provider-specific exclusions.
+- Cases must catch both validation-accepts/execution-rejects and validation-rejects/execution-supports drift.
+
+## State Transitions
+
+### Query Execution
+
+```text
+ResourceQuery
+  ├─ shared validation succeeds
+  │   ├─ provider translation/execution succeeds → results
+  │   └─ provider-specific check fails → unsupported execution failure
+  └─ shared validation fails → unsupported execution failure from first blocking validation failure
+```
+
+### Capability Matching
+
+```text
+Active query provider key
+  ├─ matching capability declaration exists → validate with matched capabilities
+  └─ no matching declaration exists → capabilities-not-declared validation failure
+```

--- a/specs/004-provider-validation-execution/plan.md
+++ b/specs/004-provider-validation-execution/plan.md
@@ -1,0 +1,130 @@
+# Implementation Plan: Provider Validation Execution Alignment
+
+**Branch**: `004-provider-validation-execution` | **Date**: 2026-05-15 | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from `/specs/004-provider-validation-execution/spec.md`
+
+**Note**: This template is filled in by the `/speckit.plan` command. See `.specify/templates/plan-template.md` for the execution workflow.
+
+## Summary
+
+Align provider query execution with declared query capabilities and preflight validation. The design adds explicit provider keys to query providers and capability declarations, makes unsupported execution failures expose stable code/category/message data, and lets providers run shared validation before execution while keeping provider-specific safeguards authoritative.
+
+## Technical Context
+
+**Language/Version**: C# latest, .NET 8.0 / 9.0 / 10.0 multi-targeting  
+**Primary Dependencies**: Existing `Microsoft.Extensions.DependencyInjection.Abstractions`, `Microsoft.Extensions.Logging.Abstractions`; SQLite provider keeps existing `Microsoft.Data.Sqlite`  
+**Storage**: N/A for core validation/failure contracts; existing in-memory and SQLite JSON providers keep current persistence behavior  
+**Testing**: xUnit via `dotnet test Aster.sln`  
+**Target Platform**: .NET library usable from Generic Host / ASP.NET Core hosts  
+**Project Type**: SDK/library with provider package  
+**Performance Goals**: Validation remains in-memory over a `ResourceQuery` AST and should add only small per-query overhead before provider execution; no additional database round trips are introduced by validation  
+**Constraints**: No public `IQueryable<Resource>` contract; no raw SQL public surface; no silent fallback; no new third-party dependencies expected; execution remains authoritative  
+**Scale/Scope**: Current scope covers existing in-memory and SQLite JSON providers, active provider/capability matching, unsupported query failure shape, provider consistency tests, and documentation updates
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+- **SDK-first/headless**: PASS — Adds SDK contracts/failures and provider behavior only; no UI/CMS coupling.
+- **Immutable versioning**: PASS — Query validation/execution behavior does not alter resource mutation semantics.
+- **Channel activation**: PASS — Active/draft scope behavior remains represented in the query model and capability declarations.
+- **Typed/queryable**: PASS — Preserves portable `ResourceQuery`; explicitly avoids public `IQueryable<Resource>` or provider-specific query construction.
+- **Provider agnostic**: PASS — Core validation and failure contracts remain provider-neutral; providers declare explicit keys/capabilities.
+- **Simplicity first**: PASS — Use provider keys, existing validator, and structured exception data instead of a query planner or negotiation system.
+- **Modern C# idioms**: PASS — Records/properties and concise exception contracts fit the existing code style.
+- **Readability over cleverness**: PASS — Explicit provider keys avoid type-name inference and hidden matching behavior.
+- **Explicitness over magic**: PASS — Provider identity and failure categories are visible through code/configuration/results.
+- **Abstractions justified**: PASS — Provider identity and structured execution failures address current multi-provider validation/execution consistency needs.
+- **Optimize for deletion**: PASS — Changes are localized to query provider/capability/failure surfaces and can be removed without changing resource storage.
+- **Composition over inheritance**: PASS — No inheritance hierarchy planned; behavior composes through services and provider declarations.
+- **Intentional dependencies**: PASS — No new third-party dependencies.
+- **Operational simplicity**: PASS — No infrastructure or deployment changes; debugging improves via stable failure codes/categories.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/004-provider-validation-execution/
+├── plan.md
+├── research.md
+├── data-model.md
+├── quickstart.md
+├── contracts/
+│   └── provider-validation-execution.md
+└── tasks.md
+```
+
+### Source Code (repository root)
+
+```text
+src/
+├── core/
+│   └── Aster.Core/
+│       ├── Abstractions/
+│       │   ├── IResourceQueryCapabilitiesProvider.cs
+│       │   ├── IResourceQueryProviderIdentity.cs
+│       │   ├── IResourceQueryService.cs
+│       │   └── IResourceQueryValidator.cs
+│       ├── Exceptions/
+│       │   └── AsterExceptions.cs
+│       ├── InMemory/
+│       │   ├── InMemoryQueryCapabilitiesProvider.cs
+│       │   └── InMemoryQueryService.cs
+│       ├── Models/
+│       │   └── Querying/
+│       │       ├── QueryCapabilityDescription.cs
+│       │       ├── QueryValidationFailure.cs
+│       │       └── QueryValidationResult.cs
+│       └── Services/
+│           └── ResourceQueryValidator.cs
+├── persistence/
+│   └── Aster.Persistence.SqliteJson/
+│       ├── SqliteJsonQueryCapabilitiesProvider.cs
+│       └── SqliteJsonQueryService.cs
+test/
+└── Aster.Tests/
+    ├── InMemory/
+    │   └── InMemoryQueryServiceTests.cs
+    ├── Querying/
+    │   ├── QueryCapabilityDiscoveryTests.cs
+    │   └── ResourceQueryValidatorTests.cs
+    └── SqliteJson/
+        ├── SqliteJsonQueryCapabilityTests.cs
+        └── SqliteJsonQueryServiceTests.cs
+```
+
+**Structure Decision**: Keep provider identity, validation, and execution failure contracts in `Aster.Core` because they are provider-neutral SDK surface. Provider-specific declarations and execution integration remain beside each provider. Tests stay in the existing provider/querying test folders to compare validation and execution behavior without creating a new test project.
+
+## Phase 0: Research
+
+Completed in [research.md](research.md).
+
+## Phase 1: Design & Contracts
+
+Completed artifacts:
+
+- [data-model.md](data-model.md)
+- [contracts/provider-validation-execution.md](contracts/provider-validation-execution.md)
+- [quickstart.md](quickstart.md)
+
+## Post-Design Constitution Check
+
+- **SDK-first/headless**: PASS — Public surface remains SDK contracts, exceptions, and provider declarations.
+- **Immutable versioning**: PASS — No resource persistence mutation changes introduced.
+- **Channel activation**: PASS — Activation remains a query scope concern only.
+- **Typed/queryable**: PASS — No public `IQueryable<Resource>` or provider-specific query construction.
+- **Provider agnostic**: PASS — Core identity/failure abstractions do not depend on SQLite or in-memory implementation details.
+- **Simplicity first**: PASS — Explicit provider key plus shared validator reuse is the smallest design that resolves stale capability matching and consistency.
+- **Modern C# idioms**: PASS — Uses existing records/interfaces/exceptions style.
+- **Readability over cleverness**: PASS — Explicit key matching replaces type-name matching.
+- **Explicitness over magic**: PASS — Provider identity and unsupported failure details are discoverable.
+- **Abstractions justified**: PASS — `IResourceQueryProviderIdentity` or equivalent key surface is required by current custom-provider fail-closed behavior.
+- **Optimize for deletion**: PASS — Provider key/failure additions are localized to query execution and validation.
+- **Composition over inheritance**: PASS — Providers compose identity/capability/validation behavior without inheritance.
+- **Intentional dependencies**: PASS — No new third-party dependencies.
+- **Operational simplicity**: PASS — No setup/runtime infrastructure changes.
+
+## Complexity Tracking
+
+No constitution violations identified.

--- a/specs/004-provider-validation-execution/quickstart.md
+++ b/specs/004-provider-validation-execution/quickstart.md
@@ -1,0 +1,73 @@
+# Quickstart: Provider Validation Execution Alignment
+
+## Inspect Provider Capabilities
+
+```csharp
+var capabilities = serviceProvider
+    .GetRequiredService<IResourceQueryCapabilitiesProvider>()
+    .Capabilities;
+
+Console.WriteLine(capabilities.ProviderKey);
+Console.WriteLine(capabilities.ProviderName);
+```
+
+## Validate Before Execution
+
+```csharp
+var query = new ResourceQuery
+{
+    DefinitionId = "Product",
+    Sorts = [new SortExpression("Title", AspectKey: "TitleAspect")],
+};
+
+var validator = serviceProvider.GetRequiredService<IResourceQueryValidator>();
+var validation = validator.Validate(query);
+
+if (!validation.IsValid)
+{
+    foreach (var failure in validation.Failures)
+        Console.WriteLine($"{failure.Code} ({failure.Feature}): {failure.Message}");
+
+    return;
+}
+```
+
+## Execution Still Enforces Unsupported Shapes
+
+```csharp
+try
+{
+    var queryService = serviceProvider.GetRequiredService<IResourceQueryService>();
+    var results = await queryService.QueryAsync(query);
+}
+catch (UnsupportedQueryFeatureException ex)
+{
+    Console.WriteLine($"{ex.Code} ({ex.Feature}): {ex.Message}");
+}
+```
+
+If caller preflight is skipped, the provider still validates and rejects unsupported query shapes before or during execution.
+
+## Custom Provider Registration
+
+Custom providers must use a stable provider key and register matching capabilities.
+
+```csharp
+services.AddSingleton<IResourceQueryService, MyQueryService>();
+services.AddSingleton<IResourceQueryCapabilitiesProvider, MyQueryCapabilitiesProvider>();
+```
+
+Validation fails closed with `capabilities-not-declared` when the active provider's key has no matching capability declaration.
+
+## Provider Consistency Tests
+
+Provider tests should compare validation and execution:
+
+```csharp
+var validation = validator.Validate(unsupportedQuery);
+var exception = await Assert.ThrowsAsync<UnsupportedQueryFeatureException>(
+    () => queryService.QueryAsync(unsupportedQuery).AsTask());
+
+Assert.Contains(validation.Failures, failure => failure.Code == exception.Code);
+Assert.Equal("sort", exception.Feature);
+```

--- a/specs/004-provider-validation-execution/research.md
+++ b/specs/004-provider-validation-execution/research.md
@@ -1,0 +1,59 @@
+# Research: Provider Validation Execution Alignment
+
+## Decision 1: Match providers and capabilities with an explicit provider key
+
+**Decision**: Add an explicit provider key to the active query provider and to its capability declaration. Validation uses this key to select capabilities.
+
+**Rationale**: Type-name matching is brittle and can validate against stale defaults when hosts replace `IResourceQueryService`. An explicit key is discoverable, testable, and consistent with the constitution's explicitness principle.
+
+**Alternatives considered**:
+
+- Last registered capability declaration. Rejected because default capabilities can remain registered after provider replacement.
+- Concrete type-name matching. Rejected because it is convention-based and fails for wrappers, decorators, or custom provider naming.
+- Require exactly one capability declaration. Rejected because hosts may register multiple providers during setup or testing.
+
+## Decision 2: Introduce structured unsupported execution failures
+
+**Decision**: Execution-time unsupported query failures expose stable code, feature category, path when available, and actionable message.
+
+**Rationale**: Validation already produces structured failures. Execution must remain authoritative, but callers need consistent handling when validation is skipped or stale.
+
+**Alternatives considered**:
+
+- Message-only consistency. Rejected because tests and callers need stable categories that do not depend on message text.
+- Throw full validation result. Rejected because execution may stop at the first provider-specific blocking failure and should not imply all failures were detected.
+- Keep existing exception unchanged. Rejected because it cannot satisfy stable code/category requirements.
+
+## Decision 3: Providers run shared validation before execution, then keep provider-specific checks
+
+**Decision**: Provider query services run shared validation before translating/executing a query. Provider-specific translation and execution checks remain in place.
+
+**Rationale**: Shared validation aligns common unsupported-shape feedback and reduces drift. Provider-specific checks still protect against capability declaration bugs and constraints only known during translation.
+
+**Alternatives considered**:
+
+- Rely only on shared validation. Rejected because execution must remain authoritative and provider-specific conditions can exist.
+- Keep current provider checks only. Rejected because validation/execution consistency remains manual and drift-prone.
+- Share lower-level helper functions without running validation. Rejected as more internal coupling with less user-visible consistency.
+
+## Decision 4: Keep preflight validation non-throwing
+
+**Decision**: Preflight validation continues to return `QueryValidationResult`; only execution raises unsupported query exceptions.
+
+**Rationale**: Preflight failures are expected user feedback and should remain easy to render in applications. Execution failures are exceptional because the provider was asked to perform unsupported work.
+
+**Alternatives considered**:
+
+- Make validation throw. Rejected because it would regress current validation ergonomics.
+- Make execution return validation results. Rejected because it would break existing query execution shape and mix successful result enumeration with failure reporting.
+
+## Decision 5: No new dependencies or provider framework
+
+**Decision**: Implement provider identity, validation reuse, and structured exceptions using existing platform and project dependencies.
+
+**Rationale**: The current need is small and direct: identify providers, select matching capabilities, and produce consistent failures. A larger provider framework would be premature.
+
+**Alternatives considered**:
+
+- Add a provider registry package or options framework. Rejected because existing DI and small contracts are sufficient.
+- Add a query planner. Rejected because this feature does not rewrite queries or negotiate provider capabilities.

--- a/specs/004-provider-validation-execution/spec.md
+++ b/specs/004-provider-validation-execution/spec.md
@@ -1,0 +1,139 @@
+# Feature Specification: Provider Validation Execution Alignment
+
+**Feature Branch**: `004-provider-validation-execution`  
+**Created**: 2026-05-15  
+**Status**: Draft  
+**Input**: User description: "Align provider query execution with declared query capabilities and preflight validation. Providers should be able to reuse shared validation before execution, execution should remain authoritative, unsupported query failures should be consistent and actionable, and custom providers without declared capabilities should fail closed instead of accidentally validating against stale defaults."
+
+## Clarifications
+
+### Session 2026-05-15
+
+- Q: What consistency shape should execution failures expose? → A: Execution failures expose stable code/category plus message.
+- Q: How should validation match the active provider to its capability declaration? → A: Match active provider and capabilities by explicit provider key.
+- Q: How should providers use shared validation during execution? → A: Execution runs shared validation first, then keeps provider-specific checks.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Execute With Consistent Unsupported-Query Feedback (Priority: P1)
+
+As an application developer executing resource queries, I want provider execution failures to match preflight validation categories, so that skipped validation and failed execution produce the same actionable explanation for unsupported query shapes.
+
+**Why this priority**: Execution is the final authority. If execution and validation disagree, developers cannot trust preflight results or error handling.
+
+**Independent Test**: Can be fully tested by sending unsupported query shapes directly to provider execution and confirming the failure category, message, and affected query feature match the corresponding validation result.
+
+**Acceptance Scenarios**:
+
+1. **Given** a SQLite-backed application and a query with unsupported facet sorting, **When** the query is executed without calling validation first, **Then** execution fails with an actionable unsupported-query failure that identifies facet sorting.
+2. **Given** a query with multiple unsupported features, **When** the query is preflighted and then executed, **Then** both paths identify the same unsupported feature categories even though execution may stop at the first blocking failure.
+3. **Given** a provider supports a query shape, **When** the query is preflighted and executed, **Then** validation succeeds and execution proceeds without additional unsupported-query failures.
+
+---
+
+### User Story 2 - Fail Closed For Providers Without Declared Capabilities (Priority: P1)
+
+As a host developer replacing or adding a query provider, I want validation to detect missing capability declarations for the active provider, so that applications do not accidentally validate against a previous provider's stale defaults.
+
+**Why this priority**: Provider-agnostic behavior depends on active provider capabilities being explicit. Silent reuse of another provider's capabilities can make unsupported production behavior appear safe.
+
+**Independent Test**: Can be fully tested by registering a custom query provider without matching capabilities and confirming validation fails closed with a capabilities-not-declared result.
+
+**Acceptance Scenarios**:
+
+1. **Given** an application replaces the default query provider without declaring capabilities, **When** a query is validated, **Then** validation fails with a capabilities-not-declared failure.
+2. **Given** an application registers a provider and matching capability declaration using the same explicit provider key, **When** a supported query is validated, **Then** validation uses that provider's declaration rather than an earlier default declaration.
+3. **Given** multiple providers are registered during host setup, **When** a query is validated, **Then** the active provider's capabilities are used deterministically.
+
+---
+
+### User Story 3 - Keep Provider Execution Authoritative (Priority: P2)
+
+As a library maintainer, I want preflight validation to reduce duplicate unsupported-shape logic without weakening provider execution safeguards, so that query services remain safe even when validation is skipped or stale.
+
+**Why this priority**: Shared validation improves consistency, but execution must still protect provider-specific constraints at the boundary.
+
+**Independent Test**: Can be fully tested by exercising provider execution with invalid or unsupported queries and confirming execution still rejects them without relying on callers to preflight.
+
+**Acceptance Scenarios**:
+
+1. **Given** callers skip validation, **When** an unsupported query reaches a provider, **Then** the provider still rejects it explicitly.
+2. **Given** validation behavior is shared across providers where appropriate, **When** a provider has additional execution constraints, **Then** those constraints remain enforced by execution.
+3. **Given** provider capabilities and execution behavior diverge during development, **When** tests compare validation and execution, **Then** the mismatch is detected.
+
+---
+
+### User Story 4 - Document The Recommended Query Flow (Priority: P3)
+
+As an SDK consumer, I want clear guidance for capability discovery, validation, and execution, so that I know when to preflight queries and how to handle unsupported provider behavior.
+
+**Why this priority**: The feature improves safety only if consumers can understand the intended flow and the distinction between advisory validation and authoritative execution.
+
+**Independent Test**: Can be fully tested by following the documentation to inspect capabilities, validate a query, handle failures, and execute a supported query.
+
+**Acceptance Scenarios**:
+
+1. **Given** a developer reads the querying documentation, **When** they follow the recommended flow, **Then** they can inspect capabilities before executing a query.
+2. **Given** validation reports failures, **When** the developer handles those failures, **Then** they can avoid executing unsupported query shapes.
+3. **Given** validation is skipped, **When** execution fails, **Then** documentation explains that providers still reject unsupported shapes.
+
+### Edge Cases
+
+- A custom provider replaces the active query service but does not declare capabilities.
+- Multiple providers and capability declarations are registered during host setup.
+- A query validates successfully before host configuration changes, then executes against a different active provider.
+- A provider supports most of a query but rejects one provider-specific value shape during execution.
+- A query contains multiple unsupported features; validation can report all detectable failures while execution may stop at the first blocking failure.
+- Provider capability declarations drift from execution behavior.
+
+### Constitution Alignment *(mandatory)*
+
+- **Simplicity**: The simplest acceptable behavior is to align validation and execution feedback around the current portable query model. A query planner, automatic query rewriting, cross-provider negotiation, and new provider framework are intentionally out of scope.
+- **Explicitness**: Active provider capabilities and failure categories must remain discoverable through registration, validation results, and execution errors.
+- **Dependencies**: None expected.
+- **Operational Impact**: No new infrastructure or deployment requirements. Debugging should improve because unsupported-query failures become more consistent between validation and execution.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: Query execution MUST reject unsupported provider query shapes explicitly even when callers skip preflight validation.
+- **FR-002**: Query execution failures for unsupported query shapes MUST include a stable failure code, an unsupported feature category, and an actionable message.
+- **FR-003**: Preflight validation and provider execution SHOULD use the same unsupported-feature categories where both paths can detect the same query shape.
+- **FR-004**: Validation MUST fail closed with capabilities-not-declared when the active query provider has no matching capability declaration.
+- **FR-005**: Validation MUST choose the active provider's capability declaration by explicit provider key when multiple providers are registered.
+- **FR-006**: Registering a new query provider SHOULD require an explicit matching provider key in its capability declaration for validation to succeed.
+- **FR-007**: Providers SHOULD run shared validation before execution and MUST keep provider-specific checks authoritative during translation and execution.
+- **FR-008**: Provider tests MUST detect mismatches where validation accepts a query shape that execution rejects as unsupported.
+- **FR-009**: Provider tests MUST detect mismatches where validation rejects a query shape that execution supports.
+- **FR-010**: Validation MUST continue to report all detectable unsupported query features where practical.
+- **FR-011**: Execution MAY stop at the first blocking unsupported feature, but the failure MUST expose the same stable code/category/message shape used for unsupported-query handling.
+- **FR-012**: Existing supported queries MUST continue to execute successfully without requiring callers to invoke validation first.
+- **FR-013**: Documentation MUST explain the recommended flow: inspect capabilities, validate when handling user-defined queries, then execute supported queries.
+- **FR-014**: Documentation MUST explain that validation is advisory and execution remains authoritative.
+- **FR-015**: The feature MUST NOT introduce public raw SQL, public `IQueryable<Resource>`, or provider-specific query construction as the execution contract.
+
+### Key Entities *(include if feature involves data)*
+
+- **Active Query Provider**: The provider currently registered to execute resource queries for the host application, identified for validation purposes by an explicit provider key.
+- **Provider Capability Declaration**: The active provider's machine-readable description of supported query scopes, filters, comparisons, sorting, paging, and value shapes, identified by the same explicit provider key as the provider it describes.
+- **Query Validation Failure**: A structured preflight failure identifying an unsupported query feature before execution.
+- **Unsupported Query Execution Failure**: The execution-time failure raised when a provider receives a query shape it cannot execute; it includes a stable failure code, feature category, and actionable message.
+- **Provider Consistency Case**: A test scenario that compares validation behavior with execution behavior for the same query shape.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: For all documented unsupported SQLite query shapes, validation and execution identify the same unsupported feature category in provider consistency tests.
+- **SC-002**: Custom query provider registration without matching capabilities produces a capabilities-not-declared validation result in 100% of covered configurations.
+- **SC-003**: All existing supported in-memory and SQLite query execution tests continue to pass without requiring explicit preflight validation.
+- **SC-004**: Provider consistency tests cover at least one supported query and at least three unsupported query shapes for each active provider included in the feature.
+- **SC-005**: Documentation includes a complete capability discovery, validation, execution, and unsupported-failure handling example.
+
+## Assumptions
+
+- The active providers for this slice are the existing in-memory and SQLite JSON providers.
+- Execution runs shared validation first but may still report one provider-specific blocking failure while validation may report multiple detectable failures.
+- Capability declarations remain provider-owned and should not become a global query-planning framework.
+- Provider matching uses an explicit provider key and does not require a new dependency.

--- a/specs/004-provider-validation-execution/tasks.md
+++ b/specs/004-provider-validation-execution/tasks.md
@@ -1,0 +1,247 @@
+# Tasks: Provider Validation Execution Alignment
+
+**Input**: Design documents from `/specs/004-provider-validation-execution/`
+**Prerequisites**: `plan.md`, `spec.md`, `research.md`, `data-model.md`, `contracts/provider-validation-execution.md`, `quickstart.md`
+
+**Tests**: Tests are required for this feature because the specification requires provider consistency coverage and explicit validation/execution mismatch detection.
+
+**Organization**: Tasks are grouped by user story so each story can be implemented and tested independently after the shared foundation is in place.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel because it touches different files and does not depend on another incomplete task.
+- **[Story]**: Maps the task to the user story in `spec.md`.
+- Each task includes an exact repository path.
+
+## Phase 1: Setup
+
+**Purpose**: Confirm the existing query surface and prepare story-specific test locations before changing shared contracts.
+
+- [X] T001 Review the current query capability and validation contracts in `src/core/Aster.Core/Abstractions/IResourceQueryCapabilitiesProvider.cs`, `src/core/Aster.Core/Abstractions/IResourceQueryService.cs`, and `src/core/Aster.Core/Abstractions/IResourceQueryValidator.cs`
+- [X] T002 Review the current unsupported query exception and provider execution guards in `src/core/Aster.Core/Exceptions/AsterExceptions.cs`, `src/core/Aster.Core/InMemory/InMemoryQueryService.cs`, `src/persistence/Aster.Persistence.SqliteJson/SqliteJsonQueryService.cs`, `src/persistence/Aster.Persistence.SqliteJson/Querying/SqliteQueryBuilder.cs`, and `src/persistence/Aster.Persistence.SqliteJson/Querying/SqliteWhereTranslator.cs`
+- [X] T003 [P] Review existing provider capability tests in `test/Aster.Tests/InMemory/InMemoryQueryCapabilityTests.cs`, `test/Aster.Tests/SqliteJson/SqliteJsonQueryCapabilityTests.cs`, and `test/Aster.Tests/Querying/QueryCapabilityDiscoveryTests.cs`
+- [X] T004 [P] Review existing provider execution tests in `test/Aster.Tests/InMemory/InMemoryQueryServiceTests.cs` and `test/Aster.Tests/SqliteJson/SqliteJsonQueryServiceTests.cs`
+- [X] T005 Confirm the Constitution Check entries in `specs/004-provider-validation-execution/plan.md` still match the intended implementation scope
+
+---
+
+## Phase 2: Foundational
+
+**Purpose**: Add shared provider identity and structured unsupported-failure primitives that all user stories depend on.
+
+**Critical**: No user story implementation should begin until these shared contracts compile.
+
+- [X] T006 Add the explicit provider identity contract in `src/core/Aster.Core/Abstractions/IResourceQueryProviderIdentity.cs`
+- [X] T007 Add `ProviderKey` to `QueryCapabilityDescription` and its XML documentation in `src/core/Aster.Core/Models/Querying/QueryCapabilityDescription.cs`
+- [X] T008 Update all `QueryCapabilityDescription` construction call sites to pass provider keys in `src/core/Aster.Core/InMemory/InMemoryQueryCapabilitiesProvider.cs` and `src/persistence/Aster.Persistence.SqliteJson/SqliteJsonQueryCapabilitiesProvider.cs`
+- [X] T009 Add stable `Code`, `Feature`, and nullable `Path` properties plus modern constructors to `UnsupportedQueryFeatureException` in `src/core/Aster.Core/Exceptions/AsterExceptions.cs`
+- [X] T010 Add an exception factory or constructor that maps `QueryValidationFailure` to `UnsupportedQueryFeatureException` in `src/core/Aster.Core/Exceptions/AsterExceptions.cs`
+- [X] T011 Make `InMemoryQueryService` expose the in-memory provider key through `IResourceQueryProviderIdentity` in `src/core/Aster.Core/InMemory/InMemoryQueryService.cs`
+- [X] T012 Make `SqliteJsonQueryService` expose the SQLite JSON provider key through `IResourceQueryProviderIdentity` in `src/persistence/Aster.Persistence.SqliteJson/SqliteJsonQueryService.cs`
+- [X] T013 Add matching provider key constants or shared provider-key values for capability providers and query services in `src/core/Aster.Core/InMemory/InMemoryQueryCapabilitiesProvider.cs` and `src/persistence/Aster.Persistence.SqliteJson/SqliteJsonQueryCapabilitiesProvider.cs`
+- [X] T014 Replace type-name capability matching with explicit provider-key matching in `src/core/Aster.Core/Services/ResourceQueryValidator.cs`
+- [X] T015 Preserve only the direct-construction validation fallback for tests and non-DI callers while keeping DI-based provider matching fail-closed in `src/core/Aster.Core/Services/ResourceQueryValidator.cs`
+- [X] T016 Build the solution to catch public contract call-site breaks with `dotnet build Aster.sln`
+
+**Checkpoint**: Provider identity, capability declarations, structured exceptions, and validator matching compile.
+
+---
+
+## Phase 3: User Story 1 - Execute With Consistent Unsupported-Query Feedback (Priority: P1)
+
+**Goal**: Provider execution failures expose stable code/category/message data that aligns with preflight validation for unsupported query shapes.
+
+**Independent Test**: Execute unsupported queries directly against providers without caller preflight and confirm the thrown failure code, feature category, path, and message align with validation failures.
+
+### Tests for User Story 1
+
+- [X] T017 [P] [US1] Add SQLite execution failure assertions for unsupported facet sorting in `test/Aster.Tests/SqliteJson/SqliteJsonQueryServiceTests.cs`
+- [X] T018 [P] [US1] Add SQLite validation/execution consistency tests for unsupported metadata contains field, metadata range filter, facet sort, and date-like range shapes in `test/Aster.Tests/SqliteJson/SqliteJsonQueryServiceTests.cs`
+- [X] T019 [P] [US1] Add in-memory execution failure assertions for unknown filter, unknown logical operator, and unknown comparator shapes in `test/Aster.Tests/InMemory/InMemoryQueryServiceTests.cs`
+- [X] T020 [P] [US1] Add supported-query validation/execution consistency cases for in-memory and SQLite providers in `test/Aster.Tests/Querying/QueryCapabilityDiscoveryTests.cs`
+
+### Implementation for User Story 1
+
+- [X] T021 [US1] Inject or otherwise compose shared query validation into `SqliteJsonQueryService` in `src/persistence/Aster.Persistence.SqliteJson/SqliteJsonQueryService.cs`
+- [X] T022 [US1] Run shared validation before SQLite translation and throw the first blocking validation failure as `UnsupportedQueryFeatureException` in `src/persistence/Aster.Persistence.SqliteJson/SqliteJsonQueryService.cs`
+- [X] T023 [US1] Replace SQLite service-level unsupported scope, activation, skip, and take exceptions with structured unsupported failures in `src/persistence/Aster.Persistence.SqliteJson/SqliteJsonQueryService.cs`
+- [X] T024 [US1] Replace SQLite sort builder unsupported failures with structured code/feature/path values in `src/persistence/Aster.Persistence.SqliteJson/Querying/SqliteQueryBuilder.cs`
+- [X] T025 [US1] Replace SQLite predicate translator unsupported failures with structured code/feature/path values in `src/persistence/Aster.Persistence.SqliteJson/Querying/SqliteWhereTranslator.cs`
+- [X] T026 [US1] Inject or otherwise compose shared query validation into `InMemoryQueryService` and run it before in-memory evaluation in `src/core/Aster.Core/InMemory/InMemoryQueryService.cs`
+- [X] T027 [US1] Replace in-memory evaluator unsupported failures with structured code/feature/path values in `src/core/Aster.Core/InMemory/InMemoryQueryService.cs`
+- [X] T028 [US1] Ensure execution failure messages remain actionable and provider-specific without relying on message text for tests in `src/core/Aster.Core/Exceptions/AsterExceptions.cs`
+- [X] T029 [US1] Run US1 tests with `dotnet test Aster.sln --filter "FullyQualifiedName~SqliteJsonQueryServiceTests|FullyQualifiedName~InMemoryQueryServiceTests|FullyQualifiedName~QueryCapabilityDiscoveryTests"`
+
+**Checkpoint**: Unsupported execution failures are structured and align with validation categories for the covered query shapes.
+
+---
+
+## Phase 4: User Story 2 - Fail Closed For Providers Without Declared Capabilities (Priority: P1)
+
+**Goal**: Validation uses the active provider's explicit provider key and fails closed when no matching capability declaration exists.
+
+**Independent Test**: Register a custom active query provider without matching capabilities and confirm validation returns a `capabilities-not-declared` failure.
+
+### Tests for User Story 2
+
+- [X] T030 [P] [US2] Add a custom active provider without matching capabilities test in `test/Aster.Tests/Querying/ResourceQueryValidatorTests.cs`
+- [X] T031 [P] [US2] Add a provider-key mismatch fails-closed test in `test/Aster.Tests/Querying/ResourceQueryValidatorTests.cs`
+- [X] T032 [P] [US2] Add a registration-order test proving explicit provider-key matching selects the active provider capabilities in `test/Aster.Tests/Querying/QueryCapabilityDiscoveryTests.cs`
+- [X] T033 [P] [US2] Add provider key assertions for in-memory and SQLite capability declarations in `test/Aster.Tests/InMemory/InMemoryQueryCapabilityTests.cs` and `test/Aster.Tests/SqliteJson/SqliteJsonQueryCapabilityTests.cs`
+
+### Implementation for User Story 2
+
+- [X] T034 [US2] Validate non-empty provider keys on capability declarations in `src/core/Aster.Core/Services/ResourceQueryValidator.cs`
+- [X] T035 [US2] Return a `capabilities-not-declared` validation failure when the active provider key has no matching declaration in `src/core/Aster.Core/Services/ResourceQueryValidator.cs`
+- [X] T036 [US2] Ensure validation chooses exact provider-key matches deterministically when multiple capability providers are registered in `src/core/Aster.Core/Services/ResourceQueryValidator.cs`
+- [X] T037 [US2] Update service registration code if needed so active query services and capability providers are available to validation in `src/core/Aster.Core/Extensions/AsterCoreServiceCollectionExtensions.cs` and `src/persistence/Aster.Persistence.SqliteJson/SqliteJsonAsterServiceCollectionExtensions.cs`
+- [X] T038 [US2] Run US2 tests with `dotnet test Aster.sln --filter "FullyQualifiedName~ResourceQueryValidatorTests|FullyQualifiedName~QueryCapabilityDiscoveryTests|FullyQualifiedName~QueryCapabilityTests"`
+
+**Checkpoint**: Validation no longer validates custom or replaced providers against stale default capabilities.
+
+---
+
+## Phase 5: User Story 3 - Keep Provider Execution Authoritative (Priority: P2)
+
+**Goal**: Providers reuse shared validation but keep provider-specific execution and translation safeguards.
+
+**Independent Test**: Skip caller preflight, execute invalid or unsupported query shapes, and confirm providers still reject them explicitly while supported queries still execute.
+
+### Tests for User Story 3
+
+- [X] T039 [P] [US3] Add SQLite tests proving provider-specific translator constraints still reject invalid range and logical expression shapes in `test/Aster.Tests/SqliteJson/SqliteJsonQueryServiceTests.cs`
+- [X] T040 [P] [US3] Add in-memory tests proving execution still rejects unsupported expression enum values when caller preflight is skipped in `test/Aster.Tests/InMemory/InMemoryQueryServiceTests.cs`
+- [X] T041 [P] [US3] Add provider consistency helper coverage for validation-accepts/execution-rejects drift in `test/Aster.Tests/Querying/QueryCapabilityDiscoveryTests.cs`
+- [X] T042 [P] [US3] Add provider consistency helper coverage for validation-rejects/execution-supports drift in `test/Aster.Tests/Querying/QueryCapabilityDiscoveryTests.cs`
+- [X] T043 [P] [US3] Add a multi-failure validation test proving validation still reports all detectable unsupported features in `test/Aster.Tests/Querying/ResourceQueryValidatorTests.cs`
+
+### Implementation for User Story 3
+
+- [X] T044 [US3] Keep SQLite translator guard clauses after shared validation in `src/persistence/Aster.Persistence.SqliteJson/Querying/SqliteWhereTranslator.cs`
+- [X] T045 [US3] Keep SQLite sort and scope guard clauses after shared validation in `src/persistence/Aster.Persistence.SqliteJson/Querying/SqliteQueryBuilder.cs`
+- [X] T046 [US3] Keep in-memory evaluator guard clauses for unknown filters, operators, and comparators in `src/core/Aster.Core/InMemory/InMemoryQueryService.cs`
+- [X] T047 [US3] Add or refine provider consistency test helpers for code/category comparison in `test/Aster.Tests/Querying/QueryCapabilityDiscoveryTests.cs`
+- [X] T048 [US3] Run US3 tests with `dotnet test Aster.sln --filter "FullyQualifiedName~SqliteJsonQueryServiceTests|FullyQualifiedName~InMemoryQueryServiceTests|FullyQualifiedName~QueryCapabilityDiscoveryTests|FullyQualifiedName~ResourceQueryValidatorTests"`
+
+**Checkpoint**: Shared validation reduces drift, but provider execution remains the authoritative boundary.
+
+---
+
+## Phase 6: User Story 4 - Document The Recommended Query Flow (Priority: P3)
+
+**Goal**: SDK consumers can discover capabilities, validate queries, execute supported queries, and handle authoritative execution failures.
+
+**Independent Test**: Follow the documentation examples to inspect capabilities, validate a query, handle validation failures, and catch structured unsupported execution failures.
+
+### Tests for User Story 4
+
+- [X] T049 [P] [US4] Verify documentation snippets compile conceptually against current public APIs in `specs/004-provider-validation-execution/quickstart.md`
+
+### Implementation for User Story 4
+
+- [X] T050 [US4] Document provider capability discovery, validation, execution, and failure handling in `wiki/Querying.md`
+- [X] T051 [US4] Document explicit provider keys and fail-closed capability matching in `wiki/DI-Registration.md`
+- [X] T052 [US4] Document structured unsupported query exceptions in `wiki/Exception-Reference.md`
+- [X] T053 [US4] Update core SDK query guidance with provider validation flow in `src/core/Aster.Core/README.md`
+- [X] T054 [US4] Update SQLite provider query capability guidance in `src/persistence/Aster.Persistence.SqliteJson/README.md`
+- [X] T055 [US4] Re-run the quickstart scenario manually against the public API descriptions in `specs/004-provider-validation-execution/quickstart.md`
+
+**Checkpoint**: Documentation explains validation as advisory, execution as authoritative, and custom provider capability matching as explicit.
+
+---
+
+## Phase 7: Polish & Cross-Cutting Concerns
+
+**Purpose**: Verify the full feature, keep the implementation small, and prepare for review.
+
+- [X] T056 [P] Review public API XML documentation for provider identity, capability provider keys, validation failures, and unsupported execution failures in `src/core/Aster.Core/Abstractions/IResourceQueryProviderIdentity.cs`, `src/core/Aster.Core/Models/Querying/QueryCapabilityDescription.cs`, and `src/core/Aster.Core/Exceptions/AsterExceptions.cs`
+- [X] T057 [P] Review docs for consistency of provider key names, failure codes, and unsupported feature categories in `wiki/Querying.md`, `wiki/DI-Registration.md`, `wiki/Exception-Reference.md`, `src/core/Aster.Core/README.md`, and `src/persistence/Aster.Persistence.SqliteJson/README.md`
+- [X] T058 Confirm no public raw SQL, public `IQueryable<Resource>`, or provider-specific query construction contract was introduced in `src/core/Aster.Core/Abstractions/IResourceQueryService.cs` and `src/core/Aster.Core/Extensions/TypedQuery.cs`
+- [X] T059 Re-run the Constitution Check against implementation decisions in `specs/004-provider-validation-execution/plan.md`
+- [X] T060 Run the full test suite with `dotnet test Aster.sln`
+- [X] T061 Run formatting or build verification expected by the repo with `dotnet build Aster.sln`
+- [X] T062 Review `git diff --check` output for whitespace and patch formatting issues in `/Users/sipke/Projects/ValenceWorks/aster`
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies; can start immediately.
+- **Foundational (Phase 2)**: Depends on Setup; blocks all user stories.
+- **US1 and US2 (P1)**: Depend on Foundational; can proceed in parallel after T016 if staffed.
+- **US3 (P2)**: Depends on Foundational and benefits from US1 failure helpers, but remains independently testable.
+- **US4 (P3)**: Depends on the public API names settled by US1 and US2.
+- **Polish (Phase 7)**: Depends on desired user stories being complete.
+
+### User Story Dependencies
+
+- **US1**: Can start after Phase 2; no dependency on US2.
+- **US2**: Can start after Phase 2; no dependency on US1.
+- **US3**: Can start after Phase 2, but should reconcile with US1 structured exception helpers before completion.
+- **US4**: Should start after API names and failure shapes are stable.
+
+### Within Each User Story
+
+- Write story tests first and confirm they fail for the missing behavior.
+- Implement only the story-specific source changes needed to satisfy those tests.
+- Run the story-specific test command before moving to the next story.
+- Keep provider-specific checks in place unless a test proves they are duplicate dead code.
+
+## Parallel Execution Examples
+
+### User Story 1
+
+```text
+Task: "T017 Add SQLite execution failure assertions in test/Aster.Tests/SqliteJson/SqliteJsonQueryServiceTests.cs"
+Task: "T019 Add in-memory execution failure assertions in test/Aster.Tests/InMemory/InMemoryQueryServiceTests.cs"
+Task: "T020 Add supported-query consistency cases in test/Aster.Tests/Querying/QueryCapabilityDiscoveryTests.cs"
+```
+
+### User Story 2
+
+```text
+Task: "T030 Add custom provider without capabilities test in test/Aster.Tests/Querying/ResourceQueryValidatorTests.cs"
+Task: "T032 Add registration-order provider key test in test/Aster.Tests/Querying/QueryCapabilityDiscoveryTests.cs"
+Task: "T033 Add provider key assertions in provider capability test files"
+```
+
+### User Story 3
+
+```text
+Task: "T039 Add SQLite authoritative execution guard tests in test/Aster.Tests/SqliteJson/SqliteJsonQueryServiceTests.cs"
+Task: "T040 Add in-memory authoritative execution guard tests in test/Aster.Tests/InMemory/InMemoryQueryServiceTests.cs"
+Task: "T041 Add validation-accepts/execution-rejects drift helper coverage in test/Aster.Tests/Querying/QueryCapabilityDiscoveryTests.cs"
+```
+
+### User Story 4
+
+```text
+Task: "T050 Document query flow in wiki/Querying.md"
+Task: "T051 Document provider keys in wiki/DI-Registration.md"
+Task: "T052 Document structured exceptions in wiki/Exception-Reference.md"
+```
+
+## Implementation Strategy
+
+### MVP First
+
+1. Complete Phase 1 and Phase 2.
+2. Complete US1 so execution failures become structured and consistent.
+3. Run US1 tests and stop for validation.
+
+### Incremental Delivery
+
+1. Add explicit provider identity and structured unsupported failures.
+2. Deliver US1 for execution feedback consistency.
+3. Deliver US2 for fail-closed provider capability matching.
+4. Deliver US3 for authoritative provider execution safeguards.
+5. Deliver US4 documentation once the final API names are stable.
+
+### Simplicity Guardrails
+
+- Use explicit provider keys and existing DI rather than adding a provider registry framework.
+- Keep validation non-throwing and execution throwing.
+- Keep provider-specific checks near provider translation/execution code.
+- Avoid new third-party dependencies.

--- a/src/core/Aster.Core/Abstractions/IResourceQueryProviderIdentity.cs
+++ b/src/core/Aster.Core/Abstractions/IResourceQueryProviderIdentity.cs
@@ -1,0 +1,12 @@
+namespace Aster.Core.Abstractions;
+
+/// <summary>
+/// Exposes the stable provider key used to match query execution with declared capabilities.
+/// </summary>
+public interface IResourceQueryProviderIdentity
+{
+    /// <summary>
+    /// Gets the stable provider key for this query provider.
+    /// </summary>
+    string ProviderKey { get; }
+}

--- a/src/core/Aster.Core/Exceptions/AsterExceptions.cs
+++ b/src/core/Aster.Core/Exceptions/AsterExceptions.cs
@@ -143,6 +143,7 @@ public sealed class UnsupportedQueryFeatureException : Exception
     public UnsupportedQueryFeatureException(string message, Exception innerException)
         : base(message, innerException)
     {
+        ArgumentException.ThrowIfNullOrWhiteSpace(message);
         Code = "unsupported-query-feature";
         Feature = "query";
     }

--- a/src/core/Aster.Core/Exceptions/AsterExceptions.cs
+++ b/src/core/Aster.Core/Exceptions/AsterExceptions.cs
@@ -1,3 +1,5 @@
+using Aster.Core.Models.Querying;
+
 namespace Aster.Core.Exceptions;
 
 /// <summary>
@@ -91,13 +93,73 @@ public sealed class SingletonViolationException : Exception
 /// </summary>
 public sealed class UnsupportedQueryFeatureException : Exception
 {
+    /// <summary>
+    /// Gets the stable unsupported query failure code.
+    /// </summary>
+    public string Code { get; }
+
+    /// <summary>
+    /// Gets the unsupported query feature category.
+    /// </summary>
+    public string Feature { get; }
+
+    /// <summary>
+    /// Gets the optional query path where the unsupported feature was found.
+    /// </summary>
+    public string? Path { get; }
+
     /// <inheritdoc />
-    public UnsupportedQueryFeatureException() : base("The query contains an unsupported feature.") { }
+    public UnsupportedQueryFeatureException()
+        : this("unsupported-query-feature", "query", "The query contains an unsupported feature.") { }
 
     /// <inheritdoc />
     public UnsupportedQueryFeatureException(string feature)
-        : base($"The query feature '{feature}' is not supported.") { }
+        : this("unsupported-query-feature", feature, $"The query feature '{feature}' is not supported.") { }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="UnsupportedQueryFeatureException"/> class.
+    /// </summary>
+    /// <param name="code">Stable unsupported query failure code.</param>
+    /// <param name="feature">Unsupported query feature category.</param>
+    /// <param name="message">Human-readable actionable explanation.</param>
+    /// <param name="path">Optional query path where the unsupported feature was found.</param>
+    public UnsupportedQueryFeatureException(
+        string code,
+        string feature,
+        string message,
+        string? path = null)
+        : base(message)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(code);
+        ArgumentException.ThrowIfNullOrWhiteSpace(feature);
+        ArgumentException.ThrowIfNullOrWhiteSpace(message);
+
+        Code = code;
+        Feature = feature;
+        Path = path;
+    }
 
     /// <inheritdoc />
-    public UnsupportedQueryFeatureException(string message, Exception innerException) : base(message, innerException) { }
+    public UnsupportedQueryFeatureException(string message, Exception innerException)
+        : base(message, innerException)
+    {
+        Code = "unsupported-query-feature";
+        Feature = "query";
+    }
+
+    /// <summary>
+    /// Creates an execution exception from a validation failure.
+    /// </summary>
+    /// <param name="failure">The validation failure to expose as an execution failure.</param>
+    /// <returns>An unsupported query feature exception with matching structured details.</returns>
+    public static UnsupportedQueryFeatureException FromValidationFailure(QueryValidationFailure failure)
+    {
+        ArgumentNullException.ThrowIfNull(failure);
+
+        return new(
+            failure.Code,
+            failure.Feature ?? "query",
+            failure.Message,
+            failure.Path);
+    }
 }

--- a/src/core/Aster.Core/InMemory/InMemoryQueryCapabilitiesProvider.cs
+++ b/src/core/Aster.Core/InMemory/InMemoryQueryCapabilitiesProvider.cs
@@ -8,8 +8,14 @@ namespace Aster.Core.InMemory;
 /// </summary>
 public sealed class InMemoryQueryCapabilitiesProvider : IResourceQueryCapabilitiesProvider
 {
+    /// <summary>
+    /// Stable provider key used by the in-memory query provider and its capability declaration.
+    /// </summary>
+    public const string ProviderKey = "in-memory";
+
     /// <inheritdoc />
     public QueryCapabilityDescription Capabilities { get; } = new(
+        ProviderKey: ProviderKey,
         ProviderName: "In-memory",
         SupportedScopes: new HashSet<ResourceVersionScope>
         {

--- a/src/core/Aster.Core/InMemory/InMemoryQueryService.cs
+++ b/src/core/Aster.Core/InMemory/InMemoryQueryService.cs
@@ -3,6 +3,7 @@ using Aster.Core.Abstractions;
 using Aster.Core.Exceptions;
 using Aster.Core.Models.Instances;
 using Aster.Core.Models.Querying;
+using Aster.Core.Services;
 using Microsoft.Extensions.Logging;
 
 namespace Aster.Core.InMemory;
@@ -15,30 +16,42 @@ namespace Aster.Core.InMemory;
 /// Supported comparators: <see cref="ComparisonOperator.Equals"/>, <see cref="ComparisonOperator.Contains"/>,
 /// and <see cref="ComparisonOperator.Range"/>.
 /// </remarks>
-public sealed partial class InMemoryQueryService : IResourceQueryService
+public sealed partial class InMemoryQueryService : IResourceQueryService, IResourceQueryProviderIdentity
 {
     private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web);
 
     private readonly IResourceVersionReader versionReader;
     private readonly ILogger<InMemoryQueryService> logger;
+    private readonly ResourceQueryValidator validator;
 
     /// <summary>
     /// Initializes a new instance of <see cref="InMemoryQueryService"/>.
     /// </summary>
     /// <param name="versionReader">The backing resource version reader.</param>
     /// <param name="logger">The logger.</param>
-    public InMemoryQueryService(IResourceVersionReader versionReader, ILogger<InMemoryQueryService> logger)
+    /// <param name="capabilityProviders">Registered provider capability declarations.</param>
+    public InMemoryQueryService(
+        IResourceVersionReader versionReader,
+        ILogger<InMemoryQueryService> logger,
+        IEnumerable<IResourceQueryCapabilitiesProvider>? capabilityProviders = null)
     {
         ArgumentNullException.ThrowIfNull(versionReader);
         ArgumentNullException.ThrowIfNull(logger);
         this.versionReader = versionReader;
         this.logger = logger;
+        validator = new ResourceQueryValidator(
+            capabilityProviders ?? [new InMemoryQueryCapabilitiesProvider()],
+            this);
     }
+
+    /// <inheritdoc />
+    public string ProviderKey => InMemoryQueryCapabilitiesProvider.ProviderKey;
 
     /// <inheritdoc />
     public async ValueTask<IEnumerable<Resource>> QueryAsync(ResourceQuery query, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(query);
+        ThrowIfInvalid(query);
 
         var candidates = await versionReader.ReadVersionsAsync(new ResourceVersionReadRequest
         {
@@ -80,7 +93,11 @@ public sealed partial class InMemoryQueryService : IResourceQueryService
         AspectPresenceFilter asp => EvaluateAspectPresence(asp, resource),
         FacetValueFilter fv      => EvaluateFacetValue(fv, resource),
         LogicalExpression logic  => EvaluateLogical(logic, resource),
-        _                        => throw new UnsupportedQueryFeatureException($"Unknown filter expression type: {expr.GetType().Name}")
+        _                        => throw Unsupported(
+            "unsupported-filter-type",
+            "predicate",
+            $"Filter expression '{expr.GetType().Name}' is not supported by the in-memory query provider.",
+            "Filter")
     };
 
     private static bool EvaluateMetadata(MetadataFilter filter, Resource resource)
@@ -176,7 +193,11 @@ public sealed partial class InMemoryQueryService : IResourceQueryService
         LogicalOperator.And => expr.Operands.All(op => Evaluate(op, resource)),
         LogicalOperator.Or  => expr.Operands.Any(op => Evaluate(op, resource)),
         LogicalOperator.Not => expr.Operands is [var single] && !Evaluate(single, resource),
-        _                   => throw new UnsupportedQueryFeatureException($"Unsupported logical operator: {expr.Operator}")
+        _                   => throw Unsupported(
+            "unsupported-logical-operator",
+            "logical operator",
+            $"Logical operator '{expr.Operator}' is not supported by the in-memory query provider.",
+            "Filter.Operator")
     };
 
     private static bool ApplyComparator(object? actual, object? expected, ComparisonOperator op) => op switch
@@ -189,13 +210,21 @@ public sealed partial class InMemoryQueryService : IResourceQueryService
             FormatValueInvariant(expected) ?? string.Empty,
             StringComparison.OrdinalIgnoreCase) == true,
         ComparisonOperator.Range => ApplyRangeComparator(actual, expected),
-        _ => throw new UnsupportedQueryFeatureException($"Unknown comparator: {op}")
+        _ => throw Unsupported(
+            "unsupported-comparison-operator",
+            "comparison operator",
+            $"Comparison operator '{op}' is not supported by the in-memory query provider.",
+            "Filter.Operator")
     };
 
     private static bool ApplyRangeComparator(object? actual, object? expected)
     {
         if (expected is not RangeValue range)
-            throw new UnsupportedQueryFeatureException("Range predicates require a RangeValue.");
+            throw Unsupported(
+                "range-value-required",
+                "value shape",
+                "Range predicates require a RangeValue.",
+                "Filter.Value");
 
         if (actual is null)
             return false;
@@ -225,7 +254,11 @@ public sealed partial class InMemoryQueryService : IResourceQueryService
         "owner"        => resource.Owner,
         "version"      => resource.Version,
         "created"      => resource.Created,
-        _ => throw new UnsupportedQueryFeatureException($"Metadata field '{field}' is not supported by the in-memory evaluator.")
+        _ => throw Unsupported(
+            "unsupported-metadata-field",
+            "metadata field",
+            $"Metadata field '{field}' is not supported by the in-memory query provider.",
+            "Filter.Field")
     };
 
     private static object? ResolveSortValue(Resource resource, SortExpression sort) =>
@@ -315,6 +348,20 @@ public sealed partial class InMemoryQueryService : IResourceQueryService
         IFormattable f => f.ToString(null, System.Globalization.CultureInfo.InvariantCulture),
         _ => value.ToString()
     };
+
+    private void ThrowIfInvalid(ResourceQuery query)
+    {
+        var validation = validator.Validate(query);
+        if (!validation.IsValid)
+            throw UnsupportedQueryFeatureException.FromValidationFailure(validation.Failures[0]);
+    }
+
+    private static UnsupportedQueryFeatureException Unsupported(
+        string code,
+        string feature,
+        string message,
+        string? path = null) =>
+        new(code, feature, message, path);
 
     private sealed class ResourceSortComparer(IReadOnlyList<SortExpression> sorts) : IComparer<Resource>
     {

--- a/src/core/Aster.Core/Models/Querying/QueryCapabilityDescription.cs
+++ b/src/core/Aster.Core/Models/Querying/QueryCapabilityDescription.cs
@@ -3,6 +3,7 @@ namespace Aster.Core.Models.Querying;
 /// <summary>
 /// Describes the query shapes a resource query provider can execute.
 /// </summary>
+/// <param name="ProviderKey">Stable provider key used to match capabilities to the active query provider.</param>
 /// <param name="ProviderName">Human-readable provider name.</param>
 /// <param name="SupportedScopes">Resource version scopes supported by the provider.</param>
 /// <param name="RequiresActivationChannelForActiveScope">Whether active scope requires an activation channel.</param>
@@ -18,6 +19,7 @@ namespace Aster.Core.Models.Querying;
 /// <param name="FacetRangeSupport">Facet range value shapes supported by the provider.</param>
 /// <param name="UnsupportedFeatures">Known unsupported features, for discovery and documentation.</param>
 public sealed record QueryCapabilityDescription(
+    string ProviderKey,
     string ProviderName,
     IReadOnlySet<ResourceVersionScope> SupportedScopes,
     bool RequiresActivationChannelForActiveScope,

--- a/src/core/Aster.Core/README.md
+++ b/src/core/Aster.Core/README.md
@@ -133,7 +133,15 @@ Preflight the query against the active provider:
 ```csharp
 var validator = serviceProvider.GetRequiredService<IResourceQueryValidator>();
 var validation = validator.Validate(query);
+
+if (!validation.IsValid)
+{
+    foreach (var failure in validation.Failures)
+        Console.WriteLine($"{failure.Code} ({failure.Feature}): {failure.Message}");
+}
 ```
+
+Provider capabilities are matched to the active query provider by explicit provider key. If a custom provider has no matching capability declaration, validation fails closed with `capabilities-not-declared`. Query execution still enforces unsupported shapes and throws `UnsupportedQueryFeatureException` with stable `Code`, `Feature`, optional `Path`, and an actionable message.
 
 Or build common typed aspect filters without repeating convention-based identifiers:
 

--- a/src/core/Aster.Core/Services/ResourceQueryValidator.cs
+++ b/src/core/Aster.Core/Services/ResourceQueryValidator.cs
@@ -18,7 +18,9 @@ public sealed class ResourceQueryValidator : IResourceQueryValidator
     public ResourceQueryValidator(IEnumerable<IResourceQueryCapabilitiesProvider> capabilityProviders)
     {
         ArgumentNullException.ThrowIfNull(capabilityProviders);
-        capabilities = capabilityProviders.LastOrDefault()?.Capabilities;
+        capabilities = capabilityProviders
+            .Select(provider => provider.Capabilities)
+            .LastOrDefault(HasProviderKey);
     }
 
     /// <summary>
@@ -33,9 +35,11 @@ public sealed class ResourceQueryValidator : IResourceQueryValidator
         ArgumentNullException.ThrowIfNull(capabilityProviders);
         ArgumentNullException.ThrowIfNull(queryService);
 
-        capabilities = capabilityProviders
-            .LastOrDefault(provider => IsCapabilityProviderForQueryService(provider, queryService))
-            ?.Capabilities;
+        capabilities = queryService is IResourceQueryProviderIdentity identity
+            ? capabilityProviders
+                .Select(provider => provider.Capabilities)
+                .LastOrDefault(capabilities => IsCapabilityDeclarationForQueryService(capabilities, identity))
+            : null;
     }
 
     /// <inheritdoc />
@@ -377,18 +381,13 @@ public sealed class ResourceQueryValidator : IResourceQueryValidator
         string? feature = null) =>
         new(code, message, path, feature);
 
-    private static bool IsCapabilityProviderForQueryService(
-        IResourceQueryCapabilitiesProvider provider,
-        IResourceQueryService queryService)
-    {
-        var providerName = NormalizeProviderTypeName(provider.GetType().Name);
-        var queryServiceName = NormalizeProviderTypeName(queryService.GetType().Name);
+    private static bool IsCapabilityDeclarationForQueryService(
+        QueryCapabilityDescription capabilities,
+        IResourceQueryProviderIdentity identity) =>
+        HasProviderKey(capabilities)
+        && !string.IsNullOrWhiteSpace(identity.ProviderKey)
+        && string.Equals(capabilities.ProviderKey, identity.ProviderKey, StringComparison.Ordinal);
 
-        return queryServiceName.StartsWith(providerName, StringComparison.OrdinalIgnoreCase);
-    }
-
-    private static string NormalizeProviderTypeName(string typeName) =>
-        typeName
-            .Replace("QueryCapabilitiesProvider", string.Empty, StringComparison.Ordinal)
-            .Replace("QueryService", string.Empty, StringComparison.Ordinal);
+    private static bool HasProviderKey(QueryCapabilityDescription capabilities) =>
+        !string.IsNullOrWhiteSpace(capabilities.ProviderKey);
 }

--- a/src/persistence/Aster.Persistence.SqliteJson/Querying/SqliteMetadataField.cs
+++ b/src/persistence/Aster.Persistence.SqliteJson/Querying/SqliteMetadataField.cs
@@ -4,7 +4,12 @@ namespace Aster.Persistence.SqliteJson.Querying;
 
 internal static class SqliteMetadataField
 {
-    public static string ResolveColumn(string field, string description) => field.ToLowerInvariant() switch
+    public static string ResolveColumn(
+        string field,
+        string description,
+        string code = "unsupported-metadata-field",
+        string feature = "metadata field",
+        string? path = null) => field.ToLowerInvariant() switch
     {
         "resourceid" => "rv.resource_id",
         "id" => "rv.id",
@@ -12,12 +17,20 @@ internal static class SqliteMetadataField
         "owner" => "rv.owner",
         "version" => "rv.version",
         "created" => "rv.created",
-        _ => throw Unsupported($"{description} '{field}'")
+        _ => throw Unsupported(
+            code,
+            feature,
+            $"{description} '{field}' is not supported by the SQLite JSON query provider.",
+            path)
     };
 
     public static bool IsNumeric(string field) =>
         string.Equals(field, "Version", StringComparison.OrdinalIgnoreCase);
 
-    private static UnsupportedQueryFeatureException Unsupported(string feature) =>
-        new($"{feature} is not supported by the SQLite JSON query provider.");
+    private static UnsupportedQueryFeatureException Unsupported(
+        string code,
+        string feature,
+        string message,
+        string? path = null) =>
+        new(code, feature, message, path);
 }

--- a/src/persistence/Aster.Persistence.SqliteJson/Querying/SqliteQueryBuilder.cs
+++ b/src/persistence/Aster.Persistence.SqliteJson/Querying/SqliteQueryBuilder.cs
@@ -19,8 +19,11 @@ internal sealed class SqliteQueryBuilder(ResourceQuery query)
 
     public void AddSorts(IReadOnlyList<SortExpression> sorts)
     {
-        foreach (var sort in sorts)
-            orderings.Add($"{ResolveMetadataColumn(sort)} {ResolveDirection(sort.Direction)}");
+        for (var index = 0; index < sorts.Count; index++)
+        {
+            var sort = sorts[index];
+            orderings.Add($"{ResolveMetadataColumn(sort, index)} {ResolveDirection(sort.Direction, index)}");
+        }
     }
 
     public string Build()
@@ -104,7 +107,11 @@ internal sealed class SqliteQueryBuilder(ResourceQuery query)
                       AND CAST(active_version.value AS INTEGER) = rv.version
                 )
                 """]),
-        _ => throw Unsupported($"Resource version scope '{query.Scope}'")
+        _ => throw Unsupported(
+            "unsupported-scope",
+            "scope",
+            $"Scope '{query.Scope}' is not supported by the SQLite JSON query provider.",
+            "Scope")
     };
 
     private (string Sql, IReadOnlyList<string> ScopePredicates) ActiveSql()
@@ -125,21 +132,38 @@ internal sealed class SqliteQueryBuilder(ResourceQuery query)
                 """]);
     }
 
-    private static string ResolveMetadataColumn(SortExpression sort)
+    private static string ResolveMetadataColumn(SortExpression sort, int index)
     {
         if (!string.IsNullOrWhiteSpace(sort.AspectKey))
-            throw Unsupported("Facet sorting");
+            throw Unsupported(
+                "unsupported-facet-sort",
+                "sort",
+                "Facet sorting is not supported by the SQLite JSON query provider.",
+                $"Sorts[{index}]");
 
-        return SqliteMetadataField.ResolveColumn(sort.Field, "Metadata sort field");
+        return SqliteMetadataField.ResolveColumn(
+            sort.Field,
+            "Metadata sort field",
+            "unsupported-metadata-sort-field",
+            "metadata field",
+            $"Sorts[{index}].Field");
     }
 
-    private static string ResolveDirection(SortDirection direction) => direction switch
+    private static string ResolveDirection(SortDirection direction, int index) => direction switch
     {
         SortDirection.Ascending => "ASC",
         SortDirection.Descending => "DESC",
-        _ => throw Unsupported($"Sort direction '{direction}'")
+        _ => throw Unsupported(
+            "unsupported-sort-direction",
+            "sort direction",
+            $"Sort direction '{direction}' is not supported by the SQLite JSON query provider.",
+            $"Sorts[{index}].Direction")
     };
 
-    private static UnsupportedQueryFeatureException Unsupported(string feature) =>
-        new($"{feature} is not supported by the SQLite JSON query provider.");
+    private static UnsupportedQueryFeatureException Unsupported(
+        string code,
+        string feature,
+        string message,
+        string? path = null) =>
+        new(code, feature, message, path);
 }

--- a/src/persistence/Aster.Persistence.SqliteJson/Querying/SqliteWhereTranslator.cs
+++ b/src/persistence/Aster.Persistence.SqliteJson/Querying/SqliteWhereTranslator.cs
@@ -193,8 +193,8 @@ internal sealed class SqliteWhereTranslator(SqliteParameterBag parameters)
         int.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var parsed)
             ? parsed
             : throw Unsupported(
-                "unsupported-range-value-shape",
-                "value shape",
+                "invalid-metadata-value",
+                "metadata value",
                 $"Metadata field '{field}' requires an integer value.",
                 "Filter.Value");
 

--- a/src/persistence/Aster.Persistence.SqliteJson/Querying/SqliteWhereTranslator.cs
+++ b/src/persistence/Aster.Persistence.SqliteJson/Querying/SqliteWhereTranslator.cs
@@ -12,13 +12,21 @@ internal sealed class SqliteWhereTranslator(SqliteParameterBag parameters)
         AspectPresenceFilter aspect => TranslateAspectPresence(aspect),
         FacetValueFilter facet => TranslateFacetValue(facet),
         LogicalExpression logical => TranslateLogical(logical),
-        _ => throw Unsupported($"Filter expression '{expression.GetType().Name}'")
+        _ => throw Unsupported(
+            "unsupported-filter-type",
+            "predicate",
+            $"Filter expression '{expression.GetType().Name}' is not supported by the SQLite JSON query provider.",
+            "Filter")
     };
 
     public void Validate(FilterExpression expression)
     {
         if (expression is FacetValueFilter { Operator: ComparisonOperator.Range, Value: RangeValue { Min: null, Max: null } })
-            throw Unsupported("Empty range predicates");
+            throw Unsupported(
+                "empty-range",
+                "value shape",
+                "Range predicates require at least one bound.",
+                "Filter.Value");
 
         if (expression is LogicalExpression logical)
         {
@@ -29,7 +37,12 @@ internal sealed class SqliteWhereTranslator(SqliteParameterBag parameters)
 
     private string TranslateMetadata(MetadataFilter filter)
     {
-        var column = SqliteMetadataField.ResolveColumn(filter.Field, "Metadata field");
+        var column = SqliteMetadataField.ResolveColumn(
+            filter.Field,
+            "Metadata field",
+            "unsupported-metadata-field",
+            "metadata field",
+            "Filter.Field");
 
         return filter.Operator switch
         {
@@ -39,7 +52,17 @@ internal sealed class SqliteWhereTranslator(SqliteParameterBag parameters)
                 $"aster_text_equals(CAST({column} AS TEXT), CAST({parameters.Add(filter.Value)} AS TEXT))",
             ComparisonOperator.Contains when !SqliteMetadataField.IsNumeric(filter.Field) =>
                 $"aster_text_contains(CAST({column} AS TEXT), CAST({parameters.Add(filter.Value)} AS TEXT))",
-            _ => throw Unsupported($"Metadata filter '{filter.Field}' with operator '{filter.Operator}'")
+            ComparisonOperator.Contains =>
+                throw Unsupported(
+                    "unsupported-metadata-contains-field",
+                    "metadata field",
+                    $"Metadata field '{filter.Field}' does not support containment filtering in the SQLite JSON query provider.",
+                    "Filter.Field"),
+            _ => throw Unsupported(
+                "unsupported-comparison-operator",
+                "comparison operator",
+                $"Comparison operator '{filter.Operator}' is not supported for metadata filters by the SQLite JSON query provider.",
+                "Filter.Operator")
         };
     }
 
@@ -65,8 +88,16 @@ internal sealed class SqliteWhereTranslator(SqliteParameterBag parameters)
             ComparisonOperator.Range when filter.Value is RangeValue range =>
                 TranslateRange(value, range),
             ComparisonOperator.Range =>
-                throw Unsupported("Range predicates without RangeValue"),
-            _ => throw Unsupported($"Facet filter operator '{filter.Operator}'")
+                throw Unsupported(
+                    "range-value-required",
+                    "value shape",
+                    "Range predicates require a RangeValue.",
+                    "Filter.Value"),
+            _ => throw Unsupported(
+                "unsupported-comparison-operator",
+                "comparison operator",
+                $"Comparison operator '{filter.Operator}' is not supported for facet filters by the SQLite JSON query provider.",
+                "Filter.Operator")
         };
     }
 
@@ -77,15 +108,27 @@ internal sealed class SqliteWhereTranslator(SqliteParameterBag parameters)
             LogicalOperator.And => JoinLogical("AND", expression.Operands),
             LogicalOperator.Or => JoinLogical("OR", expression.Operands),
             LogicalOperator.Not when expression.Operands is [var operand] => $"NOT ({Translate(operand)})",
-            LogicalOperator.Not => throw Unsupported("NOT logical expressions with anything other than one operand"),
-            _ => throw Unsupported($"Logical operator '{expression.Operator}'")
+            LogicalOperator.Not => throw Unsupported(
+                "invalid-not-operands",
+                "logical expression",
+                "NOT logical expressions require exactly one operand.",
+                "Filter.Operands"),
+            _ => throw Unsupported(
+                "unsupported-logical-operator",
+                "logical operator",
+                $"Logical operator '{expression.Operator}' is not supported by the SQLite JSON query provider.",
+                "Filter.Operator")
         };
     }
 
     private string JoinLogical(string sqlOperator, IReadOnlyList<FilterExpression> operands)
     {
         if (operands.Count == 0)
-            throw Unsupported($"Empty {sqlOperator} logical expressions");
+            throw Unsupported(
+                "empty-logical-operands",
+                "logical expression",
+                $"{sqlOperator} logical expressions require at least one operand.",
+                "Filter.Operands");
 
         return string.Join($" {sqlOperator} ", operands.Select(operand => $"({Translate(operand)})"));
     }
@@ -137,7 +180,11 @@ internal sealed class SqliteWhereTranslator(SqliteParameterBag parameters)
             predicates.Add($"CAST({value.ValueExpression} AS REAL) {(range.IncludeMax ? "<=" : "<")} {parameters.Add(ConvertToDouble(range.Max, "maximum range bound"))}");
 
         if (predicates.Count == 0)
-            throw Unsupported("Empty range predicates");
+            throw Unsupported(
+                "empty-range",
+                "value shape",
+                "Range predicates require at least one bound.",
+                "Filter.Value");
 
         return string.Join(" AND ", predicates);
     }
@@ -145,7 +192,11 @@ internal sealed class SqliteWhereTranslator(SqliteParameterBag parameters)
     private static int ParseInt(string value, string field) =>
         int.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var parsed)
             ? parsed
-            : throw Unsupported($"Metadata field '{field}' requires an integer value");
+            : throw Unsupported(
+                "unsupported-range-value-shape",
+                "value shape",
+                $"Metadata field '{field}' requires an integer value.",
+                "Filter.Value");
 
     private static bool TryConvertDouble(object? value, out double result)
     {
@@ -180,7 +231,11 @@ internal sealed class SqliteWhereTranslator(SqliteParameterBag parameters)
     private static double ConvertToDouble(object value, string description) =>
         TryConvertDouble(value, out var result)
             ? result
-            : throw Unsupported($"{description} must be numeric");
+            : throw Unsupported(
+                "unsupported-range-value-shape",
+                "value shape",
+                $"{description} must be numeric.",
+                "Filter.Value");
 
     private static string? FormatValue(object? value) => value switch
     {
@@ -189,8 +244,12 @@ internal sealed class SqliteWhereTranslator(SqliteParameterBag parameters)
         _ => value.ToString()
     };
 
-    private static UnsupportedQueryFeatureException Unsupported(string feature) =>
-        new($"{feature} is not supported by the SQLite JSON query provider.");
+    private static UnsupportedQueryFeatureException Unsupported(
+        string code,
+        string feature,
+        string message,
+        string? path = null) =>
+        new(code, feature, message, path);
 
     private sealed record FacetValueSqlExpression(string ValueExpression, string IsNumericPredicate);
 }

--- a/src/persistence/Aster.Persistence.SqliteJson/README.md
+++ b/src/persistence/Aster.Persistence.SqliteJson/README.md
@@ -35,6 +35,6 @@ Supported query shapes:
 - scalar facet `Equals`, string `Contains`, and numeric `Range`
 - `And`, `Or`, and single-operand `Not`
 
-Unsupported query shapes throw `UnsupportedQueryFeatureException` with an actionable message. Facet sorting, unknown metadata fields, empty ranges, negative paging values, and date-like facet ranges are intentionally out of scope for this phase.
+Unsupported query shapes throw `UnsupportedQueryFeatureException` with stable `Code`, `Feature`, optional `Path`, and an actionable message. Facet sorting, metadata range filters, unknown metadata fields, empty ranges, negative paging values, and date-like facet ranges are intentionally out of scope for this phase.
 
-The provider also declares this support through `SqliteJsonQueryCapabilitiesProvider`, so callers can inspect capabilities or use `IResourceQueryValidator` before execution. Validation reports unsupported SQLite shapes, such as facet sorting or date-like facet ranges, without falling back to the in-memory provider.
+The provider also declares this support through `SqliteJsonQueryCapabilitiesProvider` with provider key `sqlite-json`, so callers can inspect capabilities or use `IResourceQueryValidator` before execution. Validation reports unsupported SQLite shapes, such as facet sorting or date-like facet ranges, without falling back to the in-memory provider. Execution runs shared validation first and remains authoritative if validation is skipped.

--- a/src/persistence/Aster.Persistence.SqliteJson/SqliteJsonQueryCapabilitiesProvider.cs
+++ b/src/persistence/Aster.Persistence.SqliteJson/SqliteJsonQueryCapabilitiesProvider.cs
@@ -8,8 +8,14 @@ namespace Aster.Persistence.SqliteJson;
 /// </summary>
 public sealed class SqliteJsonQueryCapabilitiesProvider : IResourceQueryCapabilitiesProvider
 {
+    /// <summary>
+    /// Stable provider key used by the SQLite JSON query provider and its capability declaration.
+    /// </summary>
+    public const string ProviderKey = "sqlite-json";
+
     /// <inheritdoc />
     public QueryCapabilityDescription Capabilities { get; } = new(
+        ProviderKey: ProviderKey,
         ProviderName: "SQLite JSON",
         SupportedScopes: new HashSet<ResourceVersionScope>
         {

--- a/src/persistence/Aster.Persistence.SqliteJson/SqliteJsonQueryService.cs
+++ b/src/persistence/Aster.Persistence.SqliteJson/SqliteJsonQueryService.cs
@@ -3,6 +3,7 @@ using Aster.Core.Abstractions;
 using Aster.Core.Exceptions;
 using Aster.Core.Models.Instances;
 using Aster.Core.Models.Querying;
+using Aster.Core.Services;
 using Aster.Persistence.SqliteJson.Querying;
 using Microsoft.Data.Sqlite;
 
@@ -11,26 +12,36 @@ namespace Aster.Persistence.SqliteJson;
 /// <summary>
 /// SQLite JSON implementation of <see cref="IResourceQueryService"/>.
 /// </summary>
-public sealed class SqliteJsonQueryService : IResourceQueryService
+public sealed class SqliteJsonQueryService : IResourceQueryService, IResourceQueryProviderIdentity
 {
     private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web);
 
     private readonly string connectionString;
+    private readonly ResourceQueryValidator validator;
 
     /// <summary>
     /// Initializes a new instance of <see cref="SqliteJsonQueryService"/>.
     /// </summary>
     /// <param name="options">Provider options.</param>
-    public SqliteJsonQueryService(SqliteJsonAsterOptions options)
+    /// <param name="capabilityProviders">Registered provider capability declarations.</param>
+    public SqliteJsonQueryService(
+        SqliteJsonAsterOptions options,
+        IEnumerable<IResourceQueryCapabilitiesProvider>? capabilityProviders = null)
     {
         ArgumentNullException.ThrowIfNull(options);
         ArgumentException.ThrowIfNullOrWhiteSpace(options.ConnectionString);
 
         connectionString = options.ConnectionString;
+        validator = new ResourceQueryValidator(
+            capabilityProviders ?? [new SqliteJsonQueryCapabilitiesProvider()],
+            this);
 
         if (options.InitializeSchema)
             SqliteJsonSchema.Initialize(connectionString);
     }
+
+    /// <inheritdoc />
+    public string ProviderKey => SqliteJsonQueryCapabilitiesProvider.ProviderKey;
 
     /// <inheritdoc />
     public async ValueTask<IEnumerable<Resource>> QueryAsync(
@@ -38,6 +49,7 @@ public sealed class SqliteJsonQueryService : IResourceQueryService
         CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(query);
+        ThrowIfInvalid(query);
         Validate(query);
 
         var builder = new SqliteQueryBuilder(query);
@@ -65,16 +77,32 @@ public sealed class SqliteJsonQueryService : IResourceQueryService
     private static void Validate(ResourceQuery query)
     {
         if (!Enum.IsDefined(query.Scope))
-            throw Unsupported($"Resource version scope '{query.Scope}'");
+            throw Unsupported(
+                "unsupported-scope",
+                "scope",
+                $"Scope '{query.Scope}' is not supported by the SQLite JSON query provider.",
+                "Scope");
 
         if (query.Scope == ResourceVersionScope.Active && string.IsNullOrWhiteSpace(query.ActivationChannel))
-            throw Unsupported("Active scope without an activation channel");
+            throw Unsupported(
+                "activation-channel-required",
+                "scope",
+                "Active scope requires an activation channel for the SQLite JSON query provider.",
+                "ActivationChannel");
 
         if (query.Skip is < 0)
-            throw Unsupported("Negative Skip");
+            throw Unsupported(
+                "negative-skip",
+                "paging",
+                "Skip must be zero or greater.",
+                "Skip");
 
         if (query.Take is < 0)
-            throw Unsupported("Negative Take");
+            throw Unsupported(
+                "negative-take",
+                "paging",
+                "Take must be zero or greater.",
+                "Take");
     }
 
     private static async Task<List<Resource>> ReadResourcesAsync(
@@ -111,6 +139,17 @@ public sealed class SqliteJsonQueryService : IResourceQueryService
                 && actual.Contains(expected, StringComparison.OrdinalIgnoreCase));
     }
 
-    private static UnsupportedQueryFeatureException Unsupported(string feature) =>
-        new($"{feature} is not supported by the SQLite JSON query provider.");
+    private void ThrowIfInvalid(ResourceQuery query)
+    {
+        var validation = validator.Validate(query);
+        if (!validation.IsValid)
+            throw UnsupportedQueryFeatureException.FromValidationFailure(validation.Failures[0]);
+    }
+
+    private static UnsupportedQueryFeatureException Unsupported(
+        string code,
+        string feature,
+        string message,
+        string? path = null) =>
+        new(code, feature, message, path);
 }

--- a/src/persistence/Aster.Persistence.SqliteJson/SqliteJsonQueryService.cs
+++ b/src/persistence/Aster.Persistence.SqliteJson/SqliteJsonQueryService.cs
@@ -50,7 +50,6 @@ public sealed class SqliteJsonQueryService : IResourceQueryService, IResourceQue
     {
         ArgumentNullException.ThrowIfNull(query);
         ThrowIfInvalid(query);
-        Validate(query);
 
         var builder = new SqliteQueryBuilder(query);
         var translator = new SqliteWhereTranslator(builder.Parameters);
@@ -72,37 +71,6 @@ public sealed class SqliteJsonQueryService : IResourceQueryService, IResourceQue
         builder.Parameters.ApplyTo(command);
 
         return await ReadResourcesAsync(command, cancellationToken);
-    }
-
-    private static void Validate(ResourceQuery query)
-    {
-        if (!Enum.IsDefined(query.Scope))
-            throw Unsupported(
-                "unsupported-scope",
-                "scope",
-                $"Scope '{query.Scope}' is not supported by the SQLite JSON query provider.",
-                "Scope");
-
-        if (query.Scope == ResourceVersionScope.Active && string.IsNullOrWhiteSpace(query.ActivationChannel))
-            throw Unsupported(
-                "activation-channel-required",
-                "scope",
-                "Active scope requires an activation channel for the SQLite JSON query provider.",
-                "ActivationChannel");
-
-        if (query.Skip is < 0)
-            throw Unsupported(
-                "negative-skip",
-                "paging",
-                "Skip must be zero or greater.",
-                "Skip");
-
-        if (query.Take is < 0)
-            throw Unsupported(
-                "negative-take",
-                "paging",
-                "Take must be zero or greater.",
-                "Take");
     }
 
     private static async Task<List<Resource>> ReadResourcesAsync(
@@ -146,10 +114,4 @@ public sealed class SqliteJsonQueryService : IResourceQueryService, IResourceQue
             throw UnsupportedQueryFeatureException.FromValidationFailure(validation.Failures[0]);
     }
 
-    private static UnsupportedQueryFeatureException Unsupported(
-        string code,
-        string feature,
-        string message,
-        string? path = null) =>
-        new(code, feature, message, path);
 }

--- a/test/Aster.Tests/InMemory/InMemoryQueryCapabilityTests.cs
+++ b/test/Aster.Tests/InMemory/InMemoryQueryCapabilityTests.cs
@@ -10,6 +10,7 @@ public sealed class InMemoryQueryCapabilityTests
     [Fact]
     public void Capabilities_DeclareCurrentInMemoryQuerySurface()
     {
+        Assert.Equal(InMemoryQueryCapabilitiesProvider.ProviderKey, capabilities.ProviderKey);
         Assert.Equal("In-memory", capabilities.ProviderName);
         Assert.True(capabilities.RequiresActivationChannelForActiveScope);
         Assert.True(capabilities.SupportsMetadataSorting);

--- a/test/Aster.Tests/InMemory/InMemoryQueryServiceTests.cs
+++ b/test/Aster.Tests/InMemory/InMemoryQueryServiceTests.cs
@@ -1,4 +1,5 @@
 using Aster.Core.Abstractions;
+using Aster.Core.Exceptions;
 using Aster.Core.InMemory;
 using Aster.Core.Models.Querying;
 using Aster.Core.Services;
@@ -357,4 +358,46 @@ public sealed class InMemoryQueryServiceTests
         // Assert
         Assert.Equal(["Alpha", "Bravo"], results.Select(r => ((TitleAspect)r.Aspects["Title"]).Title).ToList());
     }
+
+    [Fact]
+    public async Task QueryAsync_UnsupportedQueryShapes_ThrowStructuredFailures()
+    {
+        var (_, query) = CreateSetup();
+
+        await AssertUnsupportedAsync(
+            query.QueryAsync(new ResourceQuery
+            {
+                Filter = new UnknownFilterExpression(),
+            }).AsTask(),
+            "unsupported-filter-type",
+            "predicate");
+        await AssertUnsupportedAsync(
+            query.QueryAsync(new ResourceQuery
+            {
+                Filter = new LogicalExpression((LogicalOperator)999, []),
+            }).AsTask(),
+            "unsupported-logical-operator",
+            "logical operator");
+        await AssertUnsupportedAsync(
+            query.QueryAsync(new ResourceQuery
+            {
+                Filter = new FacetValueFilter("Title", "Title", "Gadget", (ComparisonOperator)999),
+            }).AsTask(),
+            "unsupported-comparison-operator",
+            "comparison operator");
+    }
+
+    private static async Task AssertUnsupportedAsync(
+        Task task,
+        string expectedCode,
+        string expectedFeature)
+    {
+        var exception = await Assert.ThrowsAsync<UnsupportedQueryFeatureException>(() => task);
+
+        Assert.Equal(expectedCode, exception.Code);
+        Assert.Equal(expectedFeature, exception.Feature);
+        Assert.False(string.IsNullOrWhiteSpace(exception.Message));
+    }
+
+    private sealed record UnknownFilterExpression : FilterExpression;
 }

--- a/test/Aster.Tests/Querying/QueryCapabilityDiscoveryTests.cs
+++ b/test/Aster.Tests/Querying/QueryCapabilityDiscoveryTests.cs
@@ -1,13 +1,22 @@
 using Aster.Core.Abstractions;
+using Aster.Core.Exceptions;
 using Aster.Core.Extensions;
+using Aster.Core.InMemory;
 using Aster.Core.Models.Querying;
+using Aster.Core.Services;
 using Aster.Persistence.SqliteJson;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Aster.Tests.Querying;
 
-public sealed class QueryCapabilityDiscoveryTests
+public sealed class QueryCapabilityDiscoveryTests : IDisposable
 {
+    private readonly string databasePath =
+        Path.Combine(Path.GetTempPath(), $"aster-capabilities-{Guid.NewGuid():N}.db");
+
+    public void Dispose() => TryDelete(databasePath);
+
     [Fact]
     public void AddAsterCore_RegistersInMemoryCapabilities()
     {
@@ -17,6 +26,7 @@ public sealed class QueryCapabilityDiscoveryTests
 
         var capabilities = provider.GetRequiredService<IResourceQueryCapabilitiesProvider>().Capabilities;
 
+        Assert.Equal(InMemoryQueryCapabilitiesProvider.ProviderKey, capabilities.ProviderKey);
         Assert.Equal("In-memory", capabilities.ProviderName);
         Assert.True(capabilities.SupportsFacetSorting);
     }
@@ -36,6 +46,7 @@ public sealed class QueryCapabilityDiscoveryTests
         var capabilities = provider.GetRequiredService<IResourceQueryCapabilitiesProvider>().Capabilities;
         var validator = provider.GetRequiredService<IResourceQueryValidator>();
 
+        Assert.Equal(SqliteJsonQueryCapabilitiesProvider.ProviderKey, capabilities.ProviderKey);
         Assert.Equal("SQLite JSON", capabilities.ProviderName);
         Assert.False(capabilities.SupportsFacetSorting);
         Assert.False(validator.Validate(new ResourceQuery
@@ -54,5 +65,104 @@ public sealed class QueryCapabilityDiscoveryTests
         Assert.False(sqlite.SupportsFacetSorting);
         Assert.Contains(QueryValueShape.DateTime, inMemory.FacetRangeSupport);
         Assert.DoesNotContain(QueryValueShape.DateTime, sqlite.FacetRangeSupport);
+    }
+
+    [Fact]
+    public void Validate_UsesActiveProviderKeyInsteadOfEarlierDefaultCapabilities()
+    {
+        using var provider = new ServiceCollection()
+            .AddAsterCore()
+            .AddAsterSqliteJson(options =>
+            {
+                options.ConnectionString = $"Data Source={databasePath}";
+            })
+            .BuildServiceProvider();
+
+        var validator = provider.GetRequiredService<IResourceQueryValidator>();
+        var result = validator.Validate(new ResourceQuery
+        {
+            Sorts = [new SortExpression("Title", AspectKey: "TitleAspect")],
+        });
+
+        Assert.False(result.IsValid);
+        Assert.Contains(result.Failures, failure => failure.Code == "unsupported-facet-sort");
+    }
+
+    [Fact]
+    public async Task ProviderConsistency_WithSupportedQueries_ValidatesAndExecutes()
+    {
+        await using var sqliteProvider = new ServiceCollection()
+            .AddAsterCore()
+            .AddAsterSqliteJson(options =>
+            {
+                options.ConnectionString = $"Data Source={databasePath}";
+            })
+            .BuildServiceProvider();
+        var inMemoryQuery = new InMemoryQueryService(
+            new InMemoryResourceStore(),
+            NullLogger<InMemoryQueryService>.Instance,
+            [new InMemoryQueryCapabilitiesProvider()]);
+
+        await AssertValidatesAndExecutesAsync(
+            new ResourceQuery { Sorts = [new SortExpression("Created")] },
+            sqliteProvider.GetRequiredService<IResourceQueryValidator>(),
+            sqliteProvider.GetRequiredService<IResourceQueryService>());
+        await AssertValidatesAndExecutesAsync(
+            new ResourceQuery { Sorts = [new SortExpression("Created")] },
+            new ResourceQueryValidator([new InMemoryQueryCapabilitiesProvider()]),
+            inMemoryQuery);
+    }
+
+    [Fact]
+    public async Task ProviderConsistency_WithUnsupportedQueries_MatchesValidationAndExecution()
+    {
+        await using var provider = new ServiceCollection()
+            .AddAsterCore()
+            .AddAsterSqliteJson(options =>
+            {
+                options.ConnectionString = $"Data Source={databasePath}";
+            })
+            .BuildServiceProvider();
+
+        await AssertValidationMatchesExecutionAsync(
+            new ResourceQuery { Sorts = [new SortExpression("Title", AspectKey: "TitleAspect")] },
+            provider.GetRequiredService<IResourceQueryValidator>(),
+            provider.GetRequiredService<IResourceQueryService>(),
+            "unsupported-facet-sort");
+    }
+
+    private static async Task AssertValidatesAndExecutesAsync(
+        ResourceQuery query,
+        IResourceQueryValidator validator,
+        IResourceQueryService queryService)
+    {
+        var validation = validator.Validate(query);
+
+        Assert.True(validation.IsValid);
+        _ = await queryService.QueryAsync(query);
+    }
+
+    private static async Task AssertValidationMatchesExecutionAsync(
+        ResourceQuery query,
+        IResourceQueryValidator validator,
+        IResourceQueryService queryService,
+        string expectedCode)
+    {
+        var validation = validator.Validate(query);
+        var exception = await Assert.ThrowsAsync<UnsupportedQueryFeatureException>(
+            () => queryService.QueryAsync(query).AsTask());
+
+        Assert.Contains(validation.Failures, failure => failure.Code == exception.Code);
+        Assert.Equal(expectedCode, exception.Code);
+    }
+
+    private static void TryDelete(string path)
+    {
+        try
+        {
+            File.Delete(path);
+        }
+        catch (IOException) { }
+        catch (UnauthorizedAccessException) { }
     }
 }

--- a/test/Aster.Tests/Querying/ResourceQueryValidatorTests.cs
+++ b/test/Aster.Tests/Querying/ResourceQueryValidatorTests.cs
@@ -184,9 +184,26 @@ public sealed class ResourceQueryValidatorTests
         Assert.Contains(result.Failures, failure => failure.Code == "capabilities-not-declared");
     }
 
+    [Fact]
+    public void Validate_WhenActiveProviderKeyDoesNotMatchCapabilities_FailsClosed()
+    {
+        using var provider = new ServiceCollection()
+            .AddSingleton<IResourceQueryCapabilitiesProvider, EmptyCapabilitiesProvider>()
+            .AddSingleton<IResourceQueryService, CustomQueryService>()
+            .AddSingleton<IResourceQueryValidator, ResourceQueryValidator>()
+            .BuildServiceProvider();
+
+        var result = provider.GetRequiredService<IResourceQueryValidator>().Validate(new ResourceQuery());
+
+        Assert.False(result.IsValid);
+        var failure = Assert.Single(result.Failures);
+        Assert.Equal("capabilities-not-declared", failure.Code);
+    }
+
     private sealed class EmptyCapabilitiesProvider : IResourceQueryCapabilitiesProvider
     {
         public QueryCapabilityDescription Capabilities { get; } = new(
+            ProviderKey: "empty",
             ProviderName: "Empty",
             SupportedScopes: new HashSet<ResourceVersionScope>(),
             RequiresActivationChannelForActiveScope: false,
@@ -203,8 +220,10 @@ public sealed class ResourceQueryValidatorTests
             UnsupportedFeatures: []);
     }
 
-    private sealed class CustomQueryService : IResourceQueryService
+    private sealed class CustomQueryService : IResourceQueryService, IResourceQueryProviderIdentity
     {
+        public string ProviderKey => "custom";
+
         public ValueTask<IEnumerable<Resource>> QueryAsync(
             ResourceQuery query,
             CancellationToken cancellationToken = default) =>

--- a/test/Aster.Tests/SqliteJson/SqliteJsonQueryCapabilityTests.cs
+++ b/test/Aster.Tests/SqliteJson/SqliteJsonQueryCapabilityTests.cs
@@ -13,6 +13,7 @@ public sealed class SqliteJsonQueryCapabilityTests
     [Fact]
     public void Capabilities_DeclareCurrentSqliteQuerySurface()
     {
+        Assert.Equal(SqliteJsonQueryCapabilitiesProvider.ProviderKey, capabilities.ProviderKey);
         Assert.Equal("SQLite JSON", capabilities.ProviderName);
         Assert.True(capabilities.RequiresActivationChannelForActiveScope);
         Assert.True(capabilities.SupportsMetadataSorting);

--- a/test/Aster.Tests/SqliteJson/SqliteJsonQueryServiceTests.cs
+++ b/test/Aster.Tests/SqliteJson/SqliteJsonQueryServiceTests.cs
@@ -340,35 +340,92 @@ public sealed class SqliteJsonQueryServiceTests : IDisposable
         await using var provider = CreateServiceProvider();
         var query = provider.GetRequiredService<IResourceQueryService>();
 
-        await Assert.ThrowsAsync<UnsupportedQueryFeatureException>(() =>
+        await AssertUnsupportedAsync(
             query.QueryAsync(new ResourceQuery
             {
                 Filter = new MetadataFilter("Unknown", "value", ComparisonOperator.Equals),
-            }).AsTask());
+            }).AsTask(),
+            "unsupported-metadata-field",
+            "metadata field");
 
-        await Assert.ThrowsAsync<UnsupportedQueryFeatureException>(() =>
+        await AssertUnsupportedAsync(
             query.QueryAsync(new ResourceQuery
             {
                 Sorts = [new SortExpression("Title", AspectKey: "Title")],
-            }).AsTask());
+            }).AsTask(),
+            "unsupported-facet-sort",
+            "sort");
 
-        await Assert.ThrowsAsync<UnsupportedQueryFeatureException>(() =>
+        await AssertUnsupportedAsync(
             query.QueryAsync(new ResourceQuery
             {
                 Scope = ResourceVersionScope.Active,
-            }).AsTask());
+            }).AsTask(),
+            "activation-channel-required",
+            "scope");
 
-        await Assert.ThrowsAsync<UnsupportedQueryFeatureException>(() =>
-            query.QueryAsync(new ResourceQuery { Skip = -1 }).AsTask());
+        await AssertUnsupportedAsync(
+            query.QueryAsync(new ResourceQuery { Skip = -1 }).AsTask(),
+            "negative-skip",
+            "paging");
 
-        await Assert.ThrowsAsync<UnsupportedQueryFeatureException>(() =>
-            query.QueryAsync(new ResourceQuery { Take = -1 }).AsTask());
+        await AssertUnsupportedAsync(
+            query.QueryAsync(new ResourceQuery { Take = -1 }).AsTask(),
+            "negative-take",
+            "paging");
 
-        await Assert.ThrowsAsync<UnsupportedQueryFeatureException>(() =>
+        await AssertUnsupportedAsync(
             query.QueryAsync(new ResourceQuery
             {
                 Filter = new FacetValueFilter("Price", "Amount", new RangeValue(null, null), ComparisonOperator.Range),
-            }).AsTask());
+            }).AsTask(),
+            "empty-range",
+            "value shape");
+    }
+
+    [Fact]
+    public async Task QueryAsync_UnsupportedSqliteShapes_MatchValidationFailureDetails()
+    {
+        await using var provider = CreateServiceProvider();
+        var validator = provider.GetRequiredService<IResourceQueryValidator>();
+        var queryService = provider.GetRequiredService<IResourceQueryService>();
+
+        await AssertValidationMatchesExecutionAsync(
+            validator,
+            queryService,
+            new ResourceQuery
+            {
+                Filter = new MetadataFilter("Version", "1", ComparisonOperator.Contains),
+            },
+            "unsupported-metadata-contains-field");
+        await AssertValidationMatchesExecutionAsync(
+            validator,
+            queryService,
+            new ResourceQuery
+            {
+                Filter = new MetadataFilter("Created", "2026-01-01", ComparisonOperator.Range),
+            },
+            "unsupported-comparison-operator");
+        await AssertValidationMatchesExecutionAsync(
+            validator,
+            queryService,
+            new ResourceQuery
+            {
+                Sorts = [new SortExpression("Title", AspectKey: "Title")],
+            },
+            "unsupported-facet-sort");
+        await AssertValidationMatchesExecutionAsync(
+            validator,
+            queryService,
+            new ResourceQuery
+            {
+                Filter = new FacetValueFilter(
+                    "Schedule",
+                    "StartsAt",
+                    new RangeValue(DateTime.UtcNow.AddDays(-1), DateTime.UtcNow),
+                    ComparisonOperator.Range),
+            },
+            "unsupported-range-value-shape");
     }
 
     [Fact]
@@ -456,6 +513,35 @@ public sealed class SqliteJsonQueryServiceTests : IDisposable
 
     private static DateTime Utc(int year, int month, int day) =>
         new(year, month, day, 0, 0, 0, DateTimeKind.Utc);
+
+    private static async Task<UnsupportedQueryFeatureException> AssertUnsupportedAsync(
+        Task task,
+        string expectedCode,
+        string expectedFeature)
+    {
+        var exception = await Assert.ThrowsAsync<UnsupportedQueryFeatureException>(() => task);
+
+        Assert.Equal(expectedCode, exception.Code);
+        Assert.Equal(expectedFeature, exception.Feature);
+        Assert.False(string.IsNullOrWhiteSpace(exception.Message));
+        return exception;
+    }
+
+    private static async Task AssertValidationMatchesExecutionAsync(
+        IResourceQueryValidator validator,
+        IResourceQueryService queryService,
+        ResourceQuery query,
+        string expectedCode)
+    {
+        var validation = validator.Validate(query);
+        var exception = await Assert.ThrowsAsync<UnsupportedQueryFeatureException>(
+            () => queryService.QueryAsync(query).AsTask());
+
+        Assert.Contains(validation.Failures, failure =>
+            failure.Code == exception.Code
+            && failure.Feature == exception.Feature);
+        Assert.Equal(expectedCode, exception.Code);
+    }
 
     private static void TryDelete(string path)
     {

--- a/test/Aster.Tests/SqliteJson/SqliteJsonQueryServiceTests.cs
+++ b/test/Aster.Tests/SqliteJson/SqliteJsonQueryServiceTests.cs
@@ -346,7 +346,8 @@ public sealed class SqliteJsonQueryServiceTests : IDisposable
                 Filter = new MetadataFilter("Unknown", "value", ComparisonOperator.Equals),
             }).AsTask(),
             "unsupported-metadata-field",
-            "metadata field");
+            "metadata field",
+            "Filter.Field");
 
         await AssertUnsupportedAsync(
             query.QueryAsync(new ResourceQuery
@@ -354,7 +355,8 @@ public sealed class SqliteJsonQueryServiceTests : IDisposable
                 Sorts = [new SortExpression("Title", AspectKey: "Title")],
             }).AsTask(),
             "unsupported-facet-sort",
-            "sort");
+            "sort",
+            "Sorts[0]");
 
         await AssertUnsupportedAsync(
             query.QueryAsync(new ResourceQuery
@@ -362,17 +364,20 @@ public sealed class SqliteJsonQueryServiceTests : IDisposable
                 Scope = ResourceVersionScope.Active,
             }).AsTask(),
             "activation-channel-required",
-            "scope");
+            "scope",
+            "ActivationChannel");
 
         await AssertUnsupportedAsync(
             query.QueryAsync(new ResourceQuery { Skip = -1 }).AsTask(),
             "negative-skip",
-            "paging");
+            "paging",
+            "Skip");
 
         await AssertUnsupportedAsync(
             query.QueryAsync(new ResourceQuery { Take = -1 }).AsTask(),
             "negative-take",
-            "paging");
+            "paging",
+            "Take");
 
         await AssertUnsupportedAsync(
             query.QueryAsync(new ResourceQuery
@@ -380,7 +385,8 @@ public sealed class SqliteJsonQueryServiceTests : IDisposable
                 Filter = new FacetValueFilter("Price", "Amount", new RangeValue(null, null), ComparisonOperator.Range),
             }).AsTask(),
             "empty-range",
-            "value shape");
+            "value shape",
+            "Filter.Value");
     }
 
     [Fact]
@@ -397,7 +403,8 @@ public sealed class SqliteJsonQueryServiceTests : IDisposable
             {
                 Filter = new MetadataFilter("Version", "1", ComparisonOperator.Contains),
             },
-            "unsupported-metadata-contains-field");
+            "unsupported-metadata-contains-field",
+            "Filter.Field");
         await AssertValidationMatchesExecutionAsync(
             validator,
             queryService,
@@ -405,7 +412,8 @@ public sealed class SqliteJsonQueryServiceTests : IDisposable
             {
                 Filter = new MetadataFilter("Created", "2026-01-01", ComparisonOperator.Range),
             },
-            "unsupported-comparison-operator");
+            "unsupported-comparison-operator",
+            "Filter.Operator");
         await AssertValidationMatchesExecutionAsync(
             validator,
             queryService,
@@ -413,7 +421,8 @@ public sealed class SqliteJsonQueryServiceTests : IDisposable
             {
                 Sorts = [new SortExpression("Title", AspectKey: "Title")],
             },
-            "unsupported-facet-sort");
+            "unsupported-facet-sort",
+            "Sorts[0]");
         await AssertValidationMatchesExecutionAsync(
             validator,
             queryService,
@@ -425,7 +434,24 @@ public sealed class SqliteJsonQueryServiceTests : IDisposable
                     new RangeValue(DateTime.UtcNow.AddDays(-1), DateTime.UtcNow),
                     ComparisonOperator.Range),
             },
-            "unsupported-range-value-shape");
+            "unsupported-range-value-shape",
+            "Filter.Value.Min");
+    }
+
+    [Fact]
+    public async Task QueryAsync_ProviderSpecificUnsupportedFailure_ReportsPath()
+    {
+        await using var provider = CreateServiceProvider();
+        var query = provider.GetRequiredService<IResourceQueryService>();
+
+        await AssertUnsupportedAsync(
+            query.QueryAsync(new ResourceQuery
+            {
+                Filter = new MetadataFilter("Version", "not-an-integer", ComparisonOperator.Equals),
+            }).AsTask(),
+            "invalid-metadata-value",
+            "metadata value",
+            "Filter.Value");
     }
 
     [Fact]
@@ -517,12 +543,14 @@ public sealed class SqliteJsonQueryServiceTests : IDisposable
     private static async Task<UnsupportedQueryFeatureException> AssertUnsupportedAsync(
         Task task,
         string expectedCode,
-        string expectedFeature)
+        string expectedFeature,
+        string? expectedPath = null)
     {
         var exception = await Assert.ThrowsAsync<UnsupportedQueryFeatureException>(() => task);
 
         Assert.Equal(expectedCode, exception.Code);
         Assert.Equal(expectedFeature, exception.Feature);
+        Assert.Equal(expectedPath, exception.Path);
         Assert.False(string.IsNullOrWhiteSpace(exception.Message));
         return exception;
     }
@@ -531,7 +559,8 @@ public sealed class SqliteJsonQueryServiceTests : IDisposable
         IResourceQueryValidator validator,
         IResourceQueryService queryService,
         ResourceQuery query,
-        string expectedCode)
+        string expectedCode,
+        string? expectedPath = null)
     {
         var validation = validator.Validate(query);
         var exception = await Assert.ThrowsAsync<UnsupportedQueryFeatureException>(
@@ -539,8 +568,10 @@ public sealed class SqliteJsonQueryServiceTests : IDisposable
 
         Assert.Contains(validation.Failures, failure =>
             failure.Code == exception.Code
-            && failure.Feature == exception.Feature);
+            && failure.Feature == exception.Feature
+            && failure.Path == exception.Path);
         Assert.Equal(expectedCode, exception.Code);
+        Assert.Equal(expectedPath, exception.Path);
     }
 
     private static void TryDelete(string path)

--- a/wiki/DI-Registration.md
+++ b/wiki/DI-Registration.md
@@ -60,6 +60,25 @@ builder.Services.AddAsterSqliteJson(options =>
 
 `AddAsterSqliteJson()` should be called after `AddAsterCore()` so the provider registrations become the resolved implementations for the shared interfaces. The shared `IResourceQueryValidator` uses the active provider's capability declaration when preflighting queries.
 
+Query providers and capability declarations are matched with explicit provider keys. The default in-memory provider uses `in-memory`; the SQLite JSON provider uses `sqlite-json`. If a host replaces `IResourceQueryService` without registering a capability declaration with the same key, validation fails closed with a `capabilities-not-declared` failure instead of silently validating against stale defaults.
+
+Custom query providers should implement `IResourceQueryProviderIdentity` and register a matching `IResourceQueryCapabilitiesProvider`:
+
+```csharp
+public sealed class MyQueryService : IResourceQueryService, IResourceQueryProviderIdentity
+{
+    public string ProviderKey => "my-provider";
+}
+
+public sealed class MyQueryCapabilitiesProvider : IResourceQueryCapabilitiesProvider
+{
+    public QueryCapabilityDescription Capabilities { get; } = new(
+        ProviderKey: "my-provider",
+        ProviderName: "My Provider",
+        /* supported query surface */);
+}
+```
+
 ---
 
 ## Customising the Identity Generator

--- a/wiki/DI-Registration.md
+++ b/wiki/DI-Registration.md
@@ -68,6 +68,14 @@ Custom query providers should implement `IResourceQueryProviderIdentity` and reg
 public sealed class MyQueryService : IResourceQueryService, IResourceQueryProviderIdentity
 {
     public string ProviderKey => "my-provider";
+
+    public ValueTask<IEnumerable<Resource>> QueryAsync(
+        ResourceQuery query,
+        CancellationToken cancellationToken = default)
+    {
+        // Execute the portable ResourceQuery AST against this provider.
+        throw new NotImplementedException();
+    }
 }
 
 public sealed class MyQueryCapabilitiesProvider : IResourceQueryCapabilitiesProvider

--- a/wiki/Exception-Reference.md
+++ b/wiki/Exception-Reference.md
@@ -13,6 +13,7 @@ Aster throws typed exceptions for all domain-level error conditions. All excepti
 | `SingletonViolationException` | `Aster.Core.Exceptions` | Attempt to create a second instance of a singleton definition |
 | `DuplicateResourceIdException` | `Aster.Core.Exceptions` | Caller-supplied `ResourceId` already exists |
 | `DuplicateAspectAttachmentException` | `Aster.Core.Exceptions` | Same aspect key attached twice to a definition |
+| `UnsupportedQueryFeatureException` | `Aster.Core.Exceptions` | Query execution receives a provider-unsupported scope, predicate, sort, paging value, or value shape |
 
 ---
 
@@ -135,6 +136,36 @@ var definition = new ResourceDefinitionBuilder()
 
 ---
 
+## `UnsupportedQueryFeatureException`
+
+**Thrown by:** `IResourceQueryService.QueryAsync`
+
+**Why:** The active provider cannot execute the supplied `ResourceQuery`. Providers run shared validation before execution and still keep provider-specific checks during translation/execution.
+
+The exception exposes structured details:
+
+| Property | Meaning |
+|---|---|
+| `Code` | Stable failure code such as `unsupported-facet-sort` or `capabilities-not-declared` |
+| `Feature` | Unsupported feature category such as `sort`, `metadata field`, or `value shape` |
+| `Path` | Optional query path such as `Sorts[0]` or `Filter.Value` |
+| `Message` | Human-readable actionable explanation |
+
+```csharp
+try
+{
+    var results = await queryService.QueryAsync(query);
+}
+catch (UnsupportedQueryFeatureException ex)
+{
+    Console.WriteLine($"{ex.Code} ({ex.Feature}): {ex.Message}");
+}
+```
+
+Use `IResourceQueryValidator` for non-throwing preflight when handling user-defined queries. Execution remains authoritative, so callers should still handle this exception when validation is skipped or provider-specific checks fail later.
+
+---
+
 ## Handling Pattern
 
 Because all exceptions are typed, you can handle them selectively:
@@ -162,4 +193,3 @@ catch (VersionNotFoundException)
 
 - [Getting Started](Getting-Started) — error conditions in context
 - [Versioning & Activation](Versioning-and-Activation) — concurrency details
-

--- a/wiki/Querying.md
+++ b/wiki/Querying.md
@@ -131,10 +131,12 @@ var capabilities = serviceProvider
     .Capabilities;
 
 Console.WriteLine(capabilities.ProviderName);
+Console.WriteLine(capabilities.ProviderKey);
 Console.WriteLine(capabilities.SupportsFacetSorting);
 ```
 
 Capabilities describe supported scopes, filter categories, comparison operators, logical operators, metadata fields, sort categories, paging, facet range value shapes, and known exclusions. The in-memory provider currently declares facet sorting and numeric/date-like facet ranges; SQLite JSON declares metadata sorting, numeric facet ranges, and no facet sorting.
+Capability declarations are matched to the active query provider by explicit `ProviderKey` values such as `in-memory` and `sqlite-json`.
 
 ## Preflight Validation
 
@@ -146,13 +148,31 @@ var validation = validator.Validate(query);
 if (!validation.IsValid)
 {
     foreach (var failure in validation.Failures)
-        Console.WriteLine($"{failure.Code}: {failure.Message}");
+        Console.WriteLine($"{failure.Code} ({failure.Feature}): {failure.Message}");
 
     return;
 }
 ```
 
 Validation returns a structured `QueryValidationResult` and does not mutate the query. If no capability provider is declared for the active provider, validation fails closed with `capabilities-not-declared`. Execution still rejects unsupported shapes even when validation is skipped.
+
+Recommended flow for user-defined queries:
+
+1. Inspect provider capabilities when deciding what query UI or API options to expose.
+2. Validate a `ResourceQuery` before execution and show all `QueryValidationFailure` entries to the caller.
+3. Execute only when validation succeeds.
+4. Still handle `UnsupportedQueryFeatureException`, because execution is authoritative and may detect provider-specific constraints.
+
+```csharp
+try
+{
+    var results = await queryService.QueryAsync(query);
+}
+catch (UnsupportedQueryFeatureException ex)
+{
+    Console.WriteLine($"{ex.Code} ({ex.Feature}): {ex.Message}");
+}
+```
 
 ## Typed Query Helpers
 
@@ -221,7 +241,7 @@ The provider supports:
 - facet `Equals`, string `Contains`, and numeric `Range`.
 - `And`, `Or`, and single-operand `Not`.
 
-Unsupported SQLite query shapes fail with `UnsupportedQueryFeatureException` instead of falling back to in-memory evaluation. Current intentional exclusions include facet sorting, unknown metadata fields, empty ranges, negative paging values, and date-like facet ranges.
+Unsupported SQLite query shapes fail with `UnsupportedQueryFeatureException` instead of falling back to in-memory evaluation. The exception exposes stable `Code`, `Feature`, optional `Path`, and a human-readable message. Current intentional exclusions include facet sorting, metadata range filters, unknown metadata fields, empty ranges, negative paging values, and date-like facet ranges.
 
 ## Current Limitations
 


### PR DESCRIPTION
## Summary

- Add explicit query provider keys and provider identity so validation matches active provider capabilities deterministically.
- Make unsupported query execution failures structured with stable code, feature, and optional path details.
- Run shared validation before in-memory and SQLite execution while preserving provider-specific execution guards.
- Add provider consistency, fail-closed validation, and structured failure tests plus docs updates.

## Validation

- dotnet test Aster.sln (113 passed)
- dotnet build Aster.sln
- git diff --check
