### PR TITLE
Add SQLite date-like facet ranges

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "featureDir": "specs/009-portable-operators"
+  "featureDir": "specs/010-sqlite-date-ranges"
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,6 +6,7 @@ shell commands, and other important information, read the current plan
 ## Active Technologies
 - C# latest, .NET 8.0 / 9.0 / 10.0 multi-targeting + Existing core SDK, SQLite JSON provider, xUnit test stack; no new dependencies (009-portable-operators)
 - Existing resource payloads; no migration (009-portable-operators)
+- Existing resource JSON payloads; no migration or schema changes (010-sqlite-date-ranges)
 
 ## Recent Changes
 - 009-portable-operators: Added C# latest, .NET 8.0 / 9.0 / 10.0 multi-targeting + Existing core SDK, SQLite JSON provider, xUnit test stack; no new dependencies

--- a/docs/ExecutionRoadmap.md
+++ b/docs/ExecutionRoadmap.md
@@ -23,18 +23,9 @@ The active workstream is **Phase 3: Query Capabilities & Typed Querying**. The n
 | `007-sqlite-facet-sorting` | Landed | SQLite facet sorting, null-last behavior, numeric/text ordering, capability updates, and tests/docs. |
 | `008-typed-query-authoring` | Landed | Typed facet sort helpers, small logical composition helpers, and updated roadmap/query docs over the existing query AST. |
 | `009-portable-operators` | Landed | Portable `NotEquals`, `In`, `StartsWith`, and facet `Exists` operators with provider capabilities, validation, built-in execution, typed helpers, and conformance coverage. |
+| `010-sqlite-date-ranges` | Landed | SQLite date-like facet ranges for accepted JSON string date/time values with capability, validation, conformance, and docs coverage. |
 
 ## Near-Term Roadmap
-
-### 010 — SQLite Date-Like Facet Ranges
-
-**Goal:** Close the most visible remaining SQLite capability gap after numeric ranges and facet sorting.
-
-Candidate scope:
-
-- Define the accepted date/time serialization contract for facet range comparisons.
-- Translate date-like range filters in SQLite JSON when values are stored in the supported shape.
-- Keep invalid or mixed shapes fail-closed with structured diagnostics.
 
 ### 011 — Explicit Indexing Model
 

--- a/specs/010-sqlite-date-ranges/checklists/requirements.md
+++ b/specs/010-sqlite-date-ranges/checklists/requirements.md
@@ -1,0 +1,34 @@
+# Specification Quality Checklist: SQLite Date-Like Facet Ranges
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning  
+**Created**: 2026-05-18  
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [X] No implementation details (languages, frameworks, APIs)
+- [X] Focused on user value and business needs
+- [X] Written for non-technical stakeholders
+- [X] All mandatory sections completed
+
+## Requirement Completeness
+
+- [X] No [NEEDS CLARIFICATION] markers remain
+- [X] Requirements are testable and unambiguous
+- [X] Success criteria are measurable
+- [X] Success criteria are technology-agnostic (no implementation details)
+- [X] All acceptance scenarios are defined
+- [X] Edge cases are identified
+- [X] Scope is clearly bounded
+- [X] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [X] All functional requirements have clear acceptance criteria
+- [X] User scenarios cover primary flows
+- [X] Feature meets measurable outcomes defined in Success Criteria
+- [X] No implementation details leak into specification
+
+## Notes
+
+- Ready for planning and implementation.

--- a/specs/010-sqlite-date-ranges/contracts/sqlite-date-like-ranges.md
+++ b/specs/010-sqlite-date-ranges/contracts/sqlite-date-like-ranges.md
@@ -1,0 +1,52 @@
+# Contract: SQLite Date-Like Facet Ranges
+
+## Supported Query Shape
+
+SQLite JSON MUST support:
+
+```csharp
+new FacetValueFilter(
+    "Schedule",
+    "StartsAt",
+    new RangeValue(min, max, includeMin, includeMax),
+    ComparisonOperator.Range)
+```
+
+when `min` and/or `max` are date-like values.
+
+## Accepted Bounds
+
+Bounds MUST be accepted when they are:
+
+- `DateTime`
+- `DateTimeOffset`
+- strings parseable as accepted date/time values
+
+Bounds MUST be rejected when they are:
+
+- `DateOnly`
+- non-date strings
+- numbers mixed with date-like bounds
+- unsupported objects, arrays, or booleans
+
+## Accepted Stored Facet Values
+
+Stored facet values MUST match only when they are JSON string scalar values parseable as accepted date/time values.
+
+Stored values MUST NOT match when they are missing, null, malformed, non-string, numeric, boolean, object, or array values.
+
+## Capability Contract
+
+`SqliteJsonQueryCapabilitiesProvider` MUST declare `QueryValueShape.DateTime` in `FacetRangeSupport`.
+
+`UnsupportedFeatures` MUST NOT list date-like facet ranges after this capability is implemented.
+
+## Execution Contract
+
+SQLite translation MUST:
+
+- Normalize query bounds to a comparable round-trip representation.
+- Normalize stored date-like strings before comparison.
+- Honor inclusive and exclusive bounds.
+- Preserve existing numeric range semantics.
+- Use parameterized SQL for all query bound values.

--- a/specs/010-sqlite-date-ranges/data-model.md
+++ b/specs/010-sqlite-date-ranges/data-model.md
@@ -1,0 +1,50 @@
+# Data Model: SQLite Date-Like Facet Ranges
+
+## Date-Like Facet Range
+
+A facet range filter with:
+
+- `FilterExpression`: `FacetValueFilter`
+- `Operator`: `ComparisonOperator.Range`
+- `Value`: `RangeValue`
+- `RangeValue.Min` and/or `RangeValue.Max`: `DateTime`, `DateTimeOffset`, or accepted date/time string
+
+Validation rules:
+
+- At least one bound MUST be present.
+- Bounds MUST resolve to supported query value shapes.
+- Mixed numeric/date-like bounds SHOULD fail closed because they are not one coherent range type.
+
+## Accepted Stored Date Value
+
+A JSON scalar string stored inside an aspect payload.
+
+Accepted values:
+
+- Date/time strings parseable as `DateTimeOffset` or `DateTime` using invariant, round-trip-compatible parsing.
+- Values equivalent to `System.Text.Json` output for `DateTime` or `DateTimeOffset`.
+
+Rejected values:
+
+- Missing facet values.
+- JSON null.
+- Numbers, booleans, objects, or arrays.
+- Malformed strings.
+- Date-only values until date-only shape support is explicitly added.
+
+## Provider Capability Declaration
+
+SQLite JSON facet range support includes:
+
+- `QueryValueShape.Numeric`
+- `QueryValueShape.DateTime`
+
+Known unsupported features must no longer list date-like facet ranges after implementation.
+
+## Provider Authoring Failure
+
+If a provider declares date-like facet range support, validation and execution MUST agree:
+
+- Supported date-like range queries validate and execute.
+- Unsupported value shapes fail validation.
+- Provider-specific execution failures use structured `UnsupportedQueryFeatureException`.

--- a/specs/010-sqlite-date-ranges/plan.md
+++ b/specs/010-sqlite-date-ranges/plan.md
@@ -1,0 +1,66 @@
+# Implementation Plan: SQLite Date-Like Facet Ranges
+
+**Branch**: `010-sqlite-date-ranges` | **Date**: 2026-05-18 | **Spec**: [spec.md](spec.md)
+
+## Summary
+
+Close the SQLite JSON provider's date-like facet range gap by adding explicit translation for accepted ISO-8601-style string facet values. Keep the change provider-local: update SQLite capabilities, validation alignment, translator logic, conformance cases, tests, and docs without changing storage or adding query planning.
+
+## Technical Context
+
+**Language/Version**: C# latest, .NET 8.0 / 9.0 / 10.0 multi-targeting  
+**Primary Dependencies**: Existing core SDK, SQLite JSON provider, xUnit test stack; no new dependencies  
+**Storage**: Existing resource JSON payloads; no migration or schema changes  
+**Testing**: `dotnet test Aster.sln`, `dotnet build Aster.sln`, `git diff --check`  
+**Target Platform**: .NET library usable from Generic Host / ASP.NET Core hosts  
+**Project Type**: SDK/library with provider package  
+**Performance Goals**: Preserve existing query execution behavior; no indexing or planner introduced  
+**Constraints**: No public SQL API, public `IQueryable<Resource>`, runtime scanning, provider registry, schema migration, or query planner  
+**Scale/Scope**: One provider-local capability gap plus shared conformance coverage
+
+## Constitution Check
+
+- **SDK-first/headless**: PASS — SDK/provider behavior only.
+- **Immutable versioning**: PASS — Query-only change.
+- **Channel activation**: PASS — Existing scope behavior remains unchanged.
+- **Typed/queryable**: PASS — Portable AST semantics are preserved; no `IQueryable`.
+- **Provider agnostic**: PASS — Core stays provider-neutral; SQLite implementation is provider-local.
+- **Simplicity first**: PASS — Direct translator/capability/test updates.
+- **Modern C# idioms**: PASS — Uses existing records, pattern matching, and value-shape model.
+- **Readability over cleverness**: PASS — No planner or rewrite framework.
+- **Explicitness over magic**: PASS — Accepted date shape is documented and capability-declared.
+- **Abstractions justified**: PASS — No new abstraction layer.
+- **Optimize for deletion**: PASS — Changes are localized to SQLite range handling and docs/tests.
+- **Composition over inheritance**: PASS — No inheritance hierarchy.
+- **Intentional dependencies**: PASS — No new dependencies.
+- **Operational simplicity**: PASS — No migration, setup, or deployment change.
+
+## Project Structure
+
+```text
+src/persistence/Aster.Persistence.SqliteJson/
+├── Querying/SqliteWhereTranslator.cs
+├── README.md
+└── SqliteJsonQueryCapabilitiesProvider.cs
+
+src/core/Aster.Core/
+└── README.md
+
+test/Aster.Tests/
+├── Querying/ProviderConformanceTests.cs
+├── Querying/QueryCapabilityDiscoveryTests.cs
+├── Querying/ResourceQueryValidatorTests.cs
+└── SqliteJson/SqliteJsonQueryServiceTests.cs
+
+wiki/
+├── Querying.md
+└── Roadmap.md
+```
+
+## Validation
+
+- Focused SQLite date-like range tests
+- Provider conformance tests
+- `dotnet test Aster.sln`
+- `dotnet build Aster.sln`
+- `git diff --check`

--- a/specs/010-sqlite-date-ranges/quickstart.md
+++ b/specs/010-sqlite-date-ranges/quickstart.md
@@ -15,7 +15,7 @@ await manager.CreateAsync("Event", new CreateResourceRequest
 ## Query A Date Range
 
 ```csharp
-var results = await query.QueryAsync(new ResourceQuery
+var resourceQuery = new ResourceQuery
 {
     DefinitionId = "Event",
     Filter = new FacetValueFilter(
@@ -25,13 +25,15 @@ var results = await query.QueryAsync(new ResourceQuery
             Min: new DateTimeOffset(2026, 02, 01, 00, 00, 00, TimeSpan.Zero),
             Max: new DateTimeOffset(2026, 02, 28, 23, 59, 59, TimeSpan.Zero)),
         ComparisonOperator.Range),
-});
+};
+
+var results = await query.QueryAsync(resourceQuery);
 ```
 
 ## Validate First
 
 ```csharp
-var validation = validator.Validate(query);
+var validation = validator.Validate(resourceQuery);
 if (!validation.IsValid)
 {
     foreach (var failure in validation.Failures)

--- a/specs/010-sqlite-date-ranges/quickstart.md
+++ b/specs/010-sqlite-date-ranges/quickstart.md
@@ -1,0 +1,44 @@
+# Quickstart: SQLite Date-Like Facet Ranges
+
+## Store Date-Like Facets
+
+```csharp
+await manager.CreateAsync("Event", new CreateResourceRequest
+{
+    InitialAspects =
+    {
+        ["Schedule"] = new { StartsAt = new DateTimeOffset(2026, 02, 01, 10, 00, 00, TimeSpan.Zero) },
+    },
+});
+```
+
+## Query A Date Range
+
+```csharp
+var results = await query.QueryAsync(new ResourceQuery
+{
+    DefinitionId = "Event",
+    Filter = new FacetValueFilter(
+        "Schedule",
+        "StartsAt",
+        new RangeValue(
+            Min: new DateTimeOffset(2026, 02, 01, 00, 00, 00, TimeSpan.Zero),
+            Max: new DateTimeOffset(2026, 02, 28, 23, 59, 59, TimeSpan.Zero)),
+        ComparisonOperator.Range),
+});
+```
+
+## Validate First
+
+```csharp
+var validation = validator.Validate(query);
+if (!validation.IsValid)
+{
+    foreach (var failure in validation.Failures)
+        Console.WriteLine($"{failure.Code}: {failure.Message}");
+}
+```
+
+## Accepted Stored Shape
+
+Date-like SQLite facet ranges expect stored facet values to be JSON strings in the same ISO-8601-style shape emitted by `System.Text.Json` for `DateTime` or `DateTimeOffset`. Invalid strings, nulls, numbers, booleans, arrays, objects, and missing facets do not match.

--- a/specs/010-sqlite-date-ranges/research.md
+++ b/specs/010-sqlite-date-ranges/research.md
@@ -1,0 +1,36 @@
+# Research: SQLite Date-Like Facet Ranges
+
+## Decision 1: Support ISO-8601-style string facet values
+
+**Decision**: SQLite date-like facet ranges support JSON string scalar values that can be parsed as `DateTimeOffset` or `DateTime` and normalized to a round-trip UTC string for comparison.
+
+**Rationale**: `System.Text.Json` already emits date/time values as ISO-8601-style strings. Supporting that shape avoids storage changes and keeps behavior compatible with existing persisted payloads.
+
+**Alternatives considered**:
+
+- Store separate numeric ticks or generated columns. Rejected because this slice must not introduce migrations or indexing.
+- Support arbitrary local date strings. Rejected because provider behavior would be ambiguous and culture-sensitive.
+
+## Decision 2: Keep numeric and date-like range translation separate
+
+**Decision**: The SQLite translator branches numeric and date-like ranges explicitly.
+
+**Rationale**: Numeric ranges rely on JSON numeric type detection and numeric casts. Date-like ranges rely on string parse/normalization semantics. Keeping the paths separate is clearer and preserves existing numeric behavior.
+
+## Decision 3: Invalid stored values do not match
+
+**Decision**: Stored facet values that are missing, null, non-string, malformed, or not parseable as accepted date/time values do not match date-like range predicates.
+
+**Rationale**: Query results should fail closed at the row level when data does not satisfy the documented shape.
+
+## Decision 4: Invalid query bounds remain structured failures
+
+**Decision**: Query bounds that validation cannot classify as numeric or date-like continue to fail with structured value-shape errors.
+
+**Rationale**: The existing validator already owns bound-shape checks. Execution remains authoritative if validation is bypassed.
+
+## Decision 5: No query planner or indexing model
+
+**Decision**: This slice does not add planner rewrites, generated columns, or index declarations.
+
+**Rationale**: The immediate value is correctness and parity for simple date-like ranges. Indexing belongs to a later explicit indexing slice.

--- a/specs/010-sqlite-date-ranges/spec.md
+++ b/specs/010-sqlite-date-ranges/spec.md
@@ -1,0 +1,107 @@
+# Feature Specification: SQLite Date-Like Facet Ranges
+
+**Feature Branch**: `010-sqlite-date-ranges`  
+**Created**: 2026-05-18  
+**Status**: Draft  
+**Input**: User description: "Add SQLite JSON support for date-like facet range filters with an explicit accepted serialization contract, provider capability updates, validation alignment, SQL translation, conformance coverage, docs, and fail-closed diagnostics for unsupported or invalid date-like shapes."
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Query Date-Like Facet Ranges In SQLite (Priority: P1)
+
+As an SDK user using the SQLite JSON provider, I want range filters over date-like facet values to work when values are stored in the documented portable shape, so time-based resources can be queried without provider-specific workarounds.
+
+**Why this priority**: SQLite currently supports numeric facet ranges but intentionally rejects date-like facet ranges, leaving an important gap between in-memory and SQLite query behavior.
+
+**Independent Test**: Can be tested by storing resources with date/time facet values, issuing a `FacetValueFilter` with `ComparisonOperator.Range`, and asserting SQLite returns only resources inside the requested interval.
+
+**Acceptance Scenarios**:
+
+1. **Given** resources with facet values serialized as accepted date/time strings, **When** a caller filters with a date-like `RangeValue`, **Then** SQLite returns resources whose facet values fall within the requested range.
+2. **Given** inclusive and exclusive range bounds, **When** a caller executes the query, **Then** SQLite honors the bound inclusivity flags.
+3. **Given** a one-sided date-like range, **When** a caller executes the query, **Then** SQLite treats the missing bound as unbounded.
+
+---
+
+### User Story 2 - Validate Date-Like Range Support Consistently (Priority: P1)
+
+As a host or provider author, I want SQLite capability declarations and validation to describe date-like facet range support accurately, so callers can preflight queries before execution.
+
+**Why this priority**: Capability declarations are the contract used by query UIs, validators, and conformance tests.
+
+**Independent Test**: Can be tested by inspecting SQLite capabilities and validating supported date-like range queries.
+
+**Acceptance Scenarios**:
+
+1. **Given** SQLite JSON capabilities, **When** callers inspect facet range support, **Then** numeric and date-like shapes are declared.
+2. **Given** a date-like range query with supported bound values, **When** validation runs, **Then** validation succeeds.
+3. **Given** an unsupported range value shape, **When** validation runs, **Then** validation fails with a structured value-shape failure.
+
+---
+
+### User Story 3 - Fail Closed For Invalid Stored Date Values (Priority: P2)
+
+As an SDK user, I want invalid or mixed stored facet values to be ignored or rejected predictably, so bad data does not produce misleading matches.
+
+**Why this priority**: SQLite JSON documents may contain strings, numbers, nulls, or malformed values; date-like range behavior must remain explicit and debuggable.
+
+**Independent Test**: Can be tested by storing valid and invalid facet values and asserting range filters only match valid accepted values.
+
+**Acceptance Scenarios**:
+
+1. **Given** a stored facet value that is not in the accepted date/time string shape, **When** a date-like range filter executes, **Then** that resource does not match.
+2. **Given** a missing or null facet value, **When** a date-like range filter executes, **Then** that resource does not match.
+3. **Given** invalid query bound values, **When** validation or execution runs, **Then** the query fails closed with a structured unsupported query failure.
+
+### Edge Cases
+
+- Date-like range bounds MUST accept `DateTime`, `DateTimeOffset`, and accepted date/time strings.
+- Accepted stored date/time strings MUST be ISO-8601-style values that SQLite can compare lexicographically after normalization by the provider.
+- Date-only values, local ambiguous formats, malformed strings, numbers, booleans, objects, arrays, missing facets, and null facet values MUST NOT match date-like range predicates.
+- Numeric facet ranges MUST continue to behave unchanged.
+- In-memory date-like range support MUST remain unchanged.
+- The feature MUST NOT introduce a query planner, indexing model, migration, public SQL API, runtime scanning, or `IQueryable<Resource>`.
+
+### Constitution Alignment *(mandatory)*
+
+- **Simplicity**: Add direct SQLite translation for supported date-like range shapes; do not introduce indexing, planning, or schema migration.
+- **Explicitness**: Document the accepted date/time storage contract and declare support through existing capabilities.
+- **Dependencies**: None.
+- **Operational Impact**: No storage migration, deployment change, or new runtime configuration.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: SQLite JSON capabilities MUST declare `QueryValueShape.DateTime` support for facet range filters.
+- **FR-002**: SQLite JSON validation MUST accept facet range filters whose bounds are date-like values supported by the existing query value-shape model.
+- **FR-003**: SQLite JSON execution MUST translate supported date-like facet range filters into parameterized SQL over existing JSON facet values.
+- **FR-004**: SQLite JSON execution MUST continue to support numeric facet ranges exactly as before.
+- **FR-005**: SQLite JSON execution MUST NOT match missing, null, malformed, non-string, or unsupported stored facet values for date-like range filters.
+- **FR-006**: Date-like range translation MUST honor inclusive and exclusive bounds, and support min-only and max-only ranges.
+- **FR-007**: Unsupported range value shapes MUST fail closed with structured `UnsupportedQueryFeatureException`/validation failures.
+- **FR-008**: Provider conformance and SQLite query tests MUST cover date-like facet range validation and execution.
+- **FR-009**: Documentation MUST explain the accepted stored date/time shape and current exclusions.
+
+### Key Entities
+
+- **Date-like facet range**: A `FacetValueFilter` using `ComparisonOperator.Range` and a `RangeValue` whose bounds are date-like.
+- **Accepted stored date value**: A facet JSON scalar string that follows the documented date/time representation and can be compared consistently.
+- **Range bound**: The minimum or maximum value in a range predicate, including inclusivity flags.
+- **Provider capability declaration**: The SQLite provider support contract consumed by validation and conformance tests.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: SQLite JSON queries using date-like facet ranges validate and return correct results for inclusive, exclusive, and one-sided bounds.
+- **SC-002**: SQLite JSON capability tests assert both numeric and date-like facet range support.
+- **SC-003**: Provider conformance tests include a supported date-like range case for providers that declare date-like range support.
+- **SC-004**: Invalid stored date-like facet values do not match date-like range filters.
+- **SC-005**: `dotnet test Aster.sln`, `dotnet build Aster.sln`, and `git diff --check` pass.
+
+## Assumptions
+
+- Stored date/time facets are accepted when they are JSON string scalars in round-trip ISO-8601 format, such as values produced by `System.Text.Json` for `DateTime` or `DateTimeOffset`.
+- Query bounds are normalized by SQLite translation before comparison.
+- Date-only support remains out of scope until the query value-shape model explicitly includes it.

--- a/specs/010-sqlite-date-ranges/spec.md
+++ b/specs/010-sqlite-date-ranges/spec.md
@@ -2,7 +2,7 @@
 
 **Feature Branch**: `010-sqlite-date-ranges`  
 **Created**: 2026-05-18  
-**Status**: Draft  
+**Status**: Implemented
 **Input**: User description: "Add SQLite JSON support for date-like facet range filters with an explicit accepted serialization contract, provider capability updates, validation alignment, SQL translation, conformance coverage, docs, and fail-closed diagnostics for unsupported or invalid date-like shapes."
 
 ## User Scenarios & Testing *(mandatory)*

--- a/specs/010-sqlite-date-ranges/tasks.md
+++ b/specs/010-sqlite-date-ranges/tasks.md
@@ -1,0 +1,21 @@
+# Tasks: SQLite Date-Like Facet Ranges
+
+**Input**: Design documents from `specs/010-sqlite-date-ranges/`
+
+## Implementation
+
+- [X] T001 Update SQLite facet range capabilities to include date-like shapes.
+- [X] T002 Tighten range validation for mixed numeric/date-like bounds if needed.
+- [X] T003 Implement SQLite date-like facet range translation without changing numeric range behavior.
+- [X] T004 Add structured execution failures for invalid date-like query bounds when validation is bypassed.
+- [X] T005 Update provider conformance supported/unsupported date-like range cases.
+- [X] T006 Add SQLite execution tests for inclusive, exclusive, one-sided, missing, null, malformed, and non-string stored values.
+- [X] T007 Update capability, validator, and discovery tests.
+- [X] T008 Update README/wiki/provider docs and roadmap status.
+
+## Verification
+
+- [X] T009 Run focused SQLite/query capability tests.
+- [X] T010 Run `dotnet test Aster.sln`.
+- [X] T011 Run `dotnet build Aster.sln`.
+- [X] T012 Run `git diff --check`.

--- a/src/core/Aster.Core/Models/Querying/QueryDateTimeValue.cs
+++ b/src/core/Aster.Core/Models/Querying/QueryDateTimeValue.cs
@@ -70,17 +70,6 @@ public static class QueryDateTimeValue
             return true;
         }
 
-        if (DateTime.TryParseExact(
-            value,
-            AcceptedDateTimeFormats,
-            CultureInfo.InvariantCulture,
-            DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal,
-            out var dateTime))
-        {
-            key = FormatUtc(new DateTimeOffset(DateTime.SpecifyKind(dateTime, DateTimeKind.Utc)));
-            return true;
-        }
-
         key = string.Empty;
         return false;
     }

--- a/src/core/Aster.Core/Models/Querying/QueryDateTimeValue.cs
+++ b/src/core/Aster.Core/Models/Querying/QueryDateTimeValue.cs
@@ -1,0 +1,97 @@
+using System.Globalization;
+
+namespace Aster.Core.Models.Querying;
+
+/// <summary>
+/// Shared date/time value-shape rules for portable query validation and providers.
+/// </summary>
+public static class QueryDateTimeValue
+{
+    private static readonly string[] AcceptedDateTimeFormats =
+    [
+        "yyyy-MM-dd'T'HH:mm:ssK",
+        "yyyy-MM-dd'T'HH:mm:ss.FFFFFFFK",
+    ];
+
+    /// <summary>
+    /// Returns whether <paramref name="value"/> is an accepted date/time string for query ranges.
+    /// </summary>
+    /// <param name="value">The candidate date/time string.</param>
+    /// <returns><see langword="true"/> when the value uses an accepted ISO-8601-style shape.</returns>
+    public static bool IsAcceptedDateTimeString(string value) =>
+        value.Contains('T', StringComparison.Ordinal)
+        && DateTime.TryParseExact(
+            value,
+            AcceptedDateTimeFormats,
+            CultureInfo.InvariantCulture,
+            DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal,
+            out _);
+
+    /// <summary>
+    /// Attempts to normalize an accepted date/time value to a UTC key suitable for ordinal comparison.
+    /// </summary>
+    /// <param name="value">A <see cref="DateTime"/>, <see cref="DateTimeOffset"/>, or accepted date/time string.</param>
+    /// <param name="key">The normalized UTC key when successful.</param>
+    /// <returns><see langword="true"/> when the value can be normalized.</returns>
+    public static bool TryNormalizeDateKey(object? value, out string key)
+    {
+        switch (value)
+        {
+            case DateTimeOffset dateTimeOffset:
+                key = FormatUtc(dateTimeOffset);
+                return true;
+            case DateTime dateTime:
+                key = FormatUtc(new DateTimeOffset(NormalizeDateTime(dateTime)));
+                return true;
+            case string text when TryNormalizeTextDateKey(text, out key):
+                return true;
+            default:
+                key = string.Empty;
+                return false;
+        }
+    }
+
+    private static bool TryNormalizeTextDateKey(string value, out string key)
+    {
+        if (!IsAcceptedDateTimeString(value))
+        {
+            key = string.Empty;
+            return false;
+        }
+
+        if (DateTimeOffset.TryParseExact(
+            value,
+            AcceptedDateTimeFormats,
+            CultureInfo.InvariantCulture,
+            DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal,
+            out var dateTimeOffset))
+        {
+            key = FormatUtc(dateTimeOffset);
+            return true;
+        }
+
+        if (DateTime.TryParseExact(
+            value,
+            AcceptedDateTimeFormats,
+            CultureInfo.InvariantCulture,
+            DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal,
+            out var dateTime))
+        {
+            key = FormatUtc(new DateTimeOffset(DateTime.SpecifyKind(dateTime, DateTimeKind.Utc)));
+            return true;
+        }
+
+        key = string.Empty;
+        return false;
+    }
+
+    private static DateTime NormalizeDateTime(DateTime value) => value.Kind switch
+    {
+        DateTimeKind.Utc => value,
+        DateTimeKind.Local => value.ToUniversalTime(),
+        _ => DateTime.SpecifyKind(value, DateTimeKind.Utc),
+    };
+
+    private static string FormatUtc(DateTimeOffset value) =>
+        value.ToUniversalTime().ToString("yyyy-MM-dd'T'HH:mm:ss.fffffff'Z'", CultureInfo.InvariantCulture);
+}

--- a/src/core/Aster.Core/Models/Querying/QueryDateTimeValue.cs
+++ b/src/core/Aster.Core/Models/Querying/QueryDateTimeValue.cs
@@ -53,18 +53,13 @@ public static class QueryDateTimeValue
 
     private static bool TryNormalizeTextDateKey(string value, out string key)
     {
-        if (!IsAcceptedDateTimeString(value))
-        {
-            key = string.Empty;
-            return false;
-        }
-
-        if (DateTimeOffset.TryParseExact(
-            value,
-            AcceptedDateTimeFormats,
-            CultureInfo.InvariantCulture,
-            DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal,
-            out var dateTimeOffset))
+        if (value.Contains('T', StringComparison.Ordinal)
+            && DateTimeOffset.TryParseExact(
+                value,
+                AcceptedDateTimeFormats,
+                CultureInfo.InvariantCulture,
+                DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal,
+                out var dateTimeOffset))
         {
             key = FormatUtc(dateTimeOffset);
             return true;

--- a/src/core/Aster.Core/Services/ResourceQueryValidator.cs
+++ b/src/core/Aster.Core/Services/ResourceQueryValidator.cs
@@ -357,6 +357,7 @@ public sealed class ResourceQueryValidator : IResourceQueryValidator
 
         ValidateRangeBound(range.Min, $"{path}.Min", failures);
         ValidateRangeBound(range.Max, $"{path}.Max", failures);
+        ValidateRangeBoundCompatibility(range, path, failures);
     }
 
     private void ValidateRangeBound(object? value, string path, List<QueryValidationFailure> failures)
@@ -371,6 +372,24 @@ public sealed class ResourceQueryValidator : IResourceQueryValidator
         failures.Add(Failure(
             "unsupported-range-value-shape",
             $"Range value shape '{shape?.ToString() ?? value.GetType().Name}' is not supported by {capabilities!.ProviderName}.",
+            path,
+            "value shape"));
+    }
+
+    private static void ValidateRangeBoundCompatibility(RangeValue range, string path, List<QueryValidationFailure> failures)
+    {
+        if (range.Min is null || range.Max is null)
+            return;
+
+        var minShape = ResolveValueShape(range.Min);
+        var maxShape = ResolveValueShape(range.Max);
+
+        if (minShape is null || maxShape is null || minShape == maxShape)
+            return;
+
+        failures.Add(Failure(
+            "mixed-range-value-shapes",
+            $"Range bounds must use the same value shape, but received '{minShape}' and '{maxShape}'.",
             path,
             "value shape"));
     }

--- a/src/core/Aster.Core/Services/ResourceQueryValidator.cs
+++ b/src/core/Aster.Core/Services/ResourceQueryValidator.cs
@@ -456,7 +456,7 @@ public sealed class ResourceQueryValidator : IResourceQueryValidator
             if (decimal.TryParse(stringValue, NumberStyles.Number, CultureInfo.InvariantCulture, out _))
                 return QueryValueShape.Numeric;
 
-            if (IsAcceptedDateTimeString(stringValue))
+            if (QueryDateTimeValue.IsAcceptedDateTimeString(stringValue))
                 return QueryValueShape.DateTime;
 
             return QueryValueShape.String;
@@ -467,21 +467,6 @@ public sealed class ResourceQueryValidator : IResourceQueryValidator
 
         return null;
     }
-
-    private static bool IsAcceptedDateTimeString(string value) =>
-        value.Contains('T', StringComparison.Ordinal)
-        && DateTime.TryParseExact(
-            value,
-            AcceptedDateTimeFormats,
-            CultureInfo.InvariantCulture,
-            DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal,
-            out _);
-
-    private static readonly string[] AcceptedDateTimeFormats =
-    [
-        "yyyy-MM-dd'T'HH:mm:ssK",
-        "yyyy-MM-dd'T'HH:mm:ss.FFFFFFFK",
-    ];
 
     private static QueryValidationFailure Failure(
         string code,

--- a/src/core/Aster.Core/Services/ResourceQueryValidator.cs
+++ b/src/core/Aster.Core/Services/ResourceQueryValidator.cs
@@ -456,7 +456,7 @@ public sealed class ResourceQueryValidator : IResourceQueryValidator
             if (decimal.TryParse(stringValue, NumberStyles.Number, CultureInfo.InvariantCulture, out _))
                 return QueryValueShape.Numeric;
 
-            if (DateTime.TryParse(stringValue, CultureInfo.InvariantCulture, DateTimeStyles.AdjustToUniversal, out _))
+            if (IsAcceptedDateTimeString(stringValue))
                 return QueryValueShape.DateTime;
 
             return QueryValueShape.String;
@@ -467,6 +467,21 @@ public sealed class ResourceQueryValidator : IResourceQueryValidator
 
         return null;
     }
+
+    private static bool IsAcceptedDateTimeString(string value) =>
+        value.Contains('T', StringComparison.Ordinal)
+        && DateTime.TryParseExact(
+            value,
+            AcceptedDateTimeFormats,
+            CultureInfo.InvariantCulture,
+            DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal,
+            out _);
+
+    private static readonly string[] AcceptedDateTimeFormats =
+    [
+        "yyyy-MM-dd'T'HH:mm:ssK",
+        "yyyy-MM-dd'T'HH:mm:ss.FFFFFFFK",
+    ];
 
     private static QueryValidationFailure Failure(
         string code,

--- a/src/persistence/Aster.Persistence.SqliteJson/Querying/SqliteDateTimeBehavior.cs
+++ b/src/persistence/Aster.Persistence.SqliteJson/Querying/SqliteDateTimeBehavior.cs
@@ -1,0 +1,75 @@
+using System.Globalization;
+
+namespace Aster.Persistence.SqliteJson.Querying;
+
+internal static class SqliteDateTimeBehavior
+{
+    public const string DateKeyFunction = "aster_datetime_key";
+
+    public static string? NormalizeDateKey(string? value) =>
+        TryNormalizeDateKey(value, out var key) ? key : null;
+
+    public static bool TryNormalizeDateKey(object? value, out string key)
+    {
+        switch (value)
+        {
+            case DateTimeOffset dateTimeOffset:
+                key = FormatUtc(dateTimeOffset);
+                return true;
+            case DateTime dateTime:
+                key = FormatUtc(new DateTimeOffset(NormalizeDateTime(dateTime)));
+                return true;
+            case string text when TryNormalizeTextDateKey(text, out key):
+                return true;
+            default:
+                key = string.Empty;
+                return false;
+        }
+    }
+
+    private static bool TryNormalizeTextDateKey(string value, out string key)
+    {
+        if (!ContainsTimeComponent(value))
+        {
+            key = string.Empty;
+            return false;
+        }
+
+        if (DateTimeOffset.TryParse(
+            value,
+            CultureInfo.InvariantCulture,
+            DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal,
+            out var dateTimeOffset))
+        {
+            key = FormatUtc(dateTimeOffset);
+            return true;
+        }
+
+        if (DateTime.TryParse(
+            value,
+            CultureInfo.InvariantCulture,
+            DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal,
+            out var dateTime))
+        {
+            key = FormatUtc(new DateTimeOffset(DateTime.SpecifyKind(dateTime, DateTimeKind.Utc)));
+            return true;
+        }
+
+        key = string.Empty;
+        return false;
+    }
+
+    private static bool ContainsTimeComponent(string value) =>
+        value.Contains('T', StringComparison.Ordinal)
+        || value.Contains(' ', StringComparison.Ordinal);
+
+    private static DateTime NormalizeDateTime(DateTime value) => value.Kind switch
+    {
+        DateTimeKind.Utc => value,
+        DateTimeKind.Local => value.ToUniversalTime(),
+        _ => DateTime.SpecifyKind(value, DateTimeKind.Utc),
+    };
+
+    private static string FormatUtc(DateTimeOffset value) =>
+        value.ToUniversalTime().ToString("yyyy-MM-dd'T'HH:mm:ss.fffffff'Z'", CultureInfo.InvariantCulture);
+}

--- a/src/persistence/Aster.Persistence.SqliteJson/Querying/SqliteDateTimeBehavior.cs
+++ b/src/persistence/Aster.Persistence.SqliteJson/Querying/SqliteDateTimeBehavior.cs
@@ -35,8 +35,9 @@ internal static class SqliteDateTimeBehavior
             return false;
         }
 
-        if (DateTimeOffset.TryParse(
+        if (DateTimeOffset.TryParseExact(
             value,
+            AcceptedDateTimeFormats,
             CultureInfo.InvariantCulture,
             DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal,
             out var dateTimeOffset))
@@ -45,8 +46,9 @@ internal static class SqliteDateTimeBehavior
             return true;
         }
 
-        if (DateTime.TryParse(
+        if (DateTime.TryParseExact(
             value,
+            AcceptedDateTimeFormats,
             CultureInfo.InvariantCulture,
             DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal,
             out var dateTime))
@@ -60,8 +62,13 @@ internal static class SqliteDateTimeBehavior
     }
 
     private static bool ContainsTimeComponent(string value) =>
-        value.Contains('T', StringComparison.Ordinal)
-        || value.Contains(' ', StringComparison.Ordinal);
+        value.Contains('T', StringComparison.Ordinal);
+
+    private static readonly string[] AcceptedDateTimeFormats =
+    [
+        "yyyy-MM-dd'T'HH:mm:ssK",
+        "yyyy-MM-dd'T'HH:mm:ss.FFFFFFFK",
+    ];
 
     private static DateTime NormalizeDateTime(DateTime value) => value.Kind switch
     {

--- a/src/persistence/Aster.Persistence.SqliteJson/Querying/SqliteDateTimeBehavior.cs
+++ b/src/persistence/Aster.Persistence.SqliteJson/Querying/SqliteDateTimeBehavior.cs
@@ -1,4 +1,4 @@
-using System.Globalization;
+using Aster.Core.Models.Querying;
 
 namespace Aster.Persistence.SqliteJson.Querying;
 
@@ -7,76 +7,8 @@ internal static class SqliteDateTimeBehavior
     public const string DateKeyFunction = "aster_datetime_key";
 
     public static string? NormalizeDateKey(string? value) =>
-        TryNormalizeDateKey(value, out var key) ? key : null;
+        QueryDateTimeValue.TryNormalizeDateKey(value, out var key) ? key : null;
 
-    public static bool TryNormalizeDateKey(object? value, out string key)
-    {
-        switch (value)
-        {
-            case DateTimeOffset dateTimeOffset:
-                key = FormatUtc(dateTimeOffset);
-                return true;
-            case DateTime dateTime:
-                key = FormatUtc(new DateTimeOffset(NormalizeDateTime(dateTime)));
-                return true;
-            case string text when TryNormalizeTextDateKey(text, out key):
-                return true;
-            default:
-                key = string.Empty;
-                return false;
-        }
-    }
-
-    private static bool TryNormalizeTextDateKey(string value, out string key)
-    {
-        if (!ContainsTimeComponent(value))
-        {
-            key = string.Empty;
-            return false;
-        }
-
-        if (DateTimeOffset.TryParseExact(
-            value,
-            AcceptedDateTimeFormats,
-            CultureInfo.InvariantCulture,
-            DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal,
-            out var dateTimeOffset))
-        {
-            key = FormatUtc(dateTimeOffset);
-            return true;
-        }
-
-        if (DateTime.TryParseExact(
-            value,
-            AcceptedDateTimeFormats,
-            CultureInfo.InvariantCulture,
-            DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal,
-            out var dateTime))
-        {
-            key = FormatUtc(new DateTimeOffset(DateTime.SpecifyKind(dateTime, DateTimeKind.Utc)));
-            return true;
-        }
-
-        key = string.Empty;
-        return false;
-    }
-
-    private static bool ContainsTimeComponent(string value) =>
-        value.Contains('T', StringComparison.Ordinal);
-
-    private static readonly string[] AcceptedDateTimeFormats =
-    [
-        "yyyy-MM-dd'T'HH:mm:ssK",
-        "yyyy-MM-dd'T'HH:mm:ss.FFFFFFFK",
-    ];
-
-    private static DateTime NormalizeDateTime(DateTime value) => value.Kind switch
-    {
-        DateTimeKind.Utc => value,
-        DateTimeKind.Local => value.ToUniversalTime(),
-        _ => DateTime.SpecifyKind(value, DateTimeKind.Utc),
-    };
-
-    private static string FormatUtc(DateTimeOffset value) =>
-        value.ToUniversalTime().ToString("yyyy-MM-dd'T'HH:mm:ss.fffffff'Z'", CultureInfo.InvariantCulture);
+    public static bool TryNormalizeDateKey(object? value, out string key) =>
+        QueryDateTimeValue.TryNormalizeDateKey(value, out key);
 }

--- a/src/persistence/Aster.Persistence.SqliteJson/Querying/SqliteWhereTranslator.cs
+++ b/src/persistence/Aster.Persistence.SqliteJson/Querying/SqliteWhereTranslator.cs
@@ -156,6 +156,10 @@ internal sealed class SqliteWhereTranslator(SqliteParameterBag parameters)
 
     private string TranslateRange(SqliteFacetValueExpression value, RangeValue range)
     {
+        var rangeKind = ResolveRangeKind(range);
+        if (rangeKind == RangeKind.DateTime)
+            return TranslateDateTimeRange(value, range);
+
         var predicates = new List<string> { value.IsNumeric };
 
         if (range.Min is not null)
@@ -170,6 +174,24 @@ internal sealed class SqliteWhereTranslator(SqliteParameterBag parameters)
                 "value shape",
                 "Range predicates require at least one bound.",
                 "Filter.Value");
+
+        return string.Join(" AND ", predicates);
+    }
+
+    private string TranslateDateTimeRange(SqliteFacetValueExpression value, RangeValue range)
+    {
+        var dateKey = $"{SqliteDateTimeBehavior.DateKeyFunction}(CAST({value.Value} AS TEXT))";
+        var predicates = new List<string>
+        {
+            $"{value.Type} = 'text'",
+            $"{dateKey} IS NOT NULL",
+        };
+
+        if (range.Min is not null)
+            predicates.Add($"{dateKey} {(range.IncludeMin ? ">=" : ">")} {parameters.Add(ConvertToDateKey(range.Min, "minimum range bound"))}");
+
+        if (range.Max is not null)
+            predicates.Add($"{dateKey} {(range.IncludeMax ? "<=" : "<")} {parameters.Add(ConvertToDateKey(range.Max, "maximum range bound"))}");
 
         return string.Join(" AND ", predicates);
     }
@@ -287,6 +309,57 @@ internal sealed class SqliteWhereTranslator(SqliteParameterBag parameters)
                 $"{description} must be numeric.",
                 "Filter.Value");
 
+    private static string ConvertToDateKey(object value, string description) =>
+        SqliteDateTimeBehavior.TryNormalizeDateKey(value, out var key)
+            ? key
+            : throw Unsupported(
+                "unsupported-range-value-shape",
+                "value shape",
+                $"{description} must be a date-like value.",
+                "Filter.Value");
+
+    private static RangeKind ResolveRangeKind(RangeValue range)
+    {
+        var minKind = ResolveRangeBoundKind(range.Min, "minimum range bound");
+        var maxKind = ResolveRangeBoundKind(range.Max, "maximum range bound");
+
+        return (minKind, maxKind) switch
+        {
+            (null, null) => throw Unsupported(
+                "empty-range",
+                "value shape",
+                "Range predicates require at least one bound.",
+                "Filter.Value"),
+            (RangeKind.Numeric, null) or (null, RangeKind.Numeric) or (RangeKind.Numeric, RangeKind.Numeric) =>
+                RangeKind.Numeric,
+            (RangeKind.DateTime, null) or (null, RangeKind.DateTime) or (RangeKind.DateTime, RangeKind.DateTime) =>
+                RangeKind.DateTime,
+            _ => throw Unsupported(
+                "unsupported-range-value-shape",
+                "value shape",
+                "Range bounds must use the same value shape.",
+                "Filter.Value"),
+        };
+    }
+
+    private static RangeKind? ResolveRangeBoundKind(object? value, string description)
+    {
+        if (value is null)
+            return null;
+
+        if (TryConvertDouble(value, out _))
+            return RangeKind.Numeric;
+
+        if (SqliteDateTimeBehavior.TryNormalizeDateKey(value, out _))
+            return RangeKind.DateTime;
+
+        throw Unsupported(
+            "unsupported-range-value-shape",
+            "value shape",
+            $"{description} must be numeric or date-like.",
+            "Filter.Value");
+    }
+
     private static string? FormatValue(object? value) => value switch
     {
         null => null,
@@ -300,4 +373,10 @@ internal sealed class SqliteWhereTranslator(SqliteParameterBag parameters)
         string message,
         string? path = null) =>
         new(code, feature, message, path);
+
+    private enum RangeKind
+    {
+        Numeric,
+        DateTime,
+    }
 }

--- a/src/persistence/Aster.Persistence.SqliteJson/Querying/SqliteWhereTranslator.cs
+++ b/src/persistence/Aster.Persistence.SqliteJson/Querying/SqliteWhereTranslator.cs
@@ -320,8 +320,8 @@ internal sealed class SqliteWhereTranslator(SqliteParameterBag parameters)
 
     private static RangeKind ResolveRangeKind(RangeValue range)
     {
-        var minKind = ResolveRangeBoundKind(range.Min, "minimum range bound");
-        var maxKind = ResolveRangeBoundKind(range.Max, "maximum range bound");
+        var minKind = ResolveRangeBoundKind(range.Min, "minimum range bound", "Filter.Value.Min");
+        var maxKind = ResolveRangeBoundKind(range.Max, "maximum range bound", "Filter.Value.Max");
 
         return (minKind, maxKind) switch
         {
@@ -335,14 +335,14 @@ internal sealed class SqliteWhereTranslator(SqliteParameterBag parameters)
             (RangeKind.DateTime, null) or (null, RangeKind.DateTime) or (RangeKind.DateTime, RangeKind.DateTime) =>
                 RangeKind.DateTime,
             _ => throw Unsupported(
-                "unsupported-range-value-shape",
+                "mixed-range-value-shapes",
                 "value shape",
                 "Range bounds must use the same value shape.",
                 "Filter.Value"),
         };
     }
 
-    private static RangeKind? ResolveRangeBoundKind(object? value, string description)
+    private static RangeKind? ResolveRangeBoundKind(object? value, string description, string path)
     {
         if (value is null)
             return null;
@@ -357,7 +357,7 @@ internal sealed class SqliteWhereTranslator(SqliteParameterBag parameters)
             "unsupported-range-value-shape",
             "value shape",
             $"{description} must be numeric or date-like.",
-            "Filter.Value");
+            path);
     }
 
     private static string? FormatValue(object? value) => value switch

--- a/src/persistence/Aster.Persistence.SqliteJson/Querying/SqliteWhereTranslator.cs
+++ b/src/persistence/Aster.Persistence.SqliteJson/Querying/SqliteWhereTranslator.cs
@@ -188,10 +188,10 @@ internal sealed class SqliteWhereTranslator(SqliteParameterBag parameters)
         };
 
         if (range.Min is not null)
-            predicates.Add($"{dateKey} {(range.IncludeMin ? ">=" : ">")} {parameters.Add(ConvertToDateKey(range.Min, "minimum range bound"))}");
+            predicates.Add($"{dateKey} {(range.IncludeMin ? ">=" : ">")} {parameters.Add(ConvertToDateKey(range.Min, "minimum range bound", "Filter.Value.Min"))}");
 
         if (range.Max is not null)
-            predicates.Add($"{dateKey} {(range.IncludeMax ? "<=" : "<")} {parameters.Add(ConvertToDateKey(range.Max, "maximum range bound"))}");
+            predicates.Add($"{dateKey} {(range.IncludeMax ? "<=" : "<")} {parameters.Add(ConvertToDateKey(range.Max, "maximum range bound", "Filter.Value.Max"))}");
 
         return string.Join(" AND ", predicates);
     }
@@ -309,14 +309,14 @@ internal sealed class SqliteWhereTranslator(SqliteParameterBag parameters)
                 $"{description} must be numeric.",
                 "Filter.Value");
 
-    private static string ConvertToDateKey(object value, string description) =>
+    private static string ConvertToDateKey(object value, string description, string path) =>
         SqliteDateTimeBehavior.TryNormalizeDateKey(value, out var key)
             ? key
             : throw Unsupported(
                 "unsupported-range-value-shape",
                 "value shape",
                 $"{description} must be a date-like value.",
-                "Filter.Value");
+                path);
 
     private static RangeKind ResolveRangeKind(RangeValue range)
     {

--- a/src/persistence/Aster.Persistence.SqliteJson/README.md
+++ b/src/persistence/Aster.Persistence.SqliteJson/README.md
@@ -36,9 +36,11 @@ Supported query shapes:
 - metadata/facet `Equals`, `NotEquals`, and `In`
 - string `Contains` and `StartsWith`
 - facet `Exists`
-- numeric facet `Range`
+- numeric/date-like facet `Range`
 - `And`, `Or`, and single-operand `Not`
 
-Unsupported query shapes throw `UnsupportedQueryFeatureException` with stable `Code`, `Feature`, optional `Path`, and an actionable message. Metadata range filters, unknown metadata fields, empty ranges, negative paging values, and date-like facet ranges are intentionally out of scope for this phase.
+Date-like facet ranges match JSON string scalar values in the ISO-8601-style shape emitted by `System.Text.Json` for `DateTime` or `DateTimeOffset`. Date-only strings, malformed strings, numbers, booleans, objects, arrays, nulls, and missing facets do not match date-like range predicates.
 
-The provider also declares this support through `SqliteJsonQueryCapabilitiesProvider` with provider key `sqlite-json`, so callers can inspect capabilities or use `IResourceQueryValidator` before execution. Validation reports unsupported SQLite shapes, such as date-like facet ranges, without falling back to the in-memory provider. Execution runs shared validation first and remains authoritative if validation is skipped.
+Unsupported query shapes throw `UnsupportedQueryFeatureException` with stable `Code`, `Feature`, optional `Path`, and an actionable message. Metadata range filters, unknown metadata fields, empty ranges, negative paging values, mixed range bound shapes, and invalid date-like range bounds are intentionally rejected.
+
+The provider also declares this support through `SqliteJsonQueryCapabilitiesProvider` with provider key `sqlite-json`, so callers can inspect capabilities or use `IResourceQueryValidator` before execution. Execution runs shared validation first and remains authoritative if validation is skipped.

--- a/src/persistence/Aster.Persistence.SqliteJson/SqliteJsonQueryCapabilitiesProvider.cs
+++ b/src/persistence/Aster.Persistence.SqliteJson/SqliteJsonQueryCapabilitiesProvider.cs
@@ -80,10 +80,13 @@ public sealed class SqliteJsonQueryCapabilitiesProvider : IResourceQueryCapabili
         SupportsFacetSorting: true,
         SupportsSkip: true,
         SupportsTake: true,
-        FacetRangeSupport: new HashSet<QueryValueShape> { QueryValueShape.Numeric },
+        FacetRangeSupport: new HashSet<QueryValueShape>
+        {
+            QueryValueShape.Numeric,
+            QueryValueShape.DateTime,
+        },
         UnsupportedFeatures:
         [
             "Metadata range filters",
-            "Date-like facet ranges",
         ]);
 }

--- a/src/persistence/Aster.Persistence.SqliteJson/SqliteJsonQueryService.cs
+++ b/src/persistence/Aster.Persistence.SqliteJson/SqliteJsonQueryService.cs
@@ -107,6 +107,10 @@ public sealed class SqliteJsonQueryService : IResourceQueryService, IResourceQue
             SqliteTextBehavior.StartsWithFunction,
             SqliteTextBehavior.StartsWithIgnoreCase);
 
+        connection.CreateFunction<string?, string?>(
+            SqliteDateTimeBehavior.DateKeyFunction,
+            SqliteDateTimeBehavior.NormalizeDateKey);
+
         connection.CreateCollation(
             SqliteTextBehavior.OrdinalIgnoreCaseCollation,
             SqliteTextBehavior.CompareIgnoreCase);

--- a/test/Aster.Tests/Querying/ProviderConformanceTests.cs
+++ b/test/Aster.Tests/Querying/ProviderConformanceTests.cs
@@ -574,6 +574,22 @@ internal static class ProviderConformanceSuite
                 });
         }
 
+        if (capabilities.FacetRangeSupport.Contains(QueryValueShape.DateTime)
+            && capabilities.SupportsComparison(QueryFilterType.FacetValue, ComparisonOperator.Range))
+        {
+            yield return new(
+                "Date-like facet range filter",
+                "Facet filter",
+                new ResourceQuery
+                {
+                    Filter = new FacetValueFilter(
+                        "Schedule",
+                        "StartsAt",
+                        new RangeValue(Utc(2026, 2, 1), Utc(2026, 2, 3)),
+                        ComparisonOperator.Range),
+                });
+        }
+
         if (capabilities.SupportedLogicalOperators.Contains(LogicalOperator.And)
             && capabilities.SupportsComparison(QueryFilterType.FacetValue, ComparisonOperator.Equals))
         {
@@ -698,6 +714,9 @@ internal static class ProviderConformanceSuite
 
     private static string FailureCodes(IEnumerable<QueryValidationFailure> failures) =>
         string.Join(", ", failures.Select(static failure => failure.Code));
+
+    private static DateTime Utc(int year, int month, int day) =>
+        new(year, month, day, 0, 0, 0, DateTimeKind.Utc);
 
     private sealed record ProviderQueryCase(
         string Name,

--- a/test/Aster.Tests/Querying/QueryCapabilityDiscoveryTests.cs
+++ b/test/Aster.Tests/Querying/QueryCapabilityDiscoveryTests.cs
@@ -64,7 +64,7 @@ public sealed class QueryCapabilityDiscoveryTests : IDisposable
         Assert.True(inMemory.SupportsFacetSorting);
         Assert.True(sqlite.SupportsFacetSorting);
         Assert.Contains(QueryValueShape.DateTime, inMemory.FacetRangeSupport);
-        Assert.DoesNotContain(QueryValueShape.DateTime, sqlite.FacetRangeSupport);
+        Assert.Contains(QueryValueShape.DateTime, sqlite.FacetRangeSupport);
     }
 
     [Fact]
@@ -88,8 +88,7 @@ public sealed class QueryCapabilityDiscoveryTests : IDisposable
                 ComparisonOperator.Range),
         });
 
-        Assert.False(result.IsValid);
-        Assert.Contains(result.Failures, failure => failure.Code == "unsupported-range-value-shape");
+        Assert.True(result.IsValid);
     }
 
     [Fact]
@@ -134,12 +133,12 @@ public sealed class QueryCapabilityDiscoveryTests : IDisposable
                 Filter = new FacetValueFilter(
                     "Schedule",
                     "StartsAt",
-                    new RangeValue(DateTime.UtcNow.AddDays(-1), DateTime.UtcNow),
+                    new RangeValue(DateTime.UtcNow.AddDays(-1), 10),
                     ComparisonOperator.Range),
             },
             provider.GetRequiredService<IResourceQueryValidator>(),
             provider.GetRequiredService<IResourceQueryService>(),
-            "unsupported-range-value-shape");
+            "mixed-range-value-shapes");
     }
 
     private static async Task AssertValidatesAndExecutesAsync(

--- a/test/Aster.Tests/Querying/QueryCapabilityDiscoveryTests.cs
+++ b/test/Aster.Tests/Querying/QueryCapabilityDiscoveryTests.cs
@@ -65,6 +65,8 @@ public sealed class QueryCapabilityDiscoveryTests : IDisposable
         Assert.True(sqlite.SupportsFacetSorting);
         Assert.Contains(QueryValueShape.DateTime, inMemory.FacetRangeSupport);
         Assert.Contains(QueryValueShape.DateTime, sqlite.FacetRangeSupport);
+        Assert.Contains("Version", inMemory.MetadataContainsFields);
+        Assert.DoesNotContain("Version", sqlite.MetadataContainsFields);
     }
 
     [Fact]
@@ -81,14 +83,11 @@ public sealed class QueryCapabilityDiscoveryTests : IDisposable
         var validator = provider.GetRequiredService<IResourceQueryValidator>();
         var result = validator.Validate(new ResourceQuery
         {
-            Filter = new FacetValueFilter(
-                "Schedule",
-                "StartsAt",
-                new RangeValue(DateTime.UtcNow.AddDays(-1), DateTime.UtcNow),
-                ComparisonOperator.Range),
+            Filter = new MetadataFilter("Version", "1", ComparisonOperator.Contains),
         });
 
-        Assert.True(result.IsValid);
+        Assert.False(result.IsValid);
+        Assert.Contains(result.Failures, failure => failure.Code == "unsupported-metadata-contains-field");
     }
 
     [Fact]

--- a/test/Aster.Tests/Querying/ResourceQueryValidatorTests.cs
+++ b/test/Aster.Tests/Querying/ResourceQueryValidatorTests.cs
@@ -117,6 +117,21 @@ public sealed class ResourceQueryValidatorTests
     }
 
     [Fact]
+    public void Validate_AcceptsIsoStyleStringRangeBounds()
+    {
+        var result = sqliteValidator.Validate(new ResourceQuery
+        {
+            Filter = new FacetValueFilter(
+                "Schedule",
+                "StartsAt",
+                new RangeValue("2026-02-01T11:00:00+01:00", "2026-02-20T10:00:00Z"),
+                ComparisonOperator.Range),
+        });
+
+        Assert.True(result.IsValid);
+    }
+
+    [Fact]
     public void Validate_RejectsMixedRangeValueShapes()
     {
         var result = sqliteValidator.Validate(new ResourceQuery

--- a/test/Aster.Tests/Querying/ResourceQueryValidatorTests.cs
+++ b/test/Aster.Tests/Querying/ResourceQueryValidatorTests.cs
@@ -68,7 +68,7 @@ public sealed class ResourceQueryValidatorTests
         Assert.Contains(result.Failures, failure => failure.Code == "negative-take");
         Assert.Contains(result.Failures, failure => failure.Code == "unsupported-metadata-field");
         Assert.Contains(result.Failures, failure => failure.Code == "unsupported-comparison-operator");
-        Assert.Contains(result.Failures, failure => failure.Code == "unsupported-range-value-shape");
+        Assert.DoesNotContain(result.Failures, failure => failure.Code == "unsupported-range-value-shape");
     }
 
     [Fact]
@@ -100,7 +100,7 @@ public sealed class ResourceQueryValidatorTests
     }
 
     [Fact]
-    public void Validate_InMemoryAndSqliteReflectProviderDifferences()
+    public void Validate_InMemoryAndSqliteBothSupportDateLikeFacetRanges()
     {
         var dateRangeQuery = new ResourceQuery
         {
@@ -113,11 +113,23 @@ public sealed class ResourceQueryValidatorTests
         };
 
         Assert.True(inMemoryValidator.Validate(dateRangeQuery).IsValid);
+        Assert.True(sqliteValidator.Validate(dateRangeQuery).IsValid);
+    }
 
-        var sqliteResult = sqliteValidator.Validate(dateRangeQuery);
+    [Fact]
+    public void Validate_RejectsMixedRangeValueShapes()
+    {
+        var result = sqliteValidator.Validate(new ResourceQuery
+        {
+            Filter = new FacetValueFilter(
+                "Schedule",
+                "StartsAt",
+                new RangeValue(DateTime.UtcNow, 10),
+                ComparisonOperator.Range),
+        });
 
-        Assert.False(sqliteResult.IsValid);
-        Assert.Contains(sqliteResult.Failures, failure => failure.Code == "unsupported-range-value-shape");
+        Assert.False(result.IsValid);
+        Assert.Contains(result.Failures, failure => failure.Code == "mixed-range-value-shapes");
     }
 
     [Fact]

--- a/test/Aster.Tests/Querying/ResourceQueryValidatorTests.cs
+++ b/test/Aster.Tests/Querying/ResourceQueryValidatorTests.cs
@@ -237,6 +237,24 @@ public sealed class ResourceQueryValidatorTests
         Assert.Contains(result.Failures, failure => failure.Code == "unsupported-range-value-shape");
     }
 
+    [Theory]
+    [InlineData("2026-02-01")]
+    [InlineData("2026-02-01 10:00:00")]
+    public void Validate_RejectsUnsupportedDateLikeStringRangeBounds(string value)
+    {
+        var result = sqliteValidator.Validate(new ResourceQuery
+        {
+            Filter = new FacetValueFilter(
+                "Schedule",
+                "StartsAt",
+                new RangeValue(value, null),
+                ComparisonOperator.Range),
+        });
+
+        Assert.False(result.IsValid);
+        Assert.Contains(result.Failures, failure => failure.Code == "unsupported-range-value-shape");
+    }
+
     [Fact]
     public void Validate_WhenActiveQueryServiceHasNoMatchingCapabilities_FailsClosed()
     {

--- a/test/Aster.Tests/SqliteJson/SqliteJsonQueryCapabilityTests.cs
+++ b/test/Aster.Tests/SqliteJson/SqliteJsonQueryCapabilityTests.cs
@@ -32,12 +32,13 @@ public sealed class SqliteJsonQueryCapabilityTests
     }
 
     [Fact]
-    public void Capabilities_IncludeFacetSortingAndExcludeDateLikeFacetRanges()
+    public void Capabilities_IncludeFacetSortingAndDateLikeFacetRanges()
     {
         Assert.True(capabilities.SupportsFacetSorting);
         Assert.DoesNotContain("Facet sorting", capabilities.UnsupportedFeatures);
         Assert.Contains(QueryValueShape.Numeric, capabilities.FacetRangeSupport);
-        Assert.DoesNotContain(QueryValueShape.DateTime, capabilities.FacetRangeSupport);
+        Assert.Contains(QueryValueShape.DateTime, capabilities.FacetRangeSupport);
+        Assert.DoesNotContain("Date-like facet ranges", capabilities.UnsupportedFeatures);
         Assert.True(capabilities.SupportsComparison(QueryFilterType.FacetValue, ComparisonOperator.Range));
     }
 

--- a/test/Aster.Tests/SqliteJson/SqliteJsonQueryServiceTests.cs
+++ b/test/Aster.Tests/SqliteJson/SqliteJsonQueryServiceTests.cs
@@ -348,6 +348,10 @@ public sealed class SqliteJsonQueryServiceTests : IDisposable
         {
             ["Schedule"] = new { StartsAt = "2026-02-10" },
         }));
+        await store.SaveVersionAsync(CreateResource("event-space-separated", "Event", aspects: new()
+        {
+            ["Schedule"] = new { StartsAt = "2026-02-10 10:00:00" },
+        }));
         await store.SaveVersionAsync(CreateResource("event-number", "Event", aspects: new()
         {
             ["Schedule"] = new { StartsAt = 20260210 },
@@ -401,7 +405,7 @@ public sealed class SqliteJsonQueryServiceTests : IDisposable
             }).AsTask(),
             "unsupported-range-value-shape",
             "value shape",
-            "Filter.Value");
+            "Filter.Value.Min");
     }
 
     [Fact]

--- a/test/Aster.Tests/SqliteJson/SqliteJsonQueryServiceTests.cs
+++ b/test/Aster.Tests/SqliteJson/SqliteJsonQueryServiceTests.cs
@@ -386,6 +386,10 @@ public sealed class SqliteJsonQueryServiceTests : IDisposable
             query,
             min: null,
             max: new DateTimeOffset(2026, 2, 15, 10, 0, 0, TimeSpan.Zero));
+        var minOnly = await ExecuteDateRangeAsync(
+            query,
+            min: new DateTimeOffset(2026, 2, 15, 10, 0, 0, TimeSpan.Zero),
+            max: null);
         var stringBounds = await ExecuteDateRangeAsync(
             query,
             "2026-02-01T11:00:00+01:00",
@@ -394,6 +398,7 @@ public sealed class SqliteJsonQueryServiceTests : IDisposable
         Assert.Equal(["event-a", "event-b", "event-b-offset", "event-c"], inclusive);
         Assert.Equal(["event-b", "event-b-offset"], exclusive);
         Assert.Equal(["event-a", "event-b", "event-b-offset"], oneSided);
+        Assert.Equal(["event-b", "event-b-offset", "event-c", "event-d"], minOnly);
         Assert.Equal(["event-a", "event-b", "event-b-offset", "event-c"], stringBounds);
     }
 

--- a/test/Aster.Tests/SqliteJson/SqliteJsonQueryServiceTests.cs
+++ b/test/Aster.Tests/SqliteJson/SqliteJsonQueryServiceTests.cs
@@ -321,6 +321,90 @@ public sealed class SqliteJsonQueryServiceTests : IDisposable
     }
 
     [Fact]
+    public async Task QueryAsync_DateLikeFacetRanges_FilterAcceptedStoredValues()
+    {
+        var store = CreateStore();
+        await store.SaveVersionAsync(CreateResource("event-a", "Event", aspects: new()
+        {
+            ["Schedule"] = new { StartsAt = new DateTimeOffset(2026, 2, 1, 10, 0, 0, TimeSpan.Zero) },
+        }));
+        await store.SaveVersionAsync(CreateResource("event-b", "Event", aspects: new()
+        {
+            ["Schedule"] = new { StartsAt = new DateTimeOffset(2026, 2, 15, 10, 0, 0, TimeSpan.Zero) },
+        }));
+        await store.SaveVersionAsync(CreateResource("event-c", "Event", aspects: new()
+        {
+            ["Schedule"] = new { StartsAt = new DateTimeOffset(2026, 2, 20, 10, 0, 0, TimeSpan.Zero) },
+        }));
+        await store.SaveVersionAsync(CreateResource("event-d", "Event", aspects: new()
+        {
+            ["Schedule"] = new { StartsAt = new DateTimeOffset(2026, 3, 1, 10, 0, 0, TimeSpan.Zero) },
+        }));
+        await store.SaveVersionAsync(CreateResource("event-invalid-string", "Event", aspects: new()
+        {
+            ["Schedule"] = new { StartsAt = "not-a-date" },
+        }));
+        await store.SaveVersionAsync(CreateResource("event-date-only", "Event", aspects: new()
+        {
+            ["Schedule"] = new { StartsAt = "2026-02-10" },
+        }));
+        await store.SaveVersionAsync(CreateResource("event-number", "Event", aspects: new()
+        {
+            ["Schedule"] = new { StartsAt = 20260210 },
+        }));
+        await store.SaveVersionAsync(CreateResource("event-null", "Event", aspects: new()
+        {
+            ["Schedule"] = new { StartsAt = (string?)null },
+        }));
+        await store.SaveVersionAsync(CreateResource("event-missing-facet", "Event", aspects: new()
+        {
+            ["Schedule"] = new { EndsAt = new DateTimeOffset(2026, 2, 10, 10, 0, 0, TimeSpan.Zero) },
+        }));
+
+        await using var provider = CreateServiceProvider();
+        var query = provider.GetRequiredService<IResourceQueryService>();
+
+        var inclusive = await ExecuteDateRangeAsync(
+            query,
+            new DateTimeOffset(2026, 2, 1, 10, 0, 0, TimeSpan.Zero),
+            new DateTimeOffset(2026, 2, 20, 10, 0, 0, TimeSpan.Zero));
+        var exclusive = await ExecuteDateRangeAsync(
+            query,
+            new DateTimeOffset(2026, 2, 1, 10, 0, 0, TimeSpan.Zero),
+            new DateTimeOffset(2026, 2, 20, 10, 0, 0, TimeSpan.Zero),
+            includeMin: false,
+            includeMax: false);
+        var oneSided = await ExecuteDateRangeAsync(
+            query,
+            min: null,
+            max: new DateTimeOffset(2026, 2, 15, 10, 0, 0, TimeSpan.Zero));
+
+        Assert.Equal(["event-a", "event-b", "event-c"], inclusive);
+        Assert.Equal(["event-b"], exclusive);
+        Assert.Equal(["event-a", "event-b"], oneSided);
+    }
+
+    [Fact]
+    public async Task QueryAsync_DateOnlyStringRangeBound_FailsClosed()
+    {
+        await using var provider = CreateServiceProvider();
+        var query = provider.GetRequiredService<IResourceQueryService>();
+
+        await AssertUnsupportedAsync(
+            query.QueryAsync(new ResourceQuery
+            {
+                Filter = new FacetValueFilter(
+                    "Schedule",
+                    "StartsAt",
+                    new RangeValue("2026-02-01", "2026-02-28"),
+                    ComparisonOperator.Range),
+            }).AsTask(),
+            "unsupported-range-value-shape",
+            "value shape",
+            "Filter.Value");
+    }
+
+    [Fact]
     public async Task QueryAsync_TextComparisons_UseOrdinalIgnoreCaseForNonAsciiValues()
     {
         var store = CreateStore();
@@ -508,11 +592,11 @@ public sealed class SqliteJsonQueryServiceTests : IDisposable
                 Filter = new FacetValueFilter(
                     "Schedule",
                     "StartsAt",
-                    new RangeValue(DateTime.UtcNow.AddDays(-1), DateTime.UtcNow),
+                    new RangeValue(DateTime.UtcNow.AddDays(-1), 10),
                     ComparisonOperator.Range),
             },
-            "unsupported-range-value-shape",
-            "Filter.Value.Min");
+            "mixed-range-value-shapes",
+            "Filter.Value");
     }
 
     [Fact]
@@ -553,7 +637,7 @@ public sealed class SqliteJsonQueryServiceTests : IDisposable
     }
 
     [Fact]
-    public async Task QueryAsync_AfterValidationAgainstDifferentProvider_StillEnforcesSqliteCapabilities()
+    public async Task QueryAsync_AfterValidationAgainstDifferentProvider_AllowsSharedDateLikeRanges()
     {
         var queryShape = new ResourceQuery
         {
@@ -568,9 +652,10 @@ public sealed class SqliteJsonQueryServiceTests : IDisposable
         await using var provider = CreateServiceProvider();
         var query = provider.GetRequiredService<IResourceQueryService>();
 
+        var sqliteResults = await query.QueryAsync(queryShape);
+
         Assert.True(inMemoryValidation.IsValid);
-        await Assert.ThrowsAsync<UnsupportedQueryFeatureException>(() =>
-            query.QueryAsync(queryShape).AsTask());
+        Assert.Empty(sqliteResults);
     }
 
     [Fact]
@@ -620,6 +705,27 @@ public sealed class SqliteJsonQueryServiceTests : IDisposable
 
     private static DateTime Utc(int year, int month, int day) =>
         new(year, month, day, 0, 0, 0, DateTimeKind.Utc);
+
+    private static async Task<IReadOnlyList<string>> ExecuteDateRangeAsync(
+        IResourceQueryService query,
+        object? min,
+        object? max,
+        bool includeMin = true,
+        bool includeMax = true)
+    {
+        var results = (await query.QueryAsync(new ResourceQuery
+        {
+            DefinitionId = "Event",
+            Filter = new FacetValueFilter(
+                "Schedule",
+                "StartsAt",
+                new RangeValue(min, max, includeMin, includeMax),
+                ComparisonOperator.Range),
+            Sorts = [new SortExpression("ResourceId")],
+        })).ToList();
+
+        return results.Select(resource => resource.ResourceId).ToList();
+    }
 
     private static async Task<UnsupportedQueryFeatureException> AssertUnsupportedAsync(
         Task task,

--- a/test/Aster.Tests/SqliteJson/SqliteJsonQueryServiceTests.cs
+++ b/test/Aster.Tests/SqliteJson/SqliteJsonQueryServiceTests.cs
@@ -386,10 +386,15 @@ public sealed class SqliteJsonQueryServiceTests : IDisposable
             query,
             min: null,
             max: new DateTimeOffset(2026, 2, 15, 10, 0, 0, TimeSpan.Zero));
+        var stringBounds = await ExecuteDateRangeAsync(
+            query,
+            "2026-02-01T11:00:00+01:00",
+            "2026-02-20T10:00:00Z");
 
         Assert.Equal(["event-a", "event-b", "event-b-offset", "event-c"], inclusive);
         Assert.Equal(["event-b", "event-b-offset"], exclusive);
         Assert.Equal(["event-a", "event-b", "event-b-offset"], oneSided);
+        Assert.Equal(["event-a", "event-b", "event-b-offset", "event-c"], stringBounds);
     }
 
     [Fact]

--- a/test/Aster.Tests/SqliteJson/SqliteJsonQueryServiceTests.cs
+++ b/test/Aster.Tests/SqliteJson/SqliteJsonQueryServiceTests.cs
@@ -332,6 +332,10 @@ public sealed class SqliteJsonQueryServiceTests : IDisposable
         {
             ["Schedule"] = new { StartsAt = new DateTimeOffset(2026, 2, 15, 10, 0, 0, TimeSpan.Zero) },
         }));
+        await store.SaveVersionAsync(CreateResource("event-b-offset", "Event", aspects: new()
+        {
+            ["Schedule"] = new { StartsAt = new DateTimeOffset(2026, 2, 15, 12, 0, 0, TimeSpan.FromHours(2)) },
+        }));
         await store.SaveVersionAsync(CreateResource("event-c", "Event", aspects: new()
         {
             ["Schedule"] = new { StartsAt = new DateTimeOffset(2026, 2, 20, 10, 0, 0, TimeSpan.Zero) },
@@ -383,9 +387,9 @@ public sealed class SqliteJsonQueryServiceTests : IDisposable
             min: null,
             max: new DateTimeOffset(2026, 2, 15, 10, 0, 0, TimeSpan.Zero));
 
-        Assert.Equal(["event-a", "event-b", "event-c"], inclusive);
-        Assert.Equal(["event-b"], exclusive);
-        Assert.Equal(["event-a", "event-b"], oneSided);
+        Assert.Equal(["event-a", "event-b", "event-b-offset", "event-c"], inclusive);
+        Assert.Equal(["event-b", "event-b-offset"], exclusive);
+        Assert.Equal(["event-a", "event-b", "event-b-offset"], oneSided);
     }
 
     [Fact]

--- a/wiki/Querying.md
+++ b/wiki/Querying.md
@@ -92,10 +92,11 @@ new LogicalExpression(LogicalOperator.Not, [
 | `In` | Exact match against any value in a non-string enumerable candidate set | Yes | Yes |
 | `Contains` | Substring match (strings only) | Yes | Yes |
 | `StartsWith` | Prefix match (strings only, case-insensitive) | Yes | Yes |
-| `Range` | Min/max bounds via `RangeValue` | Numeric / date | Numeric scalar facets |
+| `Range` | Min/max bounds via `RangeValue` | Numeric / date | Numeric and date-like scalar facets |
 | `Exists` | Facet value is present and non-null | Facets | Facets |
 
 `Range` values use `new RangeValue(min, max, includeMin, includeMax)`. A `null` min or max means the range is unbounded on that side.
+SQLite date-like facet ranges match JSON string scalar values in the ISO-8601-style shape emitted by `System.Text.Json` for `DateTime` or `DateTimeOffset`. Date-only strings, malformed strings, numbers, booleans, objects, arrays, nulls, and missing facets do not match date-like ranges.
 `In` values must be non-null, non-string enumerables with at least one candidate. `Exists` is represented as a `FacetValueFilter`; providers ignore the value for that operator.
 `MetadataFilter.Value` now accepts `object` so metadata `In` predicates can carry enumerable candidate sets; callers that previously read it as `string` should format or pattern-match the value before using string-specific members.
 
@@ -141,7 +142,7 @@ Console.WriteLine(capabilities.ProviderKey);
 Console.WriteLine(capabilities.SupportsFacetSorting);
 ```
 
-Capabilities describe supported scopes, filter categories, comparison operators, logical operators, metadata fields, sort categories, paging, facet range value shapes, and known exclusions. The in-memory provider currently declares facet sorting and numeric/date-like facet ranges; SQLite JSON declares metadata sorting, facet sorting, and numeric facet ranges.
+Capabilities describe supported scopes, filter categories, comparison operators, logical operators, metadata fields, sort categories, paging, facet range value shapes, and known exclusions. The in-memory and SQLite JSON providers currently declare facet sorting and numeric/date-like facet ranges.
 Capability declarations are matched to the active query provider by explicit `ProviderKey` values such as `in-memory` and `sqlite-json`.
 
 Custom providers can use `AddResourceQueryProvider<TQueryService, TCapabilitiesProvider>()` to register their active query service and matching capability provider together. Validation fails closed with `capabilities-not-declared` when the active provider key has no matching declaration.
@@ -258,15 +259,15 @@ The provider supports:
 - metadata filtering and sorting over `ResourceId`, `Id`, `DefinitionId`, `Owner`, `Version`, and `Created`.
 - `Skip` and `Take`.
 - aspect presence checks.
-- metadata/facet `Equals`, `NotEquals`, `In`, string `Contains`, string `StartsWith`, facet `Exists`, numeric facet `Range`, and facet sorting.
+- metadata/facet `Equals`, `NotEquals`, `In`, string `Contains`, string `StartsWith`, facet `Exists`, numeric/date-like facet `Range`, and facet sorting.
 - `And`, `Or`, and single-operand `Not`.
 
-Unsupported SQLite query shapes fail with `UnsupportedQueryFeatureException` instead of falling back to in-memory evaluation. The exception exposes stable `Code`, `Feature`, optional `Path`, and a human-readable message. Current intentional exclusions include metadata range filters, unknown metadata fields, empty ranges, negative paging values, and date-like facet ranges.
+Unsupported SQLite query shapes fail with `UnsupportedQueryFeatureException` instead of falling back to in-memory evaluation. The exception exposes stable `Code`, `Feature`, optional `Path`, and a human-readable message. Current intentional exclusions include metadata range filters, unknown metadata fields, empty ranges, negative paging values, mixed range bound shapes, and invalid date-like range bound values.
 
 ## Current Limitations
 
 - **No provider capability planner yet** — capabilities and validation describe what a provider can execute; they do not rewrite queries.
-- **Provider-specific semantics are explicit** — SQLite facet ranges are numeric-only in this phase.
+- **Provider-specific semantics are explicit** — SQLite date-like facet ranges require accepted ISO-8601-style JSON string facet values.
 - **No public `IQueryable<Resource>`** — LINQ may be used inside a provider, but the public contract stays on the portable AST.
 
 ---

--- a/wiki/Roadmap.md
+++ b/wiki/Roadmap.md
@@ -25,8 +25,8 @@ Aster is delivered in six phases. Each phase builds on the last, with clean exte
 |---|---|---|
 | **008 Typed Query Authoring Ergonomics** | Landed | Add typed sort helpers and small composition conveniences over the existing `ResourceQuery` AST. |
 | **009 Portable Operator Expansion** | Landed | Add operators such as `NotEquals`, `In`, `StartsWith`, and facet value presence with provider capabilities and conformance coverage. |
-| **010 SQLite Date-Like Facet Ranges** | Next | Close the remaining SQLite date-like range capability gap with explicit serialization rules. |
-| **011 Explicit Indexing Model** | Planned | Introduce intentional index projection contracts without a hidden planner or runtime scanning. |
+| **010 SQLite Date-Like Facet Ranges** | Landed | Close the remaining SQLite date-like range capability gap with explicit serialization rules. |
+| **011 Explicit Indexing Model** | Next | Introduce intentional index projection contracts without a hidden planner or runtime scanning. |
 | **012 Definition Schema Versions & Upgrade Flow** | Planned | Make long-lived resource schema versioning and upgrade behavior explicit. |
 
 ---


### PR DESCRIPTION
## Summary
- add SQLite JSON date-like facet range translation for accepted ISO-8601-style JSON string values
- declare DateTime facet range support and align validator/conformance coverage
- document accepted stored shapes and fail-closed exclusions

## Validation
- dotnet test Aster.sln
- dotnet build Aster.sln
- git diff --check