### PR TITLE
Add provider conformance tests

### DIFF
--- a/.github/agents/copilot-instructions.md
+++ b/.github/agents/copilot-instructions.md
@@ -8,6 +8,8 @@ Auto-generated from all feature plans. Last updated: 2026-05-17
 - N/A for core validation/failure contracts; existing in-memory and SQLite JSON providers keep current persistence behavior (004-provider-validation-execution)
 - C# latest, .NET 8.0 / 9.0 / 10.0 multi-targeting + Existing `Microsoft.Extensions.DependencyInjection.Abstractions`, `Microsoft.Extensions.Logging.Abstractions`; no new third-party dependencies (005-provider-authoring-ergonomics)
 - N/A; no persistence format or storage behavior changes (005-provider-authoring-ergonomics)
+- C# latest, .NET 8.0 / 9.0 / 10.0 multi-targeting for libraries; tests target net10.0 + Existing xUnit and Microsoft.Extensions.DependencyInjection test stack (006-provider-conformance-tests)
+- Existing in-memory store and disposable SQLite JSON database files (006-provider-conformance-tests)
 
 - C# / .NET 9.0 (Standard 2.0/2.1 compatible ideally, but targeted for net9.0) + Microsoft.Extensions.DependencyInjection, Microsoft.Extensions.Logging (001-core-sdk-foundation)
 
@@ -27,6 +29,7 @@ tests/
 C# / .NET 9.0 (Standard 2.0/2.1 compatible ideally, but targeted for net9.0): Follow standard conventions
 
 ## Recent Changes
+- 006-provider-conformance-tests: Added C# latest, .NET 8.0 / 9.0 / 10.0 multi-targeting for libraries; tests target net10.0 + Existing xUnit and Microsoft.Extensions.DependencyInjection test stack
 - 005-provider-authoring-ergonomics: Added C# latest, .NET 8.0 / 9.0 / 10.0 multi-targeting + Existing `Microsoft.Extensions.DependencyInjection.Abstractions`, `Microsoft.Extensions.Logging.Abstractions`; no new third-party dependencies
 - 004-provider-validation-execution: Added C# latest, .NET 8.0 / 9.0 / 10.0 multi-targeting + Existing `Microsoft.Extensions.DependencyInjection.Abstractions`, `Microsoft.Extensions.Logging.Abstractions`; SQLite provider keeps existing `Microsoft.Data.Sqlite`
 

--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "featureDir": "specs/005-provider-authoring-ergonomics"
+  "featureDir": "specs/006-provider-conformance-tests"
 }

--- a/specs/006-provider-conformance-tests/checklists/requirements.md
+++ b/specs/006-provider-conformance-tests/checklists/requirements.md
@@ -1,0 +1,34 @@
+# Specification Quality Checklist: Provider Conformance Tests
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-05-17
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Ready for `/speckit-clarify` or `/speckit-plan`.

--- a/specs/006-provider-conformance-tests/data-model.md
+++ b/specs/006-provider-conformance-tests/data-model.md
@@ -1,0 +1,22 @@
+# Data Model: Provider Conformance Tests
+
+## Provider Conformance Subject
+
+- `Name`: Human-readable provider label used in failures.
+- `ExpectedProviderKey`: Provider key expected from active identity and capability declarations.
+- `Services`: Explicit service provider containing active query provider, validator, and capability declarations.
+- `RequiresNonEmptyResults`: Whether supported positive cases must match fixture data.
+
+## Conformance Query Case
+
+- `Name`: Focused case name.
+- `Area`: Capability area, such as scope, filter, sort, or paging.
+- `Query`: Portable resource query shape to validate and execute.
+- `RequiresMatch`: Whether the query should return at least one fixture result for providers seeded with data.
+
+## Conformance Failure
+
+- `ProviderName`: Subject that failed.
+- `CaseName`: Query case or registration check that failed.
+- `Area`: Capability area under test.
+- `Message`: Focused explanation of the mismatch.

--- a/specs/006-provider-conformance-tests/plan.md
+++ b/specs/006-provider-conformance-tests/plan.md
@@ -1,0 +1,49 @@
+# Implementation Plan: Provider Conformance Tests
+
+**Branch**: `006-provider-conformance-tests` | **Date**: 2026-05-17 | **Spec**: [spec.md](spec.md)
+
+## Summary
+
+Add a small test-only provider conformance harness that exercises active query providers against their declared capabilities. The harness verifies supported query shapes validate and execute, unsupported query shapes fail validation and execution, built-in providers pass the shared checks, and intentionally broken custom fixtures produce focused failures.
+
+## Technical Context
+
+**Language/Version**: C# latest, .NET 8.0 / 9.0 / 10.0 multi-targeting for libraries; tests target net10.0  
+**Primary Dependencies**: Existing xUnit and Microsoft.Extensions.DependencyInjection test stack  
+**Storage**: Existing in-memory store and disposable SQLite JSON database files  
+**Testing**: `dotnet test Aster.sln`, `dotnet build Aster.sln`, `git diff --check`  
+**Constraints**: No new runtime dependencies, no provider registry, no runtime scanning, no query planner, no public raw SQL or public `IQueryable<Resource>` API  
+
+## Constitution Check
+
+- **Simplicity first**: PASS. The suite is test-only and explicit.
+- **Modern C# idioms**: PASS. Uses records, collection expressions, and nullable-aware service resolution.
+- **Readability over cleverness**: PASS. Query cases are named and capability-driven.
+- **Explicitness over magic**: PASS. Provider subjects supply services and fixture data explicitly.
+- **Abstractions must earn their existence**: PASS. The small harness removes duplicated conformance checks and stays internal to tests.
+- **Optimize for deletion**: PASS. The suite is isolated to a single test file plus documentation.
+- **Favor composition over inheritance**: PASS. Provider subjects compose setup, expected key, services, and options.
+- **Dependencies intentional**: PASS. No new dependencies.
+- **Operational simplicity**: PASS. Tests run locally with disposable SQLite files and no external services.
+
+## Project Structure
+
+```text
+test/Aster.Tests/Querying/ProviderConformanceTests.cs
+wiki/Querying.md
+specs/006-provider-conformance-tests/
+```
+
+## Implementation Notes
+
+- Keep the conformance harness internal to the test project.
+- Treat validation and execution as separate obligations: unsupported shapes must be rejected even if validation is skipped by callers.
+- Use explicit provider keys to match active identity and capability declarations.
+- Keep provider-specific behavioral tests in place; the conformance suite covers shared expectations only.
+
+## Validation
+
+- `dotnet test test/Aster.Tests/Aster.Tests.csproj --filter FullyQualifiedName~ProviderConformanceTests`
+- `dotnet test Aster.sln`
+- `dotnet build Aster.sln`
+- `git diff --check`

--- a/specs/006-provider-conformance-tests/quickstart.md
+++ b/specs/006-provider-conformance-tests/quickstart.md
@@ -1,0 +1,24 @@
+# Quickstart: Provider Conformance Tests
+
+Provider conformance tests live in `test/Aster.Tests/Querying/ProviderConformanceTests.cs`.
+
+To add a provider to the shared conformance suite:
+
+1. Create a provider subject with an explicit service provider and expected provider key.
+2. Seed enough fixture data for the capability areas the provider declares as supported.
+3. Run `ProviderConformanceSuite.AssertConformsAsync(subject)`.
+4. Keep provider-specific edge cases in dedicated provider tests.
+
+Run the focused checks:
+
+```bash
+dotnet test test/Aster.Tests/Aster.Tests.csproj --filter FullyQualifiedName~ProviderConformanceTests
+```
+
+Run full verification:
+
+```bash
+dotnet test Aster.sln
+dotnet build Aster.sln
+git diff --check
+```

--- a/specs/006-provider-conformance-tests/research.md
+++ b/specs/006-provider-conformance-tests/research.md
@@ -1,0 +1,21 @@
+# Research: Provider Conformance Tests
+
+## Decision: Test-Only Harness Over Product API
+
+Provider conformance is useful for maintainers and provider authors, but it does not need to become runtime infrastructure. A test-only harness satisfies the current requirement while avoiding a provider registry, framework-style extension point, or additional package surface.
+
+## Decision: Explicit Provider Subjects
+
+Each provider subject supplies its service provider, expected provider key, and fixture requirements explicitly. This keeps behavior discoverable and avoids runtime scanning or automatic discovery.
+
+## Decision: Validate And Execute Unsupported Shapes
+
+Validation must fail closed, but providers remain authoritative during execution. The suite therefore checks both validation and execution for unsupported query shapes so providers cannot rely solely on callers remembering to preflight.
+
+## Decision: Capability-Driven Positive Cases
+
+Supported cases are selected from the provider's declared capabilities. This lets the same suite cover in-memory, SQLite JSON, and minimal custom providers without requiring every provider to support every query shape.
+
+## Decision: Keep Provider-Specific Tests
+
+The conformance suite catches shared contract drift. Provider-specific query semantics, SQL translation details, and edge cases remain in dedicated provider tests.

--- a/specs/006-provider-conformance-tests/spec.md
+++ b/specs/006-provider-conformance-tests/spec.md
@@ -1,0 +1,107 @@
+# Feature Specification: Provider Conformance Tests
+
+**Feature Branch**: `006-provider-conformance-tests`  
+**Created**: 2026-05-17  
+**Status**: Draft  
+**Input**: User description: "Add provider conformance tests so query provider authors can verify that an implementation matches its declared query capabilities and expected validation/execution behavior."
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Verify A Provider Matches Its Capabilities (Priority: P1)
+
+As a query provider author, I want a reusable conformance test suite that checks whether my provider accepts the query shapes it declares as supported and rejects the query shapes it declares as unsupported, so I can catch mismatches before shipping the provider.
+
+**Why this priority**: Provider capability declarations are now central to fail-closed validation. The most important value is proving those declarations are truthful.
+
+**Independent Test**: Can be fully tested by running the conformance suite against a sample provider with known supported and unsupported capabilities and confirming that mismatches are reported as test failures.
+
+**Acceptance Scenarios**:
+
+1. **Given** a provider declares support for a query shape, **When** the conformance suite runs the matching positive case, **Then** the provider completes the query without an unsupported-feature failure.
+2. **Given** a provider does not declare support for a query shape, **When** the conformance suite runs the matching negative case, **Then** validation or execution returns a structured unsupported-feature failure rather than silently accepting the shape.
+3. **Given** a provider declaration and execution behavior disagree, **When** the conformance suite runs, **Then** the mismatch is visible as a focused failing test with enough context to identify the capability area.
+
+---
+
+### User Story 2 - Reuse The Same Checks Across Built-In And Custom Providers (Priority: P2)
+
+As a maintainer, I want the same conformance expectations to exercise both built-in providers and custom provider examples, so regressions in provider behavior are caught consistently.
+
+**Why this priority**: A shared test suite is most valuable when it reduces duplicated provider-specific test logic and keeps built-in behavior aligned with public provider-authoring guidance.
+
+**Independent Test**: Can be tested by running the conformance suite against the in-memory provider, the SQLite JSON provider, and a minimal custom provider fixture.
+
+**Acceptance Scenarios**:
+
+1. **Given** an in-memory provider registration, **When** the conformance suite runs, **Then** the provider passes the checks matching its declared capabilities.
+2. **Given** a SQLite JSON provider registration, **When** the conformance suite runs, **Then** the provider passes supported checks and rejects unsupported checks matching its declared capabilities.
+3. **Given** a minimal custom provider fixture, **When** the conformance suite runs, **Then** provider authors can see the minimum setup required to reuse the suite.
+
+---
+
+### User Story 3 - Diagnose Provider Authoring Mistakes Quickly (Priority: P3)
+
+As a provider author, I want conformance failures to identify whether the issue is missing capabilities, mismatched provider keys, unsupported query handling, or incorrect accepted behavior, so I can fix the right layer without reverse-engineering test internals.
+
+**Why this priority**: Diagnostics make the suite useful beyond pass/fail, but they build on the core conformance checks.
+
+**Independent Test**: Can be tested by running the suite against intentionally broken fixtures and verifying that each failure points to the relevant provider-authoring mistake.
+
+**Acceptance Scenarios**:
+
+1. **Given** a provider has no matching capability declaration, **When** the conformance suite runs, **Then** the failure identifies missing or mismatched capabilities.
+2. **Given** a provider accepts a query shape that its capabilities reject, **When** the conformance suite runs, **Then** the failure identifies the accepted unsupported query area.
+3. **Given** a provider rejects a query shape that its capabilities allow, **When** the conformance suite runs, **Then** the failure identifies the rejected supported query area.
+
+### Edge Cases
+
+- A provider has a missing, empty, or mismatched provider key.
+- A provider advertises support for a query area but has no fixture data capable of proving the behavior.
+- A provider correctly rejects unsupported shapes during validation rather than execution.
+- A provider returns no results for a supported query because fixture data was not arranged correctly.
+- A provider supports a broad capability area but only supports a narrower value shape within that area.
+
+### Constitution Alignment *(mandatory)*
+
+- **Simplicity**: The feature SHOULD provide a small reusable conformance harness and focused fixtures. It MUST NOT introduce a provider registry, query planner, runtime scanning, public raw SQL contract, or public queryable API.
+- **Explicitness**: Provider authors SHOULD opt in by explicitly supplying provider setup, capability declarations, fixture data, and expected query cases. Behavior MUST be discoverable from test inputs and failure output.
+- **Dependencies**: None. The feature SHOULD use the existing test stack and platform capabilities.
+- **Operational Impact**: The suite SHOULD run as ordinary tests with no additional services. SQLite-backed checks SHOULD use local disposable storage and leave no durable artifacts.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The system MUST provide a reusable conformance test surface that can be applied to any active query provider with a matching capability declaration.
+- **FR-002**: The conformance suite MUST verify that supported query shapes declared by provider capabilities are accepted by the provider.
+- **FR-003**: The conformance suite MUST verify that unsupported query shapes are rejected with structured unsupported-feature behavior.
+- **FR-004**: The conformance suite MUST verify fail-closed behavior when the active provider has missing, empty, or mismatched capability declarations.
+- **FR-005**: Provider authors MUST be able to supply explicit provider setup and fixture data without relying on runtime scanning or automatic discovery.
+- **FR-006**: The suite MUST include built-in coverage for the in-memory provider.
+- **FR-007**: The suite MUST include built-in coverage for the SQLite JSON provider.
+- **FR-008**: The suite MUST include at least one minimal custom-provider fixture demonstrating how custom providers opt in.
+- **FR-009**: Conformance failures SHOULD identify the capability area under test and whether the provider unexpectedly accepted or rejected the query.
+- **FR-010**: The suite MUST preserve existing provider-specific tests; it SHOULD reduce duplication only where a shared expectation is demonstrated.
+- **FR-011**: The feature MUST document how maintainers and custom provider authors run or adapt the conformance checks.
+- **FR-012**: The feature MUST NOT add new runtime dependencies, storage formats, query-planning infrastructure, raw SQL APIs, or public queryable APIs.
+
+### Key Entities
+
+- **Provider Conformance Subject**: A provider-under-test, its provider key, matching capability declaration, setup routine, fixture data, and query execution entry point.
+- **Conformance Query Case**: A named query shape with expected supported or unsupported behavior and a capability area label.
+- **Conformance Failure**: A focused test failure describing the provider, query case, capability area, and observed behavior.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Built-in in-memory and SQLite JSON providers pass the shared conformance suite in the normal solution test run.
+- **SC-002**: At least one intentionally broken provider fixture produces a focused conformance failure for each major mistake category: missing capabilities, accepted unsupported shape, and rejected supported shape.
+- **SC-003**: A maintainer can add a new provider conformance subject by editing one explicit setup location and adding provider fixture data, without changing shared conformance logic.
+- **SC-004**: The full solution test run remains self-contained and requires no external services or durable local setup.
+
+## Assumptions
+
+- Conformance checks will focus on the existing portable `ResourceQuery` behavior and declared capability model.
+- Providers remain authoritative at execution time; validation is a shared preflight, not a substitute for provider execution checks.
+- Fixture data may be provider-specific, but conformance expectations should remain shared wherever the declared capability surface is shared.

--- a/specs/006-provider-conformance-tests/tasks.md
+++ b/specs/006-provider-conformance-tests/tasks.md
@@ -1,0 +1,28 @@
+# Tasks: Provider Conformance Tests
+
+**Input**: Design documents from `specs/006-provider-conformance-tests/`
+**Prerequisites**: spec.md, plan.md, research.md, data-model.md, quickstart.md
+
+## Phase 1: Setup
+
+- [X] T001 Create `specs/006-provider-conformance-tests/spec.md`
+- [X] T002 Create specification checklist in `specs/006-provider-conformance-tests/checklists/requirements.md`
+- [X] T003 Create planning artifacts for provider conformance tests
+
+## Phase 2: Tests And Harness
+
+- [X] T004 Add shared provider conformance subject, query case, and failure models in `test/Aster.Tests/Querying/ProviderConformanceTests.cs`
+- [X] T005 Add capability-driven supported query checks in `test/Aster.Tests/Querying/ProviderConformanceTests.cs`
+- [X] T006 Add unsupported validation and execution checks in `test/Aster.Tests/Querying/ProviderConformanceTests.cs`
+- [X] T007 Add built-in in-memory and SQLite JSON provider conformance coverage in `test/Aster.Tests/Querying/ProviderConformanceTests.cs`
+- [X] T008 Add minimal custom-provider conformance coverage in `test/Aster.Tests/Querying/ProviderConformanceTests.cs`
+- [X] T009 Add intentionally broken custom-provider fixtures for diagnostic coverage in `test/Aster.Tests/Querying/ProviderConformanceTests.cs`
+
+## Phase 3: Documentation And Verification
+
+- [X] T010 Document provider conformance guidance in `wiki/Querying.md`
+- [X] T011 Run focused provider conformance tests
+- [X] T012 Run `dotnet test Aster.sln`
+- [X] T013 Run `dotnet build Aster.sln`
+- [X] T014 Run `git diff --check`
+- [X] T015 Update agent context with `.specify/scripts/bash/update-agent-context.sh copilot`

--- a/test/Aster.Tests/Querying/ProviderConformanceTests.cs
+++ b/test/Aster.Tests/Querying/ProviderConformanceTests.cs
@@ -25,8 +25,13 @@ public sealed class ProviderConformanceTests : IDisposable
     [Fact]
     public async Task BuiltInProviders_PassSharedConformanceSuite()
     {
-        var inMemory = await CreateInMemorySubjectAsync();
+        await using var inMemoryProvider = await CreateInMemoryProviderAsync();
         await using var sqliteProvider = await CreateSqliteProviderAsync();
+        var inMemory = new ProviderConformanceSubject(
+            "In-memory",
+            InMemoryQueryCapabilitiesProvider.ProviderKey,
+            inMemoryProvider,
+            RequiresNonEmptyResults: true);
         var sqlite = new ProviderConformanceSubject(
             "SQLite JSON",
             SqliteJsonQueryCapabilitiesProvider.ProviderKey,
@@ -113,18 +118,14 @@ public sealed class ProviderConformanceTests : IDisposable
                 && failure.Message.Contains("rejected supported query", StringComparison.OrdinalIgnoreCase));
     }
 
-    private async Task<ProviderConformanceSubject> CreateInMemorySubjectAsync()
+    private static async Task<ServiceProvider> CreateInMemoryProviderAsync()
     {
         var provider = new ServiceCollection()
             .AddAsterCore()
             .BuildServiceProvider();
         await SeedAsync(provider);
 
-        return new(
-            "In-memory",
-            InMemoryQueryCapabilitiesProvider.ProviderKey,
-            provider,
-            RequiresNonEmptyResults: true);
+        return provider;
     }
 
     private async Task<ServiceProvider> CreateSqliteProviderAsync()
@@ -226,11 +227,14 @@ public sealed class ProviderConformanceTests : IDisposable
         catch (UnauthorizedAccessException) { }
     }
 
-    private sealed class ConformingCustomQueryService(
-        IEnumerable<IResourceQueryCapabilitiesProvider> capabilityProviders)
-        : IResourceQueryService, IResourceQueryProviderIdentity
+    private sealed class ConformingCustomQueryService : IResourceQueryService, IResourceQueryProviderIdentity
     {
-        private readonly ResourceQueryValidator validator = new(capabilityProviders, new ProviderIdentity());
+        private readonly ResourceQueryValidator validator;
+
+        public ConformingCustomQueryService(IEnumerable<IResourceQueryCapabilitiesProvider> capabilityProviders)
+        {
+            validator = new(capabilityProviders, this);
+        }
 
         public string ProviderKey => MinimalCustomCapabilitiesProvider.ProviderKey;
 
@@ -243,16 +247,6 @@ public sealed class ProviderConformanceTests : IDisposable
                 throw UnsupportedQueryFeatureException.FromValidationFailure(validation.Failures[0]);
 
             return new([]);
-        }
-
-        private sealed class ProviderIdentity : IResourceQueryService, IResourceQueryProviderIdentity
-        {
-            public string ProviderKey => MinimalCustomCapabilitiesProvider.ProviderKey;
-
-            public ValueTask<IEnumerable<Resource>> QueryAsync(
-                ResourceQuery query,
-                CancellationToken cancellationToken = default) =>
-                new([]);
         }
     }
 

--- a/test/Aster.Tests/Querying/ProviderConformanceTests.cs
+++ b/test/Aster.Tests/Querying/ProviderConformanceTests.cs
@@ -1,0 +1,621 @@
+using Aster.Core.Abstractions;
+using Aster.Core.Exceptions;
+using Aster.Core.Extensions;
+using Aster.Core.InMemory;
+using Aster.Core.Models.Instances;
+using Aster.Core.Models.Querying;
+using Aster.Core.Services;
+using Aster.Persistence.SqliteJson;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Aster.Tests.Querying;
+
+public sealed class ProviderConformanceTests : IDisposable
+{
+    private readonly string sqliteDatabasePath =
+        Path.Combine(Path.GetTempPath(), $"aster-conformance-{Guid.NewGuid():N}.db");
+
+    public void Dispose()
+    {
+        TryDelete(sqliteDatabasePath);
+        TryDelete($"{sqliteDatabasePath}-shm");
+        TryDelete($"{sqliteDatabasePath}-wal");
+    }
+
+    [Fact]
+    public async Task BuiltInProviders_PassSharedConformanceSuite()
+    {
+        var inMemory = await CreateInMemorySubjectAsync();
+        await using var sqliteProvider = await CreateSqliteProviderAsync();
+        var sqlite = new ProviderConformanceSubject(
+            "SQLite JSON",
+            SqliteJsonQueryCapabilitiesProvider.ProviderKey,
+            sqliteProvider,
+            RequiresNonEmptyResults: true);
+
+        await ProviderConformanceSuite.AssertConformsAsync(inMemory);
+        await ProviderConformanceSuite.AssertConformsAsync(sqlite);
+    }
+
+    [Fact]
+    public async Task CustomProvider_CanOptIntoSharedConformanceSuite()
+    {
+        await using var provider = new ServiceCollection()
+            .AddAsterCore()
+            .AddResourceQueryProvider<ConformingCustomQueryService, MinimalCustomCapabilitiesProvider>()
+            .BuildServiceProvider();
+        var subject = new ProviderConformanceSubject(
+            "Minimal custom",
+            MinimalCustomCapabilitiesProvider.ProviderKey,
+            provider);
+
+        await ProviderConformanceSuite.AssertConformsAsync(subject);
+    }
+
+    [Fact]
+    public async Task ConformanceSuite_FailsClosedWhenCapabilitiesDoNotMatchActiveProvider()
+    {
+        await using var provider = new ServiceCollection()
+            .AddAsterCore()
+            .AddSingleton<ConformingCustomQueryService>()
+            .AddSingleton<IResourceQueryService>(sp => sp.GetRequiredService<ConformingCustomQueryService>())
+            .AddSingleton<IResourceQueryProviderIdentity>(sp => sp.GetRequiredService<ConformingCustomQueryService>())
+            .BuildServiceProvider();
+        var subject = new ProviderConformanceSubject(
+            "Missing custom capabilities",
+            MinimalCustomCapabilitiesProvider.ProviderKey,
+            provider);
+
+        var failures = await ProviderConformanceSuite.EvaluateAsync(subject);
+
+        var failure = Assert.Single(failures);
+        Assert.Equal("Provider identity", failure.Area);
+        Assert.Contains("matching capability declaration", failure.Message);
+    }
+
+    [Fact]
+    public async Task ConformanceSuite_DetectsProvidersThatAcceptUnsupportedQueries()
+    {
+        await using var provider = new ServiceCollection()
+            .AddAsterCore()
+            .AddResourceQueryProvider<NonValidatingCustomQueryService, MinimalCustomCapabilitiesProvider>()
+            .BuildServiceProvider();
+        var subject = new ProviderConformanceSubject(
+            "Non-validating custom",
+            MinimalCustomCapabilitiesProvider.ProviderKey,
+            provider);
+
+        var failures = await ProviderConformanceSuite.EvaluateAsync(subject);
+
+        Assert.Contains(
+            failures,
+            failure => failure.Area == "Execution"
+                && failure.Message.Contains("accepted unsupported query", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public async Task ConformanceSuite_DetectsProvidersThatRejectSupportedQueries()
+    {
+        await using var provider = new ServiceCollection()
+            .AddAsterCore()
+            .AddResourceQueryProvider<AlwaysRejectingCustomQueryService, MinimalCustomCapabilitiesProvider>()
+            .BuildServiceProvider();
+        var subject = new ProviderConformanceSubject(
+            "Always-rejecting custom",
+            MinimalCustomCapabilitiesProvider.ProviderKey,
+            provider);
+
+        var failures = await ProviderConformanceSuite.EvaluateAsync(subject);
+
+        Assert.Contains(
+            failures,
+            failure => failure.Area == "Execution"
+                && failure.Message.Contains("rejected supported query", StringComparison.OrdinalIgnoreCase));
+    }
+
+    private async Task<ProviderConformanceSubject> CreateInMemorySubjectAsync()
+    {
+        var provider = new ServiceCollection()
+            .AddAsterCore()
+            .BuildServiceProvider();
+        await SeedAsync(provider);
+
+        return new(
+            "In-memory",
+            InMemoryQueryCapabilitiesProvider.ProviderKey,
+            provider,
+            RequiresNonEmptyResults: true);
+    }
+
+    private async Task<ServiceProvider> CreateSqliteProviderAsync()
+    {
+        var provider = new ServiceCollection()
+            .AddAsterCore()
+            .AddAsterSqliteJson(options =>
+            {
+                options.ConnectionString = $"Data Source={sqliteDatabasePath}";
+            })
+            .BuildServiceProvider();
+        await SeedAsync(provider);
+
+        return provider;
+    }
+
+    private static async Task SeedAsync(IServiceProvider provider)
+    {
+        var writer = provider.GetRequiredService<IResourceVersionWriter>();
+        await writer.SaveVersionAsync(CreateResource(
+            "product-a",
+            "Product",
+            version: 1,
+            owner: "alice",
+            created: Utc(2026, 1, 1),
+            aspects: new()
+            {
+                ["Title"] = new { Title = "Alpha Gadget" },
+                ["Price"] = new { Amount = 20 },
+                ["Inventory"] = new { Count = 5 },
+                ["Schedule"] = new { StartsAt = Utc(2026, 2, 1) },
+            }));
+        await writer.SaveVersionAsync(CreateResource(
+            "product-a",
+            "Product",
+            version: 2,
+            owner: "alice",
+            created: Utc(2026, 1, 2),
+            aspects: new()
+            {
+                ["Title"] = new { Title = "Alpha Gadget Updated" },
+                ["Price"] = new { Amount = 25 },
+                ["Inventory"] = new { Count = 10 },
+                ["Schedule"] = new { StartsAt = Utc(2026, 2, 2) },
+            }));
+        await writer.SaveVersionAsync(CreateResource(
+            "product-b",
+            "Product",
+            owner: "bob",
+            created: Utc(2026, 1, 3),
+            aspects: new()
+            {
+                ["Title"] = new { Title = "Beta Widget" },
+                ["Price"] = new { Amount = 35 },
+            }));
+        await writer.SaveVersionAsync(CreateResource(
+            "order-a",
+            "Order",
+            owner: "alice",
+            created: Utc(2026, 1, 4)));
+        await writer.UpdateActivationAsync("product-a", "Published", new ActivationState
+        {
+            ResourceId = "product-a",
+            Channel = "Published",
+            ActiveVersions = [2],
+            LastUpdated = Utc(2026, 1, 5),
+        });
+    }
+
+    private static Resource CreateResource(
+        string resourceId,
+        string definitionId,
+        int version = 1,
+        string? owner = null,
+        DateTime? created = null,
+        Dictionary<string, object>? aspects = null) =>
+        new()
+        {
+            ResourceId = resourceId,
+            Id = $"{resourceId}-v{version}",
+            DefinitionId = definitionId,
+            DefinitionVersion = 1,
+            Version = version,
+            Created = created ?? Utc(2026, 1, version),
+            Owner = owner,
+            Aspects = aspects ?? [],
+        };
+
+    private static DateTime Utc(int year, int month, int day) =>
+        new(year, month, day, 0, 0, 0, DateTimeKind.Utc);
+
+    private static void TryDelete(string path)
+    {
+        try
+        {
+            File.Delete(path);
+        }
+        catch (IOException) { }
+        catch (UnauthorizedAccessException) { }
+    }
+
+    private sealed class ConformingCustomQueryService(
+        IEnumerable<IResourceQueryCapabilitiesProvider> capabilityProviders)
+        : IResourceQueryService, IResourceQueryProviderIdentity
+    {
+        private readonly ResourceQueryValidator validator = new(capabilityProviders, new ProviderIdentity());
+
+        public string ProviderKey => MinimalCustomCapabilitiesProvider.ProviderKey;
+
+        public ValueTask<IEnumerable<Resource>> QueryAsync(
+            ResourceQuery query,
+            CancellationToken cancellationToken = default)
+        {
+            var validation = validator.Validate(query);
+            if (!validation.IsValid)
+                throw UnsupportedQueryFeatureException.FromValidationFailure(validation.Failures[0]);
+
+            return new([]);
+        }
+
+        private sealed class ProviderIdentity : IResourceQueryService, IResourceQueryProviderIdentity
+        {
+            public string ProviderKey => MinimalCustomCapabilitiesProvider.ProviderKey;
+
+            public ValueTask<IEnumerable<Resource>> QueryAsync(
+                ResourceQuery query,
+                CancellationToken cancellationToken = default) =>
+                new([]);
+        }
+    }
+
+    private sealed class NonValidatingCustomQueryService : IResourceQueryService, IResourceQueryProviderIdentity
+    {
+        public string ProviderKey => MinimalCustomCapabilitiesProvider.ProviderKey;
+
+        public ValueTask<IEnumerable<Resource>> QueryAsync(
+            ResourceQuery query,
+            CancellationToken cancellationToken = default) =>
+            new([]);
+    }
+
+    private sealed class AlwaysRejectingCustomQueryService : IResourceQueryService, IResourceQueryProviderIdentity
+    {
+        public string ProviderKey => MinimalCustomCapabilitiesProvider.ProviderKey;
+
+        public ValueTask<IEnumerable<Resource>> QueryAsync(
+            ResourceQuery query,
+            CancellationToken cancellationToken = default) =>
+            throw new UnsupportedQueryFeatureException(
+                "custom-rejected-supported-query",
+                "query",
+                "The custom provider rejected every query.");
+    }
+
+    private sealed class MinimalCustomCapabilitiesProvider : IResourceQueryCapabilitiesProvider
+    {
+        public const string ProviderKey = "minimal-custom";
+
+        public QueryCapabilityDescription Capabilities { get; } = new(
+            ProviderKey: ProviderKey,
+            ProviderName: "Minimal custom",
+            SupportedScopes: new HashSet<ResourceVersionScope> { ResourceVersionScope.Latest },
+            RequiresActivationChannelForActiveScope: false,
+            SupportedFilterTypes: new HashSet<QueryFilterType>(),
+            SupportedLogicalOperators: new HashSet<LogicalOperator>(),
+            SupportedComparisonOperators: new Dictionary<QueryFilterType, IReadOnlySet<ComparisonOperator>>(),
+            SupportedMetadataFields: new HashSet<string>(StringComparer.OrdinalIgnoreCase),
+            MetadataContainsFields: new HashSet<string>(StringComparer.OrdinalIgnoreCase),
+            SupportsMetadataSorting: false,
+            SupportsFacetSorting: false,
+            SupportsSkip: false,
+            SupportsTake: false,
+            FacetRangeSupport: new HashSet<QueryValueShape>(),
+            UnsupportedFeatures:
+            [
+                "Filtering",
+                "Sorting",
+                "Paging",
+            ]);
+    }
+}
+
+internal sealed record ProviderConformanceSubject(
+    string Name,
+    string ExpectedProviderKey,
+    IServiceProvider Services,
+    bool RequiresNonEmptyResults = false);
+
+internal sealed record ProviderConformanceFailure(
+    string ProviderName,
+    string CaseName,
+    string Area,
+    string Message);
+
+internal static class ProviderConformanceSuite
+{
+    public static async Task AssertConformsAsync(ProviderConformanceSubject subject)
+    {
+        var failures = await EvaluateAsync(subject);
+
+        Assert.True(
+            failures.Count == 0,
+            string.Join(Environment.NewLine, failures.Select(static failure =>
+                $"{failure.ProviderName} / {failure.CaseName} / {failure.Area}: {failure.Message}")));
+    }
+
+    public static async Task<IReadOnlyList<ProviderConformanceFailure>> EvaluateAsync(
+        ProviderConformanceSubject subject)
+    {
+        ArgumentNullException.ThrowIfNull(subject);
+
+        var failures = new List<ProviderConformanceFailure>();
+        var identity = subject.Services.GetService<IResourceQueryProviderIdentity>();
+        var capabilities = subject.Services.GetServices<IResourceQueryCapabilitiesProvider>()
+            .Select(provider => provider.Capabilities)
+            .LastOrDefault(capabilities =>
+                string.Equals(capabilities.ProviderKey, subject.ExpectedProviderKey, StringComparison.Ordinal));
+
+        if (identity?.ProviderKey != subject.ExpectedProviderKey || capabilities is null)
+        {
+            failures.Add(new(
+                subject.Name,
+                "Provider registration",
+                "Provider identity",
+                $"Expected active provider key '{subject.ExpectedProviderKey}' with a matching capability declaration."));
+            return failures;
+        }
+
+        var validator = subject.Services.GetRequiredService<IResourceQueryValidator>();
+        var queryService = subject.Services.GetRequiredService<IResourceQueryService>();
+
+        foreach (var queryCase in SupportedCases(capabilities))
+            await EvaluateSupportedCaseAsync(subject, validator, queryService, queryCase, failures);
+
+        foreach (var queryCase in UnsupportedCases(capabilities))
+            await EvaluateUnsupportedCaseAsync(subject, validator, queryService, queryCase, failures);
+
+        return failures;
+    }
+
+    private static async Task EvaluateSupportedCaseAsync(
+        ProviderConformanceSubject subject,
+        IResourceQueryValidator validator,
+        IResourceQueryService queryService,
+        ProviderQueryCase queryCase,
+        List<ProviderConformanceFailure> failures)
+    {
+        var validation = validator.Validate(queryCase.Query);
+        if (!validation.IsValid)
+        {
+            failures.Add(new(
+                subject.Name,
+                queryCase.Name,
+                queryCase.Area,
+                $"Validation rejected supported query with failures: {FailureCodes(validation.Failures)}."));
+            return;
+        }
+
+        try
+        {
+            var results = (await queryService.QueryAsync(queryCase.Query)).ToList();
+            if (subject.RequiresNonEmptyResults && queryCase.RequiresMatch && results.Count == 0)
+            {
+                failures.Add(new(
+                    subject.Name,
+                    queryCase.Name,
+                    "Fixture data",
+                    "Supported query executed but returned no results from the conformance fixture."));
+            }
+        }
+        catch (UnsupportedQueryFeatureException exception)
+        {
+            failures.Add(new(
+                subject.Name,
+                queryCase.Name,
+                "Execution",
+                $"Provider rejected supported query with '{exception.Code}'."));
+        }
+    }
+
+    private static async Task EvaluateUnsupportedCaseAsync(
+        ProviderConformanceSubject subject,
+        IResourceQueryValidator validator,
+        IResourceQueryService queryService,
+        ProviderQueryCase queryCase,
+        List<ProviderConformanceFailure> failures)
+    {
+        var validation = validator.Validate(queryCase.Query);
+        if (validation.IsValid)
+        {
+            failures.Add(new(
+                subject.Name,
+                queryCase.Name,
+                queryCase.Area,
+                "Validation accepted unsupported query."));
+        }
+
+        try
+        {
+            _ = await queryService.QueryAsync(queryCase.Query);
+            failures.Add(new(
+                subject.Name,
+                queryCase.Name,
+                "Execution",
+                "Provider accepted unsupported query during execution."));
+        }
+        catch (UnsupportedQueryFeatureException)
+        {
+        }
+    }
+
+    private static IEnumerable<ProviderQueryCase> SupportedCases(QueryCapabilityDescription capabilities)
+    {
+        if (capabilities.SupportedScopes.Contains(ResourceVersionScope.Latest))
+            yield return new("Latest scope", "Scope", new ResourceQuery(), RequiresMatch: false);
+
+        if (capabilities.SupportedScopes.Contains(ResourceVersionScope.Active))
+        {
+            yield return new(
+                "Active scope",
+                "Scope",
+                new ResourceQuery
+                {
+                    Scope = ResourceVersionScope.Active,
+                    ActivationChannel = capabilities.RequiresActivationChannelForActiveScope ? "Published" : null,
+                    DefinitionId = "Product",
+                });
+        }
+
+        if (capabilities.SupportedMetadataFields.Contains("Owner")
+            && capabilities.SupportsComparison(QueryFilterType.Metadata, ComparisonOperator.Equals))
+        {
+            yield return new(
+                "Metadata equals filter",
+                "Metadata filter",
+                new ResourceQuery
+                {
+                    Filter = new MetadataFilter("Owner", "alice", ComparisonOperator.Equals),
+                });
+        }
+
+        if (capabilities.SupportedFilterTypes.Contains(QueryFilterType.AspectPresence))
+        {
+            yield return new(
+                "Aspect presence filter",
+                "Aspect filter",
+                new ResourceQuery
+                {
+                    Filter = new AspectPresenceFilter("Title"),
+                });
+        }
+
+        if (capabilities.SupportsComparison(QueryFilterType.FacetValue, ComparisonOperator.Contains))
+        {
+            yield return new(
+                "Facet contains filter",
+                "Facet filter",
+                new ResourceQuery
+                {
+                    Filter = new FacetValueFilter("Title", "Title", "Gadget", ComparisonOperator.Contains),
+                });
+        }
+
+        if (capabilities.FacetRangeSupport.Contains(QueryValueShape.Numeric)
+            && capabilities.SupportsComparison(QueryFilterType.FacetValue, ComparisonOperator.Range))
+        {
+            yield return new(
+                "Numeric facet range filter",
+                "Facet filter",
+                new ResourceQuery
+                {
+                    Filter = new FacetValueFilter("Price", "Amount", new RangeValue(10, 30), ComparisonOperator.Range),
+                });
+        }
+
+        if (capabilities.SupportedLogicalOperators.Contains(LogicalOperator.And)
+            && capabilities.SupportsComparison(QueryFilterType.FacetValue, ComparisonOperator.Equals))
+        {
+            yield return new(
+                "Logical filter",
+                "Logical filter",
+                new ResourceQuery
+                {
+                    Filter = new LogicalExpression(LogicalOperator.And, [
+                        new AspectPresenceFilter("Price"),
+                        new FacetValueFilter("Inventory", "Count", 10, ComparisonOperator.Equals),
+                    ]),
+                });
+        }
+
+        if (capabilities.SupportsMetadataSorting && capabilities.SupportedMetadataFields.Contains("Created"))
+        {
+            yield return new(
+                "Metadata sort",
+                "Sort",
+                new ResourceQuery
+                {
+                    DefinitionId = "Product",
+                    Sorts = [new SortExpression("Created", SortDirection.Descending)],
+                });
+        }
+
+        if (capabilities.SupportsFacetSorting)
+        {
+            yield return new(
+                "Facet sort",
+                "Sort",
+                new ResourceQuery
+                {
+                    DefinitionId = "Product",
+                    Sorts = [new SortExpression("Title", AspectKey: "Title")],
+                });
+        }
+
+        if (capabilities.SupportsSkip && capabilities.SupportsTake)
+        {
+            yield return new(
+                "Skip and take",
+                "Paging",
+                new ResourceQuery
+                {
+                    DefinitionId = "Product",
+                    Sorts = capabilities.SupportsMetadataSorting ? [new SortExpression("Created")] : [],
+                    Skip = 1,
+                    Take = 1,
+                });
+        }
+    }
+
+    private static IEnumerable<ProviderQueryCase> UnsupportedCases(QueryCapabilityDescription capabilities)
+    {
+        yield return new(
+            "Negative skip",
+            "Paging",
+            new ResourceQuery { Skip = -1 },
+            RequiresMatch: false);
+
+        yield return new(
+            "Negative take",
+            "Paging",
+            new ResourceQuery { Take = -1 },
+            RequiresMatch: false);
+
+        if (!capabilities.SupportsFacetSorting)
+        {
+            yield return new(
+                "Unsupported facet sort",
+                "Sort",
+                new ResourceQuery
+                {
+                    Sorts = [new SortExpression("Title", AspectKey: "Title")],
+                },
+                RequiresMatch: false);
+        }
+
+        if (!capabilities.SupportsMetadataSorting)
+        {
+            yield return new(
+                "Unsupported metadata sort",
+                "Sort",
+                new ResourceQuery
+                {
+                    Sorts = [new SortExpression("Created")],
+                },
+                RequiresMatch: false);
+        }
+
+        if (!capabilities.FacetRangeSupport.Contains(QueryValueShape.DateTime)
+            && capabilities.SupportsComparison(QueryFilterType.FacetValue, ComparisonOperator.Range))
+        {
+            yield return new(
+                "Unsupported date-like facet range",
+                "Facet filter",
+                new ResourceQuery
+                {
+                    Filter = new FacetValueFilter(
+                        "Schedule",
+                        "StartsAt",
+                        new RangeValue(DateTime.UtcNow.AddDays(-1), DateTime.UtcNow),
+                        ComparisonOperator.Range),
+                },
+                RequiresMatch: false);
+        }
+    }
+
+    private static string FailureCodes(IEnumerable<QueryValidationFailure> failures) =>
+        string.Join(", ", failures.Select(static failure => failure.Code));
+
+    private sealed record ProviderQueryCase(
+        string Name,
+        string Area,
+        ResourceQuery Query,
+        bool RequiresMatch = true);
+}

--- a/wiki/Querying.md
+++ b/wiki/Querying.md
@@ -140,6 +140,10 @@ Capability declarations are matched to the active query provider by explicit `Pr
 
 Custom providers can use `AddResourceQueryProvider<TQueryService, TCapabilitiesProvider>()` to register their active query service and matching capability provider together. Validation fails closed with `capabilities-not-declared` when the active provider key has no matching declaration.
 
+Provider maintainers should cover new providers with the shared provider conformance tests in `test/Aster.Tests/Querying/ProviderConformanceTests.cs`.
+Those tests explicitly supply provider setup and fixture data, then verify that declared capabilities match validation and execution behavior.
+They are intentionally test-only: Aster still does not use provider registries, runtime scanning, query planners, raw SQL contracts, or public `IQueryable<Resource>` APIs.
+
 ## Preflight Validation
 
 Use `IResourceQueryValidator` to validate a query before execution:


### PR DESCRIPTION
## Summary
- add a test-only provider conformance harness for active query providers
- cover in-memory, SQLite JSON, minimal custom, and intentionally broken provider fixtures
- add Spec Kit artifacts and query documentation for provider conformance guidance

## Validation
- dotnet test test/Aster.Tests/Aster.Tests.csproj --filter FullyQualifiedName~ProviderConformanceTests
- dotnet test Aster.sln
- dotnet build Aster.sln
- git diff --check