### PR TITLE
[codex] Add definition schema upgrade flow

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "featureDir": "specs/011-explicit-indexing-model"
+  "featureDir": "specs/012-definition-schema-upgrades"
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 <!-- SPECKIT START -->
 For additional context about technologies to be used, project structure,
-shell commands, and other important information, read `specs/011-explicit-indexing-model/plan.md`.
+shell commands, and other important information, read `specs/012-definition-schema-upgrades/plan.md`.
 <!-- SPECKIT END -->
 
 ## Active Technologies
@@ -8,7 +8,10 @@ shell commands, and other important information, read `specs/011-explicit-indexi
 - Existing resource payloads; no migration (009-portable-operators)
 - Existing resource JSON payloads; no migration or schema changes (010-sqlite-date-ranges)
 - Existing resource JSON payloads; no schema migration or physical index creation (011-explicit-indexing-model)
+- C# latest, .NET 8.0 / 9.0 / 10.0 multi-targeting + Existing core SDK, resource manager/store abstractions, SQLite JSON provider, xUnit test stack; no new dependencies (012-definition-schema-upgrades)
+- Existing resource JSON payloads and definition versions; no schema migration or automatic data rewrite (012-definition-schema-upgrades)
 
 ## Recent Changes
+- 012-definition-schema-upgrades: Added definition schema version and explicit upgrade flow planning; no schema migration or automatic data rewrite
 - 011-explicit-indexing-model: Added explicit provider-declared indexing model planning for core SDK contracts; no storage migration or physical indexing
 - 009-portable-operators: Added C# latest, .NET 8.0 / 9.0 / 10.0 multi-targeting + Existing core SDK, SQLite JSON provider, xUnit test stack; no new dependencies

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 It provides a headless, backend-agnostic foundation for attaching reusable, cross-cutting capabilities (Tags, Owner, RBAC, Scheduling, …) to any resource type — without hard-coding every entity from scratch.
 
-> **Status:** Phase 3 in progress — Core SDK, in-memory engine, SQLite JSON persistence/querying, query capability discovery, preflight validation, and typed query helpers are available. See [Roadmap](#roadmap) for future phases.
+> **Status:** Phase 3 in progress — Core SDK, in-memory engine, SQLite JSON persistence/querying, query capability discovery, preflight validation, typed query helpers, provider conformance support, portable operators, SQLite date-like ranges, and explicit index projection contracts are available. See [Roadmap](#roadmap) for future phases.
 
 ---
 
@@ -137,6 +137,7 @@ Console.WriteLine(title?.Title); // "Super Gadget Pro"
 | `IResourceQueryService` | `InMemoryQueryService` |
 | `IResourceQueryCapabilitiesProvider` | `InMemoryQueryCapabilitiesProvider` |
 | `IResourceQueryValidator` | `ResourceQueryValidator` |
+| `IResourceSchemaVersionService` | `ResourceSchemaVersionService` |
 | `ITypedAspectBinder` | `SystemTextJsonAspectBinder` |
 | `ITypedFacetBinder` | `SystemTextJsonFacetBinder` |
 | `IIdentityGenerator` | `GuidIdentityGenerator` |
@@ -186,6 +187,7 @@ var filter = TypedQuery.For<TitleAspect>()
 ## Versioning & Activation
 
 - **Immutable versions** — every call to `UpdateAsync` appends a new version.
+- **Definition lineage** — every new resource records the active `ResourceDefinition.Version` in `Resource.DefinitionVersion`. Normal updates preserve that recorded lineage.
 - **Optimistic concurrency** — `UpdateResourceRequest.BaseVersion` must match the current latest; mismatches throw `ConcurrencyException`.
 - **Activation** — `ActivateAsync(resourceId, version, channel, allowMultipleActive)`:
   - `allowMultipleActive = false` (default): deactivates all other versions in the channel first.
@@ -196,12 +198,28 @@ var filter = TypedQuery.For<TitleAspect>()
   - `GetVersionsAsync(resourceId)` — all versions.
   - `GetActiveVersionsAsync(resourceId, channel)` — all active versions in a channel.
 
+Use `IResourceSchemaVersionService` when a host needs to inspect or explicitly advance definition lineage:
+
+```csharp
+var schemaVersions = serviceProvider.GetRequiredService<IResourceSchemaVersionService>();
+var status = await schemaVersions.GetSchemaStatusAsync(resource);
+
+var upgrade = await schemaVersions.UpgradeAsync(resource.ResourceId, new ResourceSchemaUpgradeRequest
+{
+    BaseVersion = resource.Version,
+    TargetDefinitionVersion = status.LatestDefinitionVersion,
+});
+```
+
+Schema status is evaluated for one resource version at a time. Explicit upgrades append a new resource version, default to the latest definition version when no target is supplied, preserve existing aspect data by default, and report `CarriedForwardAspectKeys` for aspect keys not declared by the target definition. A target equal to the source lineage returns `ResourceSchemaUpgradeStatus.NoOp`; invalid targets throw `ResourceSchemaUpgradeException` with a stable `Code`.
+
 ### Exception reference
 
 | Exception | When thrown |
 |---|---|
 | `ConcurrencyException` | `BaseVersion` mismatch on update or activate |
 | `VersionNotFoundException` | Requested version does not exist |
+| `ResourceSchemaUpgradeException` | Explicit schema upgrade target is invalid or unavailable |
 | `SingletonViolationException` | Creating a second instance of a singleton definition |
 | `DuplicateResourceIdException` | Caller-supplied `ResourceId` already exists |
 | `DuplicateAspectAttachmentException` | Same aspect key attached twice to a definition |

--- a/docs/ExecutionRoadmap.md
+++ b/docs/ExecutionRoadmap.md
@@ -6,9 +6,9 @@ This roadmap tracks the implementation trail we have already cut through the rep
 
 ## Current Position
 
-Aster now has a working Core SDK, in-memory runtime, SQLite JSON persistence/querying, provider capability discovery, provider validation alignment, provider authoring ergonomics, a reusable provider conformance harness, and SQLite facet sorting.
+Aster now has a working Core SDK, in-memory runtime, SQLite JSON persistence/querying, provider capability discovery, provider validation alignment, provider authoring ergonomics, a reusable provider conformance harness, SQLite facet sorting, portable operator expansion, SQLite date-like ranges, and explicit provider-declared index projections.
 
-The active workstream is **Phase 3: Query Capabilities & Typed Querying**. The next useful slices should close remaining portable query/provider gaps without introducing a planner, registry, runtime scanning, public SQL, or `IQueryable<Resource>`.
+The active workstream is **Phase 3: Query Capabilities & Typed Querying**. The next useful slice is definition schema versioning and explicit upgrade behavior, still without introducing migrations, planner behavior, runtime scanning, provider registries, public SQL, or `IQueryable<Resource>`.
 
 ## Landed Slices
 
@@ -24,18 +24,9 @@ The active workstream is **Phase 3: Query Capabilities & Typed Querying**. The n
 | `008-typed-query-authoring` | Landed | Typed facet sort helpers, small logical composition helpers, and updated roadmap/query docs over the existing query AST. |
 | `009-portable-operators` | Landed | Portable `NotEquals`, `In`, `StartsWith`, and facet `Exists` operators with provider capabilities, validation, built-in execution, typed helpers, and conformance coverage. |
 | `010-sqlite-date-ranges` | Landed | SQLite date-like facet ranges for accepted JSON string date/time values with capability, validation, conformance, and docs coverage. |
+| `011-explicit-indexing-model` | Landed | Provider-declared index projection contracts, validation, evaluation, capability discovery, and provider-authoring docs without physical indexes or query planning. |
 
 ## Near-Term Roadmap
-
-### 011 — Explicit Indexing Model
-
-**Goal:** Introduce indexing as an explicit provider capability, not hidden magic.
-
-Candidate scope:
-
-- Define index field types such as `Keyword`, `Text`, `NormalizedText`, `Boolean`, `Integer`, `Decimal`, `DateTime`, `Guid`, and `KeywordArray`.
-- Add provider-facing contracts for declaring and consuming index projections.
-- Keep SQLite JSON simple; defer heavy query planning.
 
 ### 012 — Definition Schema Versions & Upgrade Flow
 
@@ -46,6 +37,16 @@ Candidate scope:
 - Model `ResourceDefinitionVersion` references on resources.
 - Define upgrade behavior from older definition versions.
 - Add validation and tests for resources that span schema versions.
+
+### 013 — Portability Primitives
+
+**Goal:** Start Phase 4 with deterministic export/import primitives for definitions and resources.
+
+Candidate scope:
+
+- Export definition and resource snapshots with stable references.
+- Import with deterministic ID remapping and collision diagnostics.
+- Keep recipes and host lifecycle hooks separate follow-up slices.
 
 ## Later Roadmap
 

--- a/specs/012-definition-schema-upgrades/checklists/requirements.md
+++ b/specs/012-definition-schema-upgrades/checklists/requirements.md
@@ -1,0 +1,34 @@
+# Specification Quality Checklist: Definition Schema Versions & Upgrade Flow
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning  
+**Created**: 2026-05-18  
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [X] No implementation details (languages, frameworks, APIs)
+- [X] Focused on user value and business needs
+- [X] Written for non-technical stakeholders
+- [X] All mandatory sections completed
+
+## Requirement Completeness
+
+- [X] No [NEEDS CLARIFICATION] markers remain
+- [X] Requirements are testable and unambiguous
+- [X] Success criteria are measurable
+- [X] Success criteria are technology-agnostic (no implementation details)
+- [X] All acceptance scenarios are defined
+- [X] Edge cases are identified
+- [X] Scope is clearly bounded
+- [X] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [X] All functional requirements have clear acceptance criteria
+- [X] User scenarios cover primary flows
+- [X] Feature meets measurable outcomes defined in Success Criteria
+- [X] No implementation details leak into specification
+
+## Notes
+
+- Initial validation passed. Product terms such as resource definition, resource version, schema status, and upgrade result are domain concepts under specification rather than implementation details.

--- a/specs/012-definition-schema-upgrades/contracts/definition-schema-upgrades.md
+++ b/specs/012-definition-schema-upgrades/contracts/definition-schema-upgrades.md
@@ -1,0 +1,120 @@
+# Contract: Definition Schema Versions & Upgrade Flow
+
+## Public SDK Behavior
+
+The SDK exposes an explicit schema-version workflow for resource versions:
+
+1. Inspect the schema status for one resource version.
+2. Explicitly upgrade the latest resource version to an existing target definition version.
+3. Receive either an upgraded resource version, a no-op result, or structured failure diagnostics.
+
+The workflow MUST NOT automatically rewrite historical resource versions.
+
+## Schema Status Contract
+
+```csharp
+public interface IResourceSchemaVersionService
+{
+    ValueTask<ResourceSchemaStatusResult> GetSchemaStatusAsync(
+        Resource resource,
+        CancellationToken cancellationToken = default);
+
+    ValueTask<ResourceSchemaUpgradeResult> UpgradeAsync(
+        string resourceId,
+        ResourceSchemaUpgradeRequest request,
+        CancellationToken cancellationToken = default);
+}
+```
+
+`GetSchemaStatusAsync` evaluates exactly one resource version snapshot. It does not inspect every version of a resource and does not mutate state.
+
+## Status Result Contract
+
+```csharp
+public enum ResourceSchemaStatus
+{
+    Current,
+    OlderThanLatest,
+    MissingDefinition,
+    MissingDefinitionVersion,
+    UnknownResourceLineage,
+}
+
+public sealed record ResourceSchemaStatusResult
+{
+    public required string ResourceId { get; init; }
+    public required int ResourceVersion { get; init; }
+    public required string DefinitionId { get; init; }
+    public int? RecordedDefinitionVersion { get; init; }
+    public int? LatestDefinitionVersion { get; init; }
+    public required ResourceSchemaStatus Status { get; init; }
+    public required string Message { get; init; }
+}
+```
+
+## Upgrade Request Contract
+
+```csharp
+public sealed class ResourceSchemaUpgradeRequest
+{
+    public int BaseVersion { get; set; }
+    public int? TargetDefinitionVersion { get; set; }
+    public Dictionary<string, object> AspectUpdates { get; set; } = [];
+}
+```
+
+Rules:
+
+- `BaseVersion` is the existing optimistic concurrency token.
+- `TargetDefinitionVersion` defaults to latest when omitted.
+- `AspectUpdates` uses the same state-replace semantics as normal resource updates.
+- Unknown-lineage resources may be upgraded when the target definition version exists.
+
+## Upgrade Result Contract
+
+```csharp
+public enum ResourceSchemaUpgradeStatus
+{
+    Upgraded,
+    NoOp,
+}
+
+public sealed record ResourceSchemaUpgradeResult
+{
+    public required ResourceSchemaUpgradeStatus Status { get; init; }
+    public Resource? Resource { get; init; }
+    public int? SourceDefinitionVersion { get; init; }
+    public required int TargetDefinitionVersion { get; init; }
+    public IReadOnlyList<string> CarriedForwardAspectKeys { get; init; } = [];
+    public required string Message { get; init; }
+}
+```
+
+Rules:
+
+- `Upgraded` means a new immutable resource version was appended.
+- `NoOp` means the requested target equals the source definition version and no new resource version was appended.
+- `CarriedForwardAspectKeys` lists source aspect keys not declared by the target definition version and preserved by default.
+
+## Failure Contract
+
+Failures use structured SDK exceptions consistent with existing lifecycle behavior.
+
+Required failure cases:
+
+- Missing definition: `ResourceSchemaUpgradeException` with code `missing-definition`.
+- Missing target definition version: `ResourceSchemaUpgradeException` with code `missing-definition-version`.
+- Target definition version older than the source lineage: `ResourceSchemaUpgradeException` with code `target-definition-version-before-source`.
+- Target definition version newer than latest known definition version: `ResourceSchemaUpgradeException` with code `target-definition-version-too-new`.
+- Stale `BaseVersion`: existing `ConcurrencyException`.
+- Missing latest resource version: existing `VersionNotFoundException`.
+
+## Non-Goals
+
+- No automatic migration runner.
+- No background resource rewriting.
+- No transformation pipeline.
+- No provider registry.
+- No runtime scanning.
+- No query planner.
+- No public SQL or public `IQueryable<Resource>`.

--- a/specs/012-definition-schema-upgrades/data-model.md
+++ b/specs/012-definition-schema-upgrades/data-model.md
@@ -1,0 +1,128 @@
+# Data Model: Definition Schema Versions & Upgrade Flow
+
+## Resource Definition Version
+
+An immutable schema snapshot for a resource definition.
+
+**Existing fields used**:
+
+- `DefinitionId`: stable logical identifier.
+- `Version`: immutable definition version number.
+- `AspectDefinitions`: declared aspect attachments for that definition version.
+- `IsSingleton`: singleton policy for the definition version.
+
+**Validation rules**:
+
+- The latest version is resolved through the definition store.
+- A specific target version must exist before an upgrade can use it.
+
+## Resource Version Lineage
+
+The link from a resource version snapshot to the definition version that governed it.
+
+**Existing fields used**:
+
+- `Resource.DefinitionId`
+- `Resource.DefinitionVersion`
+- `Resource.Version`
+
+**Validation rules**:
+
+- New resource creation records the latest available definition version.
+- Normal resource update preserves the source resource version's `DefinitionVersion`.
+- Missing `DefinitionVersion` is `unknown-resource-lineage`.
+- Historical resource versions are never rewritten when definitions change.
+
+## Schema Status
+
+A diagnostic result for one resource version.
+
+**Fields**:
+
+- `ResourceId`
+- `ResourceVersion`
+- `DefinitionId`
+- `RecordedDefinitionVersion`
+- `LatestDefinitionVersion`
+- `Status`
+- `Message`
+
+**Status values**:
+
+- `Current`: recorded definition version equals latest definition version.
+- `OlderThanLatest`: recorded definition version exists and is lower than latest.
+- `MissingDefinition`: no definition exists for the resource's definition identifier.
+- `MissingDefinitionVersion`: definition exists, but the recorded version does not.
+- `UnknownResourceLineage`: resource version does not record definition version lineage.
+
+**Validation rules**:
+
+- Status is always for one requested resource version.
+- A recorded definition version greater than latest is treated as `MissingDefinitionVersion`.
+- Status never upgrades or mutates a resource.
+
+## Upgrade Request
+
+A caller-initiated request to append a new resource version with target definition lineage.
+
+**Fields**:
+
+- `BaseVersion`: optimistic concurrency token, matching current latest resource version.
+- `TargetDefinitionVersion`: optional explicit target; defaults to latest definition version.
+- `AspectUpdates`: optional explicit aspect changes applied during upgrade.
+
+**Validation rules**:
+
+- Base version must match latest resource version.
+- Target definition version must exist.
+- For known source lineage, target must be greater than source lineage and not greater than latest.
+- Target equal to source lineage returns no-op rather than appending a duplicate version.
+- Unknown source lineage may upgrade to an existing target version when concurrency checks pass.
+
+## Upgrade Result
+
+The outcome of an explicit upgrade request.
+
+**Fields**:
+
+- `Status`
+- `Resource`
+- `SourceDefinitionVersion`
+- `TargetDefinitionVersion`
+- `CarriedForwardAspectKeys`
+- `Message`
+
+**Status values**:
+
+- `Upgraded`: a new resource version was created.
+- `NoOp`: no new version was created because source and target definition versions already match.
+
+**Failure behavior**:
+
+- Missing target definition version fails with structured diagnostics.
+- Stale base version fails with existing optimistic concurrency behavior.
+- Invalid target ordering fails with structured diagnostics.
+
+## Carried-Forward Data
+
+Aspect data preserved during upgrade even though the target definition version does not declare that aspect key.
+
+**Fields**:
+
+- Aspect key.
+
+**Validation rules**:
+
+- Carried-forward data is reported, not removed.
+- Callers may explicitly change aspect data during upgrade through aspect updates.
+
+## State Transitions
+
+```text
+Current resource version
+  ├─ Check schema status -> diagnostic only, no mutation
+  ├─ Normal update -> new resource version, same DefinitionVersion
+  └─ Explicit upgrade
+      ├─ target equals source -> NoOp
+      └─ target newer/existing -> new resource version with TargetDefinitionVersion
+```

--- a/specs/012-definition-schema-upgrades/plan.md
+++ b/specs/012-definition-schema-upgrades/plan.md
@@ -1,0 +1,118 @@
+# Implementation Plan: Definition Schema Versions & Upgrade Flow
+
+**Branch**: `012-definition-schema-upgrades` | **Date**: 2026-05-19 | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from `/specs/012-definition-schema-upgrades/spec.md`
+
+## Summary
+
+Make resource definition version lineage explicit and actionable for long-lived resources. The current `Resource` model already records `DefinitionVersion` when resources are created, so this slice focuses on preserving that lineage during normal updates, exposing per-resource-version schema status, and adding an explicit append-only upgrade operation that can move the latest resource version to a selected newer definition version. The design preserves aspect data by default, reports carried-forward undeclared data, and avoids migrations, automatic rewriting, provider registries, runtime scanning, query planning, public SQL, or public `IQueryable<Resource>`.
+
+## Technical Context
+
+**Language/Version**: C# latest, .NET 8.0 / 9.0 / 10.0 multi-targeting  
+**Primary Dependencies**: Existing core SDK, resource manager/store abstractions, SQLite JSON provider, xUnit test stack; no new dependencies  
+**Storage**: Existing resource JSON payloads and definition versions; no schema migration or automatic data rewrite  
+**Testing**: `dotnet test Aster.sln`, focused resource schema version tests, SQLite/in-memory lifecycle compatibility tests, `dotnet build Aster.sln /m:1`, `git diff --check`  
+**Target Platform**: .NET SDK/library consumers and local test environment  
+**Project Type**: SDK/library with provider packages and tests  
+**Performance Goals**: Schema status checks use bounded definition lookups and a single resource snapshot; upgrades perform the same order of work as a normal resource update plus target-definition validation  
+**Constraints**: Append-only resource versions; preserve historical lineage; status is per resource version; upgrades use latest resource version as source; no migrations, background rewriting, runtime scanning, provider registries, query planner, public SQL, or public `IQueryable<Resource>`  
+**Scale/Scope**: Core contract and orchestration slice covering definition lineage, status, and explicit upgrades for existing in-memory and SQLite JSON-backed resources
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+- **SDK-first/headless**: PASS - Adds SDK/library contracts only and does not introduce UI or host coupling.
+- **Immutable versioning**: PASS - Upgrades append a new resource version and never mutate prior versions.
+- **Channel activation**: PASS - Activation state remains independent of resource payloads and schema status.
+- **Typed/queryable**: PASS - Typed aspects and query AST behavior are preserved; no `IQueryable` or raw SQL surface is introduced.
+- **Provider agnostic**: PASS - Core orchestration uses existing `IResourceDefinitionStore`, `IResourceManager`, and resource version abstractions.
+- **Simplicity first**: PASS - Uses a small service and result models rather than a migration engine or transformation framework.
+- **Modern C# idioms**: PASS - Records/enums and nullable-aware result models fit the existing SDK style.
+- **Readability over cleverness**: PASS - Direct status classification and upgrade branching over hidden conventions.
+- **Explicitness over magic**: PASS - Callers explicitly check schema status and explicitly request upgrades.
+- **Abstractions justified**: PASS - A dedicated schema-version service is justified by a new public SDK workflow distinct from normal resource updates.
+- **Optimize for deletion**: PASS - The service composes existing stores/managers and can be removed without changing provider storage.
+- **Composition over inheritance**: PASS - Uses explicit collaborators and result records; no inheritance hierarchy.
+- **Intentional dependencies**: PASS - No new third-party dependencies.
+- **Operational simplicity**: PASS - No deployment, provisioning, migration, or background-worker changes.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/012-definition-schema-upgrades/
+├── plan.md
+├── research.md
+├── data-model.md
+├── quickstart.md
+├── contracts/
+│   └── definition-schema-upgrades.md
+└── tasks.md
+```
+
+### Source Code (repository root)
+
+```text
+src/
+├── core/Aster.Core/
+│   ├── Abstractions/
+│   │   └── schema version service contract
+│   ├── Models/Instances/
+│   │   └── schema status and upgrade result models
+│   ├── Services/
+│   │   └── schema version service implementation
+│   └── Extensions/
+│       └── DI registration update
+└── persistence/Aster.Persistence.SqliteJson/
+    └── compatibility only; no storage migration planned
+
+test/
+└── Aster.Tests/
+    ├── InMemory/
+    ├── SqliteJson/
+    └── SchemaVersions/
+```
+
+**Structure Decision**: Keep the public schema-version contracts in `Aster.Core` because lineage and upgrade orchestration are provider-agnostic SDK behavior. Existing providers already persist the `Resource` snapshot, including `DefinitionVersion`, so provider packages should only need compatibility tests unless implementation discovers a serialization gap.
+
+## Complexity Tracking
+
+No constitution violations.
+
+## Phase 0 Research Summary
+
+Research decisions are captured in [research.md](research.md). Key outcomes:
+
+- Use existing `Resource.DefinitionVersion` as lineage rather than adding a new resource-version entity.
+- Add a small schema-version service instead of expanding `IResourceManager` for every schema-evolution operation.
+- Preserve aspect data by default and report carried-forward undeclared data.
+- Treat unknown lineage as explicit `unknown-resource-lineage` until upgrade creates a new version.
+- Keep upgrades append-only and latest-source-only through existing optimistic concurrency behavior.
+
+## Phase 1 Design Summary
+
+Design artifacts:
+
+- [data-model.md](data-model.md)
+- [contracts/definition-schema-upgrades.md](contracts/definition-schema-upgrades.md)
+- [quickstart.md](quickstart.md)
+
+## Post-Design Constitution Check
+
+- **SDK-first/headless**: PASS - Contracts remain host-agnostic and UI-free.
+- **Immutable versioning**: PASS - Upgrade results produce append-only resource versions.
+- **Channel activation**: PASS - No activation semantics change.
+- **Typed/queryable**: PASS - No query model changes and no `IQueryable`.
+- **Provider agnostic**: PASS - Implementation composes existing provider abstractions.
+- **Simplicity first**: PASS - No migration engine, transformation pipeline, or provider registry.
+- **Modern C# idioms**: PASS - Records/enums/result models keep behavior concise.
+- **Readability over cleverness**: PASS - Status and upgrade rules are explicit and testable.
+- **Explicitness over magic**: PASS - No automatic upgrades or background rewrites.
+- **Abstractions justified**: PASS - New service directly represents the user-visible schema-version workflow.
+- **Optimize for deletion**: PASS - Additive service and models are isolated from storage internals.
+- **Composition over inheritance**: PASS - No inheritance introduced.
+- **Intentional dependencies**: PASS - No new dependencies.
+- **Operational simplicity**: PASS - Existing build/test workflow remains sufficient.

--- a/specs/012-definition-schema-upgrades/quickstart.md
+++ b/specs/012-definition-schema-upgrades/quickstart.md
@@ -1,0 +1,87 @@
+# Quickstart: Definition Schema Versions & Upgrade Flow
+
+## Create Resources Across Definition Versions
+
+```csharp
+var definitionStore = serviceProvider.GetRequiredService<IResourceDefinitionStore>();
+var manager = serviceProvider.GetRequiredService<IResourceManager>();
+
+await definitionStore.RegisterDefinitionAsync(
+    new ResourceDefinitionBuilder()
+        .WithDefinitionId("Product")
+        .WithAspect<TitleAspect>()
+        .Build());
+
+var v1 = await manager.CreateAsync("Product", new CreateResourceRequest
+{
+    InitialAspects = new()
+    {
+        ["TitleAspect"] = new TitleAspect("Alpha"),
+    },
+});
+
+await definitionStore.RegisterDefinitionAsync(
+    new ResourceDefinitionBuilder()
+        .WithDefinitionId("Product")
+        .WithAspect<TitleAspect>()
+        .WithAspect<SearchAspect>()
+        .Build());
+
+var v2Product = await manager.CreateAsync("Product", new CreateResourceRequest());
+```
+
+`v1.DefinitionVersion` remains `1`. `v2Product.DefinitionVersion` records the latest definition version at creation time.
+
+## Inspect One Resource Version
+
+```csharp
+var schemaVersions = serviceProvider.GetRequiredService<IResourceSchemaVersionService>();
+var status = await schemaVersions.GetSchemaStatusAsync(v1);
+
+Console.WriteLine(status.Status);
+Console.WriteLine(status.RecordedDefinitionVersion);
+Console.WriteLine(status.LatestDefinitionVersion);
+```
+
+Status is per resource version. It does not summarize every version of the resource.
+
+## Upgrade Explicitly
+
+```csharp
+var latest = await manager.GetLatestVersionAsync(v1.ResourceId);
+
+var upgrade = await schemaVersions.UpgradeAsync(v1.ResourceId, new ResourceSchemaUpgradeRequest
+{
+    BaseVersion = latest!.Version,
+    TargetDefinitionVersion = 2,
+    AspectUpdates = new()
+    {
+        ["SearchAspect"] = new SearchAspect("alpha"),
+    },
+});
+
+if (upgrade.Status == ResourceSchemaUpgradeStatus.Upgraded)
+{
+    Console.WriteLine(upgrade.Resource!.Version);
+    Console.WriteLine(upgrade.Resource.DefinitionVersion);
+}
+```
+
+Upgrades append a new immutable resource version. Previous versions keep their original definition version lineage.
+
+## Carried-Forward Data
+
+If a target definition no longer declares an aspect key present on the source resource version, the upgrade preserves that aspect data by default:
+
+```csharp
+foreach (var key in upgrade.CarriedForwardAspectKeys)
+{
+    Console.WriteLine($"Preserved undeclared aspect: {key}");
+}
+```
+
+The caller may explicitly replace aspect data by including the aspect key in `AspectUpdates`.
+
+## No Automatic Rewrites
+
+Registering a new definition version does not update existing resources. Callers inspect schema status and request upgrades explicitly.

--- a/specs/012-definition-schema-upgrades/research.md
+++ b/specs/012-definition-schema-upgrades/research.md
@@ -1,0 +1,78 @@
+# Research: Definition Schema Versions & Upgrade Flow
+
+## Decision: Use Existing Resource Definition Version Lineage
+
+**Decision**: Use the existing `Resource.DefinitionVersion` value as the resource-version lineage field for this slice.
+
+**Rationale**: The current resource model already records the definition version active at creation time. The feature is about making that lineage explicit and actionable, not introducing a new storage shape. Reusing the existing field keeps the slice small, source-compatible, and provider-agnostic.
+
+**Alternatives considered**:
+
+- Add a separate `ResourceDefinitionVersionReference` object to every resource. Rejected because it adds model churn before a demonstrated need beyond `(DefinitionId, DefinitionVersion)`.
+- Add a separate `ResourceVersion` entity. Rejected because the current architecture intentionally treats `Resource` as the version snapshot.
+
+## Decision: Add A Small Schema Version Service
+
+**Decision**: Introduce a focused SDK service for schema status and explicit upgrades rather than putting all schema-evolution behavior directly on `IResourceManager`.
+
+**Rationale**: Schema status and upgrades are a distinct workflow. A small service can compose `IResourceManager` and `IResourceDefinitionStore` without changing the existing lifecycle contract more than necessary. This keeps normal create/update/activate APIs stable while still giving hosts an explicit schema-evolution entry point.
+
+**Alternatives considered**:
+
+- Add methods directly to `IResourceManager`. Rejected for this slice because it broadens the central lifecycle interface and makes schema-evolution behavior harder to delete or replace later.
+- Create a general migration framework. Rejected because the spec explicitly excludes migrations, automatic rewriting, and transformation pipelines.
+
+## Decision: Per-Version Schema Status
+
+**Decision**: Schema status is evaluated for one resource version at a time.
+
+**Rationale**: Aster resources are immutable version snapshots, and different versions of the same resource can legitimately reference different definition versions. Per-version status is direct, testable, and avoids ambiguous whole-resource summaries.
+
+**Alternatives considered**:
+
+- Whole-resource schema status summary. Rejected because it can hide mixed-version lineage and is derivable later.
+- Provide both per-version and whole-resource status. Rejected because it expands the first slice beyond the current requirements.
+
+## Decision: Preserve Carried-Forward Data By Default
+
+**Decision**: Explicit upgrades preserve all existing aspect data by default, even when the target definition no longer declares that aspect, and report it as carried-forward data.
+
+**Rationale**: The system is append-only and should avoid data loss by default. Reporting carried-forward data makes the behavior observable while keeping transformation decisions with the caller.
+
+**Alternatives considered**:
+
+- Drop undeclared aspect data during upgrade. Rejected because it violates the no automatic rewrite/data-loss posture.
+- Fail upgrades with undeclared data. Rejected because it makes harmless schema-version advancement harder and forces callers to build transformation handling immediately.
+
+## Decision: Latest Resource Version As Upgrade Source
+
+**Decision**: Upgrades use the latest resource version as their source and fail through existing optimistic concurrency behavior when the caller's base version is stale.
+
+**Rationale**: This matches the existing update and activation model. It avoids creating a new latest version from an arbitrary historical snapshot, which would be a separate promotion/branching workflow.
+
+**Alternatives considered**:
+
+- Allow upgrades from any historical version. Rejected because it complicates concurrency and can surprise callers by reviving old data.
+- Allow historical upgrades only with opt-in. Rejected as a future extension; the first slice should keep one clear rule.
+
+## Decision: Target Version Rules
+
+**Decision**: Upgrades default to the latest definition version, but callers may explicitly target any existing definition version newer than the source lineage and not newer than the latest known definition version.
+
+**Rationale**: This supports staged rollout and compatibility testing without allowing downgrades or imaginary future versions.
+
+**Alternatives considered**:
+
+- Always upgrade to latest only. Rejected because staged schema adoption is a reasonable near-term host need.
+- Allow downgrades. Rejected because downgrade semantics imply data transformation and conflict rules outside this slice.
+
+## Decision: Unknown Lineage Remains Unknown Until Upgrade
+
+**Decision**: Resource versions without recorded definition version lineage are classified as `unknown-resource-lineage` and are not interpreted as latest or version 1 by assumption.
+
+**Rationale**: Silent assumptions would make old data appear safer than it is. Explicit upgrade creates a new version with known target lineage once the caller chooses a target.
+
+**Alternatives considered**:
+
+- Treat missing lineage as latest. Rejected because it hides uncertainty.
+- Treat missing lineage as version 1. Rejected because not all old data necessarily came from version 1.

--- a/specs/012-definition-schema-upgrades/spec.md
+++ b/specs/012-definition-schema-upgrades/spec.md
@@ -1,0 +1,140 @@
+# Feature Specification: Definition Schema Versions & Upgrade Flow
+
+**Feature Branch**: `012-definition-schema-upgrades`  
+**Created**: 2026-05-18  
+**Status**: Draft  
+**Input**: User description: "Make the definition-version story explicit enough for long-lived resources. Model resource definition version references on resources, define upgrade behavior from older definition versions, and add validation/tests for resources that span schema versions. Keep the slice small: no migrations, no automatic data rewriting, no planner, no runtime scanning, and no provider registry."
+
+## Clarifications
+
+### Session 2026-05-19
+
+- Q: During upgrade, what happens to source aspect data that is not declared by the target definition version? → A: Preserve all existing aspect data by default, even if the target definition no longer declares that aspect; report it as carried-forward data.
+- Q: Which resource version can be used as the source for an explicit schema upgrade? → A: Upgrade only from the latest resource version; stale base versions fail with existing optimistic concurrency behavior.
+- Q: How should resources without recorded definition version lineage be classified? → A: Missing lineage remains unknown until an explicit upgrade creates a new version with current lineage.
+- Q: Which definition version may an upgrade target? → A: Upgrades default to latest, but callers may explicitly target any existing definition version newer than the source lineage and not newer than latest.
+- Q: What scope does schema status evaluate? → A: Schema status is evaluated for one resource version at a time.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Preserve Definition Version Lineage (Priority: P1)
+
+As an SDK user managing long-lived resources, I want each resource version to identify the resource definition version it was created against so historical resources remain understandable after definitions evolve.
+
+**Why this priority**: Without explicit lineage, hosts cannot safely explain or validate resource versions that outlive their original schema.
+
+**Independent Test**: Register a definition, create a resource, register a newer definition version, create or update resources again, and verify each resource version reports the correct definition version without changing historical versions.
+
+**Acceptance Scenarios**:
+
+1. **Given** a resource definition at version 1, **When** a resource is created, **Then** the created resource version records definition version 1.
+2. **Given** a resource created against definition version 1 and a later definition version 2, **When** the original resource is read, **Then** it still reports definition version 1.
+3. **Given** a definition has advanced to version 2, **When** a new resource of that definition is created, **Then** the new resource records definition version 2.
+
+---
+
+### User Story 2 - Detect Resources Behind The Latest Definition (Priority: P2)
+
+As a host application, I want to determine whether a resource version is current, behind the latest definition, or references a missing definition version so I can surface safe upgrade prompts and diagnostics.
+
+**Why this priority**: Lineage is useful only if callers can compare it against available definitions and receive structured status instead of inferring from raw numbers.
+
+**Independent Test**: Create resource versions against multiple definition versions, omit a referenced definition version in test setup, and verify per-version status results distinguish current, upgradeable, and invalid lineage.
+
+**Acceptance Scenarios**:
+
+1. **Given** a resource version that references the latest definition version, **When** schema status is checked, **Then** the status is current.
+2. **Given** a resource version that references an older available definition version, **When** schema status is checked, **Then** the status reports that a newer definition version is available.
+3. **Given** a resource version that references a definition version that cannot be found, **When** schema status is checked, **Then** the status reports a missing definition version with enough information for troubleshooting.
+4. **Given** a resource has multiple versions with different definition lineage, **When** schema status is checked for one version, **Then** the result describes only that requested resource version.
+
+---
+
+### User Story 3 - Upgrade A Resource Explicitly (Priority: P3)
+
+As an SDK user, I want to upgrade a resource to the latest compatible definition through an explicit operation that creates a new immutable resource version, preserving existing aspect data unless the caller intentionally changes it.
+
+**Why this priority**: Upgrade behavior must be deterministic before providers, hosts, or future portability features depend on schema evolution.
+
+**Independent Test**: Create a resource against an older definition version, register a newer compatible definition version, run the upgrade operation, and verify a new resource version is created with the target definition version while the prior version remains unchanged.
+
+**Acceptance Scenarios**:
+
+1. **Given** a resource version that is behind the latest compatible definition, **When** the caller upgrades it, **Then** a new resource version is appended with the latest definition version.
+2. **Given** an upgraded resource version, **When** its aspects are inspected, **Then** existing aspect data is preserved unless the caller supplied explicit updates.
+3. **Given** a resource already using the target definition version, **When** the caller requests an upgrade to that same version, **Then** no duplicate version is created and the caller receives a clear no-op result.
+4. **Given** the target definition version no longer declares an aspect that exists on the source resource version, **When** the caller upgrades without explicit data changes, **Then** that aspect data is preserved and reported as carried-forward data.
+5. **Given** a caller attempts to upgrade from a non-latest resource version, **When** a newer resource version already exists, **Then** the upgrade fails through existing optimistic concurrency behavior.
+6. **Given** a resource version using definition version 1 while versions 2 and 3 exist, **When** the caller explicitly targets definition version 2, **Then** the new resource version records definition version 2.
+
+---
+
+### Edge Cases
+
+- A resource has no recorded definition version because it was created before lineage became required; schema status reports unknown lineage until an explicit upgrade creates a new version with current lineage.
+- A resource references a definition identifier that does not exist.
+- A resource references a definition version that is older than the latest but still available.
+- A resource references a definition version number greater than the latest known definition version.
+- A caller targets an existing definition version older than or equal to the source lineage.
+- A caller targets a definition version newer than the latest known definition version.
+- A definition changes singleton status between versions while resources already exist.
+- An upgrade target removes an aspect key that exists on the source resource version; the upgrade preserves that data by default and reports it as carried-forward data.
+- A resource is upgraded while another update has already produced a newer resource version.
+- A caller attempts to upgrade a historical resource version rather than the latest resource version.
+
+### Constitution Alignment *(mandatory)*
+
+- **Simplicity**: The slice defines lineage, status, and explicit append-only upgrades only. It intentionally excludes migrations, automatic data rewriting, transformation pipelines, planner behavior, runtime scanning, and provider registries.
+- **Explicitness**: Callers choose when to inspect schema status and when to upgrade. No resource is silently rewritten because a definition changed.
+- **Dependencies**: None.
+- **Operational Impact**: Existing local development, testing, persistence setup, and debugging workflows remain unchanged. The feature adds observable schema-evolution behavior without new infrastructure.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: Resource versions MUST record the resource definition version they were created against.
+- **FR-002**: Existing historical resource versions MUST retain their recorded definition version when newer definition versions are registered.
+- **FR-003**: Creating a new resource MUST use the latest available definition version for its definition identifier.
+- **FR-004**: Updating an existing resource without an explicit schema upgrade MUST preserve the base resource version's recorded definition version.
+- **FR-005**: The system MUST provide a way to inspect one resource version's schema status relative to registered definition versions.
+- **FR-006**: Schema status MUST distinguish at least current, older-than-latest, missing-definition, missing-definition-version, and unknown-resource-lineage states.
+- **FR-007**: Schema status MUST include the resource's recorded definition identifier, recorded definition version when known, and latest available definition version when known.
+- **FR-008**: The system MUST provide an explicit upgrade action that can move a resource to a target definition version by creating a new resource version.
+- **FR-009**: The default upgrade target SHOULD be the latest available definition version for the resource's definition identifier.
+- **FR-010**: Upgrade actions MUST NOT mutate or rewrite previous resource versions.
+- **FR-011**: Upgrade actions MUST preserve existing aspect data by default.
+- **FR-012**: Upgrade actions MUST allow callers to supply explicit aspect changes as part of the new upgraded resource version.
+- **FR-013**: Upgrade actions MUST detect a request to upgrade to the same definition version and return a clear no-op result rather than appending a duplicate version.
+- **FR-014**: Upgrade actions MUST fail with structured diagnostics when the target definition version does not exist.
+- **FR-015**: Upgrade actions MUST respect existing optimistic concurrency behavior for resource updates.
+- **FR-016**: Singleton resource rules MUST remain enforceable across definition versions.
+- **FR-017**: Query and read behavior MUST preserve resources spanning multiple definition versions without requiring automatic upgrade.
+- **FR-018**: The feature MUST NOT introduce automatic migrations, background rewriting, runtime scanning, provider registries, query planning, public SQL, or public `IQueryable<Resource>`.
+- **FR-019**: Upgrade actions MUST preserve source aspect data that is not declared by the target definition version unless the caller explicitly changes it, and MUST report preserved undeclared data as carried-forward data.
+- **FR-020**: Upgrade actions MUST use the latest resource version as their source and MUST fail through existing optimistic concurrency behavior when the caller's base version is stale.
+- **FR-021**: Resource versions without recorded definition version lineage MUST be classified as unknown-resource-lineage and MUST NOT be treated as the latest or earliest definition version by assumption.
+- **FR-022**: Explicit upgrade of an unknown-lineage resource MUST create a new resource version with current target definition lineage when the target definition version exists and concurrency checks pass.
+- **FR-023**: Upgrade actions SHOULD allow callers to explicitly target any existing definition version newer than the source lineage and not newer than the latest known definition version.
+- **FR-024**: Upgrade actions MUST reject target definition versions that are older than or equal to the source lineage, unless the target equals the source lineage and the operation returns the no-op result described by FR-013.
+- **FR-025**: Upgrade actions MUST reject target definition versions newer than the latest known definition version.
+- **FR-026**: Schema status MUST be evaluated for a single requested resource version and MUST NOT summarize all versions of a resource in this slice.
+
+### Key Entities *(include if feature involves data)*
+
+- **Resource Definition Version**: An immutable schema snapshot for a resource definition, identified by a stable definition identifier and a version number.
+- **Resource Version Lineage**: The recorded link from a resource version to the definition version that governed its shape at creation time.
+- **Schema Status**: A diagnostic result that compares one resource version's lineage with currently registered definition versions.
+- **Upgrade Request**: A caller-initiated command to append a new resource version using a selected target definition version.
+- **Upgrade Result**: The outcome of an upgrade request, including whether a new version was created, no action was needed, or the request failed validation.
+- **Carried-Forward Data**: Existing resource aspect data preserved during upgrade even though the target definition version does not declare that aspect.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: A caller can create resources before and after a definition update and observe the correct definition version lineage for every resource version.
+- **SC-002**: A caller can classify at least five representative resource versions as current, older-than-latest, missing-definition, missing-definition-version, or unknown-lineage without reading provider-specific storage.
+- **SC-003**: A caller can explicitly upgrade an older resource and verify that exactly one new resource version is created while prior versions remain unchanged.
+- **SC-004**: A caller can run existing query/read flows over resources spanning multiple definition versions without first upgrading those resources.
+- **SC-005**: Existing provider-backed and in-memory resource lifecycle tests continue to pass without new infrastructure or data migration steps.

--- a/src/core/Aster.Core/Abstractions/IResourceSchemaVersionService.cs
+++ b/src/core/Aster.Core/Abstractions/IResourceSchemaVersionService.cs
@@ -1,0 +1,31 @@
+using Aster.Core.Models.Instances;
+
+namespace Aster.Core.Abstractions;
+
+/// <summary>
+/// Provides explicit schema-version status and upgrade operations for resource versions.
+/// </summary>
+public interface IResourceSchemaVersionService
+{
+    /// <summary>
+    /// Gets schema status for a single resource version snapshot.
+    /// </summary>
+    /// <param name="resource">The resource version snapshot to inspect.</param>
+    /// <param name="cancellationToken">Token to cancel the operation.</param>
+    /// <returns>The schema status for the supplied resource version.</returns>
+    ValueTask<ResourceSchemaStatusResult> GetSchemaStatusAsync(
+        Resource resource,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Explicitly upgrades the latest resource version to a target definition version.
+    /// </summary>
+    /// <param name="resourceId">The logical resource identifier.</param>
+    /// <param name="request">The schema upgrade request.</param>
+    /// <param name="cancellationToken">Token to cancel the operation.</param>
+    /// <returns>The schema upgrade result.</returns>
+    ValueTask<ResourceSchemaUpgradeResult> UpgradeAsync(
+        string resourceId,
+        ResourceSchemaUpgradeRequest request,
+        CancellationToken cancellationToken = default);
+}

--- a/src/core/Aster.Core/Exceptions/AsterExceptions.cs
+++ b/src/core/Aster.Core/Exceptions/AsterExceptions.cs
@@ -89,6 +89,61 @@ public sealed class SingletonViolationException : Exception
 }
 
 /// <summary>
+/// Thrown when an explicit resource schema upgrade request is invalid.
+/// </summary>
+public sealed class ResourceSchemaUpgradeException : Exception
+{
+    /// <summary>
+    /// Gets the stable schema-upgrade failure code.
+    /// </summary>
+    public string Code { get; }
+
+    /// <summary>
+    /// Gets the resource definition identifier associated with the failure, when available.
+    /// </summary>
+    public string? DefinitionId { get; }
+
+    /// <summary>
+    /// Gets the requested target definition version, when available.
+    /// </summary>
+    public int? TargetDefinitionVersion { get; }
+
+    /// <inheritdoc />
+    public ResourceSchemaUpgradeException()
+        : this("invalid-schema-upgrade", "The schema upgrade request is invalid.") { }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ResourceSchemaUpgradeException"/> class.
+    /// </summary>
+    /// <param name="code">Stable schema-upgrade failure code.</param>
+    /// <param name="message">Human-readable actionable explanation.</param>
+    /// <param name="definitionId">Optional resource definition identifier.</param>
+    /// <param name="targetDefinitionVersion">Optional target definition version.</param>
+    public ResourceSchemaUpgradeException(
+        string code,
+        string message,
+        string? definitionId = null,
+        int? targetDefinitionVersion = null)
+        : base(message)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(code);
+        ArgumentException.ThrowIfNullOrWhiteSpace(message);
+
+        Code = code;
+        DefinitionId = definitionId;
+        TargetDefinitionVersion = targetDefinitionVersion;
+    }
+
+    /// <inheritdoc />
+    public ResourceSchemaUpgradeException(string message, Exception innerException)
+        : base(message, innerException)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(message);
+        Code = "invalid-schema-upgrade";
+    }
+}
+
+/// <summary>
 /// Thrown when a query contains a predicate, scope, sort, or value shape that the provider cannot execute.
 /// </summary>
 public sealed class UnsupportedQueryFeatureException : Exception

--- a/src/core/Aster.Core/Extensions/AsterCoreServiceCollectionExtensions.cs
+++ b/src/core/Aster.Core/Extensions/AsterCoreServiceCollectionExtensions.cs
@@ -68,6 +68,7 @@ public static class AsterCoreServiceCollectionExtensions
         services.AddSingleton<InMemoryResourceManager>();
         services.AddSingleton<DefaultResourceManager>();
         services.AddSingleton<IResourceManager>(sp => sp.GetRequiredService<DefaultResourceManager>());
+        services.AddSingleton<IResourceSchemaVersionService, ResourceSchemaVersionService>();
 
         // Query service
         services.AddSingleton<InMemoryQueryService>();

--- a/src/core/Aster.Core/Models/Instances/ResourceSchemaStatus.cs
+++ b/src/core/Aster.Core/Models/Instances/ResourceSchemaStatus.cs
@@ -1,0 +1,49 @@
+namespace Aster.Core.Models.Instances;
+
+/// <summary>
+/// Schema-version status for a single resource version snapshot.
+/// </summary>
+public enum ResourceSchemaStatus
+{
+    /// <summary>The resource version references the latest available definition version.</summary>
+    Current,
+
+    /// <summary>The resource version references an available definition version older than latest.</summary>
+    OlderThanLatest,
+
+    /// <summary>No definition exists for the resource's definition identifier.</summary>
+    MissingDefinition,
+
+    /// <summary>The resource references a definition version that is not available.</summary>
+    MissingDefinitionVersion,
+
+    /// <summary>The resource version does not record definition version lineage.</summary>
+    UnknownResourceLineage,
+}
+
+/// <summary>
+/// Diagnostic result describing schema-version status for one resource version.
+/// </summary>
+public sealed record ResourceSchemaStatusResult
+{
+    /// <summary>Gets the logical resource identifier.</summary>
+    public required string ResourceId { get; init; }
+
+    /// <summary>Gets the resource version number that was inspected.</summary>
+    public required int ResourceVersion { get; init; }
+
+    /// <summary>Gets the resource definition identifier.</summary>
+    public required string DefinitionId { get; init; }
+
+    /// <summary>Gets the definition version recorded on the resource version, when known.</summary>
+    public int? RecordedDefinitionVersion { get; init; }
+
+    /// <summary>Gets the latest available definition version, when known.</summary>
+    public int? LatestDefinitionVersion { get; init; }
+
+    /// <summary>Gets the schema-version status.</summary>
+    public required ResourceSchemaStatus Status { get; init; }
+
+    /// <summary>Gets a human-readable status message.</summary>
+    public required string Message { get; init; }
+}

--- a/src/core/Aster.Core/Models/Instances/ResourceSchemaUpgrade.cs
+++ b/src/core/Aster.Core/Models/Instances/ResourceSchemaUpgrade.cs
@@ -1,0 +1,58 @@
+namespace Aster.Core.Models.Instances;
+
+/// <summary>
+/// Request to explicitly upgrade a resource to a target definition version.
+/// </summary>
+public sealed class ResourceSchemaUpgradeRequest
+{
+    /// <summary>
+    /// Optimistic concurrency token. Must match the current latest resource version.
+    /// </summary>
+    public int BaseVersion { get; set; }
+
+    /// <summary>
+    /// Optional target definition version. When omitted, the latest definition version is used.
+    /// </summary>
+    public int? TargetDefinitionVersion { get; set; }
+
+    /// <summary>
+    /// Aspect updates keyed by aspect key. State replace semantics match normal resource updates.
+    /// </summary>
+    public Dictionary<string, object> AspectUpdates { get; set; } = [];
+}
+
+/// <summary>
+/// Outcome kind for an explicit schema upgrade request.
+/// </summary>
+public enum ResourceSchemaUpgradeStatus
+{
+    /// <summary>A new resource version was appended.</summary>
+    Upgraded,
+
+    /// <summary>No resource version was appended because the target matches the source lineage.</summary>
+    NoOp,
+}
+
+/// <summary>
+/// Result of an explicit schema upgrade request.
+/// </summary>
+public sealed record ResourceSchemaUpgradeResult
+{
+    /// <summary>Gets the upgrade outcome kind.</summary>
+    public required ResourceSchemaUpgradeStatus Status { get; init; }
+
+    /// <summary>Gets the upgraded resource version when one was created.</summary>
+    public Resource? Resource { get; init; }
+
+    /// <summary>Gets the source definition version, when known.</summary>
+    public int? SourceDefinitionVersion { get; init; }
+
+    /// <summary>Gets the requested target definition version.</summary>
+    public required int TargetDefinitionVersion { get; init; }
+
+    /// <summary>Gets aspect keys preserved even though the target definition does not declare them.</summary>
+    public IReadOnlyList<string> CarriedForwardAspectKeys { get; init; } = [];
+
+    /// <summary>Gets a human-readable result message.</summary>
+    public required string Message { get; init; }
+}

--- a/src/core/Aster.Core/README.md
+++ b/src/core/Aster.Core/README.md
@@ -41,6 +41,7 @@ builder.Services.AddAsterCore();
 | `InMemoryQueryService` | `IResourceQueryProviderIdentity` |
 | `InMemoryQueryCapabilitiesProvider` | `IResourceQueryCapabilitiesProvider` |
 | `ResourceQueryValidator` | `IResourceQueryValidator` |
+| `ResourceSchemaVersionService` | `IResourceSchemaVersionService` |
 | `GuidIdentityGenerator` | `IIdentityGenerator` |
 | `SystemTextJsonAspectBinder` | `ITypedAspectBinder` |
 | `SystemTextJsonFacetBinder` | `ITypedFacetBinder` |
@@ -196,6 +197,30 @@ var query = new ResourceQuery
 
 ---
 
+### 7. Inspect and upgrade definition lineage
+
+`CreateAsync` records the active definition version on the new resource. Normal `UpdateAsync` calls preserve that `DefinitionVersion`; they do not silently move long-lived resources to newer schemas.
+
+```csharp
+var schemaVersions = serviceProvider.GetRequiredService<IResourceSchemaVersionService>();
+var status = await schemaVersions.GetSchemaStatusAsync(resource);
+
+if (status.Status == ResourceSchemaStatus.OlderThanLatest)
+{
+    var upgraded = await schemaVersions.UpgradeAsync(resource.ResourceId, new ResourceSchemaUpgradeRequest
+    {
+        BaseVersion = resource.Version,
+        TargetDefinitionVersion = status.LatestDefinitionVersion,
+    });
+}
+```
+
+`UpgradeAsync` appends a new resource version with the requested target definition version. When the target is omitted, it defaults to the latest definition version. Existing aspect data is carried forward unless explicitly replaced through `AspectUpdates`; undeclared carried-forward aspect keys are reported in `CarriedForwardAspectKeys`.
+
+Invalid upgrade targets throw `ResourceSchemaUpgradeException` with a stable `Code` such as `missing-definition`, `missing-definition-version`, `target-definition-version-too-new`, or `target-definition-version-before-source`. Stale base versions keep using `ConcurrencyException`.
+
+---
+
 ## Architecture overview
 
 ```
@@ -207,6 +232,7 @@ IResourceQueryService         — portable query service; default is LINQ-based 
 IResourceQueryProviderIdentity — exposes the active query provider key
 IResourceQueryCapabilitiesProvider — declares active provider query support
 IResourceQueryValidator        — preflights ResourceQuery against provider capabilities
+IResourceSchemaVersionService — inspects and explicitly upgrades resource definition lineage
 ITypedAspectBinder            — serialise/deserialise full aspects (System.Text.Json)
 ITypedFacetBinder             — serialise/deserialise individual facet values
 IIdentityGenerator            — pluggable ID strategy (default: Guid)
@@ -216,6 +242,7 @@ Key invariants:
 
 - `Resource` is **immutable** — every `UpdateAsync` call produces a **new** version snapshot. The original version is never mutated.
 - `ResourceId` is the **logical** identifier shared across all versions. Each version has its own `Id` (GUID).
+- `DefinitionVersion` records schema lineage for a resource version. Normal updates preserve it; explicit schema upgrades advance it.
 - Activation channels are independent: a resource can be active in `"Published"` at V2 and in `"Staging"` at V3 simultaneously.
 - Optimistic concurrency is enforced on `UpdateAsync` (must supply `BaseVersion == current latest Version`) and `ActivateAsync` (must supply the current latest version number).
 

--- a/src/core/Aster.Core/Services/ResourceSchemaVersionService.cs
+++ b/src/core/Aster.Core/Services/ResourceSchemaVersionService.cs
@@ -1,0 +1,211 @@
+using System.Collections.ObjectModel;
+using Aster.Core.Abstractions;
+using Aster.Core.Exceptions;
+using Aster.Core.Models.Definitions;
+using Aster.Core.Models.Instances;
+
+namespace Aster.Core.Services;
+
+/// <summary>
+/// Default implementation of explicit resource schema-version status and upgrade operations.
+/// </summary>
+public sealed class ResourceSchemaVersionService : IResourceSchemaVersionService
+{
+    private readonly IResourceDefinitionStore definitionStore;
+    private readonly IResourceManager resourceManager;
+    private readonly IIdentityGenerator identityGenerator;
+    private readonly IResourceVersionWriter versionWriter;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ResourceSchemaVersionService"/> class.
+    /// </summary>
+    /// <param name="definitionStore">The resource definition version store.</param>
+    /// <param name="resourceManager">The resource lifecycle manager.</param>
+    /// <param name="identityGenerator">The identity generator used for new version IDs.</param>
+    /// <param name="versionWriter">The resource version writer used to append upgraded versions.</param>
+    public ResourceSchemaVersionService(
+        IResourceDefinitionStore definitionStore,
+        IResourceManager resourceManager,
+        IIdentityGenerator identityGenerator,
+        IResourceVersionWriter versionWriter)
+    {
+        ArgumentNullException.ThrowIfNull(definitionStore);
+        ArgumentNullException.ThrowIfNull(resourceManager);
+        ArgumentNullException.ThrowIfNull(identityGenerator);
+        ArgumentNullException.ThrowIfNull(versionWriter);
+
+        this.definitionStore = definitionStore;
+        this.resourceManager = resourceManager;
+        this.identityGenerator = identityGenerator;
+        this.versionWriter = versionWriter;
+    }
+
+    /// <inheritdoc />
+    public async ValueTask<ResourceSchemaStatusResult> GetSchemaStatusAsync(
+        Resource resource,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(resource);
+
+        var latestDefinition = await definitionStore.GetDefinitionAsync(resource.DefinitionId, cancellationToken);
+        if (latestDefinition is null)
+            return Status(resource, ResourceSchemaStatus.MissingDefinition, latestDefinitionVersion: null,
+                $"Definition '{resource.DefinitionId}' was not found.");
+
+        if (resource.DefinitionVersion is null)
+            return Status(resource, ResourceSchemaStatus.UnknownResourceLineage, latestDefinition.Version,
+                $"Resource version {resource.Version} does not record definition version lineage.");
+
+        var recordedDefinition = await definitionStore.GetDefinitionVersionAsync(
+            resource.DefinitionId,
+            resource.DefinitionVersion.Value,
+            cancellationToken);
+        if (recordedDefinition is null)
+            return Status(resource, ResourceSchemaStatus.MissingDefinitionVersion, latestDefinition.Version,
+                $"Definition '{resource.DefinitionId}' version {resource.DefinitionVersion.Value} was not found.");
+
+        if (resource.DefinitionVersion.Value < latestDefinition.Version)
+            return Status(resource, ResourceSchemaStatus.OlderThanLatest, latestDefinition.Version,
+                $"Resource version {resource.Version} uses definition version {resource.DefinitionVersion.Value}; latest is {latestDefinition.Version}.");
+
+        if (resource.DefinitionVersion.Value == latestDefinition.Version)
+            return Status(resource, ResourceSchemaStatus.Current, latestDefinition.Version,
+                $"Resource version {resource.Version} uses the latest definition version {latestDefinition.Version}.");
+
+        return Status(resource, ResourceSchemaStatus.MissingDefinitionVersion, latestDefinition.Version,
+            $"Definition '{resource.DefinitionId}' version {resource.DefinitionVersion.Value} is newer than the latest known version {latestDefinition.Version}.");
+    }
+
+    /// <inheritdoc />
+    public async ValueTask<ResourceSchemaUpgradeResult> UpgradeAsync(
+        string resourceId,
+        ResourceSchemaUpgradeRequest request,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(resourceId);
+        ArgumentNullException.ThrowIfNull(request);
+
+        var latestResource = await resourceManager.GetLatestVersionAsync(resourceId, cancellationToken)
+            ?? throw new VersionNotFoundException(resourceId, request.BaseVersion);
+
+        if (latestResource.Version != request.BaseVersion)
+            throw new ConcurrencyException(resourceId, request.BaseVersion, latestResource.Version);
+
+        var latestDefinition = await definitionStore.GetDefinitionAsync(latestResource.DefinitionId, cancellationToken)
+            ?? throw UpgradeFailure(
+                "missing-definition",
+                $"Definition '{latestResource.DefinitionId}' was not found.",
+                latestResource.DefinitionId,
+                request.TargetDefinitionVersion);
+
+        var targetVersion = request.TargetDefinitionVersion ?? latestDefinition.Version;
+        if (targetVersion > latestDefinition.Version)
+            throw UpgradeFailure(
+                "target-definition-version-too-new",
+                $"Definition '{latestResource.DefinitionId}' version {targetVersion} is newer than the latest known version {latestDefinition.Version}.",
+                latestResource.DefinitionId,
+                targetVersion);
+
+        var targetDefinition = await definitionStore.GetDefinitionVersionAsync(
+            latestResource.DefinitionId,
+            targetVersion,
+            cancellationToken);
+        if (targetDefinition is null)
+            throw UpgradeFailure(
+                "missing-definition-version",
+                $"Definition '{latestResource.DefinitionId}' version {targetVersion} was not found.",
+                latestResource.DefinitionId,
+                targetVersion);
+
+        if (latestResource.DefinitionVersion == targetVersion)
+            return new ResourceSchemaUpgradeResult
+            {
+                Status = ResourceSchemaUpgradeStatus.NoOp,
+                Resource = latestResource,
+                SourceDefinitionVersion = latestResource.DefinitionVersion,
+                TargetDefinitionVersion = targetVersion,
+                CarriedForwardAspectKeys = [],
+                Message = $"Resource '{resourceId}' already uses definition version {targetVersion}.",
+            };
+
+        if (latestResource.DefinitionVersion is not null
+            && targetVersion < latestResource.DefinitionVersion.Value)
+        {
+            throw UpgradeFailure(
+                "target-definition-version-before-source",
+                $"Definition '{latestResource.DefinitionId}' version {targetVersion} is older than source version {latestResource.DefinitionVersion.Value}.",
+                latestResource.DefinitionId,
+                targetVersion);
+        }
+
+        var upgraded = await SaveUpgradedResourceAsync(latestResource, targetVersion, request, cancellationToken);
+        var carriedForwardAspectKeys = GetCarriedForwardAspectKeys(upgraded, targetDefinition);
+
+        return new ResourceSchemaUpgradeResult
+        {
+            Status = ResourceSchemaUpgradeStatus.Upgraded,
+            Resource = upgraded,
+            SourceDefinitionVersion = latestResource.DefinitionVersion,
+            TargetDefinitionVersion = targetVersion,
+            CarriedForwardAspectKeys = new ReadOnlyCollection<string>(carriedForwardAspectKeys),
+            Message = $"Resource '{resourceId}' upgraded to definition version {targetVersion}.",
+        };
+    }
+
+    private async ValueTask<Resource> SaveUpgradedResourceAsync(
+        Resource latestResource,
+        int targetVersion,
+        ResourceSchemaUpgradeRequest request,
+        CancellationToken cancellationToken)
+    {
+        var mergedAspects = new Dictionary<string, object>(latestResource.Aspects, StringComparer.Ordinal);
+        foreach (var (key, value) in request.AspectUpdates)
+            mergedAspects[key] = value;
+
+        var upgraded = latestResource with
+        {
+            Id = identityGenerator.NewId(),
+            Version = latestResource.Version + 1,
+            Created = DateTime.UtcNow,
+            DefinitionVersion = targetVersion,
+            Aspects = mergedAspects,
+        };
+
+        return await versionWriter.SaveVersionAsync(upgraded, cancellationToken);
+    }
+
+    private static List<string> GetCarriedForwardAspectKeys(
+        Resource resource,
+        ResourceDefinition targetDefinition)
+    {
+        var declared = targetDefinition.AspectDefinitions.Keys.ToHashSet(StringComparer.Ordinal);
+
+        return resource.Aspects.Keys
+            .Where(key => !declared.Contains(key))
+            .Order(StringComparer.Ordinal)
+            .ToList();
+    }
+
+    private static ResourceSchemaStatusResult Status(
+        Resource resource,
+        ResourceSchemaStatus status,
+        int? latestDefinitionVersion,
+        string message) =>
+        new()
+        {
+            ResourceId = resource.ResourceId,
+            ResourceVersion = resource.Version,
+            DefinitionId = resource.DefinitionId,
+            RecordedDefinitionVersion = resource.DefinitionVersion,
+            LatestDefinitionVersion = latestDefinitionVersion,
+            Status = status,
+            Message = message,
+        };
+
+    private static ResourceSchemaUpgradeException UpgradeFailure(
+        string code,
+        string message,
+        string definitionId,
+        int? targetDefinitionVersion) =>
+        new(code, message, definitionId, targetDefinitionVersion);
+}

--- a/src/core/Aster.Core/Services/ResourceSchemaVersionService.cs
+++ b/src/core/Aster.Core/Services/ResourceSchemaVersionService.cs
@@ -139,7 +139,7 @@ public sealed class ResourceSchemaVersionService : IResourceSchemaVersionService
         }
 
         var upgraded = await SaveUpgradedResourceAsync(latestResource, targetVersion, request, cancellationToken);
-        var carriedForwardAspectKeys = GetCarriedForwardAspectKeys(upgraded, targetDefinition);
+        var carriedForwardAspectKeys = GetCarriedForwardAspectKeys(latestResource, targetDefinition, request.AspectUpdates);
 
         return new ResourceSchemaUpgradeResult
         {
@@ -176,12 +176,14 @@ public sealed class ResourceSchemaVersionService : IResourceSchemaVersionService
 
     private static List<string> GetCarriedForwardAspectKeys(
         Resource resource,
-        ResourceDefinition targetDefinition)
+        ResourceDefinition targetDefinition,
+        Dictionary<string, object> explicitUpdates)
     {
         var declared = targetDefinition.AspectDefinitions.Keys.ToHashSet(StringComparer.Ordinal);
+        var explicitlyChanged = explicitUpdates.Keys.ToHashSet(StringComparer.Ordinal);
 
         return resource.Aspects.Keys
-            .Where(key => !declared.Contains(key))
+            .Where(key => !declared.Contains(key) && !explicitlyChanged.Contains(key))
             .Order(StringComparer.Ordinal)
             .ToList();
     }

--- a/test/Aster.Tests/SchemaVersions/ResourceSchemaVersionServiceTests.cs
+++ b/test/Aster.Tests/SchemaVersions/ResourceSchemaVersionServiceTests.cs
@@ -193,6 +193,39 @@ public sealed class ResourceSchemaVersionServiceTests : IDisposable
     }
 
     [Fact]
+    public async Task UpgradeAsync_DoesNotReportExplicitlyUpdatedUndeclaredAspectAsCarriedForward()
+    {
+        await using var provider = CreateInMemoryProvider();
+        var definitionStore = provider.GetRequiredService<IResourceDefinitionStore>();
+        var manager = provider.GetRequiredService<IResourceManager>();
+        var service = provider.GetRequiredService<IResourceSchemaVersionService>();
+
+        await RegisterProductDefinitionAsync(definitionStore, "TitleAspect", "LegacyAspect");
+        var v1 = await manager.CreateAsync("Product", new CreateResourceRequest
+        {
+            InitialAspects =
+            {
+                ["TitleAspect"] = new { Title = "Alpha" },
+                ["LegacyAspect"] = new { Value = "old" },
+            },
+        });
+        await RegisterProductDefinitionAsync(definitionStore, "TitleAspect");
+
+        var result = await service.UpgradeAsync(v1.ResourceId, new ResourceSchemaUpgradeRequest
+        {
+            BaseVersion = v1.Version,
+            AspectUpdates =
+            {
+                ["LegacyAspect"] = new { Value = "explicit" },
+            },
+        });
+
+        Assert.Equal(ResourceSchemaUpgradeStatus.Upgraded, result.Status);
+        Assert.Empty(result.CarriedForwardAspectKeys);
+        Assert.Equal("explicit", GetAspectValue(result.Resource!, "LegacyAspect"));
+    }
+
+    [Fact]
     public async Task UpgradeAsync_UnknownLineageCanUpgradeToExistingTarget()
     {
         await using var provider = CreateInMemoryProvider();
@@ -357,6 +390,9 @@ public sealed class ResourceSchemaVersionServiceTests : IDisposable
                 ["TitleAspect"] = new { Title = "Alpha" },
             },
         };
+
+    private static string? GetAspectValue(Resource resource, string key) =>
+        resource.Aspects[key].GetType().GetProperty("Value")?.GetValue(resource.Aspects[key]) as string;
 
     private static void TryDelete(string path)
     {

--- a/test/Aster.Tests/SchemaVersions/ResourceSchemaVersionServiceTests.cs
+++ b/test/Aster.Tests/SchemaVersions/ResourceSchemaVersionServiceTests.cs
@@ -1,0 +1,370 @@
+using Aster.Core.Abstractions;
+using Aster.Core.Definitions;
+using Aster.Core.Exceptions;
+using Aster.Core.Extensions;
+using Aster.Core.Models.Definitions;
+using Aster.Core.Models.Instances;
+using Aster.Core.Services;
+using Aster.Persistence.SqliteJson;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Aster.Tests.SchemaVersions;
+
+public sealed class ResourceSchemaVersionServiceTests : IDisposable
+{
+    private readonly string sqliteDatabasePath =
+        Path.Combine(Path.GetTempPath(), $"aster-schema-versions-{Guid.NewGuid():N}.db");
+
+    public void Dispose()
+    {
+        TryDelete(sqliteDatabasePath);
+        TryDelete($"{sqliteDatabasePath}-shm");
+        TryDelete($"{sqliteDatabasePath}-wal");
+    }
+
+    [Fact]
+    public async Task CreateAndUpdate_PreserveDefinitionVersionLineage()
+    {
+        await using var provider = CreateInMemoryProvider();
+        var definitionStore = provider.GetRequiredService<IResourceDefinitionStore>();
+        var manager = provider.GetRequiredService<IResourceManager>();
+
+        await RegisterProductDefinitionAsync(definitionStore, "TitleAspect");
+        var v1 = await manager.CreateAsync("Product", new CreateResourceRequest());
+        await RegisterProductDefinitionAsync(definitionStore, "TitleAspect", "SearchAspect");
+        var v2 = await manager.UpdateAsync(v1.ResourceId, new UpdateResourceRequest
+        {
+            BaseVersion = v1.Version,
+            AspectUpdates = { ["TitleAspect"] = new { Title = "Updated" } },
+        });
+        var other = await manager.CreateAsync("Product", new CreateResourceRequest());
+
+        Assert.Equal(1, v1.DefinitionVersion);
+        Assert.Equal(1, v2.DefinitionVersion);
+        Assert.Equal(2, other.DefinitionVersion);
+        Assert.Equal(1, (await manager.GetVersionAsync(v1.ResourceId, 1))!.DefinitionVersion);
+    }
+
+    [Fact]
+    public async Task GetSchemaStatusAsync_ClassifiesPerResourceVersionStatuses()
+    {
+        await using var provider = CreateInMemoryProvider();
+        var definitionStore = provider.GetRequiredService<IResourceDefinitionStore>();
+        var service = provider.GetRequiredService<IResourceSchemaVersionService>();
+
+        await RegisterProductDefinitionAsync(definitionStore, "TitleAspect");
+        await RegisterProductDefinitionAsync(definitionStore, "TitleAspect", "SearchAspect");
+
+        var current = await service.GetSchemaStatusAsync(CreateResource(definitionVersion: 2));
+        var older = await service.GetSchemaStatusAsync(CreateResource(definitionVersion: 1));
+        var missingDefinition = await service.GetSchemaStatusAsync(CreateResource(definitionId: "Missing", definitionVersion: 1));
+        var missingDefinitionVersion = await service.GetSchemaStatusAsync(CreateResource(definitionVersion: 99));
+        var unknown = await service.GetSchemaStatusAsync(CreateResource(definitionVersion: null));
+
+        Assert.Equal(ResourceSchemaStatus.Current, current.Status);
+        Assert.Equal(ResourceSchemaStatus.OlderThanLatest, older.Status);
+        Assert.Equal(ResourceSchemaStatus.MissingDefinition, missingDefinition.Status);
+        Assert.Equal(ResourceSchemaStatus.MissingDefinitionVersion, missingDefinitionVersion.Status);
+        Assert.Equal(ResourceSchemaStatus.UnknownResourceLineage, unknown.Status);
+        Assert.Equal(2, older.LatestDefinitionVersion);
+        Assert.Equal(1, older.RecordedDefinitionVersion);
+    }
+
+    [Fact]
+    public async Task UpgradeAsync_AppendsNewVersionWithExplicitTargetAndPreservesPreviousVersion()
+    {
+        await using var provider = CreateInMemoryProvider();
+        var definitionStore = provider.GetRequiredService<IResourceDefinitionStore>();
+        var manager = provider.GetRequiredService<IResourceManager>();
+        var service = provider.GetRequiredService<IResourceSchemaVersionService>();
+
+        await RegisterProductDefinitionAsync(definitionStore, "TitleAspect");
+        var v1 = await manager.CreateAsync("Product", new CreateResourceRequest
+        {
+            InitialAspects =
+            {
+                ["TitleAspect"] = new { Title = "Alpha" },
+            },
+        });
+        await RegisterProductDefinitionAsync(definitionStore, "TitleAspect", "SearchAspect");
+        await RegisterProductDefinitionAsync(definitionStore, "TitleAspect", "SearchAspect", "AuditAspect");
+
+        var result = await service.UpgradeAsync(v1.ResourceId, new ResourceSchemaUpgradeRequest
+        {
+            BaseVersion = v1.Version,
+            TargetDefinitionVersion = 2,
+            AspectUpdates =
+            {
+                ["SearchAspect"] = new { Text = "alpha" },
+            },
+        });
+
+        Assert.Equal(ResourceSchemaUpgradeStatus.Upgraded, result.Status);
+        Assert.NotNull(result.Resource);
+        Assert.Equal(2, result.Resource.Version);
+        Assert.Equal(2, result.Resource.DefinitionVersion);
+        Assert.Equal(1, result.SourceDefinitionVersion);
+        Assert.Equal(2, result.TargetDefinitionVersion);
+        Assert.True(result.Resource.Aspects.ContainsKey("TitleAspect"));
+        Assert.True(result.Resource.Aspects.ContainsKey("SearchAspect"));
+
+        var original = await manager.GetVersionAsync(v1.ResourceId, 1);
+        Assert.NotNull(original);
+        Assert.Equal(1, original.DefinitionVersion);
+        Assert.False(original.Aspects.ContainsKey("SearchAspect"));
+    }
+
+    [Fact]
+    public async Task UpgradeAsync_DefaultsTargetToLatestDefinitionVersion()
+    {
+        await using var provider = CreateInMemoryProvider();
+        var definitionStore = provider.GetRequiredService<IResourceDefinitionStore>();
+        var manager = provider.GetRequiredService<IResourceManager>();
+        var service = provider.GetRequiredService<IResourceSchemaVersionService>();
+
+        await RegisterProductDefinitionAsync(definitionStore, "TitleAspect");
+        var v1 = await manager.CreateAsync("Product", new CreateResourceRequest());
+        await RegisterProductDefinitionAsync(definitionStore, "TitleAspect", "SearchAspect");
+
+        var result = await service.UpgradeAsync(v1.ResourceId, new ResourceSchemaUpgradeRequest
+        {
+            BaseVersion = v1.Version,
+        });
+
+        Assert.Equal(ResourceSchemaUpgradeStatus.Upgraded, result.Status);
+        Assert.Equal(2, result.TargetDefinitionVersion);
+        Assert.Equal(2, result.Resource!.DefinitionVersion);
+    }
+
+    [Fact]
+    public async Task UpgradeAsync_ReturnsNoOpWhenTargetMatchesSourceLineage()
+    {
+        await using var provider = CreateInMemoryProvider();
+        var definitionStore = provider.GetRequiredService<IResourceDefinitionStore>();
+        var manager = provider.GetRequiredService<IResourceManager>();
+        var service = provider.GetRequiredService<IResourceSchemaVersionService>();
+
+        await RegisterProductDefinitionAsync(definitionStore, "TitleAspect");
+        var v1 = await manager.CreateAsync("Product", new CreateResourceRequest());
+
+        var result = await service.UpgradeAsync(v1.ResourceId, new ResourceSchemaUpgradeRequest
+        {
+            BaseVersion = v1.Version,
+            TargetDefinitionVersion = 1,
+        });
+
+        Assert.Equal(ResourceSchemaUpgradeStatus.NoOp, result.Status);
+        Assert.Same(v1, result.Resource);
+        Assert.Equal(1, result.TargetDefinitionVersion);
+        Assert.Empty(result.CarriedForwardAspectKeys);
+
+        var versions = (await manager.GetVersionsAsync(v1.ResourceId)).ToList();
+        Assert.Single(versions);
+    }
+
+    [Fact]
+    public async Task UpgradeAsync_ReportsCarriedForwardUndeclaredAspectData()
+    {
+        await using var provider = CreateInMemoryProvider();
+        var definitionStore = provider.GetRequiredService<IResourceDefinitionStore>();
+        var manager = provider.GetRequiredService<IResourceManager>();
+        var service = provider.GetRequiredService<IResourceSchemaVersionService>();
+
+        await RegisterProductDefinitionAsync(definitionStore, "TitleAspect", "LegacyAspect");
+        var v1 = await manager.CreateAsync("Product", new CreateResourceRequest
+        {
+            InitialAspects =
+            {
+                ["TitleAspect"] = new { Title = "Alpha" },
+                ["LegacyAspect"] = new { Value = "keep" },
+            },
+        });
+        await RegisterProductDefinitionAsync(definitionStore, "TitleAspect");
+
+        var result = await service.UpgradeAsync(v1.ResourceId, new ResourceSchemaUpgradeRequest
+        {
+            BaseVersion = v1.Version,
+        });
+
+        Assert.Equal(ResourceSchemaUpgradeStatus.Upgraded, result.Status);
+        Assert.Contains("LegacyAspect", result.Resource!.Aspects.Keys);
+        var key = Assert.Single(result.CarriedForwardAspectKeys);
+        Assert.Equal("LegacyAspect", key);
+    }
+
+    [Fact]
+    public async Task UpgradeAsync_UnknownLineageCanUpgradeToExistingTarget()
+    {
+        await using var provider = CreateInMemoryProvider();
+        var definitionStore = provider.GetRequiredService<IResourceDefinitionStore>();
+        var writer = provider.GetRequiredService<IResourceVersionWriter>();
+        var manager = provider.GetRequiredService<IResourceManager>();
+        var service = provider.GetRequiredService<IResourceSchemaVersionService>();
+
+        await RegisterProductDefinitionAsync(definitionStore, "TitleAspect");
+        var legacy = CreateResource(definitionVersion: null);
+        await writer.SaveVersionAsync(legacy);
+
+        var result = await service.UpgradeAsync(legacy.ResourceId, new ResourceSchemaUpgradeRequest
+        {
+            BaseVersion = legacy.Version,
+            TargetDefinitionVersion = 1,
+        });
+
+        Assert.Equal(ResourceSchemaUpgradeStatus.Upgraded, result.Status);
+        Assert.Null(result.SourceDefinitionVersion);
+        Assert.Equal(1, result.Resource!.DefinitionVersion);
+        Assert.Equal(2, result.Resource.Version);
+        Assert.Equal(1, (await manager.GetVersionAsync(legacy.ResourceId, 1))!.Version);
+    }
+
+    [Fact]
+    public async Task UpgradeAsync_RejectsInvalidTargetsAndStaleBase()
+    {
+        await using var provider = CreateInMemoryProvider();
+        var definitionStore = provider.GetRequiredService<IResourceDefinitionStore>();
+        var manager = provider.GetRequiredService<IResourceManager>();
+        var service = provider.GetRequiredService<IResourceSchemaVersionService>();
+
+        await RegisterProductDefinitionAsync(definitionStore, "TitleAspect");
+        var v1 = await manager.CreateAsync("Product", new CreateResourceRequest());
+        await RegisterProductDefinitionAsync(definitionStore, "TitleAspect", "SearchAspect");
+        var v2 = await service.UpgradeAsync(v1.ResourceId, new ResourceSchemaUpgradeRequest { BaseVersion = 1 });
+
+        var older = await Assert.ThrowsAsync<ResourceSchemaUpgradeException>(() =>
+            service.UpgradeAsync(v1.ResourceId, new ResourceSchemaUpgradeRequest
+            {
+                BaseVersion = v2.Resource!.Version,
+                TargetDefinitionVersion = 1,
+            }).AsTask());
+        var tooNew = await Assert.ThrowsAsync<ResourceSchemaUpgradeException>(() =>
+            service.UpgradeAsync(v1.ResourceId, new ResourceSchemaUpgradeRequest
+            {
+                BaseVersion = v2.Resource!.Version,
+                TargetDefinitionVersion = 99,
+            }).AsTask());
+        await Assert.ThrowsAsync<ConcurrencyException>(() =>
+            service.UpgradeAsync(v1.ResourceId, new ResourceSchemaUpgradeRequest
+            {
+                BaseVersion = 1,
+                TargetDefinitionVersion = 2,
+            }).AsTask());
+
+        Assert.Equal("target-definition-version-before-source", older.Code);
+        Assert.Equal("target-definition-version-too-new", tooNew.Code);
+    }
+
+    [Fact]
+    public async Task AddAsterCore_RegistersSchemaVersionService()
+    {
+        await using var provider = CreateInMemoryProvider();
+
+        var service = provider.GetRequiredService<IResourceSchemaVersionService>();
+
+        Assert.IsType<ResourceSchemaVersionService>(service);
+    }
+
+    [Fact]
+    public async Task SqliteProvider_PersistsDefinitionLineageAndSupportsUpgradeAcrossProviderInstances()
+    {
+        await using (var first = CreateSqliteProvider())
+        {
+            var definitionStore = first.GetRequiredService<IResourceDefinitionStore>();
+            var manager = first.GetRequiredService<IResourceManager>();
+
+            await RegisterProductDefinitionAsync(definitionStore, "TitleAspect");
+            var v1 = await manager.CreateAsync("Product", new CreateResourceRequest
+            {
+                ResourceId = "product-1",
+                InitialAspects = { ["TitleAspect"] = new { Title = "Alpha" } },
+            });
+            await RegisterProductDefinitionAsync(definitionStore, "TitleAspect", "SearchAspect");
+
+            Assert.Equal(1, v1.DefinitionVersion);
+        }
+
+        await using var second = CreateSqliteProvider();
+        var secondManager = second.GetRequiredService<IResourceManager>();
+        var service = second.GetRequiredService<IResourceSchemaVersionService>();
+        var loaded = await secondManager.GetLatestVersionAsync("product-1");
+
+        Assert.NotNull(loaded);
+        Assert.Equal(ResourceSchemaStatus.OlderThanLatest, (await service.GetSchemaStatusAsync(loaded)).Status);
+
+        var upgraded = await service.UpgradeAsync("product-1", new ResourceSchemaUpgradeRequest
+        {
+            BaseVersion = loaded.Version,
+            AspectUpdates = { ["SearchAspect"] = new { Text = "alpha" } },
+        });
+
+        Assert.Equal(ResourceSchemaUpgradeStatus.Upgraded, upgraded.Status);
+        Assert.Equal(2, upgraded.Resource!.DefinitionVersion);
+        Assert.Equal(2, upgraded.Resource.Version);
+    }
+
+    private ServiceProvider CreateInMemoryProvider() =>
+        new ServiceCollection()
+            .AddAsterCore()
+            .BuildServiceProvider();
+
+    private ServiceProvider CreateSqliteProvider() =>
+        new ServiceCollection()
+            .AddAsterCore()
+            .AddAsterSqliteJson(options =>
+            {
+                options.ConnectionString = $"Data Source={sqliteDatabasePath}";
+            })
+            .BuildServiceProvider();
+
+    private static async Task RegisterProductDefinitionAsync(
+        IResourceDefinitionStore definitionStore,
+        params string[] aspectKeys)
+    {
+        var definition = new ResourceDefinition
+        {
+            DefinitionId = "Product",
+            Id = Guid.NewGuid().ToString(),
+            Version = 0,
+            AspectDefinitions = aspectKeys.ToDictionary(
+                static key => key,
+                static key => new AspectDefinition
+                {
+                    AspectDefinitionId = key,
+                    Id = Guid.NewGuid().ToString(),
+                    Version = 1,
+                },
+                StringComparer.Ordinal),
+        };
+
+        await definitionStore.RegisterDefinitionAsync(definition);
+    }
+
+    private static Resource CreateResource(
+        string resourceId = "product-1",
+        string definitionId = "Product",
+        int? definitionVersion = 1,
+        int version = 1) =>
+        new()
+        {
+            ResourceId = resourceId,
+            Id = $"{resourceId}-v{version}",
+            DefinitionId = definitionId,
+            DefinitionVersion = definitionVersion,
+            Version = version,
+            Created = DateTime.UtcNow,
+            Aspects = new Dictionary<string, object>
+            {
+                ["TitleAspect"] = new { Title = "Alpha" },
+            },
+        };
+
+    private static void TryDelete(string path)
+    {
+        try
+        {
+            File.Delete(path);
+        }
+        catch (IOException) { }
+        catch (UnauthorizedAccessException) { }
+    }
+}

--- a/wiki/DI-Registration.md
+++ b/wiki/DI-Registration.md
@@ -27,6 +27,7 @@ All services are registered as **singletons**.
 | `IResourceQueryProviderIdentity` | `InMemoryQueryService` | Exposes the active provider key |
 | `IResourceQueryCapabilitiesProvider` | `InMemoryQueryCapabilitiesProvider` | Declares in-memory query support |
 | `IResourceQueryValidator` | `ResourceQueryValidator` | Preflights `ResourceQuery` against active provider capabilities |
+| `IResourceSchemaVersionService` | `ResourceSchemaVersionService` | Inspects and explicitly upgrades resource definition lineage |
 | `ITypedAspectBinder` | `SystemTextJsonAspectBinder` | Aspect POCO ↔ raw storage via `System.Text.Json` |
 | `ITypedFacetBinder` | `SystemTextJsonFacetBinder` | Facet value POCO ↔ raw storage via `System.Text.Json` |
 

--- a/wiki/Exception-Reference.md
+++ b/wiki/Exception-Reference.md
@@ -13,6 +13,7 @@ Aster throws typed exceptions for all domain-level error conditions. All excepti
 | `SingletonViolationException` | `Aster.Core.Exceptions` | Attempt to create a second instance of a singleton definition |
 | `DuplicateResourceIdException` | `Aster.Core.Exceptions` | Caller-supplied `ResourceId` already exists |
 | `DuplicateAspectAttachmentException` | `Aster.Core.Exceptions` | Same aspect key attached twice to a definition |
+| `ResourceSchemaUpgradeException` | `Aster.Core.Exceptions` | Explicit schema upgrade target is invalid or unavailable |
 | `UnsupportedQueryFeatureException` | `Aster.Core.Exceptions` | Query execution receives a provider-unsupported scope, predicate, sort, paging value, or value shape |
 
 ---
@@ -165,6 +166,45 @@ catch (UnsupportedQueryFeatureException ex)
 Use `IResourceQueryValidator` for non-throwing preflight when handling user-defined queries. Execution remains authoritative, so callers should still handle this exception when validation is skipped or provider-specific checks fail later.
 
 When validation returns `capabilities-not-declared`, the active query provider has no matching capability declaration. For custom providers, register the provider and capabilities together with `AddResourceQueryProvider<TQueryService, TCapabilitiesProvider>()` or ensure manual registrations expose the same non-empty provider key.
+
+---
+
+## `ResourceSchemaUpgradeException`
+
+**Thrown by:** `IResourceSchemaVersionService.UpgradeAsync`
+
+**Why:** The requested schema upgrade cannot be completed because the definition lineage or requested target definition version is invalid.
+
+The exception exposes structured details:
+
+| Property | Meaning |
+|---|---|
+| `Code` | Stable failure code |
+| `DefinitionId` | Definition involved in the failed upgrade, when available |
+| `TargetDefinitionVersion` | Requested target definition version, when available |
+| `Message` | Human-readable actionable explanation |
+
+Known codes:
+
+| Code | Meaning |
+|---|---|
+| `missing-definition` | The resource's definition ID has no registered definition |
+| `missing-definition-version` | The requested target definition version does not exist |
+| `target-definition-version-too-new` | The requested target is newer than the latest registered definition version |
+| `target-definition-version-before-source` | The requested target is older than the resource's recorded definition lineage |
+
+Stale upgrade requests still throw `ConcurrencyException`; missing latest resource versions still throw `VersionNotFoundException`.
+
+```csharp
+try
+{
+    await schemaVersions.UpgradeAsync(resourceId, request);
+}
+catch (ResourceSchemaUpgradeException ex)
+{
+    Console.WriteLine($"{ex.Code}: {ex.Message}");
+}
+```
 
 ---
 

--- a/wiki/Roadmap.md
+++ b/wiki/Roadmap.md
@@ -2,7 +2,7 @@
 
 Aster is delivered in six phases. Each phase builds on the last, with clean extension points so earlier work is not thrown away.
 
-> **Current status:** Phase 3 in progress — Core SDK, in-memory engine, SQLite JSON persistence/querying, query capability discovery, preflight validation, typed query authoring helpers, provider authoring/conformance support, and SQLite facet sorting are available.
+> **Current status:** Phase 3 in progress — Core SDK, in-memory engine, SQLite JSON persistence/querying, query capability discovery, preflight validation, typed query authoring helpers, provider authoring/conformance support, SQLite facet sorting, portable operators, SQLite date-like ranges, and explicit index projection contracts are available.
 >
 > For the current implementation trail and next Spec Kit slices, see [`docs/ExecutionRoadmap.md`](../docs/ExecutionRoadmap.md).
 
@@ -26,8 +26,8 @@ Aster is delivered in six phases. Each phase builds on the last, with clean exte
 | **008 Typed Query Authoring Ergonomics** | Landed | Add typed sort helpers and small composition conveniences over the existing `ResourceQuery` AST. |
 | **009 Portable Operator Expansion** | Landed | Add operators such as `NotEquals`, `In`, `StartsWith`, and facet value presence with provider capabilities and conformance coverage. |
 | **010 SQLite Date-Like Facet Ranges** | Landed | Close the remaining SQLite date-like range capability gap with explicit serialization rules. |
-| **011 Explicit Indexing Model** | Next | Introduce intentional index projection contracts without a hidden planner or runtime scanning. |
-| **012 Definition Schema Versions & Upgrade Flow** | Planned | Make long-lived resource schema versioning and upgrade behavior explicit. |
+| **011 Explicit Indexing Model** | Landed | Introduce intentional index projection contracts without a hidden planner or runtime scanning. |
+| **012 Definition Schema Versions & Upgrade Flow** | Next | Make long-lived resource schema versioning and upgrade behavior explicit. |
 
 ---
 

--- a/wiki/Versioning-and-Activation.md
+++ b/wiki/Versioning-and-Activation.md
@@ -121,6 +121,8 @@ await definitionStore.RegisterDefinitionAsync(updatedDef);
 
 Existing resources continue to reference the definition version they were created against. `DefinitionVersion` on a `Resource` records which definition version was active at creation time.
 
+Normal resource updates preserve the source resource version's `DefinitionVersion`. Registering a new definition version does not automatically rewrite existing resources or move them to the newer schema.
+
 Retrieval:
 
 ```csharp
@@ -133,6 +135,47 @@ var v1def = await definitionStore.GetDefinitionVersionAsync("Product", version: 
 // All definitions (latest version per DefinitionId)
 var all = await definitionStore.ListDefinitionsAsync();
 ```
+
+## Schema Status and Explicit Upgrades
+
+Use `IResourceSchemaVersionService` to inspect one resource version's schema status relative to registered definition versions:
+
+```csharp
+var schemaVersions = serviceProvider.GetRequiredService<IResourceSchemaVersionService>();
+var status = await schemaVersions.GetSchemaStatusAsync(resource);
+```
+
+Possible `ResourceSchemaStatus` values:
+
+| Status | Meaning |
+|---|---|
+| `Current` | The resource version references the latest available definition version |
+| `OlderThanLatest` | The resource version references an available definition version older than latest |
+| `MissingDefinition` | No definition exists for the resource's `DefinitionId` |
+| `MissingDefinitionVersion` | The recorded definition version cannot be found, or is newer than the latest known version |
+| `UnknownResourceLineage` | The resource version does not record `DefinitionVersion` |
+
+To advance lineage, explicitly request an upgrade against the latest resource version:
+
+```csharp
+var latest = await manager.GetLatestVersionAsync(resource.ResourceId);
+
+var upgrade = await schemaVersions.UpgradeAsync(resource.ResourceId, new ResourceSchemaUpgradeRequest
+{
+    BaseVersion = latest!.Version,
+    TargetDefinitionVersion = status.LatestDefinitionVersion,
+    AspectUpdates = new()
+    {
+        ["SearchAspect"] = new SearchAspect("search text"),
+    },
+});
+```
+
+`UpgradeAsync` appends a new immutable resource version with the requested target definition version. If `TargetDefinitionVersion` is omitted, it defaults to the latest definition version. If the target matches the source lineage, the result is `ResourceSchemaUpgradeStatus.NoOp` and no new version is appended.
+
+Existing aspect data is preserved by default. Aspect keys not declared by the target definition are still carried forward and listed in `CarriedForwardAspectKeys`, so hosts can warn, transform, or clean up explicitly.
+
+Upgrade failures use existing lifecycle exceptions where appropriate: stale `BaseVersion` throws `ConcurrencyException`, and a missing latest resource throws `VersionNotFoundException`. Invalid schema targets throw `ResourceSchemaUpgradeException` with stable codes including `missing-definition`, `missing-definition-version`, `target-definition-version-too-new`, and `target-definition-version-before-source`.
 
 ---
 
@@ -148,4 +191,3 @@ Phase 6 will harden this for distributed/multi-node scenarios with proper confli
 
 - [Getting Started](Getting-Started) — `CreateAsync`, `UpdateAsync`, `ActivateAsync` usage
 - [Exception Reference](Exception-Reference) — `ConcurrencyException`, `VersionNotFoundException`
-


### PR DESCRIPTION
## Summary
- add explicit resource schema status and append-only schema upgrade service
- preserve definition lineage on normal updates while enabling explicit upgrades to existing definition versions
- document the public workflow and structured schema-upgrade failures

## Validation
- dotnet test Aster.sln
- dotnet build Aster.sln /m:1
- git diff --check