### PR TITLE
Add typed query authoring helpers

### DIFF
--- a/.github/agents/copilot-instructions.md
+++ b/.github/agents/copilot-instructions.md
@@ -12,6 +12,8 @@ Auto-generated from all feature plans. Last updated: 2026-05-17
 - Existing in-memory store and disposable SQLite JSON database files (006-provider-conformance-tests)
 - C# latest, .NET 8.0 / 9.0 / 10.0 multi-targeting + Existing SQLite JSON provider and test stack (007-sqlite-facet-sorting)
 - Existing SQLite JSON payload shape; no migration (007-sqlite-facet-sorting)
+- C# latest, .NET 8.0 / 9.0 / 10.0 multi-targeting + Existing core SDK and xUnit test stack; no new dependencies (008-typed-query-authoring)
+- N/A; no persistence or schema changes (008-typed-query-authoring)
 
 - C# / .NET 9.0 (Standard 2.0/2.1 compatible ideally, but targeted for net9.0) + Microsoft.Extensions.DependencyInjection, Microsoft.Extensions.Logging (001-core-sdk-foundation)
 
@@ -31,9 +33,9 @@ tests/
 C# / .NET 9.0 (Standard 2.0/2.1 compatible ideally, but targeted for net9.0): Follow standard conventions
 
 ## Recent Changes
+- 008-typed-query-authoring: Added C# latest, .NET 8.0 / 9.0 / 10.0 multi-targeting + Existing core SDK and xUnit test stack; no new dependencies
 - 007-sqlite-facet-sorting: Added C# latest, .NET 8.0 / 9.0 / 10.0 multi-targeting + Existing SQLite JSON provider and test stack
 - 006-provider-conformance-tests: Added C# latest, .NET 8.0 / 9.0 / 10.0 multi-targeting for libraries; tests target net10.0 + Existing xUnit and Microsoft.Extensions.DependencyInjection test stack
-- 005-provider-authoring-ergonomics: Added C# latest, .NET 8.0 / 9.0 / 10.0 multi-targeting + Existing `Microsoft.Extensions.DependencyInjection.Abstractions`, `Microsoft.Extensions.Logging.Abstractions`; no new third-party dependencies
 
 
 <!-- MANUAL ADDITIONS START -->

--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "featureDir": "specs/007-sqlite-facet-sorting"
+  "featureDir": "specs/008-typed-query-authoring"
 }

--- a/docs/ExecutionRoadmap.md
+++ b/docs/ExecutionRoadmap.md
@@ -8,7 +8,7 @@ This roadmap tracks the implementation trail we have already cut through the rep
 
 Aster now has a working Core SDK, in-memory runtime, SQLite JSON persistence/querying, provider capability discovery, provider validation alignment, provider authoring ergonomics, a reusable provider conformance harness, and SQLite facet sorting.
 
-The active workstream is **Phase 3: Query Capabilities & Typed Querying**. The next useful slices should improve query authoring ergonomics and close remaining portable query/provider gaps without introducing a planner, registry, runtime scanning, public SQL, or `IQueryable<Resource>`.
+The active workstream is **Phase 3: Query Capabilities & Typed Querying**. The next useful slices should close remaining portable query/provider gaps without introducing a planner, registry, runtime scanning, public SQL, or `IQueryable<Resource>`.
 
 ## Landed Slices
 
@@ -21,26 +21,9 @@ The active workstream is **Phase 3: Query Capabilities & Typed Querying**. The n
 | `005-provider-authoring-ergonomics` | Landed | Explicit DI helper for custom query providers and provider authoring documentation. |
 | `006-provider-conformance-tests` | Landed | Reusable conformance tests that compare declared capabilities with validation and execution behavior. |
 | `007-sqlite-facet-sorting` | Landed | SQLite facet sorting, null-last behavior, numeric/text ordering, capability updates, and tests/docs. |
+| `008-typed-query-authoring` | Landed | Typed facet sort helpers, small logical composition helpers, and updated roadmap/query docs over the existing query AST. |
 
 ## Near-Term Roadmap
-
-### 008 — Typed Query Authoring Ergonomics
-
-**Goal:** Make common `ResourceQuery` construction less stringly typed now that SQLite and in-memory providers both support facet sorting.
-
-Candidate scope:
-
-- Add typed sort helpers for facet sorts, reusing the existing `TypedQuery.For<TAspect>().Facet(...)` path.
-- Add small composition helpers for `And`, `Or`, and `Not` if they reduce repeated manual `LogicalExpression` construction.
-- Add a minimal query-builder convenience only if it stays thin over the existing AST.
-- Keep output as plain `ResourceQuery`, `FilterExpression`, and `SortExpression`.
-
-Non-goals:
-
-- No LINQ provider.
-- No runtime scanning or automatic schema discovery.
-- No provider-specific SQL exposure.
-- No broad fluent framework unless the repeated usage proves it is needed.
 
 ### 009 — Portable Operator Expansion
 

--- a/docs/ExecutionRoadmap.md
+++ b/docs/ExecutionRoadmap.md
@@ -1,0 +1,109 @@
+# Aster Execution Roadmap
+
+Last updated: 2026-05-17
+
+This roadmap tracks the implementation trail we have already cut through the repo and the next product slices that should stay small enough for Spec Kit-driven PRs. It is intentionally execution-oriented; the broader architecture narrative remains in `docs/Roadmap.md` and the wiki.
+
+## Current Position
+
+Aster now has a working Core SDK, in-memory runtime, SQLite JSON persistence/querying, provider capability discovery, provider validation alignment, provider authoring ergonomics, a reusable provider conformance harness, and SQLite facet sorting.
+
+The active workstream is **Phase 3: Query Capabilities & Typed Querying**. The next useful slices should improve query authoring ergonomics and close remaining portable query/provider gaps without introducing a planner, registry, runtime scanning, public SQL, or `IQueryable<Resource>`.
+
+## Landed Slices
+
+| Slice | Status | What It Established |
+|---|---|---|
+| `001-core-sdk-foundation` | Landed | Core domain contracts, resource definitions, immutable resource versions, activation state, in-memory stores, typed aspect binding, initial query AST, and workbench endpoints. |
+| `002-sqlite-json-querying` | Landed | SQLite JSON resource persistence and provider-backed query execution over metadata, aspect presence, scalar facets, paging, and sorting. |
+| `003-query-capabilities-typed` | Landed | Provider capability descriptions, query preflight validation, provider-agnostic query semantics, and initial typed facet filter helpers. |
+| `004-provider-validation-execution` | Landed | Shared validation before execution, fail-closed missing capability behavior, and consistent unsupported-query exceptions. |
+| `005-provider-authoring-ergonomics` | Landed | Explicit DI helper for custom query providers and provider authoring documentation. |
+| `006-provider-conformance-tests` | Landed | Reusable conformance tests that compare declared capabilities with validation and execution behavior. |
+| `007-sqlite-facet-sorting` | Landed | SQLite facet sorting, null-last behavior, numeric/text ordering, capability updates, and tests/docs. |
+
+## Near-Term Roadmap
+
+### 008 — Typed Query Authoring Ergonomics
+
+**Goal:** Make common `ResourceQuery` construction less stringly typed now that SQLite and in-memory providers both support facet sorting.
+
+Candidate scope:
+
+- Add typed sort helpers for facet sorts, reusing the existing `TypedQuery.For<TAspect>().Facet(...)` path.
+- Add small composition helpers for `And`, `Or`, and `Not` if they reduce repeated manual `LogicalExpression` construction.
+- Add a minimal query-builder convenience only if it stays thin over the existing AST.
+- Keep output as plain `ResourceQuery`, `FilterExpression`, and `SortExpression`.
+
+Non-goals:
+
+- No LINQ provider.
+- No runtime scanning or automatic schema discovery.
+- No provider-specific SQL exposure.
+- No broad fluent framework unless the repeated usage proves it is needed.
+
+### 009 — Portable Operator Expansion
+
+**Goal:** Expand the portable query AST beyond `Equals`, `Contains`, and `Range` while preserving provider capability declarations.
+
+Candidate operators:
+
+- `NotEquals`
+- `In`
+- `StartsWith`
+- `Exists` for facet value presence, distinct from aspect presence
+
+Provider work:
+
+- In-memory support for all new operators.
+- SQLite support for the operators that can be translated simply and explicitly.
+- Capability and conformance updates for each operator.
+
+### 010 — SQLite Date-Like Facet Ranges
+
+**Goal:** Close the most visible remaining SQLite capability gap after numeric ranges and facet sorting.
+
+Candidate scope:
+
+- Define the accepted date/time serialization contract for facet range comparisons.
+- Translate date-like range filters in SQLite JSON when values are stored in the supported shape.
+- Keep invalid or mixed shapes fail-closed with structured diagnostics.
+
+### 011 — Explicit Indexing Model
+
+**Goal:** Introduce indexing as an explicit provider capability, not hidden magic.
+
+Candidate scope:
+
+- Define index field types such as `Keyword`, `Text`, `NormalizedText`, `Boolean`, `Integer`, `Decimal`, `DateTime`, `Guid`, and `KeywordArray`.
+- Add provider-facing contracts for declaring and consuming index projections.
+- Keep SQLite JSON simple; defer heavy query planning.
+
+### 012 — Definition Schema Versions & Upgrade Flow
+
+**Goal:** Make the definition-version story explicit enough for long-lived resources.
+
+Candidate scope:
+
+- Model `ResourceDefinitionVersion` references on resources.
+- Define upgrade behavior from older definition versions.
+- Add validation and tests for resources that span schema versions.
+
+## Later Roadmap
+
+| Area | Intent |
+|---|---|
+| Portability | Export/import definitions and resources with deterministic ID remapping. |
+| Host hooks | Lifecycle hooks around save, activation, deactivation, and import/export. |
+| Multi-tenancy | Tenant-aware definition scope and query boundaries. |
+| Policies | Retention, archival, soft-delete, and pruning policies. |
+| Operational hardening | Benchmarks, migration idempotency, concurrency hardening, and large-data test suites. |
+
+## Guardrails
+
+- Prefer the simplest architecture that satisfies the current slice.
+- Keep provider behavior explicit through capabilities and validation.
+- Keep abstractions earned by demonstrated repetition or product need.
+- Prefer composition and small helpers over framework-shaped extension points.
+- Preserve provider agnosticism in core and provider specificity in provider packages.
+- Keep local development and debugging straightforward.

--- a/specs/008-typed-query-authoring/checklists/requirements.md
+++ b/specs/008-typed-query-authoring/checklists/requirements.md
@@ -1,0 +1,34 @@
+# Specification Quality Checklist: Typed Query Authoring Ergonomics
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning  
+**Created**: 2026-05-17  
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [X] No implementation details (languages, frameworks, APIs)
+- [X] Focused on user value and business needs
+- [X] Written for non-technical stakeholders
+- [X] All mandatory sections completed
+
+## Requirement Completeness
+
+- [X] No [NEEDS CLARIFICATION] markers remain
+- [X] Requirements are testable and unambiguous
+- [X] Success criteria are measurable
+- [X] Success criteria are technology-agnostic (no implementation details)
+- [X] All acceptance scenarios are defined
+- [X] Edge cases are identified
+- [X] Scope is clearly bounded
+- [X] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [X] All functional requirements have clear acceptance criteria
+- [X] User scenarios cover primary flows
+- [X] Feature meets measurable outcomes defined in Success Criteria
+- [X] No implementation details leak into specification
+
+## Notes
+
+- Ready for `/speckit-clarify` or `/speckit-plan`.

--- a/specs/008-typed-query-authoring/contracts/typed-query-authoring.md
+++ b/specs/008-typed-query-authoring/contracts/typed-query-authoring.md
@@ -29,7 +29,7 @@ Expected behavior:
 - `Or` returns `new LogicalExpression(LogicalOperator.Or, operands)`.
 - `Not` returns `new LogicalExpression(LogicalOperator.Not, [operand])`.
 - Empty `And`/`Or` inputs are rejected.
-- `Not` accepts exactly one operand.
+- `Not` accepts exactly one operand in its public API.
 
 ## Compatibility Requirements
 

--- a/specs/008-typed-query-authoring/contracts/typed-query-authoring.md
+++ b/specs/008-typed-query-authoring/contracts/typed-query-authoring.md
@@ -1,0 +1,39 @@
+# Contract: Typed Query Authoring Ergonomics
+
+## Public Behavior
+
+Typed query authoring helpers are convenience APIs over the existing portable query AST. They MUST NOT introduce a new provider contract.
+
+## Typed Sort Helpers
+
+Expected behavior:
+
+- A typed facet selection can produce ascending and descending `SortExpression` values.
+- Convention-based identifiers match existing typed facet filter helpers:
+  - Aspect key defaults to the typed aspect CLR type name.
+  - Facet identifier defaults to the selected member name.
+- Explicit aspect key and facet identifier overrides are supported.
+- Invalid selectors fail clearly before producing a sort.
+
+Equivalent manual shape:
+
+```csharp
+new SortExpression("Title", SortDirection.Ascending, AspectKey: "TitleAspect")
+```
+
+## Logical Composition Helpers
+
+Expected behavior:
+
+- `And` returns `new LogicalExpression(LogicalOperator.And, operands)`.
+- `Or` returns `new LogicalExpression(LogicalOperator.Or, operands)`.
+- `Not` returns `new LogicalExpression(LogicalOperator.Not, [operand])`.
+- Empty `And`/`Or` inputs are rejected.
+- `Not` accepts exactly one operand.
+
+## Compatibility Requirements
+
+- Existing manual AST construction remains valid.
+- Existing validators consume helper-generated AST without special cases.
+- Existing providers execute helper-generated queries as equivalent manual queries.
+- Public abstractions still do not expose `IQueryable<Resource>`.

--- a/specs/008-typed-query-authoring/data-model.md
+++ b/specs/008-typed-query-authoring/data-model.md
@@ -1,0 +1,53 @@
+# Data Model: Typed Query Authoring Ergonomics
+
+## Typed Facet Selection
+
+Represents a typed aspect member selected through an expression.
+
+- `AspectKey`: Resolved from the aspect type name by convention or an explicit override.
+- `FacetIdentifier`: Resolved from the selected member name by convention or an explicit override.
+- `ValueType`: The selected member's value type, used only by the typed helper API surface.
+
+Validation rules:
+
+- The selector MUST identify one direct readable member on the typed aspect.
+- Method calls, nested members, static members, and computed expressions MUST be rejected.
+
+## Typed Facet Sort
+
+Represents a `SortExpression` produced from a typed facet selection.
+
+- `Field`: The resolved facet identifier.
+- `Direction`: Ascending or descending.
+- `AspectKey`: The resolved aspect key.
+
+Validation rules:
+
+- The helper MUST emit the same `SortExpression` shape a caller could construct manually.
+- Provider support is still checked by existing query validation and execution.
+
+## Logical Composition
+
+Represents a `LogicalExpression` produced from existing filters.
+
+- `Operator`: `And`, `Or`, or `Not`.
+- `Operands`: Existing `FilterExpression` values.
+
+Validation rules:
+
+- `And` and `Or` MUST require at least one operand.
+- `Not` MUST require exactly one operand.
+- Helpers MUST preserve operand order.
+
+## Portable Query AST
+
+The existing public query records remain the integration point:
+
+- `ResourceQuery`
+- `FilterExpression`
+- `FacetValueFilter`
+- `AspectPresenceFilter`
+- `LogicalExpression`
+- `SortExpression`
+
+No new provider-facing data model is introduced.

--- a/specs/008-typed-query-authoring/plan.md
+++ b/specs/008-typed-query-authoring/plan.md
@@ -1,0 +1,109 @@
+# Implementation Plan: Typed Query Authoring Ergonomics
+
+**Branch**: `008-typed-query-authoring` | **Date**: 2026-05-17 | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from `/specs/008-typed-query-authoring/spec.md`
+
+## Summary
+
+Add small typed authoring helpers over the existing portable query AST. The feature extends `TypedQuery` so typed facet selections can create `SortExpression` values, and adds minimal logical composition helpers for common `And`, `Or`, and `Not` cases. The helpers remain inspectable, provider-agnostic, and validation/execution-compatible because they emit the existing `ResourceQuery`, `FilterExpression`, and `SortExpression` records.
+
+## Technical Context
+
+**Language/Version**: C# latest, .NET 8.0 / 9.0 / 10.0 multi-targeting  
+**Primary Dependencies**: Existing core SDK and xUnit test stack; no new dependencies  
+**Storage**: N/A; no persistence or schema changes  
+**Testing**: xUnit via `dotnet test Aster.sln`, `dotnet build Aster.sln`, `git diff --check`  
+**Target Platform**: .NET library usable from Generic Host / ASP.NET Core hosts  
+**Project Type**: SDK/library  
+**Performance Goals**: Helper construction should allocate only the existing AST records and small collection wrappers needed for logical operands  
+**Constraints**: No public `IQueryable<Resource>`, no LINQ provider, no runtime scanning, no provider registry, no raw SQL, no query planner  
+**Scale/Scope**: Typed facet sorting, simple logical composition, documentation, and tests across existing in-memory/SQLite validation and execution paths
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+- **SDK-first/headless**: PASS — Adds SDK helper methods only; no UI/CMS coupling.
+- **Immutable versioning**: PASS — Query authoring helpers do not change resource mutation/versioning behavior.
+- **Channel activation**: PASS — Activation semantics remain represented by existing `ResourceQuery` scope fields.
+- **Typed/queryable**: PASS — Helpers preserve typed aspect member selection and emit the existing portable AST; no public `IQueryable` leakage.
+- **Provider agnostic**: PASS — Core helpers are provider-neutral and rely on provider capabilities/validation after AST creation.
+- **Simplicity first**: PASS — Extend the existing `TypedQuery` helper surface rather than adding a new builder framework.
+- **Modern C# idioms**: PASS — Use records, expression member selection, collection expressions, and nullable annotations already present in the project.
+- **Readability over cleverness**: PASS — Expression handling stays limited to direct member selection.
+- **Explicitness over magic**: PASS — Helper output is ordinary inspectable query records; overrides are explicit.
+- **Abstractions justified**: PASS — New helpers address repeated current call-site friction after facet sorting support landed.
+- **Optimize for deletion**: PASS — Helpers are additive and can be removed without changing provider implementations.
+- **Composition over inheritance**: PASS — Static helpers and existing records; no inheritance hierarchy.
+- **Intentional dependencies**: PASS — No new third-party dependencies.
+- **Operational simplicity**: PASS — No storage, deployment, migration, or runtime configuration changes.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/008-typed-query-authoring/
+├── spec.md
+├── plan.md
+├── research.md
+├── data-model.md
+├── contracts/
+│   └── typed-query-authoring.md
+├── quickstart.md
+└── tasks.md
+```
+
+### Source Code (repository root)
+
+```text
+src/
+└── core/
+    └── Aster.Core/
+        ├── Extensions/
+        │   └── TypedQuery.cs
+        └── README.md
+
+test/
+└── Aster.Tests/
+    └── Querying/
+        └── TypedQueryHelperTests.cs
+
+wiki/
+└── Querying.md
+```
+
+**Structure Decision**: Keep the implementation inside `Aster.Core/Extensions/TypedQuery.cs` because the feature is provider-agnostic authoring sugar over public query records. Tests extend the existing typed helper test class. Documentation updates stay in the core README and query wiki.
+
+## Phase 0: Research
+
+Completed in [research.md](research.md).
+
+## Phase 1: Design & Contracts
+
+Completed artifacts:
+
+- [data-model.md](data-model.md)
+- [contracts/typed-query-authoring.md](contracts/typed-query-authoring.md)
+- [quickstart.md](quickstart.md)
+
+## Post-Design Constitution Check
+
+- **SDK-first/headless**: PASS — Public surface remains SDK helper methods.
+- **Immutable versioning**: PASS — No persistence mutation changes.
+- **Channel activation**: PASS — Existing scope fields remain untouched.
+- **Typed/queryable**: PASS — Helpers output the existing AST and avoid `IQueryable<Resource>`.
+- **Provider agnostic**: PASS — No provider-specific dependency in core.
+- **Simplicity first**: PASS — Minimal additive helper methods.
+- **Modern C# idioms**: PASS — Modern C# patterns already used in `TypedQuery` continue.
+- **Readability over cleverness**: PASS — No arbitrary expression translation.
+- **Explicitness over magic**: PASS — AST output and overrides remain inspectable.
+- **Abstractions justified**: PASS — No new abstractions beyond small helpers.
+- **Optimize for deletion**: PASS — Additive helpers only.
+- **Composition over inheritance**: PASS — No inheritance.
+- **Intentional dependencies**: PASS — No new dependencies.
+- **Operational simplicity**: PASS — No runtime infrastructure changes.
+
+## Complexity Tracking
+
+No constitution violations identified.

--- a/specs/008-typed-query-authoring/quickstart.md
+++ b/specs/008-typed-query-authoring/quickstart.md
@@ -1,0 +1,61 @@
+# Quickstart: Typed Query Authoring Ergonomics
+
+Typed query helpers reduce string repetition while still producing the normal portable query AST.
+
+## Typed Facet Sort
+
+```csharp
+var sort = TypedQuery.For<TitleAspect>()
+    .Facet(x => x.Title)
+    .Ascending();
+
+var query = new ResourceQuery
+{
+    DefinitionId = "Product",
+    Sorts = [sort],
+};
+```
+
+Equivalent manual shape:
+
+```csharp
+new SortExpression("Title", SortDirection.Ascending, AspectKey: "TitleAspect");
+```
+
+## Descending Facet Sort With Overrides
+
+```csharp
+var sort = TypedQuery.For<PriceAspect>(aspectKey: "PriceAspect:Sale")
+    .Facet(x => x.Amount, facetIdentifier: "sale_amount")
+    .Descending();
+```
+
+## Logical Composition
+
+```csharp
+var filter = TypedQuery.And(
+    TypedQuery.For<TitleAspect>().Facet(x => x.Title).Contains("Gadget"),
+    TypedQuery.For<PriceAspect>().Facet(x => x.Amount).Range(min: 10m, max: 100m));
+
+var query = new ResourceQuery
+{
+    DefinitionId = "Product",
+    Filter = filter,
+    Sorts =
+    [
+        TypedQuery.For<PriceAspect>().Facet(x => x.Amount).Descending(),
+    ],
+};
+```
+
+## Validation And Execution
+
+Helper-generated queries use the same validation and execution path as manual AST construction:
+
+```csharp
+var validation = validator.Validate(query);
+if (validation.IsValid)
+{
+    var results = await queryService.QueryAsync(query);
+}
+```

--- a/specs/008-typed-query-authoring/research.md
+++ b/specs/008-typed-query-authoring/research.md
@@ -1,0 +1,57 @@
+# Research: Typed Query Authoring Ergonomics
+
+## Decision 1: Extend the existing `TypedQuery` helper surface
+
+**Decision**: Add typed sort and logical composition helpers to the existing `TypedQuery` area instead of creating a new query builder framework.
+
+**Rationale**: The current helper already owns typed aspect member selection and convention/override mapping. Extending it keeps the feature discoverable and avoids a second authoring style.
+
+**Alternatives considered**:
+
+- Add a new fluent `ResourceQueryBuilder`. Rejected for this slice because sort and logical helpers can solve the immediate friction with less surface area.
+- Add extension methods directly on `ResourceQuery`. Rejected because it would encourage a mutable-builder feel over immutable record construction.
+- Use LINQ-style expression predicates. Rejected because it drifts toward an `IQueryable` provider and arbitrary expression translation.
+
+## Decision 2: Typed facet sort helpers emit `SortExpression`
+
+**Decision**: A typed facet selection should be able to produce ascending and descending `SortExpression` values using the same aspect key and facet identifier resolution rules as typed facet filters.
+
+**Rationale**: Facet sorting is now a first-class portable query shape for the built-in providers. Reusing typed facet selection keeps filter and sort authoring consistent.
+
+**Alternatives considered**:
+
+- Sort only through a full `ResourceQuery` builder. Rejected because callers often compose queries manually and should be able to use the smaller part.
+- Add typed metadata sort helpers. Rejected for now because metadata fields are not typed aspect members and need a separate design.
+
+## Decision 3: Logical helpers stay small and validate obvious invalid shapes
+
+**Decision**: Add helpers for `And`, `Or`, and `Not` that return `LogicalExpression` and reject empty operand sets or invalid `Not` usage before provider validation.
+
+**Rationale**: The AST already supports logical expressions, but manual construction is noisy and `Not` is easy to shape incorrectly. These helpers improve authoring without changing provider semantics.
+
+**Alternatives considered**:
+
+- Let provider validation catch all invalid logical shapes. Rejected because helper-level argument validation gives faster and clearer feedback.
+- Add a rich boolean DSL with operator overloads. Rejected as clever and unnecessary for current requirements.
+
+## Decision 4: Preserve manual construction and provider validation
+
+**Decision**: Helpers are additive. Existing manual `ResourceQuery`, `FilterExpression`, and `SortExpression` construction remains supported, and helper-generated output flows through the same validator and provider execution paths.
+
+**Rationale**: Provider authors should not need to learn a new query pipeline, and advanced users still need direct AST construction.
+
+**Alternatives considered**:
+
+- Make helpers the preferred internal representation. Rejected because the AST is already the provider contract.
+- Add provider-specific helper behavior. Rejected because it would fragment query authoring.
+
+## Decision 5: No new dependencies or runtime mapping
+
+**Decision**: Implement the feature with the existing expression member selection logic and explicit per-query overrides. Do not add runtime scanning, global mapping registration, or external expression libraries.
+
+**Rationale**: The current convention plus override model covers the target scenarios. Runtime scanning would obscure behavior and add operational/debugging complexity.
+
+**Alternatives considered**:
+
+- Global typed aspect mapping registry. Deferred until schema metadata and index projection needs prove it out.
+- Attribute-based facet mapping. Deferred because it couples query authoring to annotation conventions and does not address named aspect overrides alone.

--- a/specs/008-typed-query-authoring/spec.md
+++ b/specs/008-typed-query-authoring/spec.md
@@ -76,7 +76,7 @@ As a provider author, I want typed authoring helpers to emit the existing portab
 - **FR-002**: Typed sort helpers MUST use the same aspect key and facet identifier resolution rules as existing typed facet filter helpers.
 - **FR-003**: Typed sort helpers MUST support per-query aspect key and facet identifier overrides.
 - **FR-004**: The SDK SHOULD provide simple logical composition helpers for `And`, `Or`, and `Not` over existing `FilterExpression` values.
-- **FR-005**: Logical composition helpers MUST reject empty operand sets and MUST reject invalid `Not` operand counts.
+- **FR-005**: Logical composition helpers MUST reject empty `And`/`Or` operand sets, and `Not` MUST accept exactly one operand in its public API.
 - **FR-006**: Helper-generated filters and sorts MUST validate and execute like equivalent manually constructed query AST values.
 - **FR-007**: The feature MUST NOT introduce a LINQ provider, public `IQueryable<Resource>`, runtime scanning, provider registry, automatic discovery, raw SQL API, or query planner.
 - **FR-008**: Existing manual `ResourceQuery`, `FilterExpression`, and `SortExpression` construction MUST remain supported.

--- a/specs/008-typed-query-authoring/spec.md
+++ b/specs/008-typed-query-authoring/spec.md
@@ -1,0 +1,106 @@
+# Feature Specification: Typed Query Authoring Ergonomics
+
+**Feature Branch**: `008-typed-query-authoring`  
+**Created**: 2026-05-17  
+**Status**: Draft  
+**Input**: User description: "Add typed query authoring ergonomics so callers can build facet sorts and simple logical filters from typed aspect members without stringly typed SortExpression and LogicalExpression construction, while preserving the existing ResourceQuery AST and avoiding LINQ/IQueryable."
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Build Typed Facet Sorts (Priority: P1)
+
+As an SDK user, I want to build facet sort expressions from typed aspect members so I do not need to repeat aspect keys and facet identifiers as raw strings when sorting query results.
+
+**Why this priority**: Facet sorting is now supported by both in-memory and SQLite JSON providers, but callers still need manual `SortExpression` construction for typed aspects.
+
+**Independent Test**: Can be tested by creating a typed sort from an aspect member and asserting that it produces the same portable sort AST as the equivalent manual expression.
+
+**Acceptance Scenarios**:
+
+1. **Given** a typed aspect with a readable member, **When** a caller builds an ascending sort for that member, **Then** the result is a `SortExpression` with the resolved aspect key, facet identifier, and ascending direction.
+2. **Given** a typed aspect with a readable member, **When** a caller builds a descending sort for that member, **Then** the result is a `SortExpression` with descending direction and the same convention-based identifiers.
+3. **Given** a caller supplies an aspect key or facet identifier override, **When** a typed sort is created, **Then** the override is reflected in the resulting `SortExpression`.
+
+---
+
+### User Story 2 - Compose Common Logical Filters (Priority: P2)
+
+As an SDK user, I want small typed-query helpers for common logical combinations so I can compose filters without manually constructing `LogicalExpression` records for simple `And`, `Or`, and `Not` cases.
+
+**Why this priority**: Logical filters are already part of the public AST, but authoring them directly is noisy and easy to make invalid for `Not`.
+
+**Independent Test**: Can be tested by composing existing typed or manual filters and asserting the resulting AST is equivalent to manual construction.
+
+**Acceptance Scenarios**:
+
+1. **Given** two or more filter expressions, **When** a caller composes them with `And`, **Then** the result is a logical `And` expression preserving operand order.
+2. **Given** two or more filter expressions, **When** a caller composes them with `Or`, **Then** the result is a logical `Or` expression preserving operand order.
+3. **Given** one filter expression, **When** a caller wraps it with `Not`, **Then** the result is a logical `Not` expression with exactly one operand.
+
+---
+
+### User Story 3 - Keep The Query AST Explicit (Priority: P3)
+
+As a provider author, I want typed authoring helpers to emit the existing portable query records so provider validation, conformance tests, and execution behavior continue to work unchanged.
+
+**Why this priority**: The helpers should reduce call-site friction without introducing a new query pipeline or provider-facing abstraction.
+
+**Independent Test**: Can be tested by validating and executing helper-generated queries against existing providers and by asserting no public `IQueryable<Resource>` surface is introduced.
+
+**Acceptance Scenarios**:
+
+1. **Given** a helper-generated filter or sort, **When** it is passed to the existing validator, **Then** validation behaves the same as it does for the equivalent manually constructed AST.
+2. **Given** a helper-generated query, **When** it executes against a provider that supports the equivalent manual query, **Then** execution returns the same results.
+3. **Given** the public SDK surface, **When** abstractions are inspected, **Then** no public `IQueryable<Resource>` provider is exposed.
+
+### Edge Cases
+
+- Non-member selector expressions MUST fail with the same clear selector error used by existing typed facet filters.
+- Static members, nested member access, method calls, and computed expressions MUST NOT be accepted as typed facet selectors.
+- Empty logical compositions MUST fail clearly rather than producing provider-specific invalid queries.
+- `Not` MUST require exactly one filter operand.
+- Helpers MUST preserve manual construction as a supported advanced path.
+
+### Constitution Alignment *(mandatory)*
+
+- **Simplicity**: The feature SHOULD add small helper methods over existing records, not a new query framework.
+- **Explicitness**: Helper output MUST be ordinary `ResourceQuery`, `FilterExpression`, and `SortExpression` values that callers and provider authors can inspect.
+- **Dependencies**: No new dependencies.
+- **Operational Impact**: No storage, deployment, migration, or provider configuration changes.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The SDK MUST allow callers to create ascending and descending facet `SortExpression` values from typed aspect member selectors.
+- **FR-002**: Typed sort helpers MUST use the same aspect key and facet identifier resolution rules as existing typed facet filter helpers.
+- **FR-003**: Typed sort helpers MUST support per-query aspect key and facet identifier overrides.
+- **FR-004**: The SDK SHOULD provide simple logical composition helpers for `And`, `Or`, and `Not` over existing `FilterExpression` values.
+- **FR-005**: Logical composition helpers MUST reject empty operand sets and MUST reject invalid `Not` operand counts.
+- **FR-006**: Helper-generated filters and sorts MUST validate and execute like equivalent manually constructed query AST values.
+- **FR-007**: The feature MUST NOT introduce a LINQ provider, public `IQueryable<Resource>`, runtime scanning, provider registry, automatic discovery, raw SQL API, or query planner.
+- **FR-008**: Existing manual `ResourceQuery`, `FilterExpression`, and `SortExpression` construction MUST remain supported.
+- **FR-009**: Documentation MUST show typed facet filtering, typed facet sorting, and logical composition examples.
+
+### Key Entities *(include if feature involves data)*
+
+- **Typed facet selector**: A readable member expression used to resolve a facet identifier from a typed aspect.
+- **Typed facet sort helper**: A helper that turns a typed facet selector into a `SortExpression`.
+- **Logical composition helper**: A helper that turns one or more existing filters into a `LogicalExpression`.
+- **Portable query AST**: The existing records consumed by validation and providers.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Callers can build typed ascending and descending facet sorts without writing an aspect key or facet identifier string in the convention-based case.
+- **SC-002**: Existing typed query helper tests cover filter helpers, sort helpers, selector rejection, overrides, and logical composition.
+- **SC-003**: Helper-generated queries pass existing provider validation and execute successfully against at least one supported provider.
+- **SC-004**: Public abstraction inspection confirms no public `IQueryable<Resource>` query provider is introduced.
+- **SC-005**: Full solution tests pass after the helper additions.
+
+## Assumptions
+
+- The helper surface remains in the core SDK near the existing `TypedQuery` helpers.
+- The feature is an authoring convenience only; provider semantics and capabilities remain unchanged.
+- Typed sort helpers target facet sorting, not metadata sorting.

--- a/specs/008-typed-query-authoring/tasks.md
+++ b/specs/008-typed-query-authoring/tasks.md
@@ -1,0 +1,21 @@
+# Tasks: Typed Query Authoring Ergonomics
+
+**Input**: Design documents from `specs/008-typed-query-authoring/`
+
+## Implementation
+
+- [X] T001 Add typed facet sort helpers to `TypedFacetQuery<TValue>`.
+- [X] T002 Add logical composition helpers to `TypedQuery`.
+- [X] T003 Add argument validation for empty logical operands and invalid `Not` operands.
+- [X] T004 Extend typed query helper tests for ascending/descending facet sorts.
+- [X] T005 Extend typed query helper tests for overrides and selector rejection on sort helpers.
+- [X] T006 Extend typed query helper tests for `And`, `Or`, and `Not` composition.
+- [X] T007 Add validation/execution coverage for helper-generated filters and sorts against existing providers.
+- [X] T008 Update core README and querying wiki examples.
+
+## Verification
+
+- [X] T009 Run focused typed query tests.
+- [X] T010 Run `dotnet test Aster.sln`.
+- [X] T011 Run `dotnet build Aster.sln`.
+- [X] T012 Run `git diff --check`.

--- a/specs/008-typed-query-authoring/tasks.md
+++ b/specs/008-typed-query-authoring/tasks.md
@@ -6,7 +6,7 @@
 
 - [X] T001 Add typed facet sort helpers to `TypedFacetQuery<TValue>`.
 - [X] T002 Add logical composition helpers to `TypedQuery`.
-- [X] T003 Add argument validation for empty logical operands and invalid `Not` operands.
+- [X] T003 Add argument validation for empty logical operands and a single-operand `Not` API.
 - [X] T004 Extend typed query helper tests for ascending/descending facet sorts.
 - [X] T005 Extend typed query helper tests for overrides and selector rejection on sort helpers.
 - [X] T006 Extend typed query helper tests for `And`, `Or`, and `Not` composition.

--- a/src/core/Aster.Core/Extensions/TypedQuery.cs
+++ b/src/core/Aster.Core/Extensions/TypedQuery.cs
@@ -58,14 +58,13 @@ public static class TypedQuery
     /// <summary>
     /// Negates a single filter expression.
     /// </summary>
-    /// <param name="operands">The single filter expression to negate.</param>
+    /// <param name="operand">The filter expression to negate.</param>
     /// <returns>A logical NOT expression.</returns>
-    public static FilterExpression Not(params FilterExpression[] operands)
+    public static FilterExpression Not(FilterExpression operand)
     {
-        if (operands.Length != 1)
-            throw new ArgumentException("Typed query Not composition requires exactly one operand.", nameof(operands));
+        ArgumentNullException.ThrowIfNull(operand);
 
-        return Logical(LogicalOperator.Not, operands);
+        return new LogicalExpression(LogicalOperator.Not, [operand]);
     }
 
     internal static string ResolveAspectKey<TAspect>(string? aspectKey) =>

--- a/src/core/Aster.Core/Extensions/TypedQuery.cs
+++ b/src/core/Aster.Core/Extensions/TypedQuery.cs
@@ -39,6 +39,35 @@ public static class TypedQuery
         return new(ResolveAspectKey<TAspect>(options.AspectKey), options.FacetIdentifier);
     }
 
+    /// <summary>
+    /// Combines filter expressions with a logical AND.
+    /// </summary>
+    /// <param name="operands">The filter expressions to combine.</param>
+    /// <returns>A logical AND expression.</returns>
+    public static FilterExpression And(params FilterExpression[] operands) =>
+        Logical(LogicalOperator.And, operands);
+
+    /// <summary>
+    /// Combines filter expressions with a logical OR.
+    /// </summary>
+    /// <param name="operands">The filter expressions to combine.</param>
+    /// <returns>A logical OR expression.</returns>
+    public static FilterExpression Or(params FilterExpression[] operands) =>
+        Logical(LogicalOperator.Or, operands);
+
+    /// <summary>
+    /// Negates a single filter expression.
+    /// </summary>
+    /// <param name="operands">The single filter expression to negate.</param>
+    /// <returns>A logical NOT expression.</returns>
+    public static FilterExpression Not(params FilterExpression[] operands)
+    {
+        if (operands.Length != 1)
+            throw new ArgumentException("Typed query Not composition requires exactly one operand.", nameof(operands));
+
+        return Logical(LogicalOperator.Not, operands);
+    }
+
     internal static string ResolveAspectKey<TAspect>(string? aspectKey) =>
         NonEmpty(aspectKey) ?? typeof(TAspect).Name;
 
@@ -71,6 +100,19 @@ public static class TypedQuery
             ?? memberName;
 
         return resolved;
+    }
+
+    private static FilterExpression Logical(LogicalOperator logicalOperator, IReadOnlyList<FilterExpression> operands)
+    {
+        ArgumentNullException.ThrowIfNull(operands);
+
+        if (operands.Count == 0)
+            throw new ArgumentException("Typed query logical composition requires at least one operand.", nameof(operands));
+
+        if (operands.Any(operand => operand is null))
+            throw new ArgumentException("Typed query logical composition does not accept null operands.", nameof(operands));
+
+        return new LogicalExpression(logicalOperator, operands);
     }
 
     private static string? NonEmpty(string? value) =>
@@ -176,4 +218,26 @@ public sealed class TypedFacetQuery<TValue>
             facetIdentifier,
             new RangeValue(min, max, includeMin, includeMax),
             ComparisonOperator.Range);
+
+    /// <summary>
+    /// Creates an ascending facet sort.
+    /// </summary>
+    /// <returns>A portable facet sort expression.</returns>
+    public SortExpression Ascending() =>
+        Sort(SortDirection.Ascending);
+
+    /// <summary>
+    /// Creates a descending facet sort.
+    /// </summary>
+    /// <returns>A portable facet sort expression.</returns>
+    public SortExpression Descending() =>
+        Sort(SortDirection.Descending);
+
+    /// <summary>
+    /// Creates a facet sort with the specified direction.
+    /// </summary>
+    /// <param name="direction">The sort direction.</param>
+    /// <returns>A portable facet sort expression.</returns>
+    public SortExpression Sort(SortDirection direction) =>
+        new(facetIdentifier, direction, aspectKey);
 }

--- a/src/core/Aster.Core/README.md
+++ b/src/core/Aster.Core/README.md
@@ -153,12 +153,27 @@ services
 
 The helper registers the provider concrete types and shared query/provider interfaces as singletons, keeping the active query service, provider identity, and capability declaration together without introducing provider discovery or a registry. Hosts that need different lifetimes can still use explicit manual DI registration.
 
-Or build common typed aspect filters without repeating convention-based identifiers:
+Or build common typed aspect filters and sorts without repeating convention-based identifiers:
 
 ```csharp
-var filter = TypedQuery.For<TitleAspect>()
+var title = TypedQuery.For<TitleAspect>()
     .Facet(x => x.Title)
     .Contains("Gadget");
+
+var price = TypedQuery.For<PriceAspect>()
+    .Facet(x => x.Amount)
+    .Range(max: 100m);
+
+var query = new ResourceQuery
+{
+    Filter = TypedQuery.And(title, price),
+    Sorts =
+    [
+        TypedQuery.For<PriceAspect>()
+            .Facet(x => x.Amount)
+            .Descending(),
+    ],
+};
 ```
 
 ---

--- a/test/Aster.Tests/Querying/TypedQueryHelperTests.cs
+++ b/test/Aster.Tests/Querying/TypedQueryHelperTests.cs
@@ -184,6 +184,7 @@ public sealed class TypedQueryHelperTests
         Assert.Throws<ArgumentException>(() => TypedQuery.Or());
         Assert.Throws<ArgumentNullException>(() => TypedQuery.Not(null!));
         Assert.Throws<ArgumentException>(() => TypedQuery.And([null!]));
+        Assert.Throws<ArgumentException>(() => TypedQuery.Or([null!]));
     }
 
     [Fact]

--- a/test/Aster.Tests/Querying/TypedQueryHelperTests.cs
+++ b/test/Aster.Tests/Querying/TypedQueryHelperTests.cs
@@ -65,6 +65,30 @@ public sealed class TypedQueryHelperTests
     }
 
     [Fact]
+    public void SortHelpers_UseAspectAndMemberNamesByConvention()
+    {
+        var ascending = TypedQuery.For<TitleAspect>()
+            .Facet(aspect => aspect.Title)
+            .Ascending();
+        var descending = TypedQuery.For<PriceAspect>()
+            .Facet(aspect => aspect.Amount)
+            .Descending();
+
+        Assert.Equal(new SortExpression("Title", SortDirection.Ascending, "TitleAspect"), ascending);
+        Assert.Equal(new SortExpression("Amount", SortDirection.Descending, "PriceAspect"), descending);
+    }
+
+    [Fact]
+    public void SortHelpers_UsePerQueryOverrides()
+    {
+        var sort = TypedQuery.For<PriceAspect>(aspectKey: "PriceAspect:Sale")
+            .Facet(aspect => aspect.Amount, facetIdentifier: "sale_amount")
+            .Descending();
+
+        Assert.Equal(new SortExpression("sale_amount", SortDirection.Descending, "PriceAspect:Sale"), sort);
+    }
+
+    [Fact]
     public void FacetHelpers_UseOptionsOverrides()
     {
         var options = new TypedQueryOptions(
@@ -98,6 +122,16 @@ public sealed class TypedQueryHelperTests
     }
 
     [Fact]
+    public void Sort_WithOverrideStillValidatesSelector()
+    {
+        var exception = Assert.Throws<ArgumentException>(() => TypedQuery.For<TitleAspect>()
+            .Facet(aspect => aspect.Title.ToUpperInvariant(), facetIdentifier: "Title")
+            .Ascending());
+
+        Assert.Contains("single readable member", exception.Message);
+    }
+
+    [Fact]
     public void Facet_WithNonDirectMemberSelector_FailsClearly()
     {
         Assert.Throws<ArgumentException>(() => TypedQuery.For<NestedAspect>()
@@ -123,6 +157,36 @@ public sealed class TypedQueryHelperTests
         });
 
         Assert.True(result.IsValid);
+    }
+
+    [Fact]
+    public void LogicalHelpers_CreateLogicalExpressions()
+    {
+        var title = TypedQuery.For<TitleAspect>().Facet(aspect => aspect.Title).Contains("Gadget");
+        var price = TypedQuery.For<PriceAspect>().Facet(aspect => aspect.Amount).Range(max: 100m);
+
+        var and = Assert.IsType<LogicalExpression>(TypedQuery.And(title, price));
+        var or = Assert.IsType<LogicalExpression>(TypedQuery.Or(title, price));
+        var not = Assert.IsType<LogicalExpression>(TypedQuery.Not(title));
+
+        Assert.Equal(LogicalOperator.And, and.Operator);
+        Assert.Equal([title, price], and.Operands);
+        Assert.Equal(LogicalOperator.Or, or.Operator);
+        Assert.Equal([title, price], or.Operands);
+        Assert.Equal(LogicalOperator.Not, not.Operator);
+        Assert.Equal([title], not.Operands);
+    }
+
+    [Fact]
+    public void LogicalHelpers_RejectInvalidOperandSets()
+    {
+        Assert.Throws<ArgumentException>(() => TypedQuery.And());
+        Assert.Throws<ArgumentException>(() => TypedQuery.Or());
+        Assert.Throws<ArgumentException>(() => TypedQuery.Not());
+        Assert.Throws<ArgumentException>(() => TypedQuery.Not(
+            TypedQuery.For<TitleAspect>().Facet(aspect => aspect.Title).Contains("Gadget"),
+            TypedQuery.For<PriceAspect>().Facet(aspect => aspect.Amount).Range(max: 100m)));
+        Assert.Throws<ArgumentException>(() => TypedQuery.And([null!]));
     }
 
     [Fact]
@@ -152,6 +216,41 @@ public sealed class TypedQueryHelperTests
 
         Assert.Single(results);
         Assert.Equal("Product", results[0].DefinitionId);
+    }
+
+    [Fact]
+    public async Task TypedSortGeneratedQuery_ExecutesAgainstSupportedProvider()
+    {
+        using var provider = new ServiceCollection()
+            .AddAsterCore()
+            .BuildServiceProvider();
+        var manager = provider.GetRequiredService<IResourceManager>();
+        var query = provider.GetRequiredService<IResourceQueryService>();
+        var binder = provider.GetRequiredService<ITypedAspectBinder>();
+
+        await manager.CreateAsync("Product", new CreateResourceRequest
+        {
+            InitialAspects = new() { ["TitleAspect"] = new TitleAspect("Bravo") },
+        });
+        await manager.CreateAsync("Product", new CreateResourceRequest
+        {
+            InitialAspects = new() { ["TitleAspect"] = new TitleAspect("Alpha") },
+        });
+
+        var results = (await query.QueryAsync(new ResourceQuery
+        {
+            Filter = TypedQuery.HasAspect<TitleAspect>(),
+            Sorts =
+            [
+                TypedQuery.For<TitleAspect>()
+                    .Facet(aspect => aspect.Title)
+                    .Ascending(),
+            ],
+        })).ToList();
+
+        Assert.Equal(["Alpha", "Bravo"], results
+            .Select(resource => resource.GetAspect<TitleAspect>("TitleAspect", binder)!.Title)
+            .ToList());
     }
 
     [Fact]

--- a/test/Aster.Tests/Querying/TypedQueryHelperTests.cs
+++ b/test/Aster.Tests/Querying/TypedQueryHelperTests.cs
@@ -182,10 +182,7 @@ public sealed class TypedQueryHelperTests
     {
         Assert.Throws<ArgumentException>(() => TypedQuery.And());
         Assert.Throws<ArgumentException>(() => TypedQuery.Or());
-        Assert.Throws<ArgumentException>(() => TypedQuery.Not());
-        Assert.Throws<ArgumentException>(() => TypedQuery.Not(
-            TypedQuery.For<TitleAspect>().Facet(aspect => aspect.Title).Contains("Gadget"),
-            TypedQuery.For<PriceAspect>().Facet(aspect => aspect.Amount).Range(max: 100m)));
+        Assert.Throws<ArgumentNullException>(() => TypedQuery.Not(null!));
         Assert.Throws<ArgumentException>(() => TypedQuery.And([null!]));
     }
 

--- a/wiki/Querying.md
+++ b/wiki/Querying.md
@@ -188,14 +188,17 @@ Typed helpers reduce repeated aspect/facet strings while still producing the sam
 public sealed record TitleAspect(string Title);
 public sealed record PriceAspect(decimal Amount);
 
-var filter = new LogicalExpression(LogicalOperator.And, [
+var filter = TypedQuery.And(
     TypedQuery.For<TitleAspect>()
         .Facet(x => x.Title)
         .Contains("Gadget"),
     TypedQuery.For<PriceAspect>()
         .Facet(x => x.Amount)
-        .Range(min: 10m, max: 100m),
-]);
+        .Range(min: 10m, max: 100m));
+
+var sort = TypedQuery.For<PriceAspect>()
+    .Facet(x => x.Amount)
+    .Descending();
 ```
 
 By default, the aspect key is the CLR type name and the facet identifier is the selected member name. Override either value per query when targeting named aspects or non-conventional identifiers:
@@ -207,6 +210,8 @@ var filter = TypedQuery.For<PriceAspect>(aspectKey: "PriceAspect:Sale")
 ```
 
 The generated `AspectPresenceFilter` or `FacetValueFilter` remains inspectable before validation or execution.
+
+Typed sort helpers generate ordinary `SortExpression` values, and logical helpers generate ordinary `LogicalExpression` values. Manual AST construction remains fully supported.
 
 ---
 

--- a/wiki/Roadmap.md
+++ b/wiki/Roadmap.md
@@ -2,7 +2,9 @@
 
 Aster is delivered in six phases. Each phase builds on the last, with clean extension points so earlier work is not thrown away.
 
-> **Current status:** Phase 3 in progress — Core SDK, in-memory engine, SQLite JSON persistence/querying, query capability discovery, preflight validation, and typed query helpers are available.
+> **Current status:** Phase 3 in progress — Core SDK, in-memory engine, SQLite JSON persistence/querying, query capability discovery, preflight validation, typed query helpers, provider authoring/conformance support, and SQLite facet sorting are available.
+>
+> For the current implementation trail and next Spec Kit slices, see [`docs/ExecutionRoadmap.md`](../docs/ExecutionRoadmap.md).
 
 ---
 
@@ -16,6 +18,16 @@ Aster is delivered in six phases. Each phase builds on the last, with clean exte
 | **4** | Portability & Integration Hooks | Planned |
 | **5** | Multi-tenancy, Policies, Advanced Versioning | Planned |
 | **6** | Operational Hardening | Planned |
+
+## Immediate Next Slices
+
+| Slice | Status | Purpose |
+|---|---|---|
+| **008 Typed Query Authoring Ergonomics** | Next | Add typed sort helpers and small composition conveniences over the existing `ResourceQuery` AST. |
+| **009 Portable Operator Expansion** | Planned | Add operators such as `NotEquals`, `In`, `StartsWith`, and facet value presence with provider capabilities and conformance coverage. |
+| **010 SQLite Date-Like Facet Ranges** | Planned | Close the remaining SQLite date-like range capability gap with explicit serialization rules. |
+| **011 Explicit Indexing Model** | Planned | Introduce intentional index projection contracts without a hidden planner or runtime scanning. |
+| **012 Definition Schema Versions & Upgrade Flow** | Planned | Make long-lived resource schema versioning and upgrade behavior explicit. |
 
 ---
 

--- a/wiki/Roadmap.md
+++ b/wiki/Roadmap.md
@@ -2,7 +2,7 @@
 
 Aster is delivered in six phases. Each phase builds on the last, with clean extension points so earlier work is not thrown away.
 
-> **Current status:** Phase 3 in progress — Core SDK, in-memory engine, SQLite JSON persistence/querying, query capability discovery, preflight validation, typed query helpers, provider authoring/conformance support, and SQLite facet sorting are available.
+> **Current status:** Phase 3 in progress — Core SDK, in-memory engine, SQLite JSON persistence/querying, query capability discovery, preflight validation, typed query authoring helpers, provider authoring/conformance support, and SQLite facet sorting are available.
 >
 > For the current implementation trail and next Spec Kit slices, see [`docs/ExecutionRoadmap.md`](../docs/ExecutionRoadmap.md).
 
@@ -23,8 +23,8 @@ Aster is delivered in six phases. Each phase builds on the last, with clean exte
 
 | Slice | Status | Purpose |
 |---|---|---|
-| **008 Typed Query Authoring Ergonomics** | Next | Add typed sort helpers and small composition conveniences over the existing `ResourceQuery` AST. |
-| **009 Portable Operator Expansion** | Planned | Add operators such as `NotEquals`, `In`, `StartsWith`, and facet value presence with provider capabilities and conformance coverage. |
+| **008 Typed Query Authoring Ergonomics** | Landed | Add typed sort helpers and small composition conveniences over the existing `ResourceQuery` AST. |
+| **009 Portable Operator Expansion** | Next | Add operators such as `NotEquals`, `In`, `StartsWith`, and facet value presence with provider capabilities and conformance coverage. |
 | **010 SQLite Date-Like Facet Ranges** | Planned | Close the remaining SQLite date-like range capability gap with explicit serialization rules. |
 | **011 Explicit Indexing Model** | Planned | Introduce intentional index projection contracts without a hidden planner or runtime scanning. |
 | **012 Definition Schema Versions & Upgrade Flow** | Planned | Make long-lived resource schema versioning and upgrade behavior explicit. |


### PR DESCRIPTION
## Summary
- Add an execution roadmap artifact and update the wiki roadmap with the next planned slices.
- Add Spec Kit artifacts for typed query authoring ergonomics.
- Extend TypedQuery with typed facet sort helpers and logical composition helpers over the existing query AST.
- Update README/wiki examples and typed query helper tests.

## Validation
- dotnet test test/Aster.Tests/Aster.Tests.csproj --filter "FullyQualifiedName~TypedQueryHelperTests"
- dotnet test Aster.sln
- dotnet build Aster.sln
- git diff --check