### PR TITLE
Add portable query operators

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "featureDir": "specs/008-typed-query-authoring"
+  "featureDir": "specs/009-portable-operators"
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,3 +2,10 @@
 For additional context about technologies to be used, project structure,
 shell commands, and other important information, read the current plan
 <!-- SPECKIT END -->
+
+## Active Technologies
+- C# latest, .NET 8.0 / 9.0 / 10.0 multi-targeting + Existing core SDK, SQLite JSON provider, xUnit test stack; no new dependencies (009-portable-operators)
+- Existing resource payloads; no migration (009-portable-operators)
+
+## Recent Changes
+- 009-portable-operators: Added C# latest, .NET 8.0 / 9.0 / 10.0 multi-targeting + Existing core SDK, SQLite JSON provider, xUnit test stack; no new dependencies

--- a/docs/ExecutionRoadmap.md
+++ b/docs/ExecutionRoadmap.md
@@ -1,6 +1,6 @@
 # Aster Execution Roadmap
 
-Last updated: 2026-05-17
+Last updated: 2026-05-18
 
 This roadmap tracks the implementation trail we have already cut through the repo and the next product slices that should stay small enough for Spec Kit-driven PRs. It is intentionally execution-oriented; the broader architecture narrative remains in `docs/Roadmap.md` and the wiki.
 
@@ -22,25 +22,9 @@ The active workstream is **Phase 3: Query Capabilities & Typed Querying**. The n
 | `006-provider-conformance-tests` | Landed | Reusable conformance tests that compare declared capabilities with validation and execution behavior. |
 | `007-sqlite-facet-sorting` | Landed | SQLite facet sorting, null-last behavior, numeric/text ordering, capability updates, and tests/docs. |
 | `008-typed-query-authoring` | Landed | Typed facet sort helpers, small logical composition helpers, and updated roadmap/query docs over the existing query AST. |
+| `009-portable-operators` | Landed | Portable `NotEquals`, `In`, `StartsWith`, and facet `Exists` operators with provider capabilities, validation, built-in execution, typed helpers, and conformance coverage. |
 
 ## Near-Term Roadmap
-
-### 009 — Portable Operator Expansion
-
-**Goal:** Expand the portable query AST beyond `Equals`, `Contains`, and `Range` while preserving provider capability declarations.
-
-Candidate operators:
-
-- `NotEquals`
-- `In`
-- `StartsWith`
-- `Exists` for facet value presence, distinct from aspect presence
-
-Provider work:
-
-- In-memory support for all new operators.
-- SQLite support for the operators that can be translated simply and explicitly.
-- Capability and conformance updates for each operator.
 
 ### 010 — SQLite Date-Like Facet Ranges
 

--- a/specs/009-portable-operators/checklists/requirements.md
+++ b/specs/009-portable-operators/checklists/requirements.md
@@ -1,0 +1,34 @@
+# Specification Quality Checklist: Portable Operator Expansion
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning  
+**Created**: 2026-05-18  
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [X] No implementation details (languages, frameworks, APIs)
+- [X] Focused on user value and business needs
+- [X] Written for non-technical stakeholders
+- [X] All mandatory sections completed
+
+## Requirement Completeness
+
+- [X] No [NEEDS CLARIFICATION] markers remain
+- [X] Requirements are testable and unambiguous
+- [X] Success criteria are measurable
+- [X] Success criteria are technology-agnostic (no implementation details)
+- [X] All acceptance scenarios are defined
+- [X] Edge cases are identified
+- [X] Scope is clearly bounded
+- [X] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [X] All functional requirements have clear acceptance criteria
+- [X] User scenarios cover primary flows
+- [X] Feature meets measurable outcomes defined in Success Criteria
+- [X] No implementation details leak into specification
+
+## Notes
+
+- Ready for planning and implementation.

--- a/specs/009-portable-operators/contracts/portable-operators.md
+++ b/specs/009-portable-operators/contracts/portable-operators.md
@@ -1,0 +1,45 @@
+# Contract: Portable Query Operators
+
+## Public Comparison Operators
+
+The portable query model MUST expose these additional comparison operators:
+
+- `NotEquals`: matches when the compared value is not equal under provider text/value semantics.
+- `In`: matches when the compared value equals any candidate in a non-empty candidate set.
+- `StartsWith`: matches when the compared text starts with the supplied prefix using existing case-insensitive text semantics.
+- `Exists`: matches when a facet value is present and non-null. Providers SHOULD support this for `FacetValueFilter`; metadata support is not required.
+
+## Validation Contract
+
+Providers MUST declare supported operators in `ResourceQueryCapabilities` for metadata and facet filters independently.
+
+Validation MUST:
+
+- Reject operators that the active provider does not declare for the filter category.
+- Reject `In` values that are null, non-enumerable, strings, or empty enumerables.
+- Preserve existing structured validation failures for unsupported comparison operators.
+- Treat `Exists` as facet-oriented support unless a provider explicitly declares otherwise.
+
+## Execution Contract
+
+Providers that declare support for an operator MUST execute it consistently with validation:
+
+- `NotEquals` MUST use the inverse of equality semantics.
+- `In` MUST use equality semantics for every candidate value.
+- `StartsWith` MUST use case-insensitive prefix semantics for text values.
+- `Exists` MUST match only when the named facet value is present and non-null.
+
+Providers MUST continue to throw structured unsupported query failures when execution encounters a shape it cannot execute.
+
+## Typed Helper Contract
+
+Typed facet helpers SHOULD provide:
+
+```csharp
+facet.NotEqualTo(value)
+facet.In(values)
+facet.StartsWith(prefix)
+facet.Exists()
+```
+
+The helpers MUST produce the same AST shape as manual `FacetValueFilter` construction with resolved aspect keys and facet identifiers.

--- a/specs/009-portable-operators/data-model.md
+++ b/specs/009-portable-operators/data-model.md
@@ -1,0 +1,35 @@
+# Data Model: Portable Operator Expansion
+
+## Comparison Operator
+
+New values:
+
+- `NotEquals`: inverse exact match.
+- `In`: exact match against any value in a candidate set.
+- `StartsWith`: case-insensitive prefix match.
+- `Exists`: facet presence match.
+
+## Membership Value Set
+
+Used by `In`.
+
+Validation rules:
+
+- MUST be non-null.
+- MUST be enumerable.
+- MUST NOT be a string treated as enumerable characters.
+- MUST contain at least one candidate value.
+
+## Facet Exists Predicate
+
+Modeled as:
+
+```csharp
+new FacetValueFilter(aspectKey, facetIdentifier, true, ComparisonOperator.Exists)
+```
+
+The value is ignored by providers.
+
+## Provider Capability Declaration
+
+Providers list the new operators in `SupportedComparisonOperators` for the filter categories they support.

--- a/specs/009-portable-operators/plan.md
+++ b/specs/009-portable-operators/plan.md
@@ -1,0 +1,67 @@
+# Implementation Plan: Portable Operator Expansion
+
+**Branch**: `009-portable-operators` | **Date**: 2026-05-18 | **Spec**: [spec.md](spec.md)
+
+## Summary
+
+Expand the existing portable query operator set with `NotEquals`, `In`, `StartsWith`, and facet `Exists`. Keep the implementation direct: extend the operator enum, capability declarations, validator checks, in-memory evaluator, SQLite JSON translator, typed facet helpers, docs, and conformance cases.
+
+## Technical Context
+
+**Language/Version**: C# latest, .NET 8.0 / 9.0 / 10.0 multi-targeting  
+**Primary Dependencies**: Existing core SDK, SQLite JSON provider, xUnit test stack; no new dependencies  
+**Storage**: Existing resource payloads; no migration  
+**Testing**: `dotnet test Aster.sln`, `dotnet build Aster.sln`, `git diff --check`  
+**Target Platform**: .NET library usable from Generic Host / ASP.NET Core hosts  
+**Project Type**: SDK/library with provider package  
+**Constraints**: No public `IQueryable<Resource>`, provider-specific SQL API, runtime scanning, automatic discovery, or query planner
+
+## Constitution Check
+
+- **SDK-first/headless**: PASS — Adds SDK query operators only.
+- **Immutable versioning**: PASS — Query-only change.
+- **Channel activation**: PASS — Existing query scopes remain unchanged.
+- **Typed/queryable**: PASS — Extends the portable AST and typed helpers; no `IQueryable`.
+- **Provider agnostic**: PASS — Core operator model remains provider-neutral; providers declare support explicitly.
+- **Simplicity first**: PASS — Direct enum/capability/translator/evaluator changes.
+- **Modern C# idioms**: PASS — Existing records, collection expressions, and pattern matching are sufficient.
+- **Readability over cleverness**: PASS — No expression translator or planner.
+- **Explicitness over magic**: PASS — Capabilities and validation expose support directly.
+- **Abstractions justified**: PASS — No new abstraction layer.
+- **Optimize for deletion**: PASS — Operators are additive and localized.
+- **Composition over inheritance**: PASS — No inheritance hierarchy.
+- **Intentional dependencies**: PASS — No new dependencies.
+- **Operational simplicity**: PASS — No infrastructure or migration changes.
+
+## Project Structure
+
+```text
+src/core/Aster.Core/
+├── Extensions/TypedQuery.cs
+├── InMemory/InMemoryQueryCapabilitiesProvider.cs
+├── InMemory/InMemoryQueryService.cs
+├── Models/Querying/ComparisonOperator.cs
+├── README.md
+└── Services/ResourceQueryValidator.cs
+
+src/persistence/Aster.Persistence.SqliteJson/
+├── Querying/SqliteTextBehavior.cs
+├── Querying/SqliteWhereTranslator.cs
+├── README.md
+└── SqliteJsonQueryCapabilitiesProvider.cs
+
+test/Aster.Tests/
+├── InMemory/InMemoryQueryCapabilityTests.cs
+├── Querying/ProviderConformanceTests.cs
+├── Querying/ResourceQueryValidatorTests.cs
+├── Querying/TypedQueryHelperTests.cs
+└── SqliteJson/SqliteJsonQueryCapabilityTests.cs
+```
+
+## Validation
+
+- Focused query/operator tests
+- Provider conformance tests
+- `dotnet test Aster.sln`
+- `dotnet build Aster.sln`
+- `git diff --check`

--- a/specs/009-portable-operators/quickstart.md
+++ b/specs/009-portable-operators/quickstart.md
@@ -1,0 +1,35 @@
+# Quickstart: Portable Operator Expansion
+
+## Manual Queries
+
+```csharp
+var query = new ResourceQuery
+{
+    DefinitionId = "Product",
+    Filter = TypedQuery.And(
+        new MetadataFilter("Owner", "archived", ComparisonOperator.NotEquals),
+        new FacetValueFilter("Title", "Title", "Pro", ComparisonOperator.StartsWith),
+        new FacetValueFilter("Status", "Code", new[] { "Draft", "Ready" }, ComparisonOperator.In),
+        new FacetValueFilter("Price", "Amount", true, ComparisonOperator.Exists)),
+};
+```
+
+## Typed Helpers
+
+```csharp
+var filter = TypedQuery.And(
+    TypedQuery.For<TitleAspect>().Facet(x => x.Title).StartsWith("Pro"),
+    TypedQuery.For<StatusAspect>().Facet(x => x.Code).In(["Draft", "Ready"]),
+    TypedQuery.For<PriceAspect>().Facet(x => x.Amount).Exists());
+```
+
+## Validation
+
+```csharp
+var validation = validator.Validate(query);
+if (!validation.IsValid)
+{
+    foreach (var failure in validation.Failures)
+        Console.WriteLine($"{failure.Code}: {failure.Message}");
+}
+```

--- a/specs/009-portable-operators/research.md
+++ b/specs/009-portable-operators/research.md
@@ -1,0 +1,36 @@
+# Research: Portable Operator Expansion
+
+## Decision 1: Extend `ComparisonOperator`
+
+**Decision**: Add `NotEquals`, `In`, `StartsWith`, and `Exists` to the existing comparison operator enum.
+
+**Rationale**: The current AST already routes metadata and facet comparisons through this enum. Extending it is simpler and more explicit than adding new filter records.
+
+**Alternatives considered**:
+
+- Add a dedicated `FacetExistsFilter`. Rejected for this slice because `FacetValueFilter` already addresses an aspect/facet pair and `Exists` can be represented as an operator.
+- Add provider-specific operators. Rejected because the goal is portable capability-discoverable query shapes.
+
+## Decision 2: Treat `Exists` as facet-only support
+
+**Decision**: Built-in providers support `Exists` for facet filters, not metadata filters.
+
+**Rationale**: Metadata fields already have a known schema; the missing gap is determining whether a facet is present inside an aspect.
+
+## Decision 3: Validate `In` value shape before execution
+
+**Decision**: `In` requires a non-string enumerable with at least one candidate.
+
+**Rationale**: Strings are enumerable but should be treated as scalar values. Empty candidate sets are usually caller mistakes and can be rejected consistently before provider execution.
+
+## Decision 4: Prefix matching follows existing text semantics
+
+**Decision**: `StartsWith` uses case-insensitive text comparison, matching existing `Contains` and `Equals` string behavior.
+
+**Rationale**: Query text semantics should remain unsurprising and provider-neutral.
+
+## Decision 5: SQLite translates only explicit/simple shapes
+
+**Decision**: SQLite JSON supports the new operators using existing metadata columns, JSON facet extraction, and registered text functions.
+
+**Rationale**: The operators can be translated directly without introducing indexes, SQL exposure, or a query planner.

--- a/specs/009-portable-operators/spec.md
+++ b/specs/009-portable-operators/spec.md
@@ -1,0 +1,105 @@
+# Feature Specification: Portable Operator Expansion
+
+**Feature Branch**: `009-portable-operators`  
+**Created**: 2026-05-18  
+**Status**: Draft  
+**Input**: User description: "Add portable query operators NotEquals, In, StartsWith, and facet value Exists with provider capability declarations, validation, in-memory execution, SQLite JSON translation where straightforward, typed helper support, docs, and conformance tests."
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Express Common Portable Predicates (Priority: P1)
+
+As an SDK user, I want to express inequality, membership, prefix matching, and facet presence with the portable query AST so I can avoid provider-specific workarounds for common query shapes.
+
+**Why this priority**: The current operator set covers equality, containment, and ranges but leaves frequent query shapes unmodeled.
+
+**Independent Test**: Can be tested by constructing manual `ResourceQuery` instances with each new operator and asserting validation and execution results against supported providers.
+
+**Acceptance Scenarios**:
+
+1. **Given** resources with different metadata or facet values, **When** a caller uses `NotEquals`, **Then** matching excludes the specified value.
+2. **Given** resources with values from a known set, **When** a caller uses `In`, **Then** matching includes any resource whose value is in the set.
+3. **Given** string metadata or facet values, **When** a caller uses `StartsWith`, **Then** matching uses case-insensitive prefix semantics.
+4. **Given** an aspect exists with or without a specific facet value, **When** a caller uses facet `Exists`, **Then** matching requires the named facet to be present.
+
+---
+
+### User Story 2 - Discover And Validate Operator Support (Priority: P1)
+
+As a host or provider author, I want provider capabilities and validation to describe the new operators so unsupported shapes fail before execution when possible.
+
+**Why this priority**: Existing query capability discovery is the contract between UI/API surfaces, validators, and providers.
+
+**Independent Test**: Can be tested by inspecting capability declarations and validating supported and unsupported queries for built-in providers.
+
+**Acceptance Scenarios**:
+
+1. **Given** a built-in provider, **When** capabilities are inspected, **Then** supported new operators are listed for the appropriate filter categories.
+2. **Given** a query using an unsupported operator for a filter category, **When** validation runs, **Then** it returns a structured unsupported comparison failure.
+3. **Given** a provider declares support for a new operator, **When** conformance tests run, **Then** validation and execution agree.
+
+---
+
+### User Story 3 - Author New Operators From Typed Helpers (Priority: P2)
+
+As an SDK user, I want typed facet helpers for the new operators so typed query authoring remains consistent with manual AST construction.
+
+**Why this priority**: Slice 008 introduced typed query authoring ergonomics; the new operators should not force callers back to string-heavy manual construction.
+
+**Independent Test**: Can be tested by generating each new facet operator from typed helpers and asserting the produced AST equals the manual shape.
+
+**Acceptance Scenarios**:
+
+1. **Given** a typed facet selection, **When** a caller creates `NotEqualTo`, `In`, `StartsWith`, or `Exists`, **Then** the resulting AST uses the resolved aspect key and facet identifier.
+2. **Given** a typed helper-generated query, **When** it is validated and executed against a supporting provider, **Then** behavior matches the equivalent manual query.
+
+### Edge Cases
+
+- `In` MUST reject null, non-enumerable, string-as-enumerable, and empty candidate sets.
+- `StartsWith` MUST remain string-oriented and fail validation or execution where a provider does not support prefix matching for that field category.
+- `Exists` MUST distinguish a present facet from a missing facet, even when the containing aspect exists.
+- New operators MUST preserve existing case-insensitive text semantics.
+- Existing manual query construction MUST remain supported.
+
+### Constitution Alignment *(mandatory)*
+
+- **Simplicity**: Add operators directly to the existing AST, validators, and providers; do not introduce a planner or query framework.
+- **Explicitness**: Provider capabilities MUST list supported operators by filter category.
+- **Dependencies**: No new dependencies.
+- **Operational Impact**: No storage, deployment, migration, or runtime configuration changes.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The portable comparison operator model MUST include `NotEquals`, `In`, `StartsWith`, and `Exists`.
+- **FR-002**: In-memory query execution MUST support the new operators for appropriate metadata and facet filters.
+- **FR-003**: SQLite JSON query execution MUST support the new operators where they can be translated explicitly over existing metadata and JSON facet values.
+- **FR-004**: Provider capability declarations MUST list the new supported operators for each filter category.
+- **FR-005**: Query validation MUST reject unsupported operators and invalid `In` candidate sets with structured failures.
+- **FR-006**: Typed facet helpers SHOULD create manual-equivalent AST values for the new facet operators.
+- **FR-007**: Provider conformance tests MUST cover supported and unsupported behavior for the new operators.
+- **FR-008**: The feature MUST NOT introduce public `IQueryable<Resource>`, provider-specific SQL APIs, runtime scanning, automatic discovery, or a query planner.
+
+### Key Entities
+
+- **Comparison operator**: A portable operator applied by metadata and facet filters.
+- **Membership value set**: The candidate values supplied to an `In` filter.
+- **Facet existence predicate**: A facet value filter that matches when a named facet is present.
+- **Provider capability declaration**: The machine-readable provider support contract used by validation and conformance tests.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Manual queries using all new supported operators validate and execute against at least one built-in provider.
+- **SC-002**: SQLite JSON and in-memory capability tests assert the new operator support.
+- **SC-003**: Typed helper tests cover all new facet operator helpers.
+- **SC-004**: Provider conformance tests include the new supported operator cases.
+- **SC-005**: Full solution tests and build pass.
+
+## Assumptions
+
+- `Exists` is modeled as a facet comparison operator on `FacetValueFilter`; the existing `Value` field is ignored for this operator.
+- `In` values are supplied as non-string enumerable candidate sets.
+- Prefix matching is case-insensitive, matching existing text comparison behavior.

--- a/specs/009-portable-operators/tasks.md
+++ b/specs/009-portable-operators/tasks.md
@@ -1,0 +1,21 @@
+# Tasks: Portable Operator Expansion
+
+**Input**: Design documents from `specs/009-portable-operators/`
+
+## Implementation
+
+- [X] T001 Add new comparison operators.
+- [X] T002 Update provider capability declarations.
+- [X] T003 Add `In` value-shape validation.
+- [X] T004 Implement new operators in the in-memory query evaluator.
+- [X] T005 Implement new operators in SQLite JSON translation.
+- [X] T006 Add typed facet helpers for the new operators.
+- [X] T007 Update capability, validator, conformance, provider, and typed-helper tests.
+- [X] T008 Update README/wiki/provider docs and roadmap status.
+
+## Verification
+
+- [X] T009 Run focused query/operator tests.
+- [X] T010 Run `dotnet test Aster.sln`.
+- [X] T011 Run `dotnet build Aster.sln`.
+- [X] T012 Run `git diff --check`.

--- a/src/core/Aster.Core/Extensions/TypedQuery.cs
+++ b/src/core/Aster.Core/Extensions/TypedQuery.cs
@@ -186,6 +186,22 @@ public sealed class TypedFacetQuery<TValue>
         new FacetValueFilter(aspectKey, facetIdentifier, value!, ComparisonOperator.Equals);
 
     /// <summary>
+    /// Creates an inequality facet filter.
+    /// </summary>
+    /// <param name="value">The value to exclude.</param>
+    /// <returns>A portable facet value filter.</returns>
+    public FilterExpression NotEqualTo(TValue value) =>
+        new FacetValueFilter(aspectKey, facetIdentifier, value!, ComparisonOperator.NotEquals);
+
+    /// <summary>
+    /// Creates a membership facet filter.
+    /// </summary>
+    /// <param name="values">The candidate values to match.</param>
+    /// <returns>A portable facet value filter.</returns>
+    public FilterExpression In(params TValue[] values) =>
+        new FacetValueFilter(aspectKey, facetIdentifier, values, ComparisonOperator.In);
+
+    /// <summary>
     /// Creates a string containment facet filter.
     /// </summary>
     /// <param name="value">The substring to match.</param>
@@ -198,6 +214,27 @@ public sealed class TypedFacetQuery<TValue>
     /// </remarks>
     public FilterExpression Contains(string value) =>
         new FacetValueFilter(aspectKey, facetIdentifier, value, ComparisonOperator.Contains);
+
+    /// <summary>
+    /// Creates a string prefix facet filter.
+    /// </summary>
+    /// <param name="value">The prefix to match.</param>
+    /// <returns>A portable facet value filter.</returns>
+    /// <remarks>
+    /// Prefix matching is a string-oriented predicate. Using this on non-string typed facets produces
+    /// a syntactically valid AST node, but execution depends on how the active provider serializes
+    /// the facet value. Prefer <see cref="EqualTo"/> or <see cref="Range"/> for strongly typed
+    /// non-string comparisons.
+    /// </remarks>
+    public FilterExpression StartsWith(string value) =>
+        new FacetValueFilter(aspectKey, facetIdentifier, value, ComparisonOperator.StartsWith);
+
+    /// <summary>
+    /// Creates a facet existence filter.
+    /// </summary>
+    /// <returns>A portable facet value filter.</returns>
+    public FilterExpression Exists() =>
+        new FacetValueFilter(aspectKey, facetIdentifier, true, ComparisonOperator.Exists);
 
     /// <summary>
     /// Creates a range facet filter.

--- a/src/core/Aster.Core/InMemory/InMemoryQueryCapabilitiesProvider.cs
+++ b/src/core/Aster.Core/InMemory/InMemoryQueryCapabilitiesProvider.cs
@@ -43,13 +43,20 @@ public sealed class InMemoryQueryCapabilitiesProvider : IResourceQueryCapabiliti
             [QueryFilterType.Metadata] = new HashSet<ComparisonOperator>
             {
                 ComparisonOperator.Equals,
+                ComparisonOperator.NotEquals,
+                ComparisonOperator.In,
                 ComparisonOperator.Contains,
+                ComparisonOperator.StartsWith,
             },
             [QueryFilterType.FacetValue] = new HashSet<ComparisonOperator>
             {
                 ComparisonOperator.Equals,
+                ComparisonOperator.NotEquals,
+                ComparisonOperator.In,
                 ComparisonOperator.Contains,
+                ComparisonOperator.StartsWith,
                 ComparisonOperator.Range,
+                ComparisonOperator.Exists,
             },
         },
         SupportedMetadataFields: new HashSet<string>(StringComparer.OrdinalIgnoreCase)

--- a/src/core/Aster.Core/InMemory/InMemoryQueryService.cs
+++ b/src/core/Aster.Core/InMemory/InMemoryQueryService.cs
@@ -238,15 +238,15 @@ public sealed partial class InMemoryQueryService : IResourceQueryService, IResou
                 "In predicates require a non-string enumerable value set.",
                 "Filter.Value");
 
-        var matchedAny = false;
+        var hasElements = false;
         foreach (var candidate in enumerable)
         {
-            matchedAny = true;
+            hasElements = true;
             if (ValuesEqual(actual, candidate))
                 return true;
         }
 
-        if (!matchedAny)
+        if (!hasElements)
             throw Unsupported(
                 "empty-in-values",
                 "value shape",

--- a/src/core/Aster.Core/InMemory/InMemoryQueryService.cs
+++ b/src/core/Aster.Core/InMemory/InMemoryQueryService.cs
@@ -1,3 +1,4 @@
+using System.Collections;
 using System.Text.Json;
 using Aster.Core.Abstractions;
 using Aster.Core.Exceptions;
@@ -13,8 +14,7 @@ namespace Aster.Core.InMemory;
 /// Evaluates <see cref="ResourceQuery"/> ASTs against versions supplied by <see cref="IResourceVersionReader"/>.
 /// </summary>
 /// <remarks>
-/// Supported comparators: <see cref="ComparisonOperator.Equals"/>, <see cref="ComparisonOperator.Contains"/>,
-/// and <see cref="ComparisonOperator.Range"/>.
+/// Supported comparators include equality, membership, text, range, and facet existence predicates.
 /// </remarks>
 public sealed partial class InMemoryQueryService : IResourceQueryService, IResourceQueryProviderIdentity
 {
@@ -117,6 +117,9 @@ public sealed partial class InMemoryQueryService : IResourceQueryService, IResou
 
         // Resolve the facet value from the aspect payload
         var facetValue = ResolveFacetValue(aspectRaw, filter.FacetDefinitionId);
+        if (filter.Operator == ComparisonOperator.Exists)
+            return facetValue is not null;
+
         if (facetValue is null)
             return false;
 
@@ -202,20 +205,56 @@ public sealed partial class InMemoryQueryService : IResourceQueryService, IResou
 
     private static bool ApplyComparator(object? actual, object? expected, ComparisonOperator op) => op switch
     {
-        ComparisonOperator.Equals => string.Equals(
-            FormatValueInvariant(actual),
-            FormatValueInvariant(expected),
-            StringComparison.OrdinalIgnoreCase),
+        ComparisonOperator.Equals => ValuesEqual(actual, expected),
+        ComparisonOperator.NotEquals => !ValuesEqual(actual, expected),
+        ComparisonOperator.In => ApplyInComparator(actual, expected),
         ComparisonOperator.Contains => FormatValueInvariant(actual)?.Contains(
             FormatValueInvariant(expected) ?? string.Empty,
             StringComparison.OrdinalIgnoreCase) == true,
+        ComparisonOperator.StartsWith => FormatValueInvariant(actual)?.StartsWith(
+            FormatValueInvariant(expected) ?? string.Empty,
+            StringComparison.OrdinalIgnoreCase) == true,
         ComparisonOperator.Range => ApplyRangeComparator(actual, expected),
+        ComparisonOperator.Exists => actual is not null,
         _ => throw Unsupported(
             "unsupported-comparison-operator",
             "comparison operator",
             $"Comparison operator '{op}' is not supported by the in-memory query provider.",
             "Filter.Operator")
     };
+
+    private static bool ValuesEqual(object? actual, object? expected) =>
+        string.Equals(
+            FormatValueInvariant(actual),
+            FormatValueInvariant(expected),
+            StringComparison.OrdinalIgnoreCase);
+
+    private static bool ApplyInComparator(object? actual, object? expected)
+    {
+        if (expected is string || expected is not IEnumerable enumerable)
+            throw Unsupported(
+                "in-values-required",
+                "value shape",
+                "In predicates require a non-string enumerable value set.",
+                "Filter.Value");
+
+        var matchedAny = false;
+        foreach (var candidate in enumerable)
+        {
+            matchedAny = true;
+            if (ValuesEqual(actual, candidate))
+                return true;
+        }
+
+        if (!matchedAny)
+            throw Unsupported(
+                "empty-in-values",
+                "value shape",
+                "In predicates require at least one candidate value.",
+                "Filter.Value");
+
+        return false;
+    }
 
     private static bool ApplyRangeComparator(object? actual, object? expected)
     {

--- a/src/core/Aster.Core/Models/Querying/ComparisonOperator.cs
+++ b/src/core/Aster.Core/Models/Querying/ComparisonOperator.cs
@@ -8,9 +8,21 @@ public enum ComparisonOperator
     /// <summary>Exact equality match (case-insensitive for strings).</summary>
     Equals,
 
+    /// <summary>Inverse equality match (case-insensitive for strings).</summary>
+    NotEquals,
+
+    /// <summary>Exact equality match against any value in a candidate set.</summary>
+    In,
+
     /// <summary>Substring containment check (strings only).</summary>
     Contains,
 
+    /// <summary>Prefix check (strings only, case-insensitive).</summary>
+    StartsWith,
+
     /// <summary>Range comparison using a <see cref="RangeValue"/> bound value.</summary>
     Range,
+
+    /// <summary>Facet value presence check.</summary>
+    Exists,
 }

--- a/src/core/Aster.Core/Models/Querying/FilterExpression.cs
+++ b/src/core/Aster.Core/Models/Querying/FilterExpression.cs
@@ -11,7 +11,7 @@ public abstract record FilterExpression;
 /// <param name="Field">The metadata field name (case-insensitive).</param>
 /// <param name="Value">The value to compare against.</param>
 /// <param name="Operator">The comparison operator to apply.</param>
-public sealed record MetadataFilter(string Field, string Value, ComparisonOperator Operator) : FilterExpression;
+public sealed record MetadataFilter(string Field, object Value, ComparisonOperator Operator) : FilterExpression;
 
 /// <summary>
 /// Filters resources that have an aspect at the specified key (presence check only).

--- a/src/core/Aster.Core/README.md
+++ b/src/core/Aster.Core/README.md
@@ -158,7 +158,11 @@ Or build common typed aspect filters and sorts without repeating convention-base
 ```csharp
 var title = TypedQuery.For<TitleAspect>()
     .Facet(x => x.Title)
-    .Contains("Gadget");
+    .StartsWith("Gadget");
+
+var titleSet = TypedQuery.For<TitleAspect>()
+    .Facet(x => x.Title)
+    .In("Gadget Pro", "Gadget Plus");
 
 var price = TypedQuery.For<PriceAspect>()
     .Facet(x => x.Amount)
@@ -166,7 +170,7 @@ var price = TypedQuery.For<PriceAspect>()
 
 var query = new ResourceQuery
 {
-    Filter = TypedQuery.And(title, price),
+    Filter = TypedQuery.And(title, titleSet, price),
     Sorts =
     [
         TypedQuery.For<PriceAspect>()

--- a/src/core/Aster.Core/Services/ResourceQueryValidator.cs
+++ b/src/core/Aster.Core/Services/ResourceQueryValidator.cs
@@ -1,4 +1,5 @@
 using System.Globalization;
+using System.Collections;
 using Aster.Core.Abstractions;
 using Aster.Core.Models.Querying;
 
@@ -185,15 +186,18 @@ public sealed class ResourceQueryValidator : IResourceQueryValidator
 
         ValidateComparison(QueryFilterType.Metadata, filter.Operator, $"{path}.Operator", failures);
 
-        if (filter.Operator == ComparisonOperator.Contains
+        if (filter.Operator is ComparisonOperator.Contains or ComparisonOperator.StartsWith
             && !capabilities.MetadataContainsFields.Contains(filter.Field))
         {
             failures.Add(Failure(
                 "unsupported-metadata-contains-field",
-                $"Metadata field '{filter.Field}' does not support containment filtering in {capabilities.ProviderName}.",
+                $"Metadata field '{filter.Field}' does not support text filtering in {capabilities.ProviderName}.",
                 $"{path}.Field",
                 "metadata field"));
         }
+
+        if (filter.Operator == ComparisonOperator.In)
+            ValidateInValue(filter.Value, $"{path}.Value", failures);
     }
 
     private void ValidateFacetValueFilter(FacetValueFilter filter, string path, List<QueryValidationFailure> failures)
@@ -205,6 +209,9 @@ public sealed class ResourceQueryValidator : IResourceQueryValidator
 
         if (filter.Operator == ComparisonOperator.Range)
             ValidateRangeValue(filter.Value, $"{path}.Value", failures);
+
+        if (filter.Operator == ComparisonOperator.In)
+            ValidateInValue(filter.Value, $"{path}.Value", failures);
     }
 
     private void ValidateLogicalExpression(LogicalExpression expression, string path, List<QueryValidationFailure> failures)
@@ -360,6 +367,46 @@ public sealed class ResourceQueryValidator : IResourceQueryValidator
             $"Range value shape '{shape?.ToString() ?? value.GetType().Name}' is not supported by {capabilities!.ProviderName}.",
             path,
             "value shape"));
+    }
+
+    private static void ValidateInValue(object? value, string path, List<QueryValidationFailure> failures)
+    {
+        if (value is null)
+        {
+            failures.Add(Failure(
+                "in-values-required",
+                "In predicates require a non-empty enumerable value set.",
+                path,
+                "value shape"));
+            return;
+        }
+
+        if (value is string || value is not IEnumerable enumerable)
+        {
+            failures.Add(Failure(
+                "in-values-required",
+                "In predicates require a non-string enumerable value set.",
+                path,
+                "value shape"));
+            return;
+        }
+
+        var enumerator = enumerable.GetEnumerator();
+        try
+        {
+            if (!enumerator.MoveNext())
+            {
+                failures.Add(Failure(
+                    "empty-in-values",
+                    "In predicates require at least one candidate value.",
+                    path,
+                    "value shape"));
+            }
+        }
+        finally
+        {
+            (enumerator as IDisposable)?.Dispose();
+        }
     }
 
     private static QueryValueShape? ResolveValueShape(object value)

--- a/src/core/Aster.Core/Services/ResourceQueryValidator.cs
+++ b/src/core/Aster.Core/Services/ResourceQueryValidator.cs
@@ -422,7 +422,7 @@ public sealed class ResourceQueryValidator : IResourceQueryValidator
 
         failures.Add(Failure(
             "text-value-required",
-            "Text predicates require a non-null string value.",
+            "Text predicates require a string value.",
             path,
             "value shape"));
     }

--- a/src/core/Aster.Core/Services/ResourceQueryValidator.cs
+++ b/src/core/Aster.Core/Services/ResourceQueryValidator.cs
@@ -196,6 +196,9 @@ public sealed class ResourceQueryValidator : IResourceQueryValidator
                 "metadata field"));
         }
 
+        if (filter.Operator is ComparisonOperator.Contains or ComparisonOperator.StartsWith)
+            ValidateTextValue(filter.Value, $"{path}.Value", failures);
+
         if (filter.Operator == ComparisonOperator.In)
             ValidateInValue(filter.Value, $"{path}.Value", failures);
     }
@@ -209,6 +212,9 @@ public sealed class ResourceQueryValidator : IResourceQueryValidator
 
         if (filter.Operator == ComparisonOperator.Range)
             ValidateRangeValue(filter.Value, $"{path}.Value", failures);
+
+        if (filter.Operator is ComparisonOperator.Contains or ComparisonOperator.StartsWith)
+            ValidateTextValue(filter.Value, $"{path}.Value", failures);
 
         if (filter.Operator == ComparisonOperator.In)
             ValidateInValue(filter.Value, $"{path}.Value", failures);
@@ -407,6 +413,18 @@ public sealed class ResourceQueryValidator : IResourceQueryValidator
         {
             (enumerator as IDisposable)?.Dispose();
         }
+    }
+
+    private static void ValidateTextValue(object? value, string path, List<QueryValidationFailure> failures)
+    {
+        if (value is string)
+            return;
+
+        failures.Add(Failure(
+            "text-value-required",
+            "Text predicates require a non-null string value.",
+            path,
+            "value shape"));
     }
 
     private static QueryValueShape? ResolveValueShape(object value)

--- a/src/persistence/Aster.Persistence.SqliteJson/Querying/SqliteTextBehavior.cs
+++ b/src/persistence/Aster.Persistence.SqliteJson/Querying/SqliteTextBehavior.cs
@@ -4,6 +4,7 @@ internal static class SqliteTextBehavior
 {
     public const string EqualsFunction = "aster_text_equals";
     public const string ContainsFunction = "aster_text_contains";
+    public const string StartsWithFunction = "aster_text_starts_with";
     public const string OrdinalIgnoreCaseCollation = "aster_ordinal_ignore_case";
 
     public static bool EqualsIgnoreCase(string? actual, string? expected) =>
@@ -13,6 +14,11 @@ internal static class SqliteTextBehavior
         actual is not null
         && expected is not null
         && actual.Contains(expected, StringComparison.OrdinalIgnoreCase);
+
+    public static bool StartsWithIgnoreCase(string? actual, string? expected) =>
+        actual is not null
+        && expected is not null
+        && actual.StartsWith(expected, StringComparison.OrdinalIgnoreCase);
 
     public static int CompareIgnoreCase(string? left, string? right) =>
         string.Compare(left, right, StringComparison.OrdinalIgnoreCase);

--- a/src/persistence/Aster.Persistence.SqliteJson/Querying/SqliteWhereTranslator.cs
+++ b/src/persistence/Aster.Persistence.SqliteJson/Querying/SqliteWhereTranslator.cs
@@ -194,6 +194,7 @@ internal sealed class SqliteWhereTranslator(SqliteParameterBag parameters)
 
     private string TranslateTextIn(string actualSql, object? expected)
     {
+        // Keep one UDF call per candidate so text IN follows the same null and case behavior as Equals.
         var predicates = ResolveInValues(expected)
             .Select(candidate => TextEquals(actualSql, candidate))
             .ToArray();

--- a/src/persistence/Aster.Persistence.SqliteJson/Querying/SqliteWhereTranslator.cs
+++ b/src/persistence/Aster.Persistence.SqliteJson/Querying/SqliteWhereTranslator.cs
@@ -1,3 +1,4 @@
+using System.Collections;
 using System.Globalization;
 using Aster.Core.Exceptions;
 using Aster.Core.Models.Querying;
@@ -49,14 +50,24 @@ internal sealed class SqliteWhereTranslator(SqliteParameterBag parameters)
             ComparisonOperator.Equals when SqliteMetadataField.IsNumeric(filter.Field) =>
                 $"{column} = {parameters.Add(ParseInt(filter.Value, filter.Field))}",
             ComparisonOperator.Equals =>
-                $"{SqliteTextBehavior.EqualsFunction}(CAST({column} AS TEXT), CAST({parameters.Add(filter.Value)} AS TEXT))",
+                TextEquals($"CAST({column} AS TEXT)", filter.Value),
+            ComparisonOperator.NotEquals when SqliteMetadataField.IsNumeric(filter.Field) =>
+                $"{column} <> {parameters.Add(ParseInt(filter.Value, filter.Field))}",
+            ComparisonOperator.NotEquals =>
+                $"NOT {TextEquals($"CAST({column} AS TEXT)", filter.Value)}",
+            ComparisonOperator.In when SqliteMetadataField.IsNumeric(filter.Field) =>
+                TranslateNumericIn(column, filter.Value, candidate => ParseInt(candidate, filter.Field)),
+            ComparisonOperator.In =>
+                TranslateTextIn($"CAST({column} AS TEXT)", filter.Value),
             ComparisonOperator.Contains when !SqliteMetadataField.IsNumeric(filter.Field) =>
-                $"{SqliteTextBehavior.ContainsFunction}(CAST({column} AS TEXT), CAST({parameters.Add(filter.Value)} AS TEXT))",
-            ComparisonOperator.Contains =>
+                TextContains($"CAST({column} AS TEXT)", filter.Value),
+            ComparisonOperator.StartsWith when !SqliteMetadataField.IsNumeric(filter.Field) =>
+                TextStartsWith($"CAST({column} AS TEXT)", filter.Value),
+            ComparisonOperator.Contains or ComparisonOperator.StartsWith =>
                 throw Unsupported(
                     "unsupported-metadata-contains-field",
                     "metadata field",
-                    $"Metadata field '{filter.Field}' does not support containment filtering in the SQLite JSON query provider.",
+                    $"Metadata field '{filter.Field}' does not support text filtering in the SQLite JSON query provider.",
                     "Filter.Field"),
             _ => throw Unsupported(
                 "unsupported-comparison-operator",
@@ -82,9 +93,19 @@ internal sealed class SqliteWhereTranslator(SqliteParameterBag parameters)
             ComparisonOperator.Equals when TryConvertDouble(filter.Value, out var number) =>
                 $"{value.IsNumeric} AND CAST({value.Value} AS REAL) = {parameters.Add(number)}",
             ComparisonOperator.Equals =>
-                $"{SqliteTextBehavior.EqualsFunction}(CAST({value.Value} AS TEXT), CAST({parameters.Add(FormatValue(filter.Value))} AS TEXT))",
+                TextEquals($"CAST({value.Value} AS TEXT)", filter.Value),
+            ComparisonOperator.NotEquals when TryConvertDouble(filter.Value, out var number) =>
+                $"{value.Value} IS NOT NULL AND NOT ({value.IsNumeric} AND CAST({value.Value} AS REAL) = {parameters.Add(number)})",
+            ComparisonOperator.NotEquals =>
+                $"{value.Value} IS NOT NULL AND NOT {TextEquals($"CAST({value.Value} AS TEXT)", filter.Value)}",
+            ComparisonOperator.In =>
+                TranslateFacetIn(value, filter.Value),
             ComparisonOperator.Contains =>
-                $"{SqliteTextBehavior.ContainsFunction}(CAST({value.Value} AS TEXT), CAST({parameters.Add(FormatValue(filter.Value))} AS TEXT))",
+                TextContains($"CAST({value.Value} AS TEXT)", filter.Value),
+            ComparisonOperator.StartsWith =>
+                TextStartsWith($"CAST({value.Value} AS TEXT)", filter.Value),
+            ComparisonOperator.Exists =>
+                $"{value.Value} IS NOT NULL",
             ComparisonOperator.Range when filter.Value is RangeValue range =>
                 TranslateRange(value, range),
             ComparisonOperator.Range =>
@@ -153,8 +174,72 @@ internal sealed class SqliteWhereTranslator(SqliteParameterBag parameters)
         return string.Join(" AND ", predicates);
     }
 
-    private static int ParseInt(string value, string field) =>
-        int.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var parsed)
+    private string TextEquals(string actualSql, object? expected) =>
+        $"{SqliteTextBehavior.EqualsFunction}({actualSql}, CAST({parameters.Add(FormatValue(expected))} AS TEXT))";
+
+    private string TextContains(string actualSql, object? expected) =>
+        $"{SqliteTextBehavior.ContainsFunction}({actualSql}, CAST({parameters.Add(FormatValue(expected))} AS TEXT))";
+
+    private string TextStartsWith(string actualSql, object? expected) =>
+        $"{SqliteTextBehavior.StartsWithFunction}({actualSql}, CAST({parameters.Add(FormatValue(expected))} AS TEXT))";
+
+    private string TranslateNumericIn<TNumber>(string actualSql, object? expected, Func<object?, TNumber> convert)
+    {
+        var parameterNames = ResolveInValues(expected)
+            .Select(candidate => parameters.Add(convert(candidate)))
+            .ToArray();
+
+        return $"{actualSql} IN ({string.Join(", ", parameterNames)})";
+    }
+
+    private string TranslateTextIn(string actualSql, object? expected)
+    {
+        var predicates = ResolveInValues(expected)
+            .Select(candidate => TextEquals(actualSql, candidate))
+            .ToArray();
+
+        return string.Join(" OR ", predicates.Select(predicate => $"({predicate})"));
+    }
+
+    private string TranslateFacetIn(SqliteFacetValueExpression value, object? expected)
+    {
+        var predicates = ResolveInValues(expected)
+            .Select(candidate => TranslateFacetEquals(value, candidate))
+            .ToArray();
+
+        return string.Join(" OR ", predicates.Select(predicate => $"({predicate})"));
+    }
+
+    private string TranslateFacetEquals(SqliteFacetValueExpression value, object? expected) =>
+        TryConvertDouble(expected, out var number)
+            ? $"{value.IsNumeric} AND CAST({value.Value} AS REAL) = {parameters.Add(number)}"
+            : TextEquals($"CAST({value.Value} AS TEXT)", expected);
+
+    private static IReadOnlyList<object?> ResolveInValues(object? value)
+    {
+        if (value is string || value is not IEnumerable enumerable)
+            throw Unsupported(
+                "in-values-required",
+                "value shape",
+                "In predicates require a non-string enumerable value set.",
+                "Filter.Value");
+
+        var values = new List<object?>();
+        foreach (var item in enumerable)
+            values.Add(item);
+
+        if (values.Count == 0)
+            throw Unsupported(
+                "empty-in-values",
+                "value shape",
+                "In predicates require at least one candidate value.",
+                "Filter.Value");
+
+        return values;
+    }
+
+    private static int ParseInt(object? value, string field) =>
+        int.TryParse(FormatValue(value), NumberStyles.Integer, CultureInfo.InvariantCulture, out var parsed)
             ? parsed
             : throw Unsupported(
                 "invalid-metadata-value",

--- a/src/persistence/Aster.Persistence.SqliteJson/README.md
+++ b/src/persistence/Aster.Persistence.SqliteJson/README.md
@@ -33,7 +33,10 @@ Supported query shapes:
 - facet sorting over scalar facet values
 - `Skip` and `Take`
 - aspect presence checks
-- scalar facet `Equals`, string `Contains`, and numeric `Range`
+- metadata/facet `Equals`, `NotEquals`, and `In`
+- string `Contains` and `StartsWith`
+- facet `Exists`
+- numeric facet `Range`
 - `And`, `Or`, and single-operand `Not`
 
 Unsupported query shapes throw `UnsupportedQueryFeatureException` with stable `Code`, `Feature`, optional `Path`, and an actionable message. Metadata range filters, unknown metadata fields, empty ranges, negative paging values, and date-like facet ranges are intentionally out of scope for this phase.

--- a/src/persistence/Aster.Persistence.SqliteJson/SqliteJsonQueryCapabilitiesProvider.cs
+++ b/src/persistence/Aster.Persistence.SqliteJson/SqliteJsonQueryCapabilitiesProvider.cs
@@ -43,13 +43,20 @@ public sealed class SqliteJsonQueryCapabilitiesProvider : IResourceQueryCapabili
             [QueryFilterType.Metadata] = new HashSet<ComparisonOperator>
             {
                 ComparisonOperator.Equals,
+                ComparisonOperator.NotEquals,
+                ComparisonOperator.In,
                 ComparisonOperator.Contains,
+                ComparisonOperator.StartsWith,
             },
             [QueryFilterType.FacetValue] = new HashSet<ComparisonOperator>
             {
                 ComparisonOperator.Equals,
+                ComparisonOperator.NotEquals,
+                ComparisonOperator.In,
                 ComparisonOperator.Contains,
+                ComparisonOperator.StartsWith,
                 ComparisonOperator.Range,
+                ComparisonOperator.Exists,
             },
         },
         SupportedMetadataFields: new HashSet<string>(StringComparer.OrdinalIgnoreCase)

--- a/src/persistence/Aster.Persistence.SqliteJson/SqliteJsonQueryService.cs
+++ b/src/persistence/Aster.Persistence.SqliteJson/SqliteJsonQueryService.cs
@@ -103,6 +103,10 @@ public sealed class SqliteJsonQueryService : IResourceQueryService, IResourceQue
             SqliteTextBehavior.ContainsFunction,
             SqliteTextBehavior.ContainsIgnoreCase);
 
+        connection.CreateFunction<string?, string?, bool>(
+            SqliteTextBehavior.StartsWithFunction,
+            SqliteTextBehavior.StartsWithIgnoreCase);
+
         connection.CreateCollation(
             SqliteTextBehavior.OrdinalIgnoreCaseCollation,
             SqliteTextBehavior.CompareIgnoreCase);

--- a/test/Aster.Tests/InMemory/InMemoryQueryCapabilityTests.cs
+++ b/test/Aster.Tests/InMemory/InMemoryQueryCapabilityTests.cs
@@ -27,6 +27,10 @@ public sealed class InMemoryQueryCapabilityTests
         Assert.Contains(QueryFilterType.AspectPresence, capabilities.SupportedFilterTypes);
         Assert.Contains(QueryFilterType.FacetValue, capabilities.SupportedFilterTypes);
         Assert.Contains(QueryFilterType.Logical, capabilities.SupportedFilterTypes);
+
+        AssertPortableOperators(QueryFilterType.Metadata);
+        AssertPortableOperators(QueryFilterType.FacetValue);
+        Assert.True(capabilities.SupportsComparison(QueryFilterType.FacetValue, ComparisonOperator.Exists));
     }
 
     [Fact]
@@ -36,5 +40,12 @@ public sealed class InMemoryQueryCapabilityTests
         Assert.Contains(QueryValueShape.Numeric, capabilities.FacetRangeSupport);
         Assert.Contains(QueryValueShape.DateTime, capabilities.FacetRangeSupport);
         Assert.True(capabilities.SupportsComparison(QueryFilterType.FacetValue, ComparisonOperator.Range));
+    }
+
+    private void AssertPortableOperators(QueryFilterType filterType)
+    {
+        Assert.True(capabilities.SupportsComparison(filterType, ComparisonOperator.NotEquals));
+        Assert.True(capabilities.SupportsComparison(filterType, ComparisonOperator.In));
+        Assert.True(capabilities.SupportsComparison(filterType, ComparisonOperator.StartsWith));
     }
 }

--- a/test/Aster.Tests/InMemory/InMemoryQueryServiceTests.cs
+++ b/test/Aster.Tests/InMemory/InMemoryQueryServiceTests.cs
@@ -136,6 +136,53 @@ public sealed class InMemoryQueryServiceTests
         Assert.Single(results);
     }
 
+    [Fact]
+    public async Task QueryAsync_PortableOperators_ReturnMatchingResources()
+    {
+        var (manager, query) = CreateSetup();
+        await manager.CreateAsync("Product", new CreateResourceRequest
+        {
+            ResourceId = "product-a",
+            InitialAspects = new()
+            {
+                ["Title"] = new TitleAspect("Alpha Gadget"),
+                ["Category"] = new CategoryAspect("Electronics"),
+            },
+        });
+        await manager.CreateAsync("Product", new CreateResourceRequest
+        {
+            ResourceId = "product-b",
+            InitialAspects = new()
+            {
+                ["Title"] = new TitleAspect("Beta Widget"),
+                ["Category"] = new CategoryAspect("Hardware"),
+            },
+        });
+        await manager.CreateAsync("Product", new CreateResourceRequest
+        {
+            ResourceId = "product-c",
+            InitialAspects = new()
+            {
+                ["Category"] = new CategoryAspect("Electronics"),
+            },
+        });
+
+        var results = (await query.QueryAsync(new ResourceQuery
+        {
+            Filter = new LogicalExpression(LogicalOperator.And, [
+                new MetadataFilter("ResourceId", "product-b", ComparisonOperator.NotEquals),
+                new MetadataFilter("ResourceId", new[] { "product-a", "product-c" }, ComparisonOperator.In),
+                new FacetValueFilter("Category", "Category", "Hardware", ComparisonOperator.NotEquals),
+                new FacetValueFilter("Category", "Category", new[] { "Electronics" }, ComparisonOperator.In),
+                new FacetValueFilter("Title", "Title", "Alpha", ComparisonOperator.StartsWith),
+                new FacetValueFilter("Title", "Title", true, ComparisonOperator.Exists),
+            ]),
+        })).ToList();
+
+        Assert.Single(results);
+        Assert.Equal("product-a", results[0].ResourceId);
+    }
+
     // ──────────────────────────────────────────────────────────────────────────
     // AND / OR composition
     // ──────────────────────────────────────────────────────────────────────────

--- a/test/Aster.Tests/Querying/ProviderConformanceTests.cs
+++ b/test/Aster.Tests/Querying/ProviderConformanceTests.cs
@@ -460,6 +460,42 @@ internal static class ProviderConformanceSuite
                 });
         }
 
+        if (capabilities.SupportedMetadataFields.Contains("Owner")
+            && capabilities.SupportsComparison(QueryFilterType.Metadata, ComparisonOperator.NotEquals))
+        {
+            yield return new(
+                "Metadata not-equals filter",
+                "Metadata filter",
+                new ResourceQuery
+                {
+                    Filter = new MetadataFilter("Owner", "bob", ComparisonOperator.NotEquals),
+                });
+        }
+
+        if (capabilities.SupportedMetadataFields.Contains("Owner")
+            && capabilities.SupportsComparison(QueryFilterType.Metadata, ComparisonOperator.In))
+        {
+            yield return new(
+                "Metadata in filter",
+                "Metadata filter",
+                new ResourceQuery
+                {
+                    Filter = new MetadataFilter("Owner", new[] { "alice", "carol" }, ComparisonOperator.In),
+                });
+        }
+
+        if (capabilities.SupportedMetadataFields.Contains("Owner")
+            && capabilities.SupportsComparison(QueryFilterType.Metadata, ComparisonOperator.StartsWith))
+        {
+            yield return new(
+                "Metadata starts-with filter",
+                "Metadata filter",
+                new ResourceQuery
+                {
+                    Filter = new MetadataFilter("Owner", "ali", ComparisonOperator.StartsWith),
+                });
+        }
+
         if (capabilities.SupportedFilterTypes.Contains(QueryFilterType.AspectPresence))
         {
             yield return new(
@@ -479,6 +515,50 @@ internal static class ProviderConformanceSuite
                 new ResourceQuery
                 {
                     Filter = new FacetValueFilter("Title", "Title", "Gadget", ComparisonOperator.Contains),
+                });
+        }
+
+        if (capabilities.SupportsComparison(QueryFilterType.FacetValue, ComparisonOperator.NotEquals))
+        {
+            yield return new(
+                "Facet not-equals filter",
+                "Facet filter",
+                new ResourceQuery
+                {
+                    Filter = new FacetValueFilter("Title", "Title", "Beta Widget", ComparisonOperator.NotEquals),
+                });
+        }
+
+        if (capabilities.SupportsComparison(QueryFilterType.FacetValue, ComparisonOperator.In))
+        {
+            yield return new(
+                "Facet in filter",
+                "Facet filter",
+                new ResourceQuery
+                {
+                    Filter = new FacetValueFilter("Title", "Title", new[] { "Alpha Gadget Updated", "Other" }, ComparisonOperator.In),
+                });
+        }
+
+        if (capabilities.SupportsComparison(QueryFilterType.FacetValue, ComparisonOperator.StartsWith))
+        {
+            yield return new(
+                "Facet starts-with filter",
+                "Facet filter",
+                new ResourceQuery
+                {
+                    Filter = new FacetValueFilter("Title", "Title", "Alpha", ComparisonOperator.StartsWith),
+                });
+        }
+
+        if (capabilities.SupportsComparison(QueryFilterType.FacetValue, ComparisonOperator.Exists))
+        {
+            yield return new(
+                "Facet exists filter",
+                "Facet filter",
+                new ResourceQuery
+                {
+                    Filter = new FacetValueFilter("Title", "Title", true, ComparisonOperator.Exists),
                 });
         }
 
@@ -561,6 +641,18 @@ internal static class ProviderConformanceSuite
             "Paging",
             new ResourceQuery { Take = -1 },
             RequiresMatch: false);
+
+        if (capabilities.SupportsComparison(QueryFilterType.FacetValue, ComparisonOperator.In))
+        {
+            yield return new(
+                "Invalid facet in value shape",
+                "Facet filter",
+                new ResourceQuery
+                {
+                    Filter = new FacetValueFilter("Title", "Title", "Alpha", ComparisonOperator.In),
+                },
+                RequiresMatch: false);
+        }
 
         if (!capabilities.SupportsFacetSorting)
         {

--- a/test/Aster.Tests/Querying/ResourceQueryValidatorTests.cs
+++ b/test/Aster.Tests/Querying/ResourceQueryValidatorTests.cs
@@ -139,6 +139,51 @@ public sealed class ResourceQueryValidatorTests
     }
 
     [Fact]
+    public void Validate_NewPortableOperators_UseCapabilityDeclarations()
+    {
+        var result = sqliteValidator.Validate(new ResourceQuery
+        {
+            Filter = new LogicalExpression(LogicalOperator.And, [
+                new MetadataFilter("Owner", "bob", ComparisonOperator.NotEquals),
+                new MetadataFilter("Owner", new[] { "alice", "carol" }, ComparisonOperator.In),
+                new MetadataFilter("Owner", "al", ComparisonOperator.StartsWith),
+                new FacetValueFilter("Title", "Title", "Beta", ComparisonOperator.NotEquals),
+                new FacetValueFilter("Category", "Category", new[] { "Hardware", "Electronics" }, ComparisonOperator.In),
+                new FacetValueFilter("Title", "Title", "Al", ComparisonOperator.StartsWith),
+                new FacetValueFilter("Title", "Title", true, ComparisonOperator.Exists),
+            ]),
+        });
+
+        Assert.True(result.IsValid);
+    }
+
+    [Theory]
+    [InlineData(null, "in-values-required")]
+    [InlineData("abc", "in-values-required")]
+    public void Validate_InOperatorRejectsInvalidValueShapes(object? value, string expectedCode)
+    {
+        var result = sqliteValidator.Validate(new ResourceQuery
+        {
+            Filter = new FacetValueFilter("Category", "Category", value!, ComparisonOperator.In),
+        });
+
+        Assert.False(result.IsValid);
+        Assert.Contains(result.Failures, failure => failure.Code == expectedCode);
+    }
+
+    [Fact]
+    public void Validate_InOperatorRejectsEmptyValueSet()
+    {
+        var result = sqliteValidator.Validate(new ResourceQuery
+        {
+            Filter = new MetadataFilter("Owner", Array.Empty<string>(), ComparisonOperator.In),
+        });
+
+        Assert.False(result.IsValid);
+        Assert.Contains(result.Failures, failure => failure.Code == "empty-in-values");
+    }
+
+    [Fact]
     public void Validate_RejectsInvalidSortDirection()
     {
         var result = sqliteValidator.Validate(new ResourceQuery

--- a/test/Aster.Tests/Querying/ResourceQueryValidatorTests.cs
+++ b/test/Aster.Tests/Querying/ResourceQueryValidatorTests.cs
@@ -183,6 +183,20 @@ public sealed class ResourceQueryValidatorTests
         Assert.Contains(result.Failures, failure => failure.Code == "empty-in-values");
     }
 
+    [Theory]
+    [InlineData(ComparisonOperator.Contains)]
+    [InlineData(ComparisonOperator.StartsWith)]
+    public void Validate_TextOperatorsRejectNullValues(ComparisonOperator comparisonOperator)
+    {
+        var result = sqliteValidator.Validate(new ResourceQuery
+        {
+            Filter = new FacetValueFilter("Title", "Title", null!, comparisonOperator),
+        });
+
+        Assert.False(result.IsValid);
+        Assert.Contains(result.Failures, failure => failure.Code == "text-value-required");
+    }
+
     [Fact]
     public void Validate_RejectsInvalidSortDirection()
     {

--- a/test/Aster.Tests/Querying/TypedQueryHelperTests.cs
+++ b/test/Aster.Tests/Querying/TypedQueryHelperTests.cs
@@ -28,16 +28,34 @@ public sealed class TypedQueryHelperTests
         var equality = Assert.IsType<FacetValueFilter>(TypedQuery.For<TitleAspect>()
             .Facet(aspect => aspect.Title)
             .EqualTo("Gadget"));
+        var inequality = Assert.IsType<FacetValueFilter>(TypedQuery.For<TitleAspect>()
+            .Facet(aspect => aspect.Title)
+            .NotEqualTo("Widget"));
+        var membership = Assert.IsType<FacetValueFilter>(TypedQuery.For<TitleAspect>()
+            .Facet(aspect => aspect.Title)
+            .In("Gadget", "Widget"));
         var contains = Assert.IsType<FacetValueFilter>(TypedQuery.For<TitleAspect>()
             .Facet(aspect => aspect.Title)
             .Contains("Gadget"));
+        var startsWith = Assert.IsType<FacetValueFilter>(TypedQuery.For<TitleAspect>()
+            .Facet(aspect => aspect.Title)
+            .StartsWith("Gad"));
+        var exists = Assert.IsType<FacetValueFilter>(TypedQuery.For<TitleAspect>()
+            .Facet(aspect => aspect.Title)
+            .Exists());
         var range = Assert.IsType<FacetValueFilter>(TypedQuery.For<PriceAspect>()
             .Facet(aspect => aspect.Amount)
             .Range(10m, 20m));
 
         Assert.Equal(("TitleAspect", "Title", ComparisonOperator.Equals), (equality.AspectKey, equality.FacetDefinitionId, equality.Operator));
+        Assert.Equal(("TitleAspect", "Title", ComparisonOperator.NotEquals), (inequality.AspectKey, inequality.FacetDefinitionId, inequality.Operator));
+        Assert.Equal(("TitleAspect", "Title", ComparisonOperator.In), (membership.AspectKey, membership.FacetDefinitionId, membership.Operator));
         Assert.Equal(("TitleAspect", "Title", ComparisonOperator.Contains), (contains.AspectKey, contains.FacetDefinitionId, contains.Operator));
+        Assert.Equal(("TitleAspect", "Title", ComparisonOperator.StartsWith), (startsWith.AspectKey, startsWith.FacetDefinitionId, startsWith.Operator));
+        Assert.Equal(("TitleAspect", "Title", ComparisonOperator.Exists), (exists.AspectKey, exists.FacetDefinitionId, exists.Operator));
         Assert.Equal(("PriceAspect", "Amount", ComparisonOperator.Range), (range.AspectKey, range.FacetDefinitionId, range.Operator));
+        Assert.Equal(new[] { "Gadget", "Widget" }, Assert.IsType<string[]>(membership.Value));
+        Assert.True(Assert.IsType<bool>(exists.Value));
         Assert.Equal(new RangeValue(10m, 20m), range.Value);
     }
 

--- a/test/Aster.Tests/SqliteJson/SqliteJsonQueryCapabilityTests.cs
+++ b/test/Aster.Tests/SqliteJson/SqliteJsonQueryCapabilityTests.cs
@@ -25,6 +25,10 @@ public sealed class SqliteJsonQueryCapabilityTests
         Assert.Contains(ResourceVersionScope.AllVersions, capabilities.SupportedScopes);
         Assert.Contains(ResourceVersionScope.Active, capabilities.SupportedScopes);
         Assert.Contains(ResourceVersionScope.Draft, capabilities.SupportedScopes);
+
+        AssertPortableOperators(QueryFilterType.Metadata);
+        AssertPortableOperators(QueryFilterType.FacetValue);
+        Assert.True(capabilities.SupportsComparison(QueryFilterType.FacetValue, ComparisonOperator.Exists));
     }
 
     [Fact]
@@ -57,5 +61,12 @@ public sealed class SqliteJsonQueryCapabilityTests
 
         Assert.True(result.IsValid);
         Assert.Empty(result.Failures);
+    }
+
+    private void AssertPortableOperators(QueryFilterType filterType)
+    {
+        Assert.True(capabilities.SupportsComparison(filterType, ComparisonOperator.NotEquals));
+        Assert.True(capabilities.SupportsComparison(filterType, ComparisonOperator.In));
+        Assert.True(capabilities.SupportsComparison(filterType, ComparisonOperator.StartsWith));
     }
 }

--- a/test/Aster.Tests/SqliteJson/SqliteJsonQueryServiceTests.cs
+++ b/test/Aster.Tests/SqliteJson/SqliteJsonQueryServiceTests.cs
@@ -310,9 +310,14 @@ public sealed class SqliteJsonQueryServiceTests : IDisposable
         {
             Filter = new FacetValueFilter("Price", "Amount", new RangeValue(-1, 1), ComparisonOperator.Range),
         })).ToList();
+        var notEqualsResults = (await query.QueryAsync(new ResourceQuery
+        {
+            Filter = new FacetValueFilter("Price", "Amount", 0, ComparisonOperator.NotEquals),
+        })).ToList();
 
         Assert.Equal(["product-b"], equalsResults.Select(r => r.ResourceId).ToList());
         Assert.Equal(["product-b"], rangeResults.Select(r => r.ResourceId).ToList());
+        Assert.Equal(["product-a"], notEqualsResults.Select(r => r.ResourceId).ToList());
     }
 
     [Fact]
@@ -338,6 +343,44 @@ public sealed class SqliteJsonQueryServiceTests : IDisposable
 
         Assert.Single(metadataResults);
         Assert.Single(facetResults);
+    }
+
+    [Fact]
+    public async Task QueryAsync_PortableOperators_AreTranslatedToSqlite()
+    {
+        var store = CreateStore();
+        await store.SaveVersionAsync(CreateResource("product-a", "Product", owner: "alice", aspects: new()
+        {
+            ["Title"] = new { Title = "Alpha Gadget" },
+            ["Category"] = new { Category = "Electronics" },
+        }));
+        await store.SaveVersionAsync(CreateResource("product-b", "Product", owner: "bob", aspects: new()
+        {
+            ["Title"] = new { Title = "Beta Widget" },
+            ["Category"] = new { Category = "Hardware" },
+        }));
+        await store.SaveVersionAsync(CreateResource("product-c", "Product", owner: "carol", aspects: new()
+        {
+            ["Category"] = new { Category = "Electronics" },
+        }));
+
+        await using var provider = CreateServiceProvider();
+        var query = provider.GetRequiredService<IResourceQueryService>();
+
+        var results = (await query.QueryAsync(new ResourceQuery
+        {
+            Filter = new LogicalExpression(LogicalOperator.And, [
+                new MetadataFilter("Owner", "bob", ComparisonOperator.NotEquals),
+                new MetadataFilter("Owner", new[] { "alice", "carol" }, ComparisonOperator.In),
+                new FacetValueFilter("Category", "Category", "Hardware", ComparisonOperator.NotEquals),
+                new FacetValueFilter("Category", "Category", new[] { "Electronics" }, ComparisonOperator.In),
+                new FacetValueFilter("Title", "Title", "Alpha", ComparisonOperator.StartsWith),
+                new FacetValueFilter("Title", "Title", true, ComparisonOperator.Exists),
+            ]),
+        })).ToList();
+
+        Assert.Single(results);
+        Assert.Equal("product-a", results[0].ResourceId);
     }
 
     [Fact]

--- a/wiki/Querying.md
+++ b/wiki/Querying.md
@@ -88,10 +88,15 @@ new LogicalExpression(LogicalOperator.Not, [
 | Operator | Description | In-memory support | SQLite JSON support |
 |---|---|---|---|
 | `Equals` | Exact match (case-insensitive for strings) | Yes | Yes |
+| `NotEquals` | Inverse exact match (case-insensitive for strings) | Yes | Yes |
+| `In` | Exact match against any value in a non-string enumerable candidate set | Yes | Yes |
 | `Contains` | Substring match (strings only) | Yes | Yes |
+| `StartsWith` | Prefix match (strings only, case-insensitive) | Yes | Yes |
 | `Range` | Min/max bounds via `RangeValue` | Numeric / date | Numeric scalar facets |
+| `Exists` | Facet value is present and non-null | Facets | Facets |
 
 `Range` values use `new RangeValue(min, max, includeMin, includeMax)`. A `null` min or max means the range is unbounded on that side.
+`In` values must be non-null, non-string enumerables with at least one candidate. `Exists` is represented as a `FacetValueFilter`; providers ignore the value for that operator.
 
 ---
 
@@ -191,7 +196,10 @@ public sealed record PriceAspect(decimal Amount);
 var filter = TypedQuery.And(
     TypedQuery.For<TitleAspect>()
         .Facet(x => x.Title)
-        .Contains("Gadget"),
+        .StartsWith("Gadget"),
+    TypedQuery.For<TitleAspect>()
+        .Facet(x => x.Title)
+        .In("Gadget Pro", "Gadget Plus"),
     TypedQuery.For<PriceAspect>()
         .Facet(x => x.Amount)
         .Range(min: 10m, max: 100m));
@@ -249,7 +257,7 @@ The provider supports:
 - metadata filtering and sorting over `ResourceId`, `Id`, `DefinitionId`, `Owner`, `Version`, and `Created`.
 - `Skip` and `Take`.
 - aspect presence checks.
-- facet `Equals`, string `Contains`, numeric `Range`, and facet sorting.
+- metadata/facet `Equals`, `NotEquals`, `In`, string `Contains`, string `StartsWith`, facet `Exists`, numeric facet `Range`, and facet sorting.
 - `And`, `Or`, and single-operand `Not`.
 
 Unsupported SQLite query shapes fail with `UnsupportedQueryFeatureException` instead of falling back to in-memory evaluation. The exception exposes stable `Code`, `Feature`, optional `Path`, and a human-readable message. Current intentional exclusions include metadata range filters, unknown metadata fields, empty ranges, negative paging values, and date-like facet ranges.

--- a/wiki/Querying.md
+++ b/wiki/Querying.md
@@ -97,6 +97,7 @@ new LogicalExpression(LogicalOperator.Not, [
 
 `Range` values use `new RangeValue(min, max, includeMin, includeMax)`. A `null` min or max means the range is unbounded on that side.
 `In` values must be non-null, non-string enumerables with at least one candidate. `Exists` is represented as a `FacetValueFilter`; providers ignore the value for that operator.
+`MetadataFilter.Value` now accepts `object` so metadata `In` predicates can carry enumerable candidate sets; callers that previously read it as `string` should format or pattern-match the value before using string-specific members.
 
 ---
 

--- a/wiki/Roadmap.md
+++ b/wiki/Roadmap.md
@@ -24,8 +24,8 @@ Aster is delivered in six phases. Each phase builds on the last, with clean exte
 | Slice | Status | Purpose |
 |---|---|---|
 | **008 Typed Query Authoring Ergonomics** | Landed | Add typed sort helpers and small composition conveniences over the existing `ResourceQuery` AST. |
-| **009 Portable Operator Expansion** | Next | Add operators such as `NotEquals`, `In`, `StartsWith`, and facet value presence with provider capabilities and conformance coverage. |
-| **010 SQLite Date-Like Facet Ranges** | Planned | Close the remaining SQLite date-like range capability gap with explicit serialization rules. |
+| **009 Portable Operator Expansion** | Landed | Add operators such as `NotEquals`, `In`, `StartsWith`, and facet value presence with provider capabilities and conformance coverage. |
+| **010 SQLite Date-Like Facet Ranges** | Next | Close the remaining SQLite date-like range capability gap with explicit serialization rules. |
 | **011 Explicit Indexing Model** | Planned | Introduce intentional index projection contracts without a hidden planner or runtime scanning. |
 | **012 Definition Schema Versions & Upgrade Flow** | Planned | Make long-lived resource schema versioning and upgrade behavior explicit. |
 


### PR DESCRIPTION
## Summary
- add portable NotEquals, In, StartsWith, and facet Exists operators
- wire validation, capabilities, in-memory execution, and SQLite JSON translation
- add spec artifacts, docs, and provider conformance coverage

## Validation
- git diff --check
- dotnet test Aster.sln
- dotnet build Aster.sln