### PR TITLE
Add provider authoring ergonomics

### DIFF
--- a/.github/agents/copilot-instructions.md
+++ b/.github/agents/copilot-instructions.md
@@ -1,6 +1,6 @@
 # main Development Guidelines
 
-Auto-generated from all feature plans. Last updated: 2026-03-04
+Auto-generated from all feature plans. Last updated: 2026-05-17
 
 ## Active Technologies
 - C# latest, .NET 8.0 / 9.0 / 10.0 multi-targeting + Existing `Microsoft.Extensions.DependencyInjection.Abstractions`, `Microsoft.Extensions.Logging.Abstractions`; SQLite provider keeps existing `Microsoft.Data.Sqlite` (003-query-capabilities-typed)

--- a/.github/agents/copilot-instructions.md
+++ b/.github/agents/copilot-instructions.md
@@ -28,7 +28,6 @@ C# / .NET 9.0 (Standard 2.0/2.1 compatible ideally, but targeted for net9.0): Fo
 
 ## Recent Changes
 - 005-provider-authoring-ergonomics: Added C# latest, .NET 8.0 / 9.0 / 10.0 multi-targeting + Existing `Microsoft.Extensions.DependencyInjection.Abstractions`, `Microsoft.Extensions.Logging.Abstractions`; no new third-party dependencies
-- 005-provider-authoring-ergonomics: Added C# latest, .NET 8.0 / 9.0 / 10.0 multi-targeting + Existing `Microsoft.Extensions.DependencyInjection.Abstractions`, `Microsoft.Extensions.Logging.Abstractions`; no new third-party dependencies
 - 004-provider-validation-execution: Added C# latest, .NET 8.0 / 9.0 / 10.0 multi-targeting + Existing `Microsoft.Extensions.DependencyInjection.Abstractions`, `Microsoft.Extensions.Logging.Abstractions`; SQLite provider keeps existing `Microsoft.Data.Sqlite`
 
 

--- a/.github/agents/copilot-instructions.md
+++ b/.github/agents/copilot-instructions.md
@@ -6,6 +6,8 @@ Auto-generated from all feature plans. Last updated: 2026-03-04
 - C# latest, .NET 8.0 / 9.0 / 10.0 multi-targeting + Existing `Microsoft.Extensions.DependencyInjection.Abstractions`, `Microsoft.Extensions.Logging.Abstractions`; SQLite provider keeps existing `Microsoft.Data.Sqlite` (003-query-capabilities-typed)
 - No new storage; existing in-memory and SQLite JSON providers declare query capabilities (003-query-capabilities-typed)
 - N/A for core validation/failure contracts; existing in-memory and SQLite JSON providers keep current persistence behavior (004-provider-validation-execution)
+- C# latest, .NET 8.0 / 9.0 / 10.0 multi-targeting + Existing `Microsoft.Extensions.DependencyInjection.Abstractions`, `Microsoft.Extensions.Logging.Abstractions`; no new third-party dependencies (005-provider-authoring-ergonomics)
+- N/A; no persistence format or storage behavior changes (005-provider-authoring-ergonomics)
 
 - C# / .NET 9.0 (Standard 2.0/2.1 compatible ideally, but targeted for net9.0) + Microsoft.Extensions.DependencyInjection, Microsoft.Extensions.Logging (001-core-sdk-foundation)
 
@@ -25,10 +27,10 @@ tests/
 C# / .NET 9.0 (Standard 2.0/2.1 compatible ideally, but targeted for net9.0): Follow standard conventions
 
 ## Recent Changes
+- 005-provider-authoring-ergonomics: Added C# latest, .NET 8.0 / 9.0 / 10.0 multi-targeting + Existing `Microsoft.Extensions.DependencyInjection.Abstractions`, `Microsoft.Extensions.Logging.Abstractions`; no new third-party dependencies
+- 005-provider-authoring-ergonomics: Added C# latest, .NET 8.0 / 9.0 / 10.0 multi-targeting + Existing `Microsoft.Extensions.DependencyInjection.Abstractions`, `Microsoft.Extensions.Logging.Abstractions`; no new third-party dependencies
 - 004-provider-validation-execution: Added C# latest, .NET 8.0 / 9.0 / 10.0 multi-targeting + Existing `Microsoft.Extensions.DependencyInjection.Abstractions`, `Microsoft.Extensions.Logging.Abstractions`; SQLite provider keeps existing `Microsoft.Data.Sqlite`
-- 003-query-capabilities-typed: Added C# latest, .NET 8.0 / 9.0 / 10.0 multi-targeting + Existing `Microsoft.Extensions.DependencyInjection.Abstractions`, `Microsoft.Extensions.Logging.Abstractions`; SQLite provider keeps existing `Microsoft.Data.Sqlite`
 
-- 001-core-sdk-foundation: Added C# / .NET 9.0 (Standard 2.0/2.1 compatible ideally, but targeted for net9.0) + Microsoft.Extensions.DependencyInjection, Microsoft.Extensions.Logging
 
 <!-- MANUAL ADDITIONS START -->
 <!-- MANUAL ADDITIONS END -->

--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,0 +1,3 @@
+{
+  "feature_directory": "specs/005-provider-authoring-ergonomics"
+}

--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "specs/005-provider-authoring-ergonomics"
+  "featureDir": "specs/005-provider-authoring-ergonomics"
 }

--- a/specs/005-provider-authoring-ergonomics/checklists/requirements.md
+++ b/specs/005-provider-authoring-ergonomics/checklists/requirements.md
@@ -1,0 +1,34 @@
+# Specification Quality Checklist: Provider Authoring Ergonomics
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-05-16
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [X] No implementation details (languages, frameworks, APIs)
+- [X] Focused on user value and business needs
+- [X] Written for non-technical stakeholders
+- [X] All mandatory sections completed
+
+## Requirement Completeness
+
+- [X] No [NEEDS CLARIFICATION] markers remain
+- [X] Requirements are testable and unambiguous
+- [X] Success criteria are measurable
+- [X] Success criteria are technology-agnostic (no implementation details)
+- [X] All acceptance scenarios are defined
+- [X] Edge cases are identified
+- [X] Scope is clearly bounded
+- [X] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [X] All functional requirements have clear acceptance criteria
+- [X] User scenarios cover primary flows
+- [X] Feature meets measurable outcomes defined in Success Criteria
+- [X] No implementation details leak into specification
+
+## Notes
+
+- Checklist completed during `/speckit-specify`; provider-authoring terms are SDK-domain concepts rather than implementation design.

--- a/specs/005-provider-authoring-ergonomics/contracts/provider-authoring-ergonomics.md
+++ b/specs/005-provider-authoring-ergonomics/contracts/provider-authoring-ergonomics.md
@@ -1,0 +1,87 @@
+# Contract: Provider Authoring Ergonomics
+
+This contract describes the public SDK behavior expected by this feature. Names are final unless implementation reveals an existing naming conflict.
+
+## Registration Helper
+
+Provider authors can register a custom query provider and capabilities together.
+
+```csharp
+public static IServiceCollection AddResourceQueryProvider<TQueryService, TCapabilitiesProvider>(
+    this IServiceCollection services)
+    where TQueryService : class, IResourceQueryService, IResourceQueryProviderIdentity
+    where TCapabilitiesProvider : class, IResourceQueryCapabilitiesProvider;
+```
+
+Expected behavior:
+
+- Registers `TQueryService` as a concrete singleton.
+- Registers `TQueryService` as the active singleton `IResourceQueryService`.
+- Registers `TQueryService` as singleton `IResourceQueryProviderIdentity`.
+- Registers `TCapabilitiesProvider` as a concrete singleton.
+- Registers `TCapabilitiesProvider` as singleton `IResourceQueryCapabilitiesProvider`.
+- Leaves alternate lifetimes to explicit manual DI registration.
+- Preserves existing last-registration-wins behavior for active query provider replacement.
+- Does not instantiate services during registration.
+- Does not validate provider key equality during registration.
+
+## Provider Identity
+
+Custom query providers expose explicit identity.
+
+```csharp
+public sealed class MyQueryService : IResourceQueryService, IResourceQueryProviderIdentity
+{
+    public string ProviderKey => "my-provider";
+}
+```
+
+Expected behavior:
+
+- Provider key must be stable and non-empty.
+- Provider key must match the capability declaration key for validation to succeed.
+- Decorators may expose their own key or pass through the wrapped provider key intentionally.
+
+## Capability Declaration
+
+Custom providers declare query capabilities using the same provider key.
+
+```csharp
+public sealed class MyQueryCapabilitiesProvider : IResourceQueryCapabilitiesProvider
+{
+    public QueryCapabilityDescription Capabilities { get; } = new(
+        ProviderKey: "my-provider",
+        ProviderName: "My Provider",
+        /* supported query surface */);
+}
+```
+
+Expected behavior:
+
+- Matching key means validation uses the custom declaration.
+- Missing or mismatched key means validation fails closed.
+- Built-in capability declarations remain unchanged.
+
+## Fail-Closed Diagnostics
+
+Validation remains non-throwing.
+
+```csharp
+var validation = validator.Validate(query);
+```
+
+Expected behavior:
+
+- Missing/mismatched active provider capabilities return `capabilities-not-declared`.
+- Failure message identifies the active provider key when available.
+- Failure message tells authors to register a matching capability declaration.
+
+## Execution Guidance
+
+Custom providers should run shared validation before execution, then keep provider-specific checks.
+
+Expected behavior:
+
+- Validation-derived execution failures use `UnsupportedQueryFeatureException.FromValidationFailure`.
+- Provider-specific execution failures use structured `UnsupportedQueryFeatureException` data.
+- Execution remains authoritative even when caller preflight is skipped.

--- a/specs/005-provider-authoring-ergonomics/data-model.md
+++ b/specs/005-provider-authoring-ergonomics/data-model.md
@@ -1,0 +1,88 @@
+# Data Model: Provider Authoring Ergonomics
+
+## Custom Query Provider
+
+Represents a host-provided query executor for the portable `ResourceQuery` model.
+
+### Fields
+
+- `ProviderKey`: Stable non-empty identifier exposed through provider identity.
+- `QueryExecution`: Provider-owned behavior for executing supported query shapes.
+- `ProviderSpecificGuards`: Execution-time checks for constraints not fully captured by shared validation.
+
+### Validation Rules
+
+- Provider key must be non-empty.
+- Provider key must match the active capability declaration for validation to succeed.
+- Execution remains authoritative and may reject provider-specific unsupported shapes.
+
+## Custom Capability Declaration
+
+Represents the query shapes a custom provider declares as supported.
+
+### Fields
+
+- `ProviderKey`: Stable key matching the custom query provider.
+- `ProviderName`: Human-readable provider name.
+- Supported scopes, filters, comparisons, sorting, paging, and value shapes.
+- Known unsupported features for discovery and documentation.
+
+### Validation Rules
+
+- Provider key and name must be non-empty.
+- If the key does not match the active query provider, validation fails closed.
+- Declarations should match execution behavior and be covered by provider tests.
+
+## Provider Registration Recipe
+
+Represents the host-visible registration path for a custom query provider.
+
+### Fields
+
+- `QueryServiceType`: Concrete active query service type.
+- `CapabilitiesProviderType`: Concrete capability declaration provider type.
+- `InterfaceMappings`: Registrations for execution, provider identity, and capability discovery.
+
+### Validation Rules
+
+- Query service type must implement both query execution and provider identity contracts.
+- Capability provider type must implement capability declaration contract.
+- Last registration wins for active single-service resolution, matching existing provider replacement behavior.
+- Manual registration remains possible.
+
+## Provider Authoring Failure
+
+Represents feedback for provider misconfiguration or unsupported query execution.
+
+### Fields
+
+- `Code`: Stable failure code such as `capabilities-not-declared`.
+- `Feature`: Failure category such as `capabilities missing` or provider-specific query feature.
+- `Message`: Actionable explanation for provider authors.
+- `Path`: Optional query path when the failure maps to a query shape location.
+
+### Validation Rules
+
+- Missing or mismatched active-provider capabilities use `capabilities-not-declared`.
+- Messages should include the active provider key when available.
+- Execution failures should use structured unsupported-query details.
+
+## State Transitions
+
+### Registration
+
+```text
+Host registers defaults
+  └─ Host registers custom provider helper
+      ├─ query service becomes active service
+      ├─ provider identity resolves to custom provider
+      └─ capability provider declaration is discoverable
+```
+
+### Validation
+
+```text
+Active provider key
+  ├─ matching capability declaration exists → validate query with custom capabilities
+  └─ no matching declaration exists → capabilities-not-declared with actionable message
+```

--- a/specs/005-provider-authoring-ergonomics/plan.md
+++ b/specs/005-provider-authoring-ergonomics/plan.md
@@ -1,0 +1,114 @@
+# Implementation Plan: Provider Authoring Ergonomics
+
+**Branch**: `005-provider-authoring-ergonomics` | **Date**: 2026-05-16 | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from `/specs/005-provider-authoring-ergonomics/spec.md`
+
+## Summary
+
+Make custom query provider authoring easier and harder to misconfigure by adding a small explicit DI registration helper for active query providers and matching capability providers, improving fail-closed validation diagnostics, and documenting the minimum provider-authoring pattern. The helper registers its concrete provider types and shared interfaces as singletons; hosts that need alternate lifetimes continue to use explicit manual DI registration. The design keeps the existing provider identity/capability model, avoids registries or runtime scanning, and preserves built-in in-memory and SQLite JSON provider behavior.
+
+## Technical Context
+
+**Language/Version**: C# latest, .NET 8.0 / 9.0 / 10.0 multi-targeting  
+**Primary Dependencies**: Existing `Microsoft.Extensions.DependencyInjection.Abstractions`, `Microsoft.Extensions.Logging.Abstractions`; no new third-party dependencies  
+**Storage**: N/A; no persistence format or storage behavior changes  
+**Testing**: xUnit via `dotnet test Aster.sln`  
+**Target Platform**: .NET library usable from Generic Host / ASP.NET Core hosts  
+**Project Type**: SDK/library with provider package  
+**Performance Goals**: Provider registration remains constant-time DI setup work; validation continues to select one capability declaration before in-memory AST validation  
+**Constraints**: No provider registry, runtime scanning, public raw SQL, public `IQueryable<Resource>`, query planner, or provider-specific query construction contract  
+**Scale/Scope**: Current scope covers custom query provider registration ergonomics, singleton-only helper behavior, fail-closed diagnostic text, provider authoring tests, and docs/quickstart updates
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+- **SDK-first/headless**: PASS — Adds SDK DI helpers, diagnostics, tests, and docs only; no UI/CMS coupling.
+- **Immutable versioning**: PASS — Query provider registration does not alter resource mutation/version semantics.
+- **Channel activation**: PASS — Activation remains a query scope/capability concern.
+- **Typed/queryable**: PASS — Preserves portable `ResourceQuery`; explicitly avoids public `IQueryable<Resource>` and raw SQL contracts.
+- **Provider agnostic**: PASS — Core helper depends on provider-neutral abstractions, not SQLite or another database implementation.
+- **Simplicity first**: PASS — A small explicit DI helper satisfies the current ergonomics need without a registry/framework.
+- **Modern C# idioms**: PASS — Generic constraints and extension methods fit existing .NET SDK conventions.
+- **Readability over cleverness**: PASS — Registration remains visible and explicit in host code.
+- **Explicitness over magic**: PASS — No scanning/discovery; provider identity and capabilities are declared in code.
+- **Abstractions justified**: PASS — The helper removes demonstrated repeated/misordered provider registration without introducing a broad new abstraction.
+- **Optimize for deletion**: PASS — Helper and docs are localized; manual registration remains possible.
+- **Composition over inheritance**: PASS — Uses interfaces and DI composition, no inheritance hierarchy.
+- **Intentional dependencies**: PASS — No new dependencies.
+- **Operational simplicity**: PASS — No deployment or infrastructure changes; local diagnostics improve.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/005-provider-authoring-ergonomics/
+├── plan.md
+├── research.md
+├── data-model.md
+├── quickstart.md
+├── contracts/
+│   └── provider-authoring-ergonomics.md
+└── tasks.md
+```
+
+### Source Code (repository root)
+
+```text
+src/
+├── core/
+│   └── Aster.Core/
+│       ├── Abstractions/
+│       │   ├── IResourceQueryCapabilitiesProvider.cs
+│       │   ├── IResourceQueryProviderIdentity.cs
+│       │   └── IResourceQueryService.cs
+│       ├── Extensions/
+│       │   └── AsterCoreServiceCollectionExtensions.cs
+│       └── Services/
+│           └── ResourceQueryValidator.cs
+test/
+└── Aster.Tests/
+    └── Querying/
+        ├── ProviderAuthoringTests.cs
+        └── ResourceQueryValidatorTests.cs
+wiki/
+├── DI-Registration.md
+├── Exception-Reference.md
+└── Querying.md
+```
+
+**Structure Decision**: Keep the registration helper in `Aster.Core.Extensions` beside `AddAsterCore()` because it is provider-neutral SDK hosting glue. Keep diagnostics in `ResourceQueryValidator`. Add tests to existing querying test files to avoid a new test project.
+
+## Phase 0: Research
+
+Completed in [research.md](research.md).
+
+## Phase 1: Design & Contracts
+
+Completed artifacts:
+
+- [data-model.md](data-model.md)
+- [contracts/provider-authoring-ergonomics.md](contracts/provider-authoring-ergonomics.md)
+- [quickstart.md](quickstart.md)
+
+## Post-Design Constitution Check
+
+- **SDK-first/headless**: PASS — Public surface remains SDK DI/helper contracts and documentation.
+- **Immutable versioning**: PASS — No mutation/storage changes.
+- **Channel activation**: PASS — No activation behavior changes.
+- **Typed/queryable**: PASS — Custom providers still receive `ResourceQuery`; no public queryable/raw SQL escape hatch.
+- **Provider agnostic**: PASS — Helper is generic over existing query provider abstractions.
+- **Simplicity first**: PASS — Single helper plus diagnostics is the smallest selected affordance.
+- **Modern C# idioms**: PASS — Uses generic constraints and extension methods already familiar to .NET developers.
+- **Readability over cleverness**: PASS — Host code explicitly names the query provider and capability provider.
+- **Explicitness over magic**: PASS — No scanning, no implicit discovery, no hidden provider registry.
+- **Abstractions justified**: PASS — Helper prevents demonstrated active-provider/capability misregistration.
+- **Optimize for deletion**: PASS — Removing the helper does not affect manual registration or provider contracts.
+- **Composition over inheritance**: PASS — Composition via DI registrations.
+- **Intentional dependencies**: PASS — No new dependencies.
+- **Operational simplicity**: PASS — Same hosting/deployment model; clearer local failures.
+
+## Complexity Tracking
+
+No constitution violations identified.

--- a/specs/005-provider-authoring-ergonomics/quickstart.md
+++ b/specs/005-provider-authoring-ergonomics/quickstart.md
@@ -5,14 +5,24 @@
 ```csharp
 public sealed class MyQueryService : IResourceQueryService, IResourceQueryProviderIdentity
 {
+    private readonly ResourceQueryValidator validator;
+
+    public MyQueryService(IEnumerable<IResourceQueryCapabilitiesProvider> capabilityProviders)
+    {
+        validator = new(capabilityProviders, this);
+    }
+
     public string ProviderKey => "my-provider";
 
     public ValueTask<IEnumerable<Resource>> QueryAsync(
         ResourceQuery query,
         CancellationToken cancellationToken = default)
     {
-        // Run shared validation before provider-specific translation/execution.
-        // Keep provider-specific checks authoritative.
+        var validation = validator.Validate(query);
+        if (!validation.IsValid)
+            throw UnsupportedQueryFeatureException.FromValidationFailure(validation.Failures[0]);
+
+        // Keep provider-specific checks authoritative during translation/execution.
         return new([]);
     }
 }

--- a/specs/005-provider-authoring-ergonomics/quickstart.md
+++ b/specs/005-provider-authoring-ergonomics/quickstart.md
@@ -1,0 +1,92 @@
+# Quickstart: Provider Authoring Ergonomics
+
+## Define Provider Identity And Execution
+
+```csharp
+public sealed class MyQueryService : IResourceQueryService, IResourceQueryProviderIdentity
+{
+    public string ProviderKey => "my-provider";
+
+    public ValueTask<IEnumerable<Resource>> QueryAsync(
+        ResourceQuery query,
+        CancellationToken cancellationToken = default)
+    {
+        // Run shared validation before provider-specific translation/execution.
+        // Keep provider-specific checks authoritative.
+        return new([]);
+    }
+}
+```
+
+## Declare Matching Capabilities
+
+```csharp
+public sealed class MyQueryCapabilitiesProvider : IResourceQueryCapabilitiesProvider
+{
+    public QueryCapabilityDescription Capabilities { get; } = new(
+        ProviderKey: "my-provider",
+        ProviderName: "My Provider",
+        SupportedScopes: new HashSet<ResourceVersionScope> { ResourceVersionScope.Latest },
+        RequiresActivationChannelForActiveScope: false,
+        SupportedFilterTypes: new HashSet<QueryFilterType>(),
+        SupportedLogicalOperators: new HashSet<LogicalOperator>(),
+        SupportedComparisonOperators: new Dictionary<QueryFilterType, IReadOnlySet<ComparisonOperator>>(),
+        SupportedMetadataFields: new HashSet<string>(),
+        MetadataContainsFields: new HashSet<string>(),
+        SupportsMetadataSorting: false,
+        SupportsFacetSorting: false,
+        SupportsSkip: false,
+        SupportsTake: false,
+        FacetRangeSupport: new HashSet<QueryValueShape>(),
+        UnsupportedFeatures: []);
+}
+```
+
+## Register Provider
+
+```csharp
+services
+    .AddAsterCore()
+    .AddResourceQueryProvider<MyQueryService, MyQueryCapabilitiesProvider>();
+```
+
+The helper registers the query service, provider identity, and capability provider together as singletons for both concrete types and shared interfaces. The custom provider becomes the active query provider by normal DI last-registration-wins behavior. Use manual DI registration when a host needs alternate lifetimes.
+
+## Validate And Execute
+
+```csharp
+var validator = serviceProvider.GetRequiredService<IResourceQueryValidator>();
+var validation = validator.Validate(query);
+
+if (!validation.IsValid)
+{
+    foreach (var failure in validation.Failures)
+        Console.WriteLine($"{failure.Code} ({failure.Feature}): {failure.Message}");
+
+    return;
+}
+
+var queryService = serviceProvider.GetRequiredService<IResourceQueryService>();
+var results = await queryService.QueryAsync(query);
+```
+
+## Troubleshoot Missing Capabilities
+
+If validation returns `capabilities-not-declared`, confirm:
+
+- The active query provider implements `IResourceQueryProviderIdentity`.
+- The active provider key is non-empty.
+- An `IResourceQueryCapabilitiesProvider` is registered.
+- The capability declaration `ProviderKey` exactly matches the active provider key.
+
+## Provider-Specific Execution Failure
+
+```csharp
+throw new UnsupportedQueryFeatureException(
+    code: "unsupported-custom-value",
+    feature: "value shape",
+    message: "This provider cannot execute the supplied custom value shape.",
+    path: "Filter.Value");
+```
+
+Execution should remain authoritative even when validation succeeds.

--- a/specs/005-provider-authoring-ergonomics/research.md
+++ b/specs/005-provider-authoring-ergonomics/research.md
@@ -1,0 +1,56 @@
+# Research: Provider Authoring Ergonomics
+
+## Decision 1: Add a small explicit DI helper instead of a provider registry
+
+**Decision**: Add a provider-neutral `IServiceCollection` extension that registers a custom query service and matching capability provider together.
+
+**Rationale**: Custom provider authors currently have to remember several related registrations and registration order. A small helper removes that repeated setup while keeping behavior explicit in host code.
+
+**Alternatives considered**:
+
+- Provider registry. Rejected because the feature needs registration ergonomics, not a new provider framework.
+- Runtime scanning/discovery. Rejected because it violates explicitness and can hide provider selection.
+- Docs/tests only. Rejected because the user selected a DI affordance and the current registration pattern is easy to misorder.
+
+## Decision 2: Keep key mismatch detection in validation
+
+**Decision**: The registration helper does not compare provider keys at registration time. Validation remains responsible for fail-closed behavior when the active provider key has no matching capability declaration.
+
+**Rationale**: DI registration should stay simple and not instantiate services early or add lifecycle rules. Validation already has the active provider and capability declarations at runtime.
+
+**Alternatives considered**:
+
+- Instantiate services during registration to compare keys. Rejected because registration should not create singleton instances or require provider constructors to be side-effect-free.
+- Add an options validator. Rejected as extra infrastructure for a small SDK affordance.
+
+## Decision 3: Improve capabilities-not-declared diagnostics
+
+**Decision**: Keep the stable failure code `capabilities-not-declared`, but include the active provider key when available and explain that a matching capability declaration must be registered.
+
+**Rationale**: The current failure is safe but generic. Provider authors need fast feedback about what key is missing or mismatched.
+
+**Alternatives considered**:
+
+- Add a new failure code for mismatched keys. Rejected because both missing and mismatched declarations mean the active provider capabilities are not declared.
+- Throw during validation construction. Rejected because preflight validation should remain non-throwing.
+
+## Decision 4: Manual registration remains supported
+
+**Decision**: The helper is the recommended path, but manual `IResourceQueryService` and `IResourceQueryCapabilitiesProvider` registration remains valid for advanced cases.
+
+**Rationale**: Existing hosts and providers may already use manual registrations, decorators, or tests that require direct control.
+
+**Alternatives considered**:
+
+- Require all custom providers to use the helper. Rejected as unnecessarily restrictive.
+- Change built-in providers to depend on a registry. Rejected as broad and speculative.
+
+## Decision 5: No new dependencies or storage changes
+
+**Decision**: Implement with existing DI abstractions, tests, and documentation only.
+
+**Rationale**: Provider authoring ergonomics do not require new packages or operational infrastructure.
+
+**Alternatives considered**:
+
+- Add validation packages or source generators. Rejected as disproportionate and contrary to simplicity.

--- a/specs/005-provider-authoring-ergonomics/spec.md
+++ b/specs/005-provider-authoring-ergonomics/spec.md
@@ -1,0 +1,133 @@
+# Feature Specification: Provider Authoring Ergonomics
+
+**Feature Branch**: `005-provider-authoring-ergonomics`  
+**Created**: 2026-05-16  
+**Status**: Draft  
+**Input**: User description: "Provider authoring ergonomics: make custom query provider registration easier and harder to misconfigure after explicit provider keys and fail-closed validation. Add clear guidance and small SDK affordances so provider authors can declare identity, capabilities, and active query service wiring consistently without introducing a provider registry framework."
+
+## Clarifications
+
+### Session 2026-05-17
+
+- Q: Should the new provider registration helper support configurable lifetimes or remain singleton-only? → A: `AddResourceQueryProvider<TQueryService, TCapabilitiesProvider>()` registers both concrete implementations and shared interfaces as singletons; other lifetimes use manual registration.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Register A Custom Query Provider Correctly (Priority: P1)
+
+As a provider author, I want a clear and repeatable way to register a custom query provider and its matching capabilities, so that validation uses my provider instead of failing closed or accidentally relying on defaults.
+
+**Why this priority**: Provider extensibility is only useful if custom providers can be wired correctly without studying the built-in providers.
+
+**Independent Test**: Can be fully tested by registering a custom provider with a matching provider key and confirming capability discovery, validation, and execution all use the custom provider.
+
+**Acceptance Scenarios**:
+
+1. **Given** a custom query provider with a declared provider key and matching capabilities, **When** the host registers it as the active query provider, **Then** validation succeeds for query shapes declared by that provider.
+2. **Given** default in-memory services are already registered, **When** a custom query provider is registered afterward with matching capabilities, **Then** validation uses the custom provider capabilities instead of earlier defaults.
+3. **Given** a host resolves provider capabilities after custom registration, **When** capabilities are inspected, **Then** the active custom provider identity and supported query surface are discoverable.
+
+---
+
+### User Story 2 - Catch Provider Registration Mistakes Early (Priority: P1)
+
+As a host developer, I want provider registration mistakes to be obvious during local development and tests, so that missing or mismatched capability declarations do not survive until production query execution.
+
+**Why this priority**: Fail-closed validation is safe, but authors still need fast feedback that explains how to fix the registration.
+
+**Independent Test**: Can be fully tested by intentionally registering incomplete or mismatched custom provider pieces and confirming validation reports actionable failures.
+
+**Acceptance Scenarios**:
+
+1. **Given** a custom query provider is registered without matching capabilities, **When** a query is validated, **Then** validation fails with a capabilities-not-declared result that identifies missing active-provider capabilities.
+2. **Given** a custom provider key and capability provider key do not match, **When** validation runs, **Then** validation fails closed and the failure message explains that provider identity and capabilities must match.
+3. **Given** multiple capability declarations are registered, **When** validation runs for the active provider, **Then** the active provider's declaration is selected deterministically by explicit key.
+
+---
+
+### User Story 3 - Reuse Validation In Custom Provider Execution (Priority: P2)
+
+As a provider author, I want guidance and reusable patterns for invoking shared validation before execution, so that my provider reports unsupported query shapes consistently while still enforcing provider-specific constraints.
+
+**Why this priority**: Consistent failure behavior reduces duplicated validation logic, but provider execution must remain authoritative.
+
+**Independent Test**: Can be fully tested by implementing a small custom provider test double that runs shared validation before execution and still rejects a provider-specific unsupported value shape.
+
+**Acceptance Scenarios**:
+
+1. **Given** a custom provider receives an unsupported query shape, **When** execution runs without caller preflight, **Then** execution raises a structured unsupported-query failure aligned with validation.
+2. **Given** a custom provider has an execution-only constraint, **When** validation accepts the query but execution cannot complete it, **Then** execution raises a structured provider-specific unsupported-query failure.
+3. **Given** a supported query shape reaches the custom provider, **When** execution runs, **Then** shared validation does not block execution.
+
+---
+
+### User Story 4 - Follow Provider Authoring Documentation (Priority: P3)
+
+As an SDK consumer evaluating provider extensibility, I want concise provider-authoring documentation and examples, so that I can understand the minimum required pieces without reverse-engineering built-in providers.
+
+**Why this priority**: Documentation turns the new provider identity and fail-closed behavior into an approachable extension story.
+
+**Independent Test**: Can be fully tested by following the documentation to create a minimal custom provider, declare capabilities, register it, validate a query, and handle execution failures.
+
+**Acceptance Scenarios**:
+
+1. **Given** a developer reads the provider authoring guide, **When** they follow the minimal example, **Then** they can identify the required provider identity, capability declaration, query service, and registration steps.
+2. **Given** validation fails because capabilities are missing or mismatched, **When** the developer reads troubleshooting guidance, **Then** they can identify the registration problem and fix it.
+3. **Given** a provider has unsupported query behavior, **When** the developer follows the guide, **Then** they can expose structured unsupported-query failures with stable code, feature, message, and optional path.
+
+### Edge Cases
+
+- A host registers a custom query provider but forgets to register matching capabilities.
+- A host registers matching capabilities before the custom provider becomes active.
+- A host registers multiple capability declarations with overlapping provider names but distinct provider keys.
+- A custom provider wraps or decorates another provider while exposing its own provider key.
+- A provider declares support for a query shape but rejects a provider-specific value during execution.
+- A provider author tries to solve registration by introducing a global provider registry instead of explicit registration.
+
+### Constitution Alignment *(mandatory)*
+
+- **Simplicity**: The simplest acceptable behavior is small provider-authoring affordances, tests, and documentation around the existing provider identity/capability model. A global provider registry, provider framework, query planner, automatic provider discovery, and runtime scanning are intentionally out of scope.
+- **Explicitness**: Provider identity, capability declarations, validation matching, and registration order must remain visible through code and configuration.
+- **Dependencies**: None expected.
+- **Operational Impact**: No new infrastructure or deployment requirements. Local development and debugging should improve because provider registration mistakes become easier to diagnose.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The SDK MUST provide a clear supported path for registering a custom query provider and matching capability declaration.
+- **FR-002**: Provider registration guidance MUST make the active provider key and capability provider key relationship explicit.
+- **FR-003**: Validation MUST continue to fail closed when the active query provider has no matching capability declaration.
+- **FR-004**: Validation failure messages for missing or mismatched active-provider capabilities SHOULD be actionable for provider authors.
+- **FR-005**: Custom provider registration tests MUST prove that a matching provider key causes validation to use custom capabilities instead of defaults.
+- **FR-006**: Custom provider registration tests MUST prove that missing or mismatched capabilities fail closed.
+- **FR-007**: Provider authoring guidance SHOULD show how a provider can run shared validation before execution without making validation the only execution safeguard.
+- **FR-008**: Provider authoring guidance MUST explain that provider execution remains authoritative and may still reject provider-specific constraints.
+- **FR-009**: Structured unsupported-query failure guidance MUST include stable code, feature category, actionable message, and optional path handling.
+- **FR-010**: The feature MUST NOT introduce a global provider registry, runtime scanning convention, public raw SQL, public `IQueryable<Resource>`, or provider-specific query construction as the custom provider contract.
+- **FR-011**: Existing built-in in-memory and SQLite JSON provider registration behavior MUST remain compatible.
+- **FR-012**: Documentation MUST include a minimal custom provider example and a troubleshooting section for missing or mismatched capabilities.
+- **FR-013**: The custom provider registration helper MUST register the query service and capabilities provider as singletons for both concrete types and shared interfaces; hosts that require different lifetimes MUST use explicit manual DI registration.
+
+### Key Entities *(include if feature involves data)*
+
+- **Custom Query Provider**: A host-provided implementation that executes portable resource queries and exposes a stable provider key.
+- **Custom Capability Declaration**: A provider-owned declaration of supported query shapes using the same provider key as the active custom provider.
+- **Provider Registration Recipe**: The minimum host configuration needed to make the custom provider active for execution and validation. The SDK helper recipe uses singleton registrations; manual registration remains the supported recipe for alternate lifetimes.
+- **Provider Authoring Failure**: A validation or execution failure that helps provider authors diagnose missing capabilities, mismatched keys, or unsupported provider-specific behavior.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: A minimal custom provider can be registered in tests and validated successfully with matching capabilities.
+- **SC-002**: Missing or mismatched custom provider capabilities produce capabilities-not-declared validation results in all covered configurations.
+- **SC-003**: Documentation includes a complete minimal custom provider registration example, including provider identity, capabilities, query service registration, validation, and execution failure handling.
+- **SC-004**: Existing built-in provider registration and query validation tests continue to pass.
+- **SC-005**: No new third-party dependencies, runtime scanning mechanisms, or provider registry abstractions are introduced.
+
+## Assumptions
+
+- This slice builds on explicit provider keys and structured unsupported-query failures from `004-provider-validation-execution`.
+- The primary provider-authoring target is query provider registration and validation behavior, not full persistence provider packaging.
+- Small SDK affordances are acceptable when they remove current duplication or prevent demonstrated misregistration, but broad extension frameworks are out of scope.

--- a/specs/005-provider-authoring-ergonomics/tasks.md
+++ b/specs/005-provider-authoring-ergonomics/tasks.md
@@ -1,6 +1,6 @@
 # Tasks: Provider Authoring Ergonomics
 
-**Input**: Design documents from `/specs/005-provider-authoring-ergonomics/`
+**Input**: Design documents from `specs/005-provider-authoring-ergonomics/`
 **Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/provider-authoring-ergonomics.md, quickstart.md
 **Tests**: Required by FR-005, FR-006, FR-011, SC-001, SC-002, SC-004
 
@@ -16,10 +16,10 @@
 
 **Purpose**: Confirm the feature branch and existing provider/querying surface are ready for implementation.
 
-- [X] T001 Inspect existing query provider DI registrations in `/Users/sipke/Projects/ValenceWorks/aster/src/core/Aster.Core/Extensions/AsterCoreServiceCollectionExtensions.cs`
-- [X] T002 [P] Inspect existing provider identity and capability contracts in `/Users/sipke/Projects/ValenceWorks/aster/src/core/Aster.Core/Abstractions/IResourceQueryProviderIdentity.cs` and `/Users/sipke/Projects/ValenceWorks/aster/src/core/Aster.Core/Abstractions/IResourceQueryCapabilitiesProvider.cs`
-- [X] T003 [P] Inspect existing query validation diagnostics in `/Users/sipke/Projects/ValenceWorks/aster/src/core/Aster.Core/Services/ResourceQueryValidator.cs`
-- [X] T004 Confirm no new dependency or storage changes are needed by checking `/Users/sipke/Projects/ValenceWorks/aster/specs/005-provider-authoring-ergonomics/plan.md`
+- [X] T001 Inspect existing query provider DI registrations in `src/core/Aster.Core/Extensions/AsterCoreServiceCollectionExtensions.cs`
+- [X] T002 [P] Inspect existing provider identity and capability contracts in `src/core/Aster.Core/Abstractions/IResourceQueryProviderIdentity.cs` and `src/core/Aster.Core/Abstractions/IResourceQueryCapabilitiesProvider.cs`
+- [X] T003 [P] Inspect existing query validation diagnostics in `src/core/Aster.Core/Services/ResourceQueryValidator.cs`
+- [X] T004 Confirm no new dependency or storage changes are needed by checking `specs/005-provider-authoring-ergonomics/plan.md`
 
 ---
 
@@ -29,10 +29,10 @@
 
 **CRITICAL**: No user story work should begin until this phase is complete.
 
-- [X] T005 Create provider-authoring test scaffolding in `/Users/sipke/Projects/ValenceWorks/aster/test/Aster.Tests/Querying/ProviderAuthoringTests.cs`
-- [X] T006 Add custom provider test doubles implementing `IResourceQueryService` and `IResourceQueryProviderIdentity` in `/Users/sipke/Projects/ValenceWorks/aster/test/Aster.Tests/Querying/ProviderAuthoringTests.cs`
-- [X] T007 Add custom capabilities provider test doubles implementing `IResourceQueryCapabilitiesProvider` in `/Users/sipke/Projects/ValenceWorks/aster/test/Aster.Tests/Querying/ProviderAuthoringTests.cs`
-- [X] T008 Add shared custom query builder or fixture helpers for provider-authoring tests in `/Users/sipke/Projects/ValenceWorks/aster/test/Aster.Tests/Querying/ProviderAuthoringTests.cs`
+- [X] T005 Create provider-authoring test scaffolding in `test/Aster.Tests/Querying/ProviderAuthoringTests.cs`
+- [X] T006 Add custom provider test doubles implementing `IResourceQueryService` and `IResourceQueryProviderIdentity` in `test/Aster.Tests/Querying/ProviderAuthoringTests.cs`
+- [X] T007 Add custom capabilities provider test doubles implementing `IResourceQueryCapabilitiesProvider` in `test/Aster.Tests/Querying/ProviderAuthoringTests.cs`
+- [X] T008 Add shared custom query builder or fixture helpers for provider-authoring tests in `test/Aster.Tests/Querying/ProviderAuthoringTests.cs`
 
 **Checkpoint**: Test scaffolding exists and user story work can proceed.
 
@@ -46,16 +46,16 @@
 
 ### Tests for User Story 1
 
-- [X] T009 [US1] Add a failing test proving `AddResourceQueryProvider<TQueryService, TCapabilitiesProvider>()` resolves the custom provider as active `IResourceQueryService` in `/Users/sipke/Projects/ValenceWorks/aster/test/Aster.Tests/Querying/ProviderAuthoringTests.cs`
-- [X] T010 [US1] Add a failing test proving the helper resolves the custom provider identity and matching capability declaration in `/Users/sipke/Projects/ValenceWorks/aster/test/Aster.Tests/Querying/ProviderAuthoringTests.cs`
-- [X] T011 [US1] Add a failing test proving custom capabilities are used instead of earlier in-memory defaults in `/Users/sipke/Projects/ValenceWorks/aster/test/Aster.Tests/Querying/ProviderAuthoringTests.cs`
-- [X] T012 [US1] Add a failing test proving the helper registers query service and capabilities provider concrete types plus shared interfaces as singletons in `/Users/sipke/Projects/ValenceWorks/aster/test/Aster.Tests/Querying/ProviderAuthoringTests.cs`
+- [X] T009 [US1] Add a failing test proving `AddResourceQueryProvider<TQueryService, TCapabilitiesProvider>()` resolves the custom provider as active `IResourceQueryService` in `test/Aster.Tests/Querying/ProviderAuthoringTests.cs`
+- [X] T010 [US1] Add a failing test proving the helper resolves the custom provider identity and matching capability declaration in `test/Aster.Tests/Querying/ProviderAuthoringTests.cs`
+- [X] T011 [US1] Add a failing test proving custom capabilities are used instead of earlier in-memory defaults in `test/Aster.Tests/Querying/ProviderAuthoringTests.cs`
+- [X] T012 [US1] Add a failing test proving the helper registers query service and capabilities provider concrete types plus shared interfaces as singletons in `test/Aster.Tests/Querying/ProviderAuthoringTests.cs`
 
 ### Implementation for User Story 1
 
-- [X] T013 [US1] Implement `AddResourceQueryProvider<TQueryService, TCapabilitiesProvider>()` in `/Users/sipke/Projects/ValenceWorks/aster/src/core/Aster.Core/Extensions/AsterCoreServiceCollectionExtensions.cs`
-- [X] T014 [US1] Apply generic constraints requiring `TQueryService` to implement `IResourceQueryService` and `IResourceQueryProviderIdentity` and `TCapabilitiesProvider` to implement `IResourceQueryCapabilitiesProvider` in `/Users/sipke/Projects/ValenceWorks/aster/src/core/Aster.Core/Extensions/AsterCoreServiceCollectionExtensions.cs`
-- [X] T015 [US1] Register the query service and capabilities provider concrete types and shared interfaces as singletons while preserving last-registration-wins behavior in `/Users/sipke/Projects/ValenceWorks/aster/src/core/Aster.Core/Extensions/AsterCoreServiceCollectionExtensions.cs`
+- [X] T013 [US1] Implement `AddResourceQueryProvider<TQueryService, TCapabilitiesProvider>()` in `src/core/Aster.Core/Extensions/AsterCoreServiceCollectionExtensions.cs`
+- [X] T014 [US1] Apply generic constraints requiring `TQueryService` to implement `IResourceQueryService` and `IResourceQueryProviderIdentity` and `TCapabilitiesProvider` to implement `IResourceQueryCapabilitiesProvider` in `src/core/Aster.Core/Extensions/AsterCoreServiceCollectionExtensions.cs`
+- [X] T015 [US1] Register the query service and capabilities provider concrete types and shared interfaces as singletons while preserving last-registration-wins behavior in `src/core/Aster.Core/Extensions/AsterCoreServiceCollectionExtensions.cs`
 
 **Checkpoint**: User Story 1 is functional and independently testable.
 
@@ -69,15 +69,15 @@
 
 ### Tests for User Story 2
 
-- [X] T016 [US2] Add a failing test for missing custom provider capabilities returning `capabilities-not-declared` in `/Users/sipke/Projects/ValenceWorks/aster/test/Aster.Tests/Querying/ProviderAuthoringTests.cs`
-- [X] T017 [US2] Add a failing test for mismatched provider keys returning `capabilities-not-declared` with the active provider key in `/Users/sipke/Projects/ValenceWorks/aster/test/Aster.Tests/Querying/ProviderAuthoringTests.cs`
-- [X] T018 [P] [US2] Update existing validator diagnostic assertions for actionable provider-key guidance in `/Users/sipke/Projects/ValenceWorks/aster/test/Aster.Tests/Querying/ResourceQueryValidatorTests.cs`
+- [X] T016 [US2] Add a failing test for missing custom provider capabilities returning `capabilities-not-declared` in `test/Aster.Tests/Querying/ProviderAuthoringTests.cs`
+- [X] T017 [US2] Add a failing test for mismatched provider keys returning `capabilities-not-declared` with the active provider key in `test/Aster.Tests/Querying/ProviderAuthoringTests.cs`
+- [X] T018 [P] [US2] Update existing validator diagnostic assertions for actionable provider-key guidance in `test/Aster.Tests/Querying/ResourceQueryValidatorTests.cs`
 
 ### Implementation for User Story 2
 
-- [X] T019 [US2] Update `ResourceQueryValidator` to track the active provider key from `IResourceQueryProviderIdentity` when available in `/Users/sipke/Projects/ValenceWorks/aster/src/core/Aster.Core/Services/ResourceQueryValidator.cs`
-- [X] T020 [US2] Improve the `capabilities-not-declared` message for missing identity, empty provider key, and mismatched capabilities in `/Users/sipke/Projects/ValenceWorks/aster/src/core/Aster.Core/Services/ResourceQueryValidator.cs`
-- [X] T021 [US2] Confirm validation still returns failures instead of throwing for missing or mismatched capabilities in `/Users/sipke/Projects/ValenceWorks/aster/src/core/Aster.Core/Services/ResourceQueryValidator.cs`
+- [X] T019 [US2] Update `ResourceQueryValidator` to track the active provider key from `IResourceQueryProviderIdentity` when available in `src/core/Aster.Core/Services/ResourceQueryValidator.cs`
+- [X] T020 [US2] Improve the `capabilities-not-declared` message for missing identity, empty provider key, and mismatched capabilities in `src/core/Aster.Core/Services/ResourceQueryValidator.cs`
+- [X] T021 [US2] Confirm validation still returns failures instead of throwing for missing or mismatched capabilities in `src/core/Aster.Core/Services/ResourceQueryValidator.cs`
 
 **Checkpoint**: User Story 2 is functional and independently testable.
 
@@ -91,14 +91,14 @@
 
 ### Tests for User Story 3
 
-- [X] T022 [US3] Add a failing test proving a custom provider can run shared validation before execution in `/Users/sipke/Projects/ValenceWorks/aster/test/Aster.Tests/Querying/ProviderAuthoringTests.cs`
-- [X] T023 [US3] Add a failing test proving provider-specific execution failures remain structured and authoritative in `/Users/sipke/Projects/ValenceWorks/aster/test/Aster.Tests/Querying/ProviderAuthoringTests.cs`
+- [X] T022 [US3] Add a failing test proving a custom provider can run shared validation before execution in `test/Aster.Tests/Querying/ProviderAuthoringTests.cs`
+- [X] T023 [US3] Add a failing test proving provider-specific execution failures remain structured and authoritative in `test/Aster.Tests/Querying/ProviderAuthoringTests.cs`
 
 ### Implementation for User Story 3
 
-- [X] T024 [US3] Add or adjust custom provider test-double execution logic that maps validation failures through structured unsupported-query failures in `/Users/sipke/Projects/ValenceWorks/aster/test/Aster.Tests/Querying/ProviderAuthoringTests.cs`
-- [X] T025 [US3] Document shared validation before execution and execution-authoritative behavior in `/Users/sipke/Projects/ValenceWorks/aster/wiki/Querying.md`
-- [X] T026 [US3] Document structured provider-specific unsupported-query failures in `/Users/sipke/Projects/ValenceWorks/aster/wiki/Exception-Reference.md`
+- [X] T024 [US3] Add or adjust custom provider test-double execution logic that maps validation failures through structured unsupported-query failures in `test/Aster.Tests/Querying/ProviderAuthoringTests.cs`
+- [X] T025 [US3] Document shared validation before execution and execution-authoritative behavior in `wiki/Querying.md`
+- [X] T026 [US3] Document structured provider-specific unsupported-query failures in `wiki/Exception-Reference.md`
 
 **Checkpoint**: User Story 3 is functional and independently testable.
 
@@ -112,15 +112,15 @@
 
 ### Tests for User Story 4
 
-- [X] T027 [US4] Verify the quickstart minimal registration example is represented by tests in `/Users/sipke/Projects/ValenceWorks/aster/test/Aster.Tests/Querying/ProviderAuthoringTests.cs`
-- [X] T028 [US4] Verify existing built-in `AddAsterCore()` and `AddAsterSqliteJson()` behavior remains unchanged in `/Users/sipke/Projects/ValenceWorks/aster/test/Aster.Tests/Querying/ProviderAuthoringTests.cs`
+- [X] T027 [US4] Verify the quickstart minimal registration example is represented by tests in `test/Aster.Tests/Querying/ProviderAuthoringTests.cs`
+- [X] T028 [US4] Verify existing built-in `AddAsterCore()` and `AddAsterSqliteJson()` behavior remains unchanged in `test/Aster.Tests/Querying/ProviderAuthoringTests.cs`
 
 ### Implementation for User Story 4
 
-- [X] T029 [P] [US4] Document the provider registration helper and manual-registration lifetime escape hatch in `/Users/sipke/Projects/ValenceWorks/aster/wiki/DI-Registration.md`
-- [X] T030 [P] [US4] Add provider-authoring guidance to the package README in `/Users/sipke/Projects/ValenceWorks/aster/src/core/Aster.Core/README.md`
-- [X] T031 [P] [US4] Update the feature quickstart with the singleton helper contract and troubleshooting guidance in `/Users/sipke/Projects/ValenceWorks/aster/specs/005-provider-authoring-ergonomics/quickstart.md`
-- [X] T032 [P] [US4] Update the public contract document with singleton helper behavior in `/Users/sipke/Projects/ValenceWorks/aster/specs/005-provider-authoring-ergonomics/contracts/provider-authoring-ergonomics.md`
+- [X] T029 [P] [US4] Document the provider registration helper and manual-registration lifetime escape hatch in `wiki/DI-Registration.md`
+- [X] T030 [P] [US4] Add provider-authoring guidance to the package README in `src/core/Aster.Core/README.md`
+- [X] T031 [P] [US4] Update the feature quickstart with the singleton helper contract and troubleshooting guidance in `specs/005-provider-authoring-ergonomics/quickstart.md`
+- [X] T032 [P] [US4] Update the public contract document with singleton helper behavior in `specs/005-provider-authoring-ergonomics/contracts/provider-authoring-ergonomics.md`
 
 **Checkpoint**: User Story 4 is documented and independently verifiable.
 
@@ -130,11 +130,11 @@
 
 **Purpose**: Verify compatibility, constitution alignment, and final quality.
 
-- [X] T033 [P] Update agent context after planning artifacts are current by running `.specify/scripts/bash/update-agent-context.sh copilot` from `/Users/sipke/Projects/ValenceWorks/aster`
-- [X] T034 [P] Review implementation for unnecessary abstractions, runtime scanning, provider registry behavior, public raw SQL, and public `IQueryable<Resource>` in `/Users/sipke/Projects/ValenceWorks/aster/src/core/Aster.Core`
-- [X] T035 Run `dotnet test Aster.sln` from `/Users/sipke/Projects/ValenceWorks/aster`
-- [X] T036 Run `dotnet build Aster.sln` from `/Users/sipke/Projects/ValenceWorks/aster`
-- [X] T037 Run `git diff --check` from `/Users/sipke/Projects/ValenceWorks/aster`
+- [X] T033 [P] Update agent context after planning artifacts are current by running `.specify/scripts/bash/update-agent-context.sh copilot` from `repository root`
+- [X] T034 [P] Review implementation for unnecessary abstractions, runtime scanning, provider registry behavior, public raw SQL, and public `IQueryable<Resource>` in `src/core/Aster.Core`
+- [X] T035 Run `dotnet test Aster.sln` from `repository root`
+- [X] T036 Run `dotnet build Aster.sln` from `repository root`
+- [X] T037 Run `git diff --check` from `repository root`
 
 ---
 
@@ -169,8 +169,8 @@
 ## Parallel Example: User Story 2
 
 ```bash
-Task: "Add a failing test for missing custom provider capabilities returning capabilities-not-declared in /Users/sipke/Projects/ValenceWorks/aster/test/Aster.Tests/Querying/ProviderAuthoringTests.cs"
-Task: "Update existing validator diagnostic assertions for actionable provider-key guidance in /Users/sipke/Projects/ValenceWorks/aster/test/Aster.Tests/Querying/ResourceQueryValidatorTests.cs"
+Task: "Add a failing test for missing custom provider capabilities returning capabilities-not-declared in test/Aster.Tests/Querying/ProviderAuthoringTests.cs"
+Task: "Update existing validator diagnostic assertions for actionable provider-key guidance in test/Aster.Tests/Querying/ResourceQueryValidatorTests.cs"
 ```
 
 ---

--- a/specs/005-provider-authoring-ergonomics/tasks.md
+++ b/specs/005-provider-authoring-ergonomics/tasks.md
@@ -1,0 +1,198 @@
+# Tasks: Provider Authoring Ergonomics
+
+**Input**: Design documents from `/specs/005-provider-authoring-ergonomics/`
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/provider-authoring-ergonomics.md, quickstart.md
+**Tests**: Required by FR-005, FR-006, FR-011, SC-001, SC-002, SC-004
+
+**Organization**: Tasks are grouped by user story to enable independent implementation and testing.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel because it touches different files or does not depend on incomplete tasks
+- **[Story]**: Which user story this task belongs to
+- Every task includes an exact repository path
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Confirm the feature branch and existing provider/querying surface are ready for implementation.
+
+- [X] T001 Inspect existing query provider DI registrations in `/Users/sipke/Projects/ValenceWorks/aster/src/core/Aster.Core/Extensions/AsterCoreServiceCollectionExtensions.cs`
+- [X] T002 [P] Inspect existing provider identity and capability contracts in `/Users/sipke/Projects/ValenceWorks/aster/src/core/Aster.Core/Abstractions/IResourceQueryProviderIdentity.cs` and `/Users/sipke/Projects/ValenceWorks/aster/src/core/Aster.Core/Abstractions/IResourceQueryCapabilitiesProvider.cs`
+- [X] T003 [P] Inspect existing query validation diagnostics in `/Users/sipke/Projects/ValenceWorks/aster/src/core/Aster.Core/Services/ResourceQueryValidator.cs`
+- [X] T004 Confirm no new dependency or storage changes are needed by checking `/Users/sipke/Projects/ValenceWorks/aster/specs/005-provider-authoring-ergonomics/plan.md`
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Establish shared implementation and test scaffolding before story-specific work.
+
+**CRITICAL**: No user story work should begin until this phase is complete.
+
+- [X] T005 Create provider-authoring test scaffolding in `/Users/sipke/Projects/ValenceWorks/aster/test/Aster.Tests/Querying/ProviderAuthoringTests.cs`
+- [X] T006 Add custom provider test doubles implementing `IResourceQueryService` and `IResourceQueryProviderIdentity` in `/Users/sipke/Projects/ValenceWorks/aster/test/Aster.Tests/Querying/ProviderAuthoringTests.cs`
+- [X] T007 Add custom capabilities provider test doubles implementing `IResourceQueryCapabilitiesProvider` in `/Users/sipke/Projects/ValenceWorks/aster/test/Aster.Tests/Querying/ProviderAuthoringTests.cs`
+- [X] T008 Add shared custom query builder or fixture helpers for provider-authoring tests in `/Users/sipke/Projects/ValenceWorks/aster/test/Aster.Tests/Querying/ProviderAuthoringTests.cs`
+
+**Checkpoint**: Test scaffolding exists and user story work can proceed.
+
+---
+
+## Phase 3: User Story 1 - Register A Custom Query Provider Correctly (Priority: P1) MVP
+
+**Goal**: Provide a clear SDK path that registers a custom query provider, provider identity, and matching capabilities together.
+
+**Independent Test**: Register a custom provider with matching capabilities and confirm validation uses the custom capabilities instead of defaults.
+
+### Tests for User Story 1
+
+- [X] T009 [US1] Add a failing test proving `AddResourceQueryProvider<TQueryService, TCapabilitiesProvider>()` resolves the custom provider as active `IResourceQueryService` in `/Users/sipke/Projects/ValenceWorks/aster/test/Aster.Tests/Querying/ProviderAuthoringTests.cs`
+- [X] T010 [US1] Add a failing test proving the helper resolves the custom provider identity and matching capability declaration in `/Users/sipke/Projects/ValenceWorks/aster/test/Aster.Tests/Querying/ProviderAuthoringTests.cs`
+- [X] T011 [US1] Add a failing test proving custom capabilities are used instead of earlier in-memory defaults in `/Users/sipke/Projects/ValenceWorks/aster/test/Aster.Tests/Querying/ProviderAuthoringTests.cs`
+- [X] T012 [US1] Add a failing test proving the helper registers query service and capabilities provider concrete types plus shared interfaces as singletons in `/Users/sipke/Projects/ValenceWorks/aster/test/Aster.Tests/Querying/ProviderAuthoringTests.cs`
+
+### Implementation for User Story 1
+
+- [X] T013 [US1] Implement `AddResourceQueryProvider<TQueryService, TCapabilitiesProvider>()` in `/Users/sipke/Projects/ValenceWorks/aster/src/core/Aster.Core/Extensions/AsterCoreServiceCollectionExtensions.cs`
+- [X] T014 [US1] Apply generic constraints requiring `TQueryService` to implement `IResourceQueryService` and `IResourceQueryProviderIdentity` and `TCapabilitiesProvider` to implement `IResourceQueryCapabilitiesProvider` in `/Users/sipke/Projects/ValenceWorks/aster/src/core/Aster.Core/Extensions/AsterCoreServiceCollectionExtensions.cs`
+- [X] T015 [US1] Register the query service and capabilities provider concrete types and shared interfaces as singletons while preserving last-registration-wins behavior in `/Users/sipke/Projects/ValenceWorks/aster/src/core/Aster.Core/Extensions/AsterCoreServiceCollectionExtensions.cs`
+
+**Checkpoint**: User Story 1 is functional and independently testable.
+
+---
+
+## Phase 4: User Story 2 - Catch Provider Registration Mistakes Early (Priority: P1)
+
+**Goal**: Keep validation fail-closed while making missing or mismatched capabilities actionable.
+
+**Independent Test**: Register incomplete or mismatched custom provider pieces and confirm validation reports `capabilities-not-declared` with active provider key guidance.
+
+### Tests for User Story 2
+
+- [X] T016 [US2] Add a failing test for missing custom provider capabilities returning `capabilities-not-declared` in `/Users/sipke/Projects/ValenceWorks/aster/test/Aster.Tests/Querying/ProviderAuthoringTests.cs`
+- [X] T017 [US2] Add a failing test for mismatched provider keys returning `capabilities-not-declared` with the active provider key in `/Users/sipke/Projects/ValenceWorks/aster/test/Aster.Tests/Querying/ProviderAuthoringTests.cs`
+- [X] T018 [P] [US2] Update existing validator diagnostic assertions for actionable provider-key guidance in `/Users/sipke/Projects/ValenceWorks/aster/test/Aster.Tests/Querying/ResourceQueryValidatorTests.cs`
+
+### Implementation for User Story 2
+
+- [X] T019 [US2] Update `ResourceQueryValidator` to track the active provider key from `IResourceQueryProviderIdentity` when available in `/Users/sipke/Projects/ValenceWorks/aster/src/core/Aster.Core/Services/ResourceQueryValidator.cs`
+- [X] T020 [US2] Improve the `capabilities-not-declared` message for missing identity, empty provider key, and mismatched capabilities in `/Users/sipke/Projects/ValenceWorks/aster/src/core/Aster.Core/Services/ResourceQueryValidator.cs`
+- [X] T021 [US2] Confirm validation still returns failures instead of throwing for missing or mismatched capabilities in `/Users/sipke/Projects/ValenceWorks/aster/src/core/Aster.Core/Services/ResourceQueryValidator.cs`
+
+**Checkpoint**: User Story 2 is functional and independently testable.
+
+---
+
+## Phase 5: User Story 3 - Reuse Validation In Custom Provider Execution (Priority: P2)
+
+**Goal**: Document and test the provider authoring pattern where custom providers run shared validation before execution while preserving provider-specific execution authority.
+
+**Independent Test**: Implement a custom provider test double that runs shared validation before execution and still rejects a provider-specific unsupported shape.
+
+### Tests for User Story 3
+
+- [X] T022 [US3] Add a failing test proving a custom provider can run shared validation before execution in `/Users/sipke/Projects/ValenceWorks/aster/test/Aster.Tests/Querying/ProviderAuthoringTests.cs`
+- [X] T023 [US3] Add a failing test proving provider-specific execution failures remain structured and authoritative in `/Users/sipke/Projects/ValenceWorks/aster/test/Aster.Tests/Querying/ProviderAuthoringTests.cs`
+
+### Implementation for User Story 3
+
+- [X] T024 [US3] Add or adjust custom provider test-double execution logic that maps validation failures through structured unsupported-query failures in `/Users/sipke/Projects/ValenceWorks/aster/test/Aster.Tests/Querying/ProviderAuthoringTests.cs`
+- [X] T025 [US3] Document shared validation before execution and execution-authoritative behavior in `/Users/sipke/Projects/ValenceWorks/aster/wiki/Querying.md`
+- [X] T026 [US3] Document structured provider-specific unsupported-query failures in `/Users/sipke/Projects/ValenceWorks/aster/wiki/Exception-Reference.md`
+
+**Checkpoint**: User Story 3 is functional and independently testable.
+
+---
+
+## Phase 6: User Story 4 - Follow Provider Authoring Documentation (Priority: P3)
+
+**Goal**: Provide concise provider-authoring documentation and examples that a consumer can follow without reverse-engineering built-ins.
+
+**Independent Test**: Follow the docs to define provider identity, declare capabilities, register the provider, validate a query, and understand troubleshooting.
+
+### Tests for User Story 4
+
+- [X] T027 [US4] Verify the quickstart minimal registration example is represented by tests in `/Users/sipke/Projects/ValenceWorks/aster/test/Aster.Tests/Querying/ProviderAuthoringTests.cs`
+- [X] T028 [US4] Verify existing built-in `AddAsterCore()` and `AddAsterSqliteJson()` behavior remains unchanged in `/Users/sipke/Projects/ValenceWorks/aster/test/Aster.Tests/Querying/ProviderAuthoringTests.cs`
+
+### Implementation for User Story 4
+
+- [X] T029 [P] [US4] Document the provider registration helper and manual-registration lifetime escape hatch in `/Users/sipke/Projects/ValenceWorks/aster/wiki/DI-Registration.md`
+- [X] T030 [P] [US4] Add provider-authoring guidance to the package README in `/Users/sipke/Projects/ValenceWorks/aster/src/core/Aster.Core/README.md`
+- [X] T031 [P] [US4] Update the feature quickstart with the singleton helper contract and troubleshooting guidance in `/Users/sipke/Projects/ValenceWorks/aster/specs/005-provider-authoring-ergonomics/quickstart.md`
+- [X] T032 [P] [US4] Update the public contract document with singleton helper behavior in `/Users/sipke/Projects/ValenceWorks/aster/specs/005-provider-authoring-ergonomics/contracts/provider-authoring-ergonomics.md`
+
+**Checkpoint**: User Story 4 is documented and independently verifiable.
+
+---
+
+## Phase 7: Polish & Cross-Cutting Concerns
+
+**Purpose**: Verify compatibility, constitution alignment, and final quality.
+
+- [X] T033 [P] Update agent context after planning artifacts are current by running `.specify/scripts/bash/update-agent-context.sh copilot` from `/Users/sipke/Projects/ValenceWorks/aster`
+- [X] T034 [P] Review implementation for unnecessary abstractions, runtime scanning, provider registry behavior, public raw SQL, and public `IQueryable<Resource>` in `/Users/sipke/Projects/ValenceWorks/aster/src/core/Aster.Core`
+- [X] T035 Run `dotnet test Aster.sln` from `/Users/sipke/Projects/ValenceWorks/aster`
+- [X] T036 Run `dotnet build Aster.sln` from `/Users/sipke/Projects/ValenceWorks/aster`
+- [X] T037 Run `git diff --check` from `/Users/sipke/Projects/ValenceWorks/aster`
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies
+- **Foundational (Phase 2)**: Depends on Setup completion and blocks all user stories
+- **US1 (Phase 3)**: Depends on Foundational; provides the registration helper
+- **US2 (Phase 4)**: Depends on Foundational; can proceed independently of US1 except for helper-based test setup convenience
+- **US3 (Phase 5)**: Depends on Foundational; documentation can proceed after behavior is confirmed
+- **US4 (Phase 6)**: Depends on US1, US2, and US3 behavior decisions
+- **Polish (Phase 7)**: Depends on all desired user stories
+
+### User Story Dependencies
+
+- **User Story 1 (P1)**: No dependency on other user stories
+- **User Story 2 (P1)**: No dependency on other user stories
+- **User Story 3 (P2)**: Can start after Foundational, but benefits from US2 diagnostic behavior
+- **User Story 4 (P3)**: Depends on finalized behavior from US1-US3
+
+### Parallel Opportunities
+
+- T002-T003 can run in parallel after T001.
+- T018 can run in parallel with T016-T017 because it updates a separate test file.
+- T029-T032 can run in parallel because they update separate documentation artifacts.
+- T033-T034 can run in parallel before final verification commands.
+
+---
+
+## Parallel Example: User Story 2
+
+```bash
+Task: "Add a failing test for missing custom provider capabilities returning capabilities-not-declared in /Users/sipke/Projects/ValenceWorks/aster/test/Aster.Tests/Querying/ProviderAuthoringTests.cs"
+Task: "Update existing validator diagnostic assertions for actionable provider-key guidance in /Users/sipke/Projects/ValenceWorks/aster/test/Aster.Tests/Querying/ResourceQueryValidatorTests.cs"
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First
+
+1. Complete Phase 1 and Phase 2.
+2. Complete User Story 1 to provide the minimal registration helper.
+3. Validate User Story 1 independently with `dotnet test Aster.sln`.
+
+### Incremental Delivery
+
+1. Add User Story 1 for correct registration.
+2. Add User Story 2 for fail-closed diagnostics.
+3. Add User Story 3 for validation-before-execution guidance.
+4. Add User Story 4 for docs and compatibility verification.
+5. Run final build, test, and diff checks.
+
+### Constitution Guardrails
+
+- Keep the helper explicit and singleton-only.
+- Keep manual registration supported for alternate lifetimes.
+- Do not introduce a provider registry, runtime scanning, query planner, raw SQL contract, public `IQueryable<Resource>`, storage change, or new third-party dependency.

--- a/src/core/Aster.Core/Extensions/AsterCoreServiceCollectionExtensions.cs
+++ b/src/core/Aster.Core/Extensions/AsterCoreServiceCollectionExtensions.cs
@@ -14,6 +14,30 @@ namespace Aster.Core.Extensions;
 public static class AsterCoreServiceCollectionExtensions
 {
     /// <summary>
+    /// Registers a custom resource query provider and its matching capability declaration.
+    /// </summary>
+    /// <typeparam name="TQueryService">The concrete query service type.</typeparam>
+    /// <typeparam name="TCapabilitiesProvider">The concrete capability provider type.</typeparam>
+    /// <param name="services">The service collection to add services to.</param>
+    /// <returns>The <paramref name="services"/> for chaining.</returns>
+    public static IServiceCollection AddResourceQueryProvider<TQueryService, TCapabilitiesProvider>(
+        this IServiceCollection services)
+        where TQueryService : class, IResourceQueryService, IResourceQueryProviderIdentity
+        where TCapabilitiesProvider : class, IResourceQueryCapabilitiesProvider
+    {
+        ArgumentNullException.ThrowIfNull(services);
+
+        services.AddSingleton<TQueryService>();
+        services.AddSingleton<IResourceQueryService>(sp => sp.GetRequiredService<TQueryService>());
+        services.AddSingleton<IResourceQueryProviderIdentity>(sp => sp.GetRequiredService<TQueryService>());
+
+        services.AddSingleton<TCapabilitiesProvider>();
+        services.AddSingleton<IResourceQueryCapabilitiesProvider>(sp => sp.GetRequiredService<TCapabilitiesProvider>());
+
+        return services;
+    }
+
+    /// <summary>
     /// Registers all Aster Core in-memory services:
     /// <see cref="InMemoryResourceDefinitionStore"/>, <see cref="InMemoryResourceManager"/>,
     /// <see cref="InMemoryQueryService"/>, <see cref="SystemTextJsonAspectBinder"/>,

--- a/src/core/Aster.Core/Extensions/AsterCoreServiceCollectionExtensions.cs
+++ b/src/core/Aster.Core/Extensions/AsterCoreServiceCollectionExtensions.cs
@@ -72,6 +72,7 @@ public static class AsterCoreServiceCollectionExtensions
         // Query service
         services.AddSingleton<InMemoryQueryService>();
         services.AddSingleton<IResourceQueryService>(sp => sp.GetRequiredService<InMemoryQueryService>());
+        services.AddSingleton<IResourceQueryProviderIdentity>(sp => sp.GetRequiredService<InMemoryQueryService>());
         services.AddSingleton<InMemoryQueryCapabilitiesProvider>();
         services.AddSingleton<IResourceQueryCapabilitiesProvider>(sp => sp.GetRequiredService<InMemoryQueryCapabilitiesProvider>());
         services.AddSingleton<IResourceQueryValidator, ResourceQueryValidator>();

--- a/src/core/Aster.Core/README.md
+++ b/src/core/Aster.Core/README.md
@@ -143,6 +143,16 @@ if (!validation.IsValid)
 
 Provider capabilities are matched to the active query provider by explicit provider key. If a custom provider has no matching capability declaration, validation fails closed with `capabilities-not-declared`. Query execution still enforces unsupported shapes and throws `UnsupportedQueryFeatureException` with stable `Code`, `Feature`, optional `Path`, and an actionable message.
 
+Custom query providers can be registered with the provider-authoring helper:
+
+```csharp
+services
+    .AddAsterCore()
+    .AddResourceQueryProvider<MyQueryService, MyQueryCapabilitiesProvider>();
+```
+
+The helper registers the provider concrete types and shared query/provider interfaces as singletons, keeping the active query service, provider identity, and capability declaration together without introducing provider discovery or a registry. Hosts that need different lifetimes can still use explicit manual DI registration.
+
 Or build common typed aspect filters without repeating convention-based identifiers:
 
 ```csharp

--- a/src/core/Aster.Core/Services/ResourceQueryValidator.cs
+++ b/src/core/Aster.Core/Services/ResourceQueryValidator.cs
@@ -10,6 +10,8 @@ namespace Aster.Core.Services;
 public sealed class ResourceQueryValidator : IResourceQueryValidator
 {
     private readonly QueryCapabilityDescription? capabilities;
+    private readonly string? activeProviderKey;
+    private readonly bool activeProviderExposesIdentity;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="ResourceQueryValidator"/> class.
@@ -18,6 +20,7 @@ public sealed class ResourceQueryValidator : IResourceQueryValidator
     public ResourceQueryValidator(IEnumerable<IResourceQueryCapabilitiesProvider> capabilityProviders)
     {
         ArgumentNullException.ThrowIfNull(capabilityProviders);
+        activeProviderExposesIdentity = false;
         capabilities = capabilityProviders
             .Select(provider => provider.Capabilities)
             .LastOrDefault(HasProviderKey);
@@ -35,11 +38,18 @@ public sealed class ResourceQueryValidator : IResourceQueryValidator
         ArgumentNullException.ThrowIfNull(capabilityProviders);
         ArgumentNullException.ThrowIfNull(queryService);
 
-        capabilities = queryService is IResourceQueryProviderIdentity identity
-            ? capabilityProviders
+        if (queryService is IResourceQueryProviderIdentity identity)
+        {
+            activeProviderExposesIdentity = true;
+            activeProviderKey = identity.ProviderKey;
+            capabilities = capabilityProviders
                 .Select(provider => provider.Capabilities)
-                .LastOrDefault(capabilities => IsCapabilityDeclarationForQueryService(capabilities, identity))
-            : null;
+                .LastOrDefault(capabilities => IsCapabilityDeclarationForQueryService(capabilities, identity));
+        }
+        else
+        {
+            activeProviderExposesIdentity = false;
+        }
     }
 
     /// <inheritdoc />
@@ -52,7 +62,7 @@ public sealed class ResourceQueryValidator : IResourceQueryValidator
             return new([
                 Failure(
                     "capabilities-not-declared",
-                    "Query capabilities are not declared for the active provider.",
+                    CapabilitiesNotDeclaredMessage(),
                     feature: "capabilities missing"),
             ]);
         }
@@ -390,4 +400,19 @@ public sealed class ResourceQueryValidator : IResourceQueryValidator
 
     private static bool HasProviderKey(QueryCapabilityDescription capabilities) =>
         !string.IsNullOrWhiteSpace(capabilities.ProviderKey);
+
+    private string CapabilitiesNotDeclaredMessage()
+    {
+        if (!activeProviderExposesIdentity)
+        {
+            return "Query capabilities are not declared for the active provider. Register a query provider that implements IResourceQueryProviderIdentity and an IResourceQueryCapabilitiesProvider with a matching ProviderKey.";
+        }
+
+        if (string.IsNullOrWhiteSpace(activeProviderKey))
+        {
+            return "Query capabilities are not declared for the active provider because its ProviderKey is empty. Use a stable non-empty ProviderKey and register an IResourceQueryCapabilitiesProvider with the same ProviderKey.";
+        }
+
+        return $"Query capabilities are not declared for active provider key '{activeProviderKey}'. Register an IResourceQueryCapabilitiesProvider with a matching ProviderKey.";
+    }
 }

--- a/src/persistence/Aster.Persistence.SqliteJson/SqliteJsonAsterServiceCollectionExtensions.cs
+++ b/src/persistence/Aster.Persistence.SqliteJson/SqliteJsonAsterServiceCollectionExtensions.cs
@@ -32,6 +32,7 @@ public static class SqliteJsonAsterServiceCollectionExtensions
         services.AddSingleton<IResourceVersionReader>(sp => sp.GetRequiredService<SqliteJsonResourceStore>());
         services.AddSingleton<IResourceVersionWriter>(sp => sp.GetRequiredService<SqliteJsonResourceStore>());
         services.AddSingleton<IResourceQueryService>(sp => sp.GetRequiredService<SqliteJsonQueryService>());
+        services.AddSingleton<IResourceQueryProviderIdentity>(sp => sp.GetRequiredService<SqliteJsonQueryService>());
         services.AddSingleton<IResourceQueryCapabilitiesProvider>(sp => sp.GetRequiredService<SqliteJsonQueryCapabilitiesProvider>());
 
         return services;

--- a/src/persistence/Aster.Persistence.SqliteJson/SqliteJsonAsterServiceCollectionExtensions.cs
+++ b/src/persistence/Aster.Persistence.SqliteJson/SqliteJsonAsterServiceCollectionExtensions.cs
@@ -27,12 +27,13 @@ public static class SqliteJsonAsterServiceCollectionExtensions
         services.AddSingleton(options);
         services.AddSingleton<SqliteJsonResourceStore>();
         services.AddSingleton<SqliteJsonQueryService>();
+        services.AddSingleton<SqliteJsonQueryProviderIdentity>();
         services.AddSingleton<SqliteJsonQueryCapabilitiesProvider>();
         services.AddSingleton<IResourceDefinitionStore>(sp => sp.GetRequiredService<SqliteJsonResourceStore>());
         services.AddSingleton<IResourceVersionReader>(sp => sp.GetRequiredService<SqliteJsonResourceStore>());
         services.AddSingleton<IResourceVersionWriter>(sp => sp.GetRequiredService<SqliteJsonResourceStore>());
         services.AddSingleton<IResourceQueryService>(sp => sp.GetRequiredService<SqliteJsonQueryService>());
-        services.AddSingleton<IResourceQueryProviderIdentity>(sp => sp.GetRequiredService<SqliteJsonQueryService>());
+        services.AddSingleton<IResourceQueryProviderIdentity>(sp => sp.GetRequiredService<SqliteJsonQueryProviderIdentity>());
         services.AddSingleton<IResourceQueryCapabilitiesProvider>(sp => sp.GetRequiredService<SqliteJsonQueryCapabilitiesProvider>());
 
         return services;

--- a/src/persistence/Aster.Persistence.SqliteJson/SqliteJsonQueryProviderIdentity.cs
+++ b/src/persistence/Aster.Persistence.SqliteJson/SqliteJsonQueryProviderIdentity.cs
@@ -1,0 +1,12 @@
+using Aster.Core.Abstractions;
+
+namespace Aster.Persistence.SqliteJson;
+
+/// <summary>
+/// Side-effect-free provider identity for the SQLite JSON query provider.
+/// </summary>
+internal sealed class SqliteJsonQueryProviderIdentity : IResourceQueryProviderIdentity
+{
+    /// <inheritdoc />
+    public string ProviderKey => SqliteJsonQueryCapabilitiesProvider.ProviderKey;
+}

--- a/test/Aster.Tests/Querying/ProviderAuthoringTests.cs
+++ b/test/Aster.Tests/Querying/ProviderAuthoringTests.cs
@@ -162,8 +162,33 @@ public sealed class ProviderAuthoringTests
 
         Assert.Equal(InMemoryQueryCapabilitiesProvider.ProviderKey, inMemoryCapabilities.ProviderKey);
         Assert.Equal(SqliteJsonQueryCapabilitiesProvider.ProviderKey, sqliteCapabilities.ProviderKey);
+        Assert.Equal(
+            InMemoryQueryCapabilitiesProvider.ProviderKey,
+            inMemoryProvider.GetRequiredService<IResourceQueryProviderIdentity>().ProviderKey);
+        Assert.Equal(
+            SqliteJsonQueryCapabilitiesProvider.ProviderKey,
+            sqliteProvider.GetRequiredService<IResourceQueryProviderIdentity>().ProviderKey);
         Assert.True(inMemoryCapabilities.SupportsFacetSorting);
         Assert.False(sqliteCapabilities.SupportsFacetSorting);
+    }
+
+    [Fact]
+    public void AddAsterSqliteJson_ReplacesCustomProviderIdentityWhenRegisteredAfterCustomProvider()
+    {
+        using var provider = new ServiceCollection()
+            .AddAsterCore()
+            .AddResourceQueryProvider<CustomQueryService, CustomCapabilitiesProvider>()
+            .AddAsterSqliteJson(options =>
+            {
+                options.ConnectionString = "Data Source=:memory:";
+                options.InitializeSchema = false;
+            })
+            .BuildServiceProvider();
+
+        Assert.IsType<SqliteJsonQueryService>(provider.GetRequiredService<IResourceQueryService>());
+        Assert.Equal(
+            SqliteJsonQueryCapabilitiesProvider.ProviderKey,
+            provider.GetRequiredService<IResourceQueryProviderIdentity>().ProviderKey);
     }
 
     private sealed class CustomQueryService : IResourceQueryService, IResourceQueryProviderIdentity

--- a/test/Aster.Tests/Querying/ProviderAuthoringTests.cs
+++ b/test/Aster.Tests/Querying/ProviderAuthoringTests.cs
@@ -1,0 +1,247 @@
+using Aster.Core.Abstractions;
+using Aster.Core.Exceptions;
+using Aster.Core.Extensions;
+using Aster.Core.InMemory;
+using Aster.Core.Models.Instances;
+using Aster.Core.Models.Querying;
+using Aster.Core.Services;
+using Aster.Persistence.SqliteJson;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Aster.Tests.Querying;
+
+public sealed class ProviderAuthoringTests
+{
+    [Fact]
+    public void AddResourceQueryProvider_RegistersCustomProviderAsActiveQueryProvider()
+    {
+        using var provider = new ServiceCollection()
+            .AddAsterCore()
+            .AddResourceQueryProvider<CustomQueryService, CustomCapabilitiesProvider>()
+            .BuildServiceProvider();
+
+        var queryService = Assert.IsType<CustomQueryService>(provider.GetRequiredService<IResourceQueryService>());
+        var identity = provider.GetRequiredService<IResourceQueryProviderIdentity>();
+        var capabilities = provider.GetRequiredService<IResourceQueryCapabilitiesProvider>().Capabilities;
+
+        Assert.Same(queryService, identity);
+        Assert.Equal(CustomQueryService.ProviderKeyValue, identity.ProviderKey);
+        Assert.Equal(CustomQueryService.ProviderKeyValue, capabilities.ProviderKey);
+    }
+
+    [Fact]
+    public void AddResourceQueryProvider_RegistersConcreteTypesAndSharedInterfacesAsSingletons()
+    {
+        using var provider = new ServiceCollection()
+            .AddAsterCore()
+            .AddResourceQueryProvider<CustomQueryService, CustomCapabilitiesProvider>()
+            .BuildServiceProvider();
+
+        var queryService = provider.GetRequiredService<CustomQueryService>();
+        var activeQueryService = provider.GetRequiredService<IResourceQueryService>();
+        var identity = provider.GetRequiredService<IResourceQueryProviderIdentity>();
+        var capabilitiesProvider = provider.GetRequiredService<CustomCapabilitiesProvider>();
+        var activeCapabilitiesProvider = provider.GetRequiredService<IResourceQueryCapabilitiesProvider>();
+
+        Assert.Same(queryService, activeQueryService);
+        Assert.Same(queryService, provider.GetRequiredService<IResourceQueryService>());
+        Assert.Same(queryService, identity);
+        Assert.Same(capabilitiesProvider, activeCapabilitiesProvider);
+        Assert.Same(capabilitiesProvider, provider.GetRequiredService<IResourceQueryCapabilitiesProvider>());
+    }
+
+    [Fact]
+    public void AddResourceQueryProvider_UsesCustomCapabilitiesInsteadOfDefaults()
+    {
+        using var provider = new ServiceCollection()
+            .AddAsterCore()
+            .AddResourceQueryProvider<CustomQueryService, CustomCapabilitiesProvider>()
+            .BuildServiceProvider();
+
+        var validator = provider.GetRequiredService<IResourceQueryValidator>();
+        var facetSortResult = validator.Validate(new ResourceQuery
+        {
+            Sorts = [new SortExpression("Title", AspectKey: "TitleAspect")],
+        });
+
+        Assert.False(facetSortResult.IsValid);
+        Assert.Contains(facetSortResult.Failures, failure => failure.Code == "unsupported-facet-sort");
+        Assert.True(validator.Validate(new ResourceQuery()).IsValid);
+    }
+
+    [Fact]
+    public void Validate_WithMissingCustomCapabilities_FailsClosedWithProviderKey()
+    {
+        using var provider = new ServiceCollection()
+            .AddAsterCore()
+            .AddSingleton<CustomQueryService>()
+            .AddSingleton<IResourceQueryService>(sp => sp.GetRequiredService<CustomQueryService>())
+            .AddSingleton<IResourceQueryProviderIdentity>(sp => sp.GetRequiredService<CustomQueryService>())
+            .BuildServiceProvider();
+
+        var result = provider.GetRequiredService<IResourceQueryValidator>().Validate(new ResourceQuery());
+
+        Assert.False(result.IsValid);
+        var failure = Assert.Single(result.Failures);
+        Assert.Equal("capabilities-not-declared", failure.Code);
+        Assert.Contains(CustomQueryService.ProviderKeyValue, failure.Message);
+        Assert.Contains("matching ProviderKey", failure.Message);
+    }
+
+    [Fact]
+    public void Validate_WithMismatchedCustomCapabilities_FailsClosedWithProviderKey()
+    {
+        using var provider = new ServiceCollection()
+            .AddAsterCore()
+            .AddResourceQueryProvider<CustomQueryService, MismatchedCapabilitiesProvider>()
+            .BuildServiceProvider();
+
+        var result = provider.GetRequiredService<IResourceQueryValidator>().Validate(new ResourceQuery());
+
+        Assert.False(result.IsValid);
+        var failure = Assert.Single(result.Failures);
+        Assert.Equal("capabilities-not-declared", failure.Code);
+        Assert.Contains(CustomQueryService.ProviderKeyValue, failure.Message);
+        Assert.Contains("matching ProviderKey", failure.Message);
+    }
+
+    [Fact]
+    public async Task CustomProviderExecution_CanRunSharedValidationBeforeExecution()
+    {
+        using var provider = new ServiceCollection()
+            .AddAsterCore()
+            .AddResourceQueryProvider<ValidatingCustomQueryService, CustomCapabilitiesProvider>()
+            .BuildServiceProvider();
+
+        var queryService = provider.GetRequiredService<IResourceQueryService>();
+
+        await Assert.ThrowsAsync<UnsupportedQueryFeatureException>(() =>
+            queryService.QueryAsync(new ResourceQuery
+            {
+                Sorts = [new SortExpression("Title", AspectKey: "TitleAspect")],
+            }).AsTask());
+        Assert.Empty(await queryService.QueryAsync(new ResourceQuery()));
+    }
+
+    [Fact]
+    public async Task CustomProviderExecution_CanRaiseProviderSpecificStructuredFailures()
+    {
+        using var provider = new ServiceCollection()
+            .AddAsterCore()
+            .AddResourceQueryProvider<ProviderSpecificRejectingQueryService, CustomCapabilitiesProvider>()
+            .BuildServiceProvider();
+
+        var queryService = provider.GetRequiredService<IResourceQueryService>();
+
+        var exception = await Assert.ThrowsAsync<UnsupportedQueryFeatureException>(() =>
+            queryService.QueryAsync(new ResourceQuery()).AsTask());
+
+        Assert.Equal("unsupported-custom-value", exception.Code);
+        Assert.Equal("value shape", exception.Feature);
+        Assert.Equal("Filter.Value", exception.Path);
+        Assert.Contains("custom value shape", exception.Message);
+    }
+
+    [Fact]
+    public void BuiltInProviderRegistrations_RemainCompatible()
+    {
+        using var inMemoryProvider = new ServiceCollection()
+            .AddAsterCore()
+            .BuildServiceProvider();
+        using var sqliteProvider = new ServiceCollection()
+            .AddAsterCore()
+            .AddAsterSqliteJson(options =>
+            {
+                options.ConnectionString = "Data Source=:memory:";
+                options.InitializeSchema = false;
+            })
+            .BuildServiceProvider();
+
+        var inMemoryCapabilities = inMemoryProvider.GetRequiredService<IResourceQueryCapabilitiesProvider>().Capabilities;
+        var sqliteCapabilities = sqliteProvider.GetRequiredService<IResourceQueryCapabilitiesProvider>().Capabilities;
+
+        Assert.Equal(InMemoryQueryCapabilitiesProvider.ProviderKey, inMemoryCapabilities.ProviderKey);
+        Assert.Equal(SqliteJsonQueryCapabilitiesProvider.ProviderKey, sqliteCapabilities.ProviderKey);
+        Assert.True(inMemoryCapabilities.SupportsFacetSorting);
+        Assert.False(sqliteCapabilities.SupportsFacetSorting);
+    }
+
+    private sealed class CustomQueryService : IResourceQueryService, IResourceQueryProviderIdentity
+    {
+        public const string ProviderKeyValue = "custom-provider";
+
+        public string ProviderKey => ProviderKeyValue;
+
+        public ValueTask<IEnumerable<Resource>> QueryAsync(
+            ResourceQuery query,
+            CancellationToken cancellationToken = default) =>
+            new([]);
+    }
+
+    private sealed class ValidatingCustomQueryService : IResourceQueryService, IResourceQueryProviderIdentity
+    {
+        private readonly ResourceQueryValidator validator;
+
+        public ValidatingCustomQueryService(IEnumerable<IResourceQueryCapabilitiesProvider> capabilityProviders)
+        {
+            validator = new(capabilityProviders, this);
+        }
+
+        public string ProviderKey => CustomQueryService.ProviderKeyValue;
+
+        public ValueTask<IEnumerable<Resource>> QueryAsync(
+            ResourceQuery query,
+            CancellationToken cancellationToken = default)
+        {
+            var validation = validator.Validate(query);
+            if (!validation.IsValid)
+                throw UnsupportedQueryFeatureException.FromValidationFailure(validation.Failures[0]);
+
+            return new([]);
+        }
+    }
+
+    private sealed class ProviderSpecificRejectingQueryService : IResourceQueryService, IResourceQueryProviderIdentity
+    {
+        public string ProviderKey => CustomQueryService.ProviderKeyValue;
+
+        public ValueTask<IEnumerable<Resource>> QueryAsync(
+            ResourceQuery query,
+            CancellationToken cancellationToken = default)
+        {
+            throw new UnsupportedQueryFeatureException(
+                code: "unsupported-custom-value",
+                feature: "value shape",
+                message: "This provider cannot execute the supplied custom value shape.",
+                path: "Filter.Value");
+        }
+    }
+
+    private sealed class CustomCapabilitiesProvider : IResourceQueryCapabilitiesProvider
+    {
+        public QueryCapabilityDescription Capabilities { get; } = CreateCapabilities(CustomQueryService.ProviderKeyValue);
+    }
+
+    private sealed class MismatchedCapabilitiesProvider : IResourceQueryCapabilitiesProvider
+    {
+        public QueryCapabilityDescription Capabilities { get; } = CreateCapabilities("other-provider");
+    }
+
+    private static QueryCapabilityDescription CreateCapabilities(string providerKey) =>
+        new(
+            ProviderKey: providerKey,
+            ProviderName: "Custom Provider",
+            SupportedScopes: new HashSet<ResourceVersionScope> { ResourceVersionScope.Latest },
+            RequiresActivationChannelForActiveScope: false,
+            SupportedFilterTypes: new HashSet<QueryFilterType>(),
+            SupportedLogicalOperators: new HashSet<LogicalOperator>(),
+            SupportedComparisonOperators: new Dictionary<QueryFilterType, IReadOnlySet<ComparisonOperator>>(),
+            SupportedMetadataFields: new HashSet<string>(),
+            MetadataContainsFields: new HashSet<string>(),
+            SupportsMetadataSorting: false,
+            SupportsFacetSorting: false,
+            SupportsSkip: false,
+            SupportsTake: false,
+            FacetRangeSupport: new HashSet<QueryValueShape>(),
+            UnsupportedFeatures: []);
+}

--- a/test/Aster.Tests/Querying/ProviderAuthoringTests.cs
+++ b/test/Aster.Tests/Querying/ProviderAuthoringTests.cs
@@ -191,6 +191,32 @@ public sealed class ProviderAuthoringTests
             provider.GetRequiredService<IResourceQueryProviderIdentity>().ProviderKey);
     }
 
+    [Fact]
+    public void AddAsterSqliteJson_ResolvesProviderIdentityWithoutInitializingSqlite()
+    {
+        var databasePath = Path.Combine(Path.GetTempPath(), $"{Guid.NewGuid():N}.db");
+
+        try
+        {
+            using var provider = new ServiceCollection()
+                .AddAsterCore()
+                .AddAsterSqliteJson(options =>
+                {
+                    options.ConnectionString = $"Data Source={databasePath}";
+                })
+                .BuildServiceProvider();
+
+            var identity = provider.GetRequiredService<IResourceQueryProviderIdentity>();
+
+            Assert.Equal(SqliteJsonQueryCapabilitiesProvider.ProviderKey, identity.ProviderKey);
+            Assert.False(File.Exists(databasePath));
+        }
+        finally
+        {
+            File.Delete(databasePath);
+        }
+    }
+
     private sealed class CustomQueryService : IResourceQueryService, IResourceQueryProviderIdentity
     {
         public const string ProviderKeyValue = "custom-provider";

--- a/test/Aster.Tests/Querying/ResourceQueryValidatorTests.cs
+++ b/test/Aster.Tests/Querying/ResourceQueryValidatorTests.cs
@@ -182,6 +182,8 @@ public sealed class ResourceQueryValidatorTests
 
         Assert.False(result.IsValid);
         Assert.Contains(result.Failures, failure => failure.Code == "capabilities-not-declared");
+        Assert.Contains("custom", result.Failures[0].Message);
+        Assert.Contains("matching ProviderKey", result.Failures[0].Message);
     }
 
     [Fact]
@@ -198,6 +200,8 @@ public sealed class ResourceQueryValidatorTests
         Assert.False(result.IsValid);
         var failure = Assert.Single(result.Failures);
         Assert.Equal("capabilities-not-declared", failure.Code);
+        Assert.Contains("custom", failure.Message);
+        Assert.Contains("matching ProviderKey", failure.Message);
     }
 
     private sealed class EmptyCapabilitiesProvider : IResourceQueryCapabilitiesProvider

--- a/test/Aster.Tests/Querying/ResourceQueryValidatorTests.cs
+++ b/test/Aster.Tests/Querying/ResourceQueryValidatorTests.cs
@@ -181,9 +181,28 @@ public sealed class ResourceQueryValidatorTests
         var result = provider.GetRequiredService<IResourceQueryValidator>().Validate(new ResourceQuery());
 
         Assert.False(result.IsValid);
-        Assert.Contains(result.Failures, failure => failure.Code == "capabilities-not-declared");
-        Assert.Contains("custom", result.Failures[0].Message);
-        Assert.Contains("matching ProviderKey", result.Failures[0].Message);
+        var failure = Assert.Single(result.Failures);
+        Assert.Equal("capabilities-not-declared", failure.Code);
+        Assert.Contains("custom", failure.Message);
+        Assert.Contains("matching ProviderKey", failure.Message);
+    }
+
+    [Fact]
+    public void Validate_WhenActiveQueryServiceHasNoProviderIdentity_FailsClosedWithIdentityGuidance()
+    {
+        using var provider = new ServiceCollection()
+            .AddSingleton<IResourceQueryCapabilitiesProvider, InMemoryQueryCapabilitiesProvider>()
+            .AddSingleton<IResourceQueryService, QueryServiceWithoutProviderIdentity>()
+            .AddSingleton<IResourceQueryValidator, ResourceQueryValidator>()
+            .BuildServiceProvider();
+
+        var result = provider.GetRequiredService<IResourceQueryValidator>().Validate(new ResourceQuery());
+
+        Assert.False(result.IsValid);
+        var failure = Assert.Single(result.Failures);
+        Assert.Equal("capabilities-not-declared", failure.Code);
+        Assert.Contains("IResourceQueryProviderIdentity", failure.Message);
+        Assert.Contains("matching ProviderKey", failure.Message);
     }
 
     [Fact]
@@ -246,6 +265,14 @@ public sealed class ResourceQueryValidatorTests
     {
         public string ProviderKey => "custom";
 
+        public ValueTask<IEnumerable<Resource>> QueryAsync(
+            ResourceQuery query,
+            CancellationToken cancellationToken = default) =>
+            new([]);
+    }
+
+    private sealed class QueryServiceWithoutProviderIdentity : IResourceQueryService
+    {
         public ValueTask<IEnumerable<Resource>> QueryAsync(
             ResourceQuery query,
             CancellationToken cancellationToken = default) =>

--- a/test/Aster.Tests/Querying/ResourceQueryValidatorTests.cs
+++ b/test/Aster.Tests/Querying/ResourceQueryValidatorTests.cs
@@ -204,6 +204,24 @@ public sealed class ResourceQueryValidatorTests
         Assert.Contains("matching ProviderKey", failure.Message);
     }
 
+    [Fact]
+    public void Validate_WhenActiveProviderKeyIsEmpty_FailsClosedWithProviderKeyGuidance()
+    {
+        using var provider = new ServiceCollection()
+            .AddSingleton<IResourceQueryCapabilitiesProvider, InMemoryQueryCapabilitiesProvider>()
+            .AddSingleton<IResourceQueryService, EmptyProviderKeyQueryService>()
+            .AddSingleton<IResourceQueryValidator, ResourceQueryValidator>()
+            .BuildServiceProvider();
+
+        var result = provider.GetRequiredService<IResourceQueryValidator>().Validate(new ResourceQuery());
+
+        Assert.False(result.IsValid);
+        var failure = Assert.Single(result.Failures);
+        Assert.Equal("capabilities-not-declared", failure.Code);
+        Assert.Contains("ProviderKey is empty", failure.Message);
+        Assert.Contains("non-empty ProviderKey", failure.Message);
+    }
+
     private sealed class EmptyCapabilitiesProvider : IResourceQueryCapabilitiesProvider
     {
         public QueryCapabilityDescription Capabilities { get; } = new(
@@ -227,6 +245,16 @@ public sealed class ResourceQueryValidatorTests
     private sealed class CustomQueryService : IResourceQueryService, IResourceQueryProviderIdentity
     {
         public string ProviderKey => "custom";
+
+        public ValueTask<IEnumerable<Resource>> QueryAsync(
+            ResourceQuery query,
+            CancellationToken cancellationToken = default) =>
+            new([]);
+    }
+
+    private sealed class EmptyProviderKeyQueryService : IResourceQueryService, IResourceQueryProviderIdentity
+    {
+        public string ProviderKey => " ";
 
         public ValueTask<IEnumerable<Resource>> QueryAsync(
             ResourceQuery query,

--- a/wiki/DI-Registration.md
+++ b/wiki/DI-Registration.md
@@ -93,7 +93,7 @@ services
 
 The helper keeps provider selection explicit and does not scan assemblies or create a provider registry. It registers both concrete types and the shared `IResourceQueryService`, `IResourceQueryProviderIdentity`, and `IResourceQueryCapabilitiesProvider` interfaces as singletons. The active `IResourceQueryService` and `IResourceQueryProviderIdentity` resolve to `MyQueryService`; `IResourceQueryCapabilitiesProvider` resolves to `MyQueryCapabilitiesProvider` by normal last-registration-wins DI behavior.
 
-Manual registration remains supported for advanced hosts, including hosts that need non-singleton lifetimes:
+Manual registration remains supported for advanced hosts. Use the same lifetime consistently for the concrete query service and its shared interface mappings:
 
 ```csharp
 services.AddSingleton<MyQueryService>();
@@ -101,6 +101,16 @@ services.AddSingleton<IResourceQueryService>(sp => sp.GetRequiredService<MyQuery
 services.AddSingleton<IResourceQueryProviderIdentity>(sp => sp.GetRequiredService<MyQueryService>());
 services.AddSingleton<MyQueryCapabilitiesProvider>();
 services.AddSingleton<IResourceQueryCapabilitiesProvider>(sp => sp.GetRequiredService<MyQueryCapabilitiesProvider>());
+```
+
+For a scoped provider, use scoped registrations for the concrete provider types and the shared interfaces:
+
+```csharp
+services.AddScoped<MyQueryService>();
+services.AddScoped<IResourceQueryService>(sp => sp.GetRequiredService<MyQueryService>());
+services.AddScoped<IResourceQueryProviderIdentity>(sp => sp.GetRequiredService<MyQueryService>());
+services.AddScoped<MyQueryCapabilitiesProvider>();
+services.AddScoped<IResourceQueryCapabilitiesProvider>(sp => sp.GetRequiredService<MyQueryCapabilitiesProvider>());
 ```
 
 If validation returns `capabilities-not-declared`, check that the active query service implements `IResourceQueryProviderIdentity`, exposes a non-empty `ProviderKey`, and has a registered capability declaration with the exact same `ProviderKey`.

--- a/wiki/DI-Registration.md
+++ b/wiki/DI-Registration.md
@@ -57,7 +57,7 @@ builder.Services.AddAsterSqliteJson(options =>
 | `IResourceVersionWriter` | `SqliteJsonResourceStore` | Persists resource versions and activation state |
 | `IResourceVersionReader` | `SqliteJsonResourceStore` | Reads persisted version sets |
 | `IResourceQueryService` | `SqliteJsonQueryService` | Translates supported `ResourceQuery` ASTs to SQLite SQL/JSON queries |
-| `IResourceQueryProviderIdentity` | `SqliteJsonQueryService` | Exposes the active provider key |
+| `IResourceQueryProviderIdentity` | `SqliteJsonQueryProviderIdentity` | Exposes the active provider key without opening SQLite |
 | `IResourceQueryCapabilitiesProvider` | `SqliteJsonQueryCapabilitiesProvider` | Declares SQLite JSON query support |
 
 `AddAsterSqliteJson()` should be called after `AddAsterCore()` so the provider registrations become the resolved implementations for the shared interfaces. The shared `IResourceQueryValidator` uses the active provider's capability declaration when preflighting queries.

--- a/wiki/DI-Registration.md
+++ b/wiki/DI-Registration.md
@@ -24,6 +24,7 @@ All services are registered as **singletons**.
 | `IResourceVersionWriter` | `InMemoryResourceStore` | Version/activation write primitive |
 | `IResourceVersionReader` | `InMemoryResourceStore` | Query/read candidate version primitive |
 | `IResourceQueryService` | `InMemoryQueryService` | LINQ-based query evaluator |
+| `IResourceQueryProviderIdentity` | `InMemoryQueryService` | Exposes the active provider key |
 | `IResourceQueryCapabilitiesProvider` | `InMemoryQueryCapabilitiesProvider` | Declares in-memory query support |
 | `IResourceQueryValidator` | `ResourceQueryValidator` | Preflights `ResourceQuery` against active provider capabilities |
 | `ITypedAspectBinder` | `SystemTextJsonAspectBinder` | Aspect POCO ↔ raw storage via `System.Text.Json` |
@@ -56,6 +57,7 @@ builder.Services.AddAsterSqliteJson(options =>
 | `IResourceVersionWriter` | `SqliteJsonResourceStore` | Persists resource versions and activation state |
 | `IResourceVersionReader` | `SqliteJsonResourceStore` | Reads persisted version sets |
 | `IResourceQueryService` | `SqliteJsonQueryService` | Translates supported `ResourceQuery` ASTs to SQLite SQL/JSON queries |
+| `IResourceQueryProviderIdentity` | `SqliteJsonQueryService` | Exposes the active provider key |
 | `IResourceQueryCapabilitiesProvider` | `SqliteJsonQueryCapabilitiesProvider` | Declares SQLite JSON query support |
 
 `AddAsterSqliteJson()` should be called after `AddAsterCore()` so the provider registrations become the resolved implementations for the shared interfaces. The shared `IResourceQueryValidator` uses the active provider's capability declaration when preflighting queries.
@@ -103,15 +105,7 @@ services.AddSingleton<MyQueryCapabilitiesProvider>();
 services.AddSingleton<IResourceQueryCapabilitiesProvider>(sp => sp.GetRequiredService<MyQueryCapabilitiesProvider>());
 ```
 
-For a scoped provider, use scoped registrations for the concrete provider types and the shared interfaces:
-
-```csharp
-services.AddScoped<MyQueryService>();
-services.AddScoped<IResourceQueryService>(sp => sp.GetRequiredService<MyQueryService>());
-services.AddScoped<IResourceQueryProviderIdentity>(sp => sp.GetRequiredService<MyQueryService>());
-services.AddScoped<MyQueryCapabilitiesProvider>();
-services.AddScoped<IResourceQueryCapabilitiesProvider>(sp => sp.GetRequiredService<MyQueryCapabilitiesProvider>());
-```
+Hosts that use scoped or transient query providers must also replace `IResourceQueryValidator` with a compatible lifetime, because `AddAsterCore()` registers the default validator as a singleton. Keep non-singleton provider wiring in host-owned registration code and cover it with host tests.
 
 If validation returns `capabilities-not-declared`, check that the active query service implements `IResourceQueryProviderIdentity`, exposes a non-empty `ProviderKey`, and has a registered capability declaration with the exact same `ProviderKey`.
 

--- a/wiki/DI-Registration.md
+++ b/wiki/DI-Registration.md
@@ -62,7 +62,7 @@ builder.Services.AddAsterSqliteJson(options =>
 
 Query providers and capability declarations are matched with explicit provider keys. The default in-memory provider uses `in-memory`; the SQLite JSON provider uses `sqlite-json`. If a host replaces `IResourceQueryService` without registering a capability declaration with the same key, validation fails closed with a `capabilities-not-declared` failure instead of silently validating against stale defaults.
 
-Custom query providers should implement `IResourceQueryProviderIdentity` and register a matching `IResourceQueryCapabilitiesProvider`:
+Custom query providers should implement `IResourceQueryProviderIdentity` and register a matching `IResourceQueryCapabilitiesProvider`. The recommended path is `AddResourceQueryProvider<TQueryService, TCapabilitiesProvider>()`, which registers the query service, provider identity, and capability provider together:
 
 ```csharp
 public sealed class MyQueryService : IResourceQueryService, IResourceQueryProviderIdentity
@@ -85,7 +85,25 @@ public sealed class MyQueryCapabilitiesProvider : IResourceQueryCapabilitiesProv
         ProviderName: "My Provider",
         /* supported query surface */);
 }
+
+services
+    .AddAsterCore()
+    .AddResourceQueryProvider<MyQueryService, MyQueryCapabilitiesProvider>();
 ```
+
+The helper keeps provider selection explicit and does not scan assemblies or create a provider registry. It registers both concrete types and the shared `IResourceQueryService`, `IResourceQueryProviderIdentity`, and `IResourceQueryCapabilitiesProvider` interfaces as singletons. The active `IResourceQueryService` and `IResourceQueryProviderIdentity` resolve to `MyQueryService`; `IResourceQueryCapabilitiesProvider` resolves to `MyQueryCapabilitiesProvider` by normal last-registration-wins DI behavior.
+
+Manual registration remains supported for advanced hosts, including hosts that need non-singleton lifetimes:
+
+```csharp
+services.AddSingleton<MyQueryService>();
+services.AddSingleton<IResourceQueryService>(sp => sp.GetRequiredService<MyQueryService>());
+services.AddSingleton<IResourceQueryProviderIdentity>(sp => sp.GetRequiredService<MyQueryService>());
+services.AddSingleton<MyQueryCapabilitiesProvider>();
+services.AddSingleton<IResourceQueryCapabilitiesProvider>(sp => sp.GetRequiredService<MyQueryCapabilitiesProvider>());
+```
+
+If validation returns `capabilities-not-declared`, check that the active query service implements `IResourceQueryProviderIdentity`, exposes a non-empty `ProviderKey`, and has a registered capability declaration with the exact same `ProviderKey`.
 
 ---
 

--- a/wiki/Exception-Reference.md
+++ b/wiki/Exception-Reference.md
@@ -164,6 +164,8 @@ catch (UnsupportedQueryFeatureException ex)
 
 Use `IResourceQueryValidator` for non-throwing preflight when handling user-defined queries. Execution remains authoritative, so callers should still handle this exception when validation is skipped or provider-specific checks fail later.
 
+When validation returns `capabilities-not-declared`, the active query provider has no matching capability declaration. For custom providers, register the provider and capabilities together with `AddResourceQueryProvider<TQueryService, TCapabilitiesProvider>()` or ensure manual registrations expose the same non-empty provider key.
+
 ---
 
 ## Handling Pattern

--- a/wiki/Querying.md
+++ b/wiki/Querying.md
@@ -138,6 +138,8 @@ Console.WriteLine(capabilities.SupportsFacetSorting);
 Capabilities describe supported scopes, filter categories, comparison operators, logical operators, metadata fields, sort categories, paging, facet range value shapes, and known exclusions. The in-memory provider currently declares facet sorting and numeric/date-like facet ranges; SQLite JSON declares metadata sorting, numeric facet ranges, and no facet sorting.
 Capability declarations are matched to the active query provider by explicit `ProviderKey` values such as `in-memory` and `sqlite-json`.
 
+Custom providers can use `AddResourceQueryProvider<TQueryService, TCapabilitiesProvider>()` to register their active query service and matching capability provider together. Validation fails closed with `capabilities-not-declared` when the active provider key has no matching declaration.
+
 ## Preflight Validation
 
 Use `IResourceQueryValidator` to validate a query before execution:


### PR DESCRIPTION
## Summary
- add a singleton-only DI helper for registering custom query providers with matching capabilities
- improve fail-closed provider capability diagnostics with active provider key guidance
- add provider-authoring tests and documentation/spec-kit artifacts

## Validation
- dotnet test Aster.sln
- dotnet build Aster.sln
- git diff --check