### PR TITLE
Add SQLite JSON facet sorting

### DIFF
--- a/.github/agents/copilot-instructions.md
+++ b/.github/agents/copilot-instructions.md
@@ -10,6 +10,8 @@ Auto-generated from all feature plans. Last updated: 2026-05-17
 - N/A; no persistence format or storage behavior changes (005-provider-authoring-ergonomics)
 - C# latest, .NET 8.0 / 9.0 / 10.0 multi-targeting for libraries; tests target net10.0 + Existing xUnit and Microsoft.Extensions.DependencyInjection test stack (006-provider-conformance-tests)
 - Existing in-memory store and disposable SQLite JSON database files (006-provider-conformance-tests)
+- C# latest, .NET 8.0 / 9.0 / 10.0 multi-targeting + Existing SQLite JSON provider and test stack (007-sqlite-facet-sorting)
+- Existing SQLite JSON payload shape; no migration (007-sqlite-facet-sorting)
 
 - C# / .NET 9.0 (Standard 2.0/2.1 compatible ideally, but targeted for net9.0) + Microsoft.Extensions.DependencyInjection, Microsoft.Extensions.Logging (001-core-sdk-foundation)
 
@@ -29,9 +31,9 @@ tests/
 C# / .NET 9.0 (Standard 2.0/2.1 compatible ideally, but targeted for net9.0): Follow standard conventions
 
 ## Recent Changes
+- 007-sqlite-facet-sorting: Added C# latest, .NET 8.0 / 9.0 / 10.0 multi-targeting + Existing SQLite JSON provider and test stack
 - 006-provider-conformance-tests: Added C# latest, .NET 8.0 / 9.0 / 10.0 multi-targeting for libraries; tests target net10.0 + Existing xUnit and Microsoft.Extensions.DependencyInjection test stack
 - 005-provider-authoring-ergonomics: Added C# latest, .NET 8.0 / 9.0 / 10.0 multi-targeting + Existing `Microsoft.Extensions.DependencyInjection.Abstractions`, `Microsoft.Extensions.Logging.Abstractions`; no new third-party dependencies
-- 004-provider-validation-execution: Added C# latest, .NET 8.0 / 9.0 / 10.0 multi-targeting + Existing `Microsoft.Extensions.DependencyInjection.Abstractions`, `Microsoft.Extensions.Logging.Abstractions`; SQLite provider keeps existing `Microsoft.Data.Sqlite`
 
 
 <!-- MANUAL ADDITIONS START -->

--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "featureDir": "specs/006-provider-conformance-tests"
+  "featureDir": "specs/007-sqlite-facet-sorting"
 }

--- a/specs/007-sqlite-facet-sorting/checklists/requirements.md
+++ b/specs/007-sqlite-facet-sorting/checklists/requirements.md
@@ -1,0 +1,34 @@
+# Specification Quality Checklist: SQLite JSON Facet Sorting
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-05-17
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Ready for implementation validation.

--- a/specs/007-sqlite-facet-sorting/data-model.md
+++ b/specs/007-sqlite-facet-sorting/data-model.md
@@ -1,0 +1,17 @@
+# Data Model: SQLite JSON Facet Sorting
+
+## Facet Sort Expression
+
+- `AspectKey`: Aspect payload key to inspect.
+- `Field`: Facet definition id to sort by.
+- `Direction`: Ascending or descending.
+
+## SQLite Facet Value Expression
+
+- `Value`: SQL expression that resolves the first matching facet value.
+- `IsNumeric`: SQL predicate that identifies integer or real JSON values.
+
+## Capability Declaration
+
+- `SupportsFacetSorting`: Declares whether SQLite JSON accepts facet sort expressions.
+- `UnsupportedFeatures`: No longer lists facet sorting once execution support exists.

--- a/specs/007-sqlite-facet-sorting/plan.md
+++ b/specs/007-sqlite-facet-sorting/plan.md
@@ -1,0 +1,32 @@
+# Implementation Plan: SQLite JSON Facet Sorting
+
+**Branch**: `007-sqlite-facet-sorting` | **Date**: 2026-05-17 | **Spec**: [spec.md](spec.md)
+
+## Summary
+
+Enable SQLite JSON facet sorting by reusing the provider's JSON facet lookup logic in both filters and sort orderings. Update SQLite capabilities, validation expectations, conformance coverage, docs, and tests.
+
+## Technical Context
+
+**Language/Version**: C# latest, .NET 8.0 / 9.0 / 10.0 multi-targeting  
+**Primary Dependencies**: Existing SQLite JSON provider and test stack  
+**Storage**: Existing SQLite JSON payload shape; no migration  
+**Testing**: `dotnet test Aster.sln`, `dotnet build Aster.sln`, `git diff --check`  
+
+## Constitution Check
+
+- **Simplicity first**: PASS. Reuses existing JSON expression approach.
+- **Modern C# idioms**: PASS. Uses small records and collection expressions.
+- **Readability over cleverness**: PASS. Keeps lookup construction isolated.
+- **Explicitness over magic**: PASS. Capability declaration is updated directly.
+- **Abstractions must earn their existence**: PASS. Shared facet expression removes duplicated SQL fragment construction.
+- **Dependencies intentional**: PASS. No new dependencies.
+- **Operational simplicity**: PASS. No storage or deployment change.
+
+## Validation
+
+- Focused SQLite JSON query and capability tests
+- Provider conformance tests
+- `dotnet test Aster.sln`
+- `dotnet build Aster.sln`
+- `git diff --check`

--- a/specs/007-sqlite-facet-sorting/quickstart.md
+++ b/specs/007-sqlite-facet-sorting/quickstart.md
@@ -1,0 +1,25 @@
+# Quickstart: SQLite JSON Facet Sorting
+
+Facet sorting is available on SQLite JSON queries by setting `AspectKey` on `SortExpression`:
+
+```csharp
+var results = await query.QueryAsync(new ResourceQuery
+{
+    DefinitionId = "Product",
+    Sorts = [new SortExpression("Title", AspectKey: "Title")]
+});
+```
+
+Verify focused behavior:
+
+```bash
+dotnet test test/Aster.Tests/Aster.Tests.csproj --filter "FullyQualifiedName~SqliteJsonQueryServiceTests|FullyQualifiedName~SqliteJsonQueryCapabilityTests|FullyQualifiedName~ProviderConformanceTests"
+```
+
+Full verification:
+
+```bash
+dotnet test Aster.sln
+dotnet build Aster.sln
+git diff --check
+```

--- a/specs/007-sqlite-facet-sorting/research.md
+++ b/specs/007-sqlite-facet-sorting/research.md
@@ -1,0 +1,17 @@
+# Research: SQLite JSON Facet Sorting
+
+## Decision: Reuse Existing Facet JSON Lookup
+
+SQLite facet filters already resolve facet values through `json_each` over the persisted aspect payload. Facet sorting should reuse that lookup so filtering and sorting resolve named/camel-case facet candidates consistently.
+
+## Decision: Sort Numeric Facets Numerically
+
+Numeric facet values must sort by numeric value, not by text representation. SQLite JSON type information is used to choose numeric ordering for integer and real values.
+
+## Decision: Missing Facets Sort Last
+
+Resources without the sorted facet sort after resources with facet values. This gives predictable list behavior and avoids missing data appearing before meaningful values.
+
+## Decision: Keep Date-Like Range Filtering Unsupported
+
+This feature only adds facet sorting. Date-like range filtering remains outside the SQLite JSON capability declaration.

--- a/specs/007-sqlite-facet-sorting/spec.md
+++ b/specs/007-sqlite-facet-sorting/spec.md
@@ -1,0 +1,85 @@
+# Feature Specification: SQLite JSON Facet Sorting
+
+**Feature Branch**: `007-sqlite-facet-sorting`  
+**Created**: 2026-05-17  
+**Status**: Draft  
+**Input**: User description: "Add SQLite JSON facet sorting support so the SQLite provider can sort query results by facet values when a SortExpression specifies an AspectKey, update capabilities, validation, docs, and tests."
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Sort SQLite Results By Facet Values (Priority: P1)
+
+As an application developer using the SQLite JSON provider, I want queries to sort by scalar facet values so SQLite-backed resource lists can be ordered by domain data such as title, price, or count.
+
+**Why this priority**: Facet sorting is already part of the portable query model and supported by the in-memory provider. Adding it to SQLite closes a visible provider gap.
+
+**Independent Test**: Seed SQLite resources with facet values, query with `SortExpression` using `AspectKey`, and verify result order.
+
+**Acceptance Scenarios**:
+
+1. **Given** resources with text facet values, **When** a query sorts ascending by that facet, **Then** SQLite returns resources in text facet order.
+2. **Given** resources with numeric facet values, **When** a query sorts descending by that facet, **Then** SQLite returns resources in numeric facet order.
+3. **Given** resources missing the sorted facet, **When** a facet sort runs, **Then** matching facet values sort first and missing values sort predictably after them.
+
+---
+
+### User Story 2 - Declare The New SQLite Capability (Priority: P1)
+
+As a caller that uses query capability discovery or validation, I want SQLite JSON capabilities to report facet sorting support so preflight validation matches execution behavior.
+
+**Why this priority**: Capability declarations are the public contract for provider behavior.
+
+**Independent Test**: Inspect SQLite capabilities and validate a facet-sort query.
+
+**Acceptance Scenarios**:
+
+1. **Given** an application configured with SQLite JSON, **When** capabilities are inspected, **Then** facet sorting is reported as supported.
+2. **Given** a facet-sort query for SQLite JSON, **When** shared validation runs, **Then** validation succeeds unless another unsupported shape is present.
+
+### Edge Cases
+
+- Sorted facet is absent on some resources.
+- Sorted facet is numeric.
+- Sorted facet is text.
+- Multiple sorts still include stable resource id and version tie-breakers.
+- Date-like facet ranges remain unsupported; this feature does not add date-like range filtering.
+
+### Constitution Alignment *(mandatory)*
+
+- **Simplicity**: Reuse the existing SQLite JSON facet lookup and query builder path; do not introduce a planner or query framework.
+- **Explicitness**: Capability support changes are visible through `SqliteJsonQueryCapabilitiesProvider`.
+- **Dependencies**: None.
+- **Operational Impact**: No new storage or deployment requirements.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: SQLite JSON query execution MUST support `SortExpression` with `AspectKey`.
+- **FR-002**: Text facet sorting MUST order by the scalar facet value case-insensitively.
+- **FR-003**: Numeric facet sorting MUST order by numeric value rather than text representation.
+- **FR-004**: Resources missing the sorted facet SHOULD appear after resources with a sortable value.
+- **FR-005**: SQLite JSON capabilities MUST declare facet sorting as supported.
+- **FR-006**: Shared validation MUST accept SQLite facet-sort queries when no other unsupported query shape is present.
+- **FR-007**: Date-like facet range filtering MUST remain unsupported.
+- **FR-008**: The implementation MUST NOT add a query planner, public raw SQL API, public queryable API, storage migration, or runtime dependency.
+
+### Key Entities
+
+- **Facet Sort Expression**: A sort expression whose field identifies a facet and whose aspect key identifies the aspect payload.
+- **SQLite Facet Value Expression**: Reusable SQLite JSON expression that resolves a facet value from a resource payload.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: SQLite JSON facet-sort tests pass for text and numeric facets.
+- **SC-002**: SQLite JSON capabilities and validation tests report facet sorting as supported.
+- **SC-003**: Existing provider conformance tests pass with SQLite facet sorting enabled.
+- **SC-004**: Full solution test and build complete without warnings or errors.
+
+## Assumptions
+
+- Sorting is limited to scalar facet values in the existing JSON aspect shape.
+- Missing facet values sort after present facet values.
+- Stable tie-breakers remain resource id and version after requested sorts.

--- a/specs/007-sqlite-facet-sorting/tasks.md
+++ b/specs/007-sqlite-facet-sorting/tasks.md
@@ -1,0 +1,20 @@
+# Tasks: SQLite JSON Facet Sorting
+
+**Input**: Design documents from `specs/007-sqlite-facet-sorting/`
+
+## Implementation
+
+- [X] T001 Add reusable SQLite facet value expression helper.
+- [X] T002 Use the shared facet value expression from facet filters.
+- [X] T003 Add facet sort ordering in the SQLite query builder.
+- [X] T004 Update SQLite JSON capabilities to declare facet sorting.
+- [X] T005 Update SQLite facet sorting tests.
+- [X] T006 Update capability, validator, provider-authoring, and conformance expectations.
+- [X] T007 Update SQLite querying docs.
+
+## Verification
+
+- [X] T008 Run focused SQLite/capability/conformance tests.
+- [X] T009 Run `dotnet test Aster.sln`.
+- [X] T010 Run `dotnet build Aster.sln`.
+- [X] T011 Run `git diff --check`.

--- a/src/persistence/Aster.Persistence.SqliteJson/Querying/SqliteFacetValueExpression.cs
+++ b/src/persistence/Aster.Persistence.SqliteJson/Querying/SqliteFacetValueExpression.cs
@@ -1,7 +1,9 @@
 namespace Aster.Persistence.SqliteJson.Querying;
 
-internal sealed record SqliteFacetValueExpression(string Value, string IsNumeric)
+internal sealed record SqliteFacetValueExpression(string Value, string Type)
 {
+    public string IsNumeric => $"{Type} IN ('integer', 'real')";
+
     public static SqliteFacetValueExpression Create(
         SqliteParameterBag parameters,
         string aspectKey,
@@ -37,7 +39,7 @@ internal sealed record SqliteFacetValueExpression(string Value, string IsNumeric
                   AND facet.key IN ({typeFacetKeyList})
                 ORDER BY CASE facet.key WHEN {typeFacetKeyParameters[0]} THEN 0 ELSE 1 END
                 LIMIT 1
-            ) IN ('integer', 'real')
+            )
             """);
     }
 }

--- a/src/persistence/Aster.Persistence.SqliteJson/Querying/SqliteFacetValueExpression.cs
+++ b/src/persistence/Aster.Persistence.SqliteJson/Querying/SqliteFacetValueExpression.cs
@@ -1,0 +1,43 @@
+namespace Aster.Persistence.SqliteJson.Querying;
+
+internal sealed record SqliteFacetValueExpression(string Value, string IsNumeric)
+{
+    public static SqliteFacetValueExpression Create(
+        SqliteParameterBag parameters,
+        string aspectKey,
+        string facetDefinitionId)
+    {
+        var aspectsPath = parameters.Add(SqliteJsonPath.Aspects);
+        var typeAspectsPath = parameters.Add(SqliteJsonPath.Aspects);
+        var aspectKeyParameter = parameters.Add(aspectKey);
+        var typeAspectKeyParameter = parameters.Add(aspectKey);
+        var facetKeys = SqliteJsonPath.FacetCandidates(facetDefinitionId).ToList();
+        var facetKeyParameters = facetKeys.Select(parameters.Add).ToList();
+        var typeFacetKeyParameters = facetKeys.Select(parameters.Add).ToList();
+        var facetKeyList = string.Join(", ", facetKeyParameters);
+        var typeFacetKeyList = string.Join(", ", typeFacetKeyParameters);
+
+        return new($"""
+            (
+                SELECT facet.value
+                FROM json_each(json_extract(rv.payload, {aspectsPath})) aspect
+                JOIN json_each(aspect.value) facet
+                WHERE aspect.key = {aspectKeyParameter}
+                  AND facet.key IN ({facetKeyList})
+                ORDER BY CASE facet.key WHEN {facetKeyParameters[0]} THEN 0 ELSE 1 END
+                LIMIT 1
+            )
+            """,
+            $"""
+            (
+                SELECT facet.type
+                FROM json_each(json_extract(rv.payload, {typeAspectsPath})) aspect
+                JOIN json_each(aspect.value) facet
+                WHERE aspect.key = {typeAspectKeyParameter}
+                  AND facet.key IN ({typeFacetKeyList})
+                ORDER BY CASE facet.key WHEN {typeFacetKeyParameters[0]} THEN 0 ELSE 1 END
+                LIMIT 1
+            ) IN ('integer', 'real')
+            """);
+    }
+}

--- a/src/persistence/Aster.Persistence.SqliteJson/Querying/SqliteQueryBuilder.cs
+++ b/src/persistence/Aster.Persistence.SqliteJson/Querying/SqliteQueryBuilder.cs
@@ -22,7 +22,7 @@ internal sealed class SqliteQueryBuilder(ResourceQuery query)
         for (var index = 0; index < sorts.Count; index++)
         {
             var sort = sorts[index];
-            orderings.Add($"{ResolveMetadataColumn(sort, index)} {ResolveDirection(sort.Direction, index)}");
+            orderings.Add(ResolveOrdering(sort, index));
         }
     }
 
@@ -132,22 +132,28 @@ internal sealed class SqliteQueryBuilder(ResourceQuery query)
                 """]);
     }
 
-    private static string ResolveMetadataColumn(SortExpression sort, int index)
+    private string ResolveOrdering(SortExpression sort, int index)
     {
-        if (!string.IsNullOrWhiteSpace(sort.AspectKey))
-            throw Unsupported(
-                "unsupported-facet-sort",
-                "sort",
-                "Facet sorting is not supported by the SQLite JSON query provider.",
-                $"Sorts[{index}]");
+        var direction = ResolveDirection(sort.Direction, index);
 
-        return SqliteMetadataField.ResolveColumn(
-            sort.Field,
+        if (string.IsNullOrWhiteSpace(sort.AspectKey))
+            return $"{ResolveMetadataColumn(sort.Field, index)} {direction}";
+
+        var facet = SqliteFacetValueExpression.Create(Parameters, sort.AspectKey, sort.Field);
+        return string.Join(", ", [
+            $"({facet.Value}) IS NULL ASC",
+            $"CASE WHEN {facet.IsNumeric} THEN CAST({facet.Value} AS REAL) END {direction}",
+            $"CASE WHEN NOT ({facet.IsNumeric}) THEN CAST({facet.Value} AS TEXT) END COLLATE {SqliteTextBehavior.OrdinalIgnoreCaseCollation} {direction}",
+        ]);
+    }
+
+    private static string ResolveMetadataColumn(string field, int index) =>
+        SqliteMetadataField.ResolveColumn(
+            field,
             "Metadata sort field",
             "unsupported-metadata-sort-field",
             "metadata field",
             $"Sorts[{index}].Field");
-    }
 
     private static string ResolveDirection(SortDirection direction, int index) => direction switch
     {

--- a/src/persistence/Aster.Persistence.SqliteJson/Querying/SqliteQueryBuilder.cs
+++ b/src/persistence/Aster.Persistence.SqliteJson/Querying/SqliteQueryBuilder.cs
@@ -8,6 +8,7 @@ internal sealed class SqliteQueryBuilder(ResourceQuery query)
 {
     private readonly List<string> predicates = [];
     private readonly List<string> orderings = [];
+    private readonly List<string> projections = [];
 
     public SqliteParameterBag Parameters { get; } = new();
 
@@ -29,7 +30,11 @@ internal sealed class SqliteQueryBuilder(ResourceQuery query)
     public string Build()
     {
         var (baseSql, scopePredicates) = BuildScopeSql();
-        var sql = new StringBuilder(baseSql);
+        var sql = new StringBuilder();
+        sql.Append("SELECT ");
+        sql.AppendJoin(", ", ["rv.payload", .. projections]);
+        sql.AppendLine();
+        sql.Append(baseSql);
         predicates.AddRange(scopePredicates);
 
         if (!string.IsNullOrWhiteSpace(query.DefinitionId))
@@ -80,7 +85,6 @@ internal sealed class SqliteQueryBuilder(ResourceQuery query)
     private (string Sql, IReadOnlyList<string> ScopePredicates) BuildScopeSql() => query.Scope switch
     {
         ResourceVersionScope.Latest => ("""
-            SELECT rv.payload
             FROM resource_versions rv
             INNER JOIN (
                 SELECT resource_id, MAX(version) AS version
@@ -91,12 +95,10 @@ internal sealed class SqliteQueryBuilder(ResourceQuery query)
                 AND latest.version = rv.version
             """, []),
         ResourceVersionScope.AllVersions => ("""
-            SELECT rv.payload
             FROM resource_versions rv
             """, []),
         ResourceVersionScope.Active => ActiveSql(),
         ResourceVersionScope.Draft => ("""
-            SELECT rv.payload
             FROM resource_versions rv
             """, ["""
                 NOT EXISTS (
@@ -118,7 +120,6 @@ internal sealed class SqliteQueryBuilder(ResourceQuery query)
     {
         var channel = Parameters.Add(query.ActivationChannel);
         return ($$"""
-            SELECT rv.payload
             FROM resource_versions rv
             INNER JOIN activation_states active_state
                 ON active_state.resource_id = rv.resource_id
@@ -140,10 +141,17 @@ internal sealed class SqliteQueryBuilder(ResourceQuery query)
             return $"{ResolveMetadataColumn(sort.Field, index)} {direction}";
 
         var facet = SqliteFacetValueExpression.Create(Parameters, sort.AspectKey, sort.Field);
+        var valueAlias = $"facet_sort_{index}_value";
+        var typeAlias = $"facet_sort_{index}_type";
+        var isNumeric = $"{typeAlias} IN ('integer', 'real')";
+
+        projections.Add($"{facet.Value} AS {valueAlias}");
+        projections.Add($"{facet.Type} AS {typeAlias}");
+
         return string.Join(", ", [
-            $"({facet.Value}) IS NULL ASC",
-            $"CASE WHEN {facet.IsNumeric} THEN CAST({facet.Value} AS REAL) END {direction}",
-            $"CASE WHEN NOT ({facet.IsNumeric}) THEN CAST({facet.Value} AS TEXT) END COLLATE {SqliteTextBehavior.OrdinalIgnoreCaseCollation} {direction}",
+            $"{valueAlias} IS NULL ASC",
+            $"CASE WHEN {isNumeric} THEN CAST({valueAlias} AS REAL) END {direction}",
+            $"CASE WHEN NOT ({isNumeric}) THEN CAST({valueAlias} AS TEXT) END COLLATE {SqliteTextBehavior.OrdinalIgnoreCaseCollation} {direction}",
         ]);
     }
 

--- a/src/persistence/Aster.Persistence.SqliteJson/Querying/SqliteTextBehavior.cs
+++ b/src/persistence/Aster.Persistence.SqliteJson/Querying/SqliteTextBehavior.cs
@@ -1,0 +1,19 @@
+namespace Aster.Persistence.SqliteJson.Querying;
+
+internal static class SqliteTextBehavior
+{
+    public const string EqualsFunction = "aster_text_equals";
+    public const string ContainsFunction = "aster_text_contains";
+    public const string OrdinalIgnoreCaseCollation = "aster_ordinal_ignore_case";
+
+    public static bool EqualsIgnoreCase(string? actual, string? expected) =>
+        string.Equals(actual, expected, StringComparison.OrdinalIgnoreCase);
+
+    public static bool ContainsIgnoreCase(string? actual, string? expected) =>
+        actual is not null
+        && expected is not null
+        && actual.Contains(expected, StringComparison.OrdinalIgnoreCase);
+
+    public static int CompareIgnoreCase(string? left, string? right) =>
+        string.Compare(left, right, StringComparison.OrdinalIgnoreCase);
+}

--- a/src/persistence/Aster.Persistence.SqliteJson/Querying/SqliteWhereTranslator.cs
+++ b/src/persistence/Aster.Persistence.SqliteJson/Querying/SqliteWhereTranslator.cs
@@ -49,9 +49,9 @@ internal sealed class SqliteWhereTranslator(SqliteParameterBag parameters)
             ComparisonOperator.Equals when SqliteMetadataField.IsNumeric(filter.Field) =>
                 $"{column} = {parameters.Add(ParseInt(filter.Value, filter.Field))}",
             ComparisonOperator.Equals =>
-                $"aster_text_equals(CAST({column} AS TEXT), CAST({parameters.Add(filter.Value)} AS TEXT))",
+                $"{SqliteTextBehavior.EqualsFunction}(CAST({column} AS TEXT), CAST({parameters.Add(filter.Value)} AS TEXT))",
             ComparisonOperator.Contains when !SqliteMetadataField.IsNumeric(filter.Field) =>
-                $"aster_text_contains(CAST({column} AS TEXT), CAST({parameters.Add(filter.Value)} AS TEXT))",
+                $"{SqliteTextBehavior.ContainsFunction}(CAST({column} AS TEXT), CAST({parameters.Add(filter.Value)} AS TEXT))",
             ComparisonOperator.Contains =>
                 throw Unsupported(
                     "unsupported-metadata-contains-field",
@@ -75,16 +75,16 @@ internal sealed class SqliteWhereTranslator(SqliteParameterBag parameters)
 
     private string TranslateFacetValue(FacetValueFilter filter)
     {
-        var value = FacetValueSql(filter.AspectKey, filter.FacetDefinitionId);
+        var value = SqliteFacetValueExpression.Create(parameters, filter.AspectKey, filter.FacetDefinitionId);
 
         return filter.Operator switch
         {
             ComparisonOperator.Equals when TryConvertDouble(filter.Value, out var number) =>
-                $"{value.IsNumericPredicate} AND CAST({value.ValueExpression} AS REAL) = {parameters.Add(number)}",
+                $"{value.IsNumeric} AND CAST({value.Value} AS REAL) = {parameters.Add(number)}",
             ComparisonOperator.Equals =>
-                $"aster_text_equals(CAST({value.ValueExpression} AS TEXT), CAST({parameters.Add(FormatValue(filter.Value))} AS TEXT))",
+                $"{SqliteTextBehavior.EqualsFunction}(CAST({value.Value} AS TEXT), CAST({parameters.Add(FormatValue(filter.Value))} AS TEXT))",
             ComparisonOperator.Contains =>
-                $"aster_text_contains(CAST({value.ValueExpression} AS TEXT), CAST({parameters.Add(FormatValue(filter.Value))} AS TEXT))",
+                $"{SqliteTextBehavior.ContainsFunction}(CAST({value.Value} AS TEXT), CAST({parameters.Add(FormatValue(filter.Value))} AS TEXT))",
             ComparisonOperator.Range when filter.Value is RangeValue range =>
                 TranslateRange(value, range),
             ComparisonOperator.Range =>
@@ -133,51 +133,15 @@ internal sealed class SqliteWhereTranslator(SqliteParameterBag parameters)
         return string.Join($" {sqlOperator} ", operands.Select(operand => $"({Translate(operand)})"));
     }
 
-    private FacetValueSqlExpression FacetValueSql(string aspectKey, string facetDefinitionId)
+    private string TranslateRange(SqliteFacetValueExpression value, RangeValue range)
     {
-        var aspectsPath = parameters.Add(SqliteJsonPath.Aspects);
-        var typeAspectsPath = parameters.Add(SqliteJsonPath.Aspects);
-        var aspectKeyParameter = parameters.Add(aspectKey);
-        var typeAspectKeyParameter = parameters.Add(aspectKey);
-        var facetKeys = SqliteJsonPath.FacetCandidates(facetDefinitionId).ToList();
-        var facetKeyParameters = facetKeys.Select(parameters.Add).ToList();
-        var typeFacetKeyParameters = facetKeys.Select(parameters.Add).ToList();
-        var facetKeyList = string.Join(", ", facetKeyParameters);
-        var typeFacetKeyList = string.Join(", ", typeFacetKeyParameters);
-
-        return new($"""
-            (
-                SELECT facet.value
-                FROM json_each(json_extract(rv.payload, {aspectsPath})) aspect
-                JOIN json_each(aspect.value) facet
-                WHERE aspect.key = {aspectKeyParameter}
-                  AND facet.key IN ({facetKeyList})
-                ORDER BY CASE facet.key WHEN {facetKeyParameters[0]} THEN 0 ELSE 1 END
-                LIMIT 1
-            )
-            """,
-            $"""
-            (
-                SELECT facet.type
-                FROM json_each(json_extract(rv.payload, {typeAspectsPath})) aspect
-                JOIN json_each(aspect.value) facet
-                WHERE aspect.key = {typeAspectKeyParameter}
-                  AND facet.key IN ({typeFacetKeyList})
-                ORDER BY CASE facet.key WHEN {typeFacetKeyParameters[0]} THEN 0 ELSE 1 END
-                LIMIT 1
-            ) IN ('integer', 'real')
-            """);
-    }
-
-    private string TranslateRange(FacetValueSqlExpression value, RangeValue range)
-    {
-        var predicates = new List<string> { value.IsNumericPredicate };
+        var predicates = new List<string> { value.IsNumeric };
 
         if (range.Min is not null)
-            predicates.Add($"CAST({value.ValueExpression} AS REAL) {(range.IncludeMin ? ">=" : ">")} {parameters.Add(ConvertToDouble(range.Min, "minimum range bound"))}");
+            predicates.Add($"CAST({value.Value} AS REAL) {(range.IncludeMin ? ">=" : ">")} {parameters.Add(ConvertToDouble(range.Min, "minimum range bound"))}");
 
         if (range.Max is not null)
-            predicates.Add($"CAST({value.ValueExpression} AS REAL) {(range.IncludeMax ? "<=" : "<")} {parameters.Add(ConvertToDouble(range.Max, "maximum range bound"))}");
+            predicates.Add($"CAST({value.Value} AS REAL) {(range.IncludeMax ? "<=" : "<")} {parameters.Add(ConvertToDouble(range.Max, "maximum range bound"))}");
 
         if (predicates.Count == 0)
             throw Unsupported(
@@ -250,6 +214,4 @@ internal sealed class SqliteWhereTranslator(SqliteParameterBag parameters)
         string message,
         string? path = null) =>
         new(code, feature, message, path);
-
-    private sealed record FacetValueSqlExpression(string ValueExpression, string IsNumericPredicate);
 }

--- a/src/persistence/Aster.Persistence.SqliteJson/README.md
+++ b/src/persistence/Aster.Persistence.SqliteJson/README.md
@@ -30,11 +30,12 @@ Supported query shapes:
 - `DefinitionId` shortcut filtering
 - metadata filters over `ResourceId`, `Id`, `DefinitionId`, `Owner`, `Version`, and `Created`
 - metadata sorting over the same fields
+- facet sorting over scalar facet values
 - `Skip` and `Take`
 - aspect presence checks
 - scalar facet `Equals`, string `Contains`, and numeric `Range`
 - `And`, `Or`, and single-operand `Not`
 
-Unsupported query shapes throw `UnsupportedQueryFeatureException` with stable `Code`, `Feature`, optional `Path`, and an actionable message. Facet sorting, metadata range filters, unknown metadata fields, empty ranges, negative paging values, and date-like facet ranges are intentionally out of scope for this phase.
+Unsupported query shapes throw `UnsupportedQueryFeatureException` with stable `Code`, `Feature`, optional `Path`, and an actionable message. Metadata range filters, unknown metadata fields, empty ranges, negative paging values, and date-like facet ranges are intentionally out of scope for this phase.
 
-The provider also declares this support through `SqliteJsonQueryCapabilitiesProvider` with provider key `sqlite-json`, so callers can inspect capabilities or use `IResourceQueryValidator` before execution. Validation reports unsupported SQLite shapes, such as facet sorting or date-like facet ranges, without falling back to the in-memory provider. Execution runs shared validation first and remains authoritative if validation is skipped.
+The provider also declares this support through `SqliteJsonQueryCapabilitiesProvider` with provider key `sqlite-json`, so callers can inspect capabilities or use `IResourceQueryValidator` before execution. Validation reports unsupported SQLite shapes, such as date-like facet ranges, without falling back to the in-memory provider. Execution runs shared validation first and remains authoritative if validation is skipped.

--- a/src/persistence/Aster.Persistence.SqliteJson/SqliteJsonQueryCapabilitiesProvider.cs
+++ b/src/persistence/Aster.Persistence.SqliteJson/SqliteJsonQueryCapabilitiesProvider.cs
@@ -70,13 +70,12 @@ public sealed class SqliteJsonQueryCapabilitiesProvider : IResourceQueryCapabili
             "Created",
         },
         SupportsMetadataSorting: true,
-        SupportsFacetSorting: false,
+        SupportsFacetSorting: true,
         SupportsSkip: true,
         SupportsTake: true,
         FacetRangeSupport: new HashSet<QueryValueShape> { QueryValueShape.Numeric },
         UnsupportedFeatures:
         [
-            "Facet sorting",
             "Metadata range filters",
             "Date-like facet ranges",
         ]);

--- a/src/persistence/Aster.Persistence.SqliteJson/SqliteJsonQueryService.cs
+++ b/src/persistence/Aster.Persistence.SqliteJson/SqliteJsonQueryService.cs
@@ -64,7 +64,7 @@ public sealed class SqliteJsonQueryService : IResourceQueryService, IResourceQue
 
         await using var connection = new SqliteConnection(connectionString);
         await connection.OpenAsync(cancellationToken);
-        RegisterTextFunctions(connection);
+        RegisterTextBehavior(connection);
 
         await using var command = connection.CreateCommand();
         command.CommandText = builder.Build();
@@ -93,18 +93,19 @@ public sealed class SqliteJsonQueryService : IResourceQueryService, IResourceQue
         JsonSerializer.Deserialize<Resource>(payload, JsonOptions)
         ?? throw new InvalidOperationException("Unable to deserialize persisted Resource payload.");
 
-    private static void RegisterTextFunctions(SqliteConnection connection)
+    private static void RegisterTextBehavior(SqliteConnection connection)
     {
         connection.CreateFunction<string?, string?, bool>(
-            "aster_text_equals",
-            (actual, expected) => string.Equals(actual, expected, StringComparison.OrdinalIgnoreCase));
+            SqliteTextBehavior.EqualsFunction,
+            SqliteTextBehavior.EqualsIgnoreCase);
 
         connection.CreateFunction<string?, string?, bool>(
-            "aster_text_contains",
-            (actual, expected) =>
-                actual is not null
-                && expected is not null
-                && actual.Contains(expected, StringComparison.OrdinalIgnoreCase));
+            SqliteTextBehavior.ContainsFunction,
+            SqliteTextBehavior.ContainsIgnoreCase);
+
+        connection.CreateCollation(
+            SqliteTextBehavior.OrdinalIgnoreCaseCollation,
+            SqliteTextBehavior.CompareIgnoreCase);
     }
 
     private void ThrowIfInvalid(ResourceQuery query)

--- a/test/Aster.Tests/Querying/ProviderAuthoringTests.cs
+++ b/test/Aster.Tests/Querying/ProviderAuthoringTests.cs
@@ -169,7 +169,7 @@ public sealed class ProviderAuthoringTests
             SqliteJsonQueryCapabilitiesProvider.ProviderKey,
             sqliteProvider.GetRequiredService<IResourceQueryProviderIdentity>().ProviderKey);
         Assert.True(inMemoryCapabilities.SupportsFacetSorting);
-        Assert.False(sqliteCapabilities.SupportsFacetSorting);
+        Assert.True(sqliteCapabilities.SupportsFacetSorting);
     }
 
     [Fact]

--- a/test/Aster.Tests/Querying/QueryCapabilityDiscoveryTests.cs
+++ b/test/Aster.Tests/Querying/QueryCapabilityDiscoveryTests.cs
@@ -48,8 +48,8 @@ public sealed class QueryCapabilityDiscoveryTests : IDisposable
 
         Assert.Equal(SqliteJsonQueryCapabilitiesProvider.ProviderKey, capabilities.ProviderKey);
         Assert.Equal("SQLite JSON", capabilities.ProviderName);
-        Assert.False(capabilities.SupportsFacetSorting);
-        Assert.False(validator.Validate(new ResourceQuery
+        Assert.True(capabilities.SupportsFacetSorting);
+        Assert.True(validator.Validate(new ResourceQuery
         {
             Sorts = [new SortExpression("Title", AspectKey: "TitleAspect")],
         }).IsValid);
@@ -62,7 +62,7 @@ public sealed class QueryCapabilityDiscoveryTests : IDisposable
         var sqlite = new SqliteJsonQueryCapabilitiesProvider().Capabilities;
 
         Assert.True(inMemory.SupportsFacetSorting);
-        Assert.False(sqlite.SupportsFacetSorting);
+        Assert.True(sqlite.SupportsFacetSorting);
         Assert.Contains(QueryValueShape.DateTime, inMemory.FacetRangeSupport);
         Assert.DoesNotContain(QueryValueShape.DateTime, sqlite.FacetRangeSupport);
     }
@@ -81,11 +81,15 @@ public sealed class QueryCapabilityDiscoveryTests : IDisposable
         var validator = provider.GetRequiredService<IResourceQueryValidator>();
         var result = validator.Validate(new ResourceQuery
         {
-            Sorts = [new SortExpression("Title", AspectKey: "TitleAspect")],
+            Filter = new FacetValueFilter(
+                "Schedule",
+                "StartsAt",
+                new RangeValue(DateTime.UtcNow.AddDays(-1), DateTime.UtcNow),
+                ComparisonOperator.Range),
         });
 
         Assert.False(result.IsValid);
-        Assert.Contains(result.Failures, failure => failure.Code == "unsupported-facet-sort");
+        Assert.Contains(result.Failures, failure => failure.Code == "unsupported-range-value-shape");
     }
 
     [Fact]
@@ -125,10 +129,17 @@ public sealed class QueryCapabilityDiscoveryTests : IDisposable
             .BuildServiceProvider();
 
         await AssertValidationMatchesExecutionAsync(
-            new ResourceQuery { Sorts = [new SortExpression("Title", AspectKey: "TitleAspect")] },
+            new ResourceQuery
+            {
+                Filter = new FacetValueFilter(
+                    "Schedule",
+                    "StartsAt",
+                    new RangeValue(DateTime.UtcNow.AddDays(-1), DateTime.UtcNow),
+                    ComparisonOperator.Range),
+            },
             provider.GetRequiredService<IResourceQueryValidator>(),
             provider.GetRequiredService<IResourceQueryService>(),
-            "unsupported-facet-sort");
+            "unsupported-range-value-shape");
     }
 
     private static async Task AssertValidatesAndExecutesAsync(

--- a/test/Aster.Tests/Querying/ResourceQueryValidatorTests.cs
+++ b/test/Aster.Tests/Querying/ResourceQueryValidatorTests.cs
@@ -60,7 +60,6 @@ public sealed class ResourceQueryValidatorTests
                     new RangeValue(DateTime.UtcNow.AddDays(-1), DateTime.UtcNow),
                     ComparisonOperator.Range),
             ]),
-            Sorts = [new SortExpression("Title", AspectKey: "Title")],
         });
 
         Assert.False(result.IsValid);
@@ -70,7 +69,6 @@ public sealed class ResourceQueryValidatorTests
         Assert.Contains(result.Failures, failure => failure.Code == "unsupported-metadata-field");
         Assert.Contains(result.Failures, failure => failure.Code == "unsupported-comparison-operator");
         Assert.Contains(result.Failures, failure => failure.Code == "unsupported-range-value-shape");
-        Assert.Contains(result.Failures, failure => failure.Code == "unsupported-facet-sort");
     }
 
     [Fact]
@@ -120,7 +118,6 @@ public sealed class ResourceQueryValidatorTests
 
         Assert.False(sqliteResult.IsValid);
         Assert.Contains(sqliteResult.Failures, failure => failure.Code == "unsupported-range-value-shape");
-        Assert.Contains(sqliteResult.Failures, failure => failure.Code == "unsupported-facet-sort");
     }
 
     [Fact]

--- a/test/Aster.Tests/SqliteJson/SqliteJsonQueryCapabilityTests.cs
+++ b/test/Aster.Tests/SqliteJson/SqliteJsonQueryCapabilityTests.cs
@@ -17,7 +17,7 @@ public sealed class SqliteJsonQueryCapabilityTests
         Assert.Equal("SQLite JSON", capabilities.ProviderName);
         Assert.True(capabilities.RequiresActivationChannelForActiveScope);
         Assert.True(capabilities.SupportsMetadataSorting);
-        Assert.False(capabilities.SupportsFacetSorting);
+        Assert.True(capabilities.SupportsFacetSorting);
         Assert.True(capabilities.SupportsSkip);
         Assert.True(capabilities.SupportsTake);
 
@@ -28,17 +28,17 @@ public sealed class SqliteJsonQueryCapabilityTests
     }
 
     [Fact]
-    public void Capabilities_ExcludeFacetSortingAndDateLikeFacetRanges()
+    public void Capabilities_IncludeFacetSortingAndExcludeDateLikeFacetRanges()
     {
-        Assert.False(capabilities.SupportsFacetSorting);
-        Assert.Contains("Facet sorting", capabilities.UnsupportedFeatures);
+        Assert.True(capabilities.SupportsFacetSorting);
+        Assert.DoesNotContain("Facet sorting", capabilities.UnsupportedFeatures);
         Assert.Contains(QueryValueShape.Numeric, capabilities.FacetRangeSupport);
         Assert.DoesNotContain(QueryValueShape.DateTime, capabilities.FacetRangeSupport);
         Assert.True(capabilities.SupportsComparison(QueryFilterType.FacetValue, ComparisonOperator.Range));
     }
 
     [Fact]
-    public void Validator_RejectsFacetSortingForSqliteCapabilities()
+    public void Validator_AcceptsFacetSortingForSqliteCapabilities()
     {
         var validator = new ServiceCollection()
             .AddAsterCore()
@@ -55,7 +55,7 @@ public sealed class SqliteJsonQueryCapabilityTests
             Sorts = [new SortExpression("Title", AspectKey: "TitleAspect")],
         });
 
-        Assert.False(result.IsValid);
-        Assert.Contains(result.Failures, failure => failure.Code == "unsupported-facet-sort");
+        Assert.True(result.IsValid);
+        Assert.Empty(result.Failures);
     }
 }

--- a/test/Aster.Tests/SqliteJson/SqliteJsonQueryServiceTests.cs
+++ b/test/Aster.Tests/SqliteJson/SqliteJsonQueryServiceTests.cs
@@ -156,6 +156,57 @@ public sealed class SqliteJsonQueryServiceTests : IDisposable
     }
 
     [Fact]
+    public async Task QueryAsync_FacetSorts_OrderByTextFacetValue()
+    {
+        var store = CreateStore();
+        await store.SaveVersionAsync(CreateResource("product-a", "Product", aspects: new()
+        {
+            ["Title"] = new { Title = "Bravo" },
+        }));
+        await store.SaveVersionAsync(CreateResource("product-b", "Product", aspects: new()
+        {
+            ["Title"] = new { Title = "alpha" },
+        }));
+        await store.SaveVersionAsync(CreateResource("product-c", "Product"));
+
+        await using var provider = CreateServiceProvider();
+        var query = provider.GetRequiredService<IResourceQueryService>();
+
+        var results = (await query.QueryAsync(new ResourceQuery
+        {
+            DefinitionId = "Product",
+            Sorts = [new SortExpression("Title", AspectKey: "Title")],
+        })).ToList();
+
+        Assert.Equal(["product-b", "product-a", "product-c"], results.Select(r => r.ResourceId).ToList());
+    }
+
+    [Fact]
+    public async Task QueryAsync_FacetSorts_OrderByNumericFacetValueDescending()
+    {
+        var store = CreateStore();
+        await store.SaveVersionAsync(CreateResource("product-a", "Product", aspects: new()
+        {
+            ["Price"] = new { Amount = 20 },
+        }));
+        await store.SaveVersionAsync(CreateResource("product-b", "Product", aspects: new()
+        {
+            ["Price"] = new { Amount = 30 },
+        }));
+
+        await using var provider = CreateServiceProvider();
+        var query = provider.GetRequiredService<IResourceQueryService>();
+
+        var results = (await query.QueryAsync(new ResourceQuery
+        {
+            DefinitionId = "Product",
+            Sorts = [new SortExpression("Amount", SortDirection.Descending, AspectKey: "Price")],
+        })).ToList();
+
+        Assert.Equal(["product-b", "product-a"], results.Select(r => r.ResourceId).ToList());
+    }
+
+    [Fact]
     public async Task QueryAsync_AspectPresenceAndFacetFilters_ReadPersistedJson()
     {
         var store = CreateStore();
@@ -352,15 +403,6 @@ public sealed class SqliteJsonQueryServiceTests : IDisposable
         await AssertUnsupportedAsync(
             query.QueryAsync(new ResourceQuery
             {
-                Sorts = [new SortExpression("Title", AspectKey: "Title")],
-            }).AsTask(),
-            "unsupported-facet-sort",
-            "sort",
-            "Sorts[0]");
-
-        await AssertUnsupportedAsync(
-            query.QueryAsync(new ResourceQuery
-            {
                 Scope = ResourceVersionScope.Active,
             }).AsTask(),
             "activation-channel-required",
@@ -419,15 +461,6 @@ public sealed class SqliteJsonQueryServiceTests : IDisposable
             queryService,
             new ResourceQuery
             {
-                Sorts = [new SortExpression("Title", AspectKey: "Title")],
-            },
-            "unsupported-facet-sort",
-            "Sorts[0]");
-        await AssertValidationMatchesExecutionAsync(
-            validator,
-            queryService,
-            new ResourceQuery
-            {
                 Filter = new FacetValueFilter(
                     "Schedule",
                     "StartsAt",
@@ -480,7 +513,11 @@ public sealed class SqliteJsonQueryServiceTests : IDisposable
     {
         var queryShape = new ResourceQuery
         {
-            Sorts = [new SortExpression("Title", AspectKey: "Title")],
+            Filter = new FacetValueFilter(
+                "Schedule",
+                "StartsAt",
+                new RangeValue(DateTime.UtcNow.AddDays(-1), DateTime.UtcNow),
+                ComparisonOperator.Range),
         };
         var inMemoryValidation = new ResourceQueryValidator([new InMemoryQueryCapabilitiesProvider()])
             .Validate(queryShape);

--- a/test/Aster.Tests/SqliteJson/SqliteJsonQueryServiceTests.cs
+++ b/test/Aster.Tests/SqliteJson/SqliteJsonQueryServiceTests.cs
@@ -193,6 +193,7 @@ public sealed class SqliteJsonQueryServiceTests : IDisposable
         {
             ["Price"] = new { Amount = 30 },
         }));
+        await store.SaveVersionAsync(CreateResource("product-c", "Product"));
 
         await using var provider = CreateServiceProvider();
         var query = provider.GetRequiredService<IResourceQueryService>();
@@ -203,7 +204,7 @@ public sealed class SqliteJsonQueryServiceTests : IDisposable
             Sorts = [new SortExpression("Amount", SortDirection.Descending, AspectKey: "Price")],
         })).ToList();
 
-        Assert.Equal(["product-b", "product-a"], results.Select(r => r.ResourceId).ToList());
+        Assert.Equal(["product-b", "product-a", "product-c"], results.Select(r => r.ResourceId).ToList());
     }
 
     [Fact]

--- a/wiki/Querying.md
+++ b/wiki/Querying.md
@@ -135,7 +135,7 @@ Console.WriteLine(capabilities.ProviderKey);
 Console.WriteLine(capabilities.SupportsFacetSorting);
 ```
 
-Capabilities describe supported scopes, filter categories, comparison operators, logical operators, metadata fields, sort categories, paging, facet range value shapes, and known exclusions. The in-memory provider currently declares facet sorting and numeric/date-like facet ranges; SQLite JSON declares metadata sorting, numeric facet ranges, and no facet sorting.
+Capabilities describe supported scopes, filter categories, comparison operators, logical operators, metadata fields, sort categories, paging, facet range value shapes, and known exclusions. The in-memory provider currently declares facet sorting and numeric/date-like facet ranges; SQLite JSON declares metadata sorting, facet sorting, and numeric facet ranges.
 Capability declarations are matched to the active query provider by explicit `ProviderKey` values such as `in-memory` and `sqlite-json`.
 
 Custom providers can use `AddResourceQueryProvider<TQueryService, TCapabilitiesProvider>()` to register their active query service and matching capability provider together. Validation fails closed with `capabilities-not-declared` when the active provider key has no matching declaration.
@@ -244,10 +244,10 @@ The provider supports:
 - metadata filtering and sorting over `ResourceId`, `Id`, `DefinitionId`, `Owner`, `Version`, and `Created`.
 - `Skip` and `Take`.
 - aspect presence checks.
-- facet `Equals`, string `Contains`, and numeric `Range`.
+- facet `Equals`, string `Contains`, numeric `Range`, and facet sorting.
 - `And`, `Or`, and single-operand `Not`.
 
-Unsupported SQLite query shapes fail with `UnsupportedQueryFeatureException` instead of falling back to in-memory evaluation. The exception exposes stable `Code`, `Feature`, optional `Path`, and a human-readable message. Current intentional exclusions include facet sorting, metadata range filters, unknown metadata fields, empty ranges, negative paging values, and date-like facet ranges.
+Unsupported SQLite query shapes fail with `UnsupportedQueryFeatureException` instead of falling back to in-memory evaluation. The exception exposes stable `Code`, `Feature`, optional `Path`, and a human-readable message. Current intentional exclusions include metadata range filters, unknown metadata fields, empty ranges, negative paging values, and date-like facet ranges.
 
 ## Current Limitations
 


### PR DESCRIPTION
## Summary
- Add SQLite JSON facet sorting over scalar facet values using the provider's existing facet lookup behavior.
- Declare SQLite facet sorting support in capabilities and update validation/provider conformance expectations.
- Add Spec Kit artifacts, docs, and tests for text/numeric facet sorting.

## Validation
- dotnet test test/Aster.Tests/Aster.Tests.csproj --filter "FullyQualifiedName~SqliteJsonQueryServiceTests|FullyQualifiedName~SqliteJsonQueryCapabilityTests|FullyQualifiedName~QueryCapabilityDiscoveryTests|FullyQualifiedName~ResourceQueryValidatorTests|FullyQualifiedName~ProviderAuthoringTests|FullyQualifiedName~ProviderConformanceTests"
- dotnet test Aster.sln
- dotnet build Aster.sln
- git diff --check