### PR TITLE
[codex] Plan portability primitives

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "featureDir": "specs/012-definition-schema-upgrades"
+  "featureDir": "specs/013-portability-primitives"
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 <!-- SPECKIT START -->
 For additional context about technologies to be used, project structure,
-shell commands, and other important information, read `specs/012-definition-schema-upgrades/plan.md`.
+shell commands, and other important information, read `specs/013-portability-primitives/plan.md`.
 <!-- SPECKIT END -->
 
 ## Active Technologies
@@ -10,8 +10,11 @@ shell commands, and other important information, read `specs/012-definition-sche
 - Existing resource JSON payloads; no schema migration or physical index creation (011-explicit-indexing-model)
 - C# latest, .NET 8.0 / 9.0 / 10.0 multi-targeting + Existing core SDK, resource manager/store abstractions, SQLite JSON provider, xUnit test stack; no new dependencies (012-definition-schema-upgrades)
 - Existing resource JSON payloads and definition versions; no schema migration or automatic data rewrite (012-definition-schema-upgrades)
+- C# latest, .NET 8.0 / 9.0 / 10.0 multi-targeting + Existing core SDK, resource definition/resource version abstractions, in-memory store, SQLite JSON provider, xUnit test stack; no new dependencies (013-portability-primitives)
+- Existing resource definitions, resource versions, and activation state; no schema migration planned for SQLite JSON or in-memory stores (013-portability-primitives)
 
 ## Recent Changes
+- 013-portability-primitives: Added deterministic export/import portability planning over existing definitions, resources, and activation state; no schema migration planned
 - 012-definition-schema-upgrades: Added definition schema version and explicit upgrade flow planning; no schema migration or automatic data rewrite
 - 011-explicit-indexing-model: Added explicit provider-declared indexing model planning for core SDK contracts; no storage migration or physical indexing
 - 009-portable-operators: Added C# latest, .NET 8.0 / 9.0 / 10.0 multi-targeting + Existing core SDK, SQLite JSON provider, xUnit test stack; no new dependencies

--- a/docs/ExecutionRoadmap.md
+++ b/docs/ExecutionRoadmap.md
@@ -6,9 +6,9 @@ This roadmap tracks the implementation trail we have already cut through the rep
 
 ## Current Position
 
-Aster now has a working Core SDK, in-memory runtime, SQLite JSON persistence/querying, provider capability discovery, provider validation alignment, provider authoring ergonomics, a reusable provider conformance harness, SQLite facet sorting, portable operator expansion, SQLite date-like ranges, and explicit provider-declared index projections.
+Aster now has a working Core SDK, in-memory runtime, SQLite JSON persistence/querying, provider capability discovery, provider validation alignment, provider authoring ergonomics, a reusable provider conformance harness, SQLite facet sorting, portable operator expansion, SQLite date-like ranges, explicit provider-declared index projections, and explicit definition schema upgrade behavior.
 
-The active workstream is **Phase 3: Query Capabilities & Typed Querying**. The next useful slice is definition schema versioning and explicit upgrade behavior, still without introducing migrations, planner behavior, runtime scanning, provider registries, public SQL, or `IQueryable<Resource>`.
+The active workstream is moving into **Phase 4: Portability & Integration Hooks**. The next useful slice is portability primitives for deterministic export/import of definitions and resources, still without introducing recipes, lifecycle hooks, live sync, migrations, planner behavior, runtime scanning, provider registries, public SQL, or `IQueryable<Resource>`.
 
 ## Landed Slices
 
@@ -25,18 +25,9 @@ The active workstream is **Phase 3: Query Capabilities & Typed Querying**. The n
 | `009-portable-operators` | Landed | Portable `NotEquals`, `In`, `StartsWith`, and facet `Exists` operators with provider capabilities, validation, built-in execution, typed helpers, and conformance coverage. |
 | `010-sqlite-date-ranges` | Landed | SQLite date-like facet ranges for accepted JSON string date/time values with capability, validation, conformance, and docs coverage. |
 | `011-explicit-indexing-model` | Landed | Provider-declared index projection contracts, validation, evaluation, capability discovery, and provider-authoring docs without physical indexes or query planning. |
+| `012-definition-schema-upgrades` | Landed | Explicit resource definition lineage, schema status inspection, append-only schema upgrades, and carried-forward data diagnostics. |
 
 ## Near-Term Roadmap
-
-### 012 — Definition Schema Versions & Upgrade Flow
-
-**Goal:** Make the definition-version story explicit enough for long-lived resources.
-
-Candidate scope:
-
-- Model `ResourceDefinitionVersion` references on resources.
-- Define upgrade behavior from older definition versions.
-- Add validation and tests for resources that span schema versions.
 
 ### 013 — Portability Primitives
 

--- a/specs/013-portability-primitives/checklists/requirements.md
+++ b/specs/013-portability-primitives/checklists/requirements.md
@@ -1,7 +1,7 @@
 # Specification Quality Checklist: Portability Primitives
 
-**Purpose**: Validate specification completeness and quality before proceeding to planning  
-**Created**: 2026-05-19  
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-05-19
 **Feature**: [spec.md](../spec.md)
 
 ## Content Quality

--- a/specs/013-portability-primitives/checklists/requirements.md
+++ b/specs/013-portability-primitives/checklists/requirements.md
@@ -1,0 +1,34 @@
+# Specification Quality Checklist: Portability Primitives
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning  
+**Created**: 2026-05-19  
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [X] No implementation details (languages, frameworks, APIs)
+- [X] Focused on user value and business needs
+- [X] Written for non-technical stakeholders
+- [X] All mandatory sections completed
+
+## Requirement Completeness
+
+- [X] No [NEEDS CLARIFICATION] markers remain
+- [X] Requirements are testable and unambiguous
+- [X] Success criteria are measurable
+- [X] Success criteria are technology-agnostic (no implementation details)
+- [X] All acceptance scenarios are defined
+- [X] Edge cases are identified
+- [X] Scope is clearly bounded
+- [X] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [X] All functional requirements have clear acceptance criteria
+- [X] User scenarios cover primary flows
+- [X] Feature meets measurable outcomes defined in Success Criteria
+- [X] No implementation details leak into specification
+
+## Notes
+
+- Initial validation passed. Product terms such as portable snapshot, import preview, identity mapping, and collision diagnostic are domain concepts under specification rather than implementation details.

--- a/specs/013-portability-primitives/contracts/portability-primitives.md
+++ b/specs/013-portability-primitives/contracts/portability-primitives.md
@@ -153,7 +153,7 @@ public sealed record PortableSnapshotValidationResult
 public sealed record PortableImportPreview
 {
     public required bool CanImport { get; init; }
-    public required PortableImportCounts Counts { get; init; }
+    public required PortablePlannedImportCounts Counts { get; init; }
     public IReadOnlyList<PortableIdentityMapping> IdentityMap { get; init; } = [];
     public IReadOnlyList<PortableDiagnostic> Diagnostics { get; init; } = [];
 }
@@ -161,7 +161,7 @@ public sealed record PortableImportPreview
 public sealed record PortableImportResult
 {
     public required PortableImportStatus Status { get; init; }
-    public required PortableImportCounts Counts { get; init; }
+    public required PortableActualImportCounts Counts { get; init; }
     public IReadOnlyList<PortableIdentityMapping> IdentityMap { get; init; } = [];
     public IReadOnlyList<PortableDiagnostic> Diagnostics { get; init; } = [];
 }
@@ -173,7 +173,7 @@ public enum PortableImportStatus
     Failed,
 }
 
-public sealed record PortableImportCounts
+public sealed record PortablePlannedImportCounts
 {
     public int Definitions { get; init; }
     public int Resources { get; init; }
@@ -183,12 +183,36 @@ public sealed record PortableImportCounts
     public int RemappedItems { get; init; }
 }
 
+public sealed record PortableActualImportCounts
+{
+    public int DefinitionsWritten { get; init; }
+    public int ResourcesWritten { get; init; }
+    public int ResourceVersionsWritten { get; init; }
+    public int ActivationEntriesWritten { get; init; }
+    public int ReusedIdenticalItems { get; init; }
+    public int RemappedItems { get; init; }
+}
+
+public enum SkippedActivationReason
+{
+    ExcludedByResourceVersionScope,
+}
+
 public sealed record SkippedActivationEntry
 {
     public required string ResourceId { get; init; }
     public required string Channel { get; init; }
     public required int Version { get; init; }
-    public required string Reason { get; init; }
+    public required SkippedActivationReason Reason { get; init; }
+}
+
+public enum PortableEntityKind
+{
+    Definition,
+    DefinitionVersion,
+    Resource,
+    ResourceVersion,
+    ActivationEntry,
 }
 
 public enum PortableIdentityMappingReason
@@ -200,12 +224,14 @@ public enum PortableIdentityMappingReason
 
 public sealed record PortableIdentityMapping
 {
-    public required string EntityKind { get; init; }
+    public required PortableEntityKind EntityKind { get; init; }
     public required string OriginalId { get; init; }
     public required string ImportedId { get; init; }
     public required PortableIdentityMappingReason Reason { get; init; }
 }
 ```
+
+`PortableImportResult.Counts` reports actual writes. For `Failed`, all write counts are zero; diagnostics carry the failure details. For `NoOp`, write counts are zero and `ReusedIdenticalItems` reports already-satisfied content. For `Imported`, write counts report committed items after remapping.
 
 Required diagnostic codes include:
 

--- a/specs/013-portability-primitives/contracts/portability-primitives.md
+++ b/specs/013-portability-primitives/contracts/portability-primitives.md
@@ -48,6 +48,12 @@ public sealed class PortableSnapshotExportRequest
     public HashSet<ResourceVersionReference> SpecificResourceVersions { get; set; } = [];
 }
 
+public sealed record ResourceVersionReference
+{
+    public required string ResourceId { get; init; }
+    public required int Version { get; init; }
+}
+
 public enum PortableExportScopeMode
 {
     DefinitionsOnly,
@@ -131,12 +137,73 @@ public enum PortableDiagnosticSeverity
     Error,
 }
 
+public sealed record PortableSnapshotExportResult
+{
+    public PortableSnapshot? Snapshot { get; init; }
+    public IReadOnlyList<PortableDiagnostic> Diagnostics { get; init; } = [];
+    public IReadOnlyList<SkippedActivationEntry> SkippedActivationEntries { get; init; } = [];
+}
+
+public sealed record PortableSnapshotValidationResult
+{
+    public required bool IsValid { get; init; }
+    public IReadOnlyList<PortableDiagnostic> Diagnostics { get; init; } = [];
+}
+
+public sealed record PortableImportPreview
+{
+    public required bool CanImport { get; init; }
+    public required PortableImportCounts Counts { get; init; }
+    public IReadOnlyList<PortableIdentityMapping> IdentityMap { get; init; } = [];
+    public IReadOnlyList<PortableDiagnostic> Diagnostics { get; init; } = [];
+}
+
+public sealed record PortableImportResult
+{
+    public required PortableImportStatus Status { get; init; }
+    public required PortableImportCounts Counts { get; init; }
+    public IReadOnlyList<PortableIdentityMapping> IdentityMap { get; init; } = [];
+    public IReadOnlyList<PortableDiagnostic> Diagnostics { get; init; } = [];
+}
+
+public enum PortableImportStatus
+{
+    Imported,
+    NoOp,
+    Failed,
+}
+
+public sealed record PortableImportCounts
+{
+    public int Definitions { get; init; }
+    public int Resources { get; init; }
+    public int ResourceVersions { get; init; }
+    public int ActivationEntries { get; init; }
+    public int ReusedIdenticalItems { get; init; }
+    public int RemappedItems { get; init; }
+}
+
+public sealed record SkippedActivationEntry
+{
+    public required string ResourceId { get; init; }
+    public required string Channel { get; init; }
+    public required int Version { get; init; }
+    public required string Reason { get; init; }
+}
+
+public enum PortableIdentityMappingReason
+{
+    Preserved,
+    ReusedIdentical,
+    RemappedCollision,
+}
+
 public sealed record PortableIdentityMapping
 {
     public required string EntityKind { get; init; }
     public required string OriginalId { get; init; }
     public required string ImportedId { get; init; }
-    public required string Reason { get; init; }
+    public required PortableIdentityMappingReason Reason { get; init; }
 }
 ```
 
@@ -172,6 +239,24 @@ public interface IResourcePortabilityStore
     ValueTask ApplyImportAsync(
         PortableSnapshot plannedSnapshot,
         CancellationToken cancellationToken = default);
+}
+
+public sealed record PortableStoreReadRequest
+{
+    public required PortableSnapshotExportRequest ExportRequest { get; init; }
+}
+
+public sealed record PortableStoreSnapshot
+{
+    public required PortableSnapshot Snapshot { get; init; }
+    public IReadOnlyList<SkippedActivationEntry> SkippedActivationEntries { get; init; } = [];
+}
+
+public sealed record PortableTargetState
+{
+    public IReadOnlyList<ResourceDefinition> ExistingDefinitions { get; init; } = [];
+    public IReadOnlyList<Resource> ExistingResources { get; init; } = [];
+    public IReadOnlyList<ActivationState> ExistingActivationStates { get; init; } = [];
 }
 ```
 

--- a/specs/013-portability-primitives/contracts/portability-primitives.md
+++ b/specs/013-portability-primitives/contracts/portability-primitives.md
@@ -185,10 +185,10 @@ public sealed record PortablePlannedImportCounts
 
 public sealed record PortableActualImportCounts
 {
-    public int DefinitionsWritten { get; init; }
-    public int ResourcesWritten { get; init; }
-    public int ResourceVersionsWritten { get; init; }
-    public int ActivationEntriesWritten { get; init; }
+    public int Definitions { get; init; }
+    public int Resources { get; init; }
+    public int ResourceVersions { get; init; }
+    public int ActivationEntries { get; init; }
     public int ReusedIdenticalItems { get; init; }
     public int RemappedItems { get; init; }
 }

--- a/specs/013-portability-primitives/contracts/portability-primitives.md
+++ b/specs/013-portability-primitives/contracts/portability-primitives.md
@@ -1,0 +1,182 @@
+# Contract: Portability Primitives
+
+## Public SDK Behavior
+
+The SDK exposes an explicit portability workflow:
+
+1. Export definitions, resources, resource versions, and activation state into a portable snapshot.
+2. Validate a snapshot before writing it.
+3. Preview import to see planned counts, identity mappings, and diagnostics without mutation.
+4. Write import as an all-or-nothing operation.
+
+The workflow MUST NOT introduce recipes, lifecycle hooks, live synchronization, runtime scanning, provider registries, migration engines, public SQL, or public `IQueryable<Resource>`.
+
+## Service Contract
+
+```csharp
+public interface IResourcePortabilityService
+{
+    ValueTask<PortableSnapshotExportResult> ExportAsync(
+        PortableSnapshotExportRequest request,
+        CancellationToken cancellationToken = default);
+
+    ValueTask<PortableSnapshotValidationResult> ValidateAsync(
+        PortableSnapshot snapshot,
+        CancellationToken cancellationToken = default);
+
+    ValueTask<PortableImportPreview> PreviewImportAsync(
+        PortableSnapshot snapshot,
+        PortableImportOptions? options = null,
+        CancellationToken cancellationToken = default);
+
+    ValueTask<PortableImportResult> ImportAsync(
+        PortableSnapshot snapshot,
+        PortableImportOptions? options = null,
+        CancellationToken cancellationToken = default);
+}
+```
+
+## Export Contract
+
+```csharp
+public sealed class PortableSnapshotExportRequest
+{
+    public PortableExportScopeMode ScopeMode { get; set; }
+    public HashSet<string> DefinitionIds { get; set; } = [];
+    public HashSet<string> ResourceIds { get; set; } = [];
+    public PortableResourceVersionScope ResourceVersionScope { get; set; }
+    public HashSet<ResourceVersionReference> SpecificResourceVersions { get; set; } = [];
+}
+
+public enum PortableExportScopeMode
+{
+    DefinitionsOnly,
+    SelectedResources,
+    DefinitionWithResources,
+}
+
+public enum PortableResourceVersionScope
+{
+    AllVersions,
+    LatestOnly,
+    SpecificVersions,
+}
+```
+
+Rules:
+
+- Export scope is explicit; no implicit whole-store export.
+- Exporting resources includes referenced definition versions.
+- Activation entries are included only when their referenced resource versions are exported.
+- Skipped activation entries are reported as diagnostics.
+
+## Snapshot Contract
+
+```csharp
+public sealed record PortableSnapshot
+{
+    public required int FormatVersion { get; init; }
+    public IReadOnlyList<ResourceDefinition> Definitions { get; init; } = [];
+    public IReadOnlyList<Resource> Resources { get; init; } = [];
+    public IReadOnlyList<ActivationState> ActivationStates { get; init; } = [];
+}
+```
+
+Rules:
+
+- Initial supported `FormatVersion` is `1`.
+- Snapshot identity is based on SDK model identifiers and version numbers.
+- A snapshot may contain warnings, diagnostics, or skipped activation metadata in result objects; imported snapshot content is limited to definitions, resources, and activation state.
+
+## Import Contract
+
+```csharp
+public sealed class PortableImportOptions
+{
+    public PortableImportCollisionMode CollisionMode { get; set; } = PortableImportCollisionMode.Strict;
+}
+
+public enum PortableImportCollisionMode
+{
+    Strict,
+    RemapDivergent,
+}
+```
+
+Rules:
+
+- Strict mode is the default.
+- Identical existing content is reused/no-op.
+- Divergent existing content is a collision.
+- Strict mode fails before writing when divergent collisions exist.
+- Remap mode maps divergent collisions to deterministic replacement identifiers.
+- Preview import is non-mutating.
+- Write import is all-or-nothing.
+
+## Result And Diagnostic Contract
+
+```csharp
+public sealed record PortableDiagnostic
+{
+    public required string Code { get; init; }
+    public required PortableDiagnosticSeverity Severity { get; init; }
+    public string? Path { get; init; }
+    public required string Message { get; init; }
+}
+
+public enum PortableDiagnosticSeverity
+{
+    Info,
+    Warning,
+    Error,
+}
+
+public sealed record PortableIdentityMapping
+{
+    public required string EntityKind { get; init; }
+    public required string OriginalId { get; init; }
+    public required string ImportedId { get; init; }
+    public required string Reason { get; init; }
+}
+```
+
+Required diagnostic codes include:
+
+- `missing-definition`
+- `missing-definition-version`
+- `missing-resource`
+- `missing-resource-version`
+- `duplicate-snapshot-identity`
+- `unresolved-definition-reference`
+- `unresolved-resource-reference`
+- `divergent-identity-collision`
+- `unsupported-snapshot-format`
+- `malformed-snapshot`
+- `skipped-activation-entry`
+
+## Provider-Facing Store Contract
+
+The implementation may introduce a narrow provider-facing contract for exact portability reads and atomic writes:
+
+```csharp
+public interface IResourcePortabilityStore
+{
+    ValueTask<PortableStoreSnapshot> ReadSnapshotAsync(
+        PortableStoreReadRequest request,
+        CancellationToken cancellationToken = default);
+
+    ValueTask<PortableTargetState> ReadTargetStateAsync(
+        PortableSnapshot snapshot,
+        CancellationToken cancellationToken = default);
+
+    ValueTask ApplyImportAsync(
+        PortableSnapshot plannedSnapshot,
+        CancellationToken cancellationToken = default);
+}
+```
+
+Rules:
+
+- This contract is provider infrastructure, not provider discovery.
+- It exists because lifecycle APIs do not expose all activation channels or exact definition-version writes.
+- Providers own atomic apply behavior.

--- a/specs/013-portability-primitives/data-model.md
+++ b/specs/013-portability-primitives/data-model.md
@@ -75,7 +75,7 @@ Non-mutating result describing what a write import would do.
 
 **Fields**:
 
-- `Counts`: planned counts for definitions, resources, resource versions, and activation entries.
+- `Counts`: planned counts for definitions, resources, resource versions, activation entries, reused identical items, and remapped items.
 - `IdentityMap`: original-to-imported identity mappings.
 - `Diagnostics`: validation, collision, and remap diagnostics.
 - `CanImport`: true only when no error diagnostics remain.
@@ -91,14 +91,14 @@ Write import outcome.
 
 **Fields**:
 
-- `Counts`: imported or reused counts.
+- `Counts`: actual write counts, reused identical item counts, and remapped item counts.
 - `IdentityMap`: original-to-imported identity mappings used for writes.
 - `Diagnostics`: warnings and informational diagnostics.
 - `Status`: `Imported`, `NoOp`, or `Failed`.
 
 **Validation rules**:
 
-- Failed imports leave no partial definitions, resources, resource versions, or activation entries.
+- Failed imports leave no partial definitions, resources, resource versions, or activation entries and report zero actual write counts.
 - No-op import is valid when all snapshot content already exists with identical content.
 - Successful import preserves snapshot relationships after remapping.
 
@@ -108,7 +108,7 @@ Original-to-imported identifier relationship.
 
 **Fields**:
 
-- `EntityKind`: definition, definition version, resource, resource version, or activation entry.
+- `EntityKind`: `Definition`, `DefinitionVersion`, `Resource`, `ResourceVersion`, or `ActivationEntry`.
 - `OriginalId`: identifier from the snapshot.
 - `ImportedId`: identifier used in the target store.
 - `Reason`: `Preserved`, `ReusedIdentical`, or `RemappedCollision`.
@@ -118,6 +118,22 @@ Original-to-imported identifier relationship.
 - Remapped definition identifiers update resource `DefinitionId` and lineage references.
 - Remapped resource identifiers update resource versions and activation entries.
 - Mapping output is deterministic for the same snapshot and target-store state.
+
+## Skipped Activation Entry
+
+An activation entry omitted from export metadata because its resource version was outside the selected resource version scope.
+
+**Fields**:
+
+- `ResourceId`: logical resource identifier.
+- `Channel`: activation channel name.
+- `Version`: omitted active resource version.
+- `Reason`: `ExcludedByResourceVersionScope`.
+
+**Validation rules**:
+
+- Skipped activation entries are reported by export results and are not imported.
+- Skipped activation reasons are a closed set so callers can handle them exhaustively.
 
 ## Portability Diagnostic
 

--- a/specs/013-portability-primitives/data-model.md
+++ b/specs/013-portability-primitives/data-model.md
@@ -10,7 +10,6 @@ A self-contained SDK snapshot for moving definitions, resources, resource versio
 - `Definitions`: definition version snapshots.
 - `Resources`: resource version snapshots.
 - `ActivationStates`: activation entries for exported resource versions.
-- `SkippedActivations`: activation entries omitted because their resource versions were not exported.
 
 **Validation rules**:
 
@@ -19,7 +18,22 @@ A self-contained SDK snapshot for moving definitions, resources, resource versio
 - Resource entries must have unique `(ResourceId, Version)` pairs and unique version-specific `Id` values.
 - Every resource with known definition lineage must reference a definition version present in the snapshot.
 - Activation entries must reference resource versions present in the snapshot.
-- Skipped activation entries are diagnostics and are not imported.
+- Skipped activation entries are reported on export results and are not part of imported snapshot content.
+
+## Export Result
+
+The outcome of an export request.
+
+**Fields**:
+
+- `Snapshot`: portable snapshot when export succeeds.
+- `Diagnostics`: export diagnostics, including skipped activation entries and missing scope data.
+- `SkippedActivationEntries`: activation entries omitted because their resource versions were not exported.
+
+**Validation rules**:
+
+- A completed export returns either a valid snapshot or error diagnostics.
+- Skipped activation entries are observable export metadata and are not imported.
 
 ## Export Request
 

--- a/specs/013-portability-primitives/data-model.md
+++ b/specs/013-portability-primitives/data-model.md
@@ -1,0 +1,154 @@
+# Data Model: Portability Primitives
+
+## Portable Snapshot
+
+A self-contained SDK snapshot for moving definitions, resources, resource versions, and activation state.
+
+**Fields**:
+
+- `FormatVersion`: snapshot format version, initially `1`.
+- `Definitions`: definition version snapshots.
+- `Resources`: resource version snapshots.
+- `ActivationStates`: activation entries for exported resource versions.
+- `SkippedActivations`: activation entries omitted because their resource versions were not exported.
+
+**Validation rules**:
+
+- Format version must be supported.
+- Definition entries must have unique `(DefinitionId, Version)` pairs.
+- Resource entries must have unique `(ResourceId, Version)` pairs and unique version-specific `Id` values.
+- Every resource with known definition lineage must reference a definition version present in the snapshot.
+- Activation entries must reference resource versions present in the snapshot.
+- Skipped activation entries are diagnostics and are not imported.
+
+## Export Request
+
+Caller-selected scope for creating a portable snapshot.
+
+**Fields**:
+
+- `ExportScopeMode`: `DefinitionsOnly`, `SelectedResources`, or `DefinitionWithResources`.
+- `DefinitionIds`: selected definition identifiers.
+- `ResourceIds`: selected resource identifiers.
+- `ResourceVersionScope`: `AllVersions`, `LatestOnly`, or `SpecificVersions`.
+- `SpecificResourceVersions`: optional selected `(ResourceId, Version)` pairs.
+
+**Validation rules**:
+
+- Definitions-only exports require at least one definition identifier.
+- Selected-resources exports require at least one resource identifier or specific resource version.
+- Definition-with-resources exports require at least one definition identifier.
+- Specific-version scope requires at least one specific resource version.
+- Export fails with diagnostics when requested definitions or resource versions cannot be found.
+
+## Import Options
+
+Caller-selected import behavior.
+
+**Fields**:
+
+- `CollisionMode`: `Strict` by default, or `RemapDivergent`.
+
+**Validation rules**:
+
+- Strict mode fails before writing when divergent collisions exist.
+- Remap mode plans deterministic replacement identifiers for divergent collisions.
+- Identical existing content is treated as already satisfied in all modes.
+
+## Import Preview
+
+Non-mutating result describing what a write import would do.
+
+**Fields**:
+
+- `Counts`: planned counts for definitions, resources, resource versions, and activation entries.
+- `IdentityMap`: original-to-imported identity mappings.
+- `Diagnostics`: validation, collision, and remap diagnostics.
+- `CanImport`: true only when no error diagnostics remain.
+
+**Validation rules**:
+
+- Preview must not mutate the target store.
+- Repeating preview with the same snapshot and target state must produce the same identity map and diagnostics.
+
+## Import Result
+
+Write import outcome.
+
+**Fields**:
+
+- `Counts`: imported or reused counts.
+- `IdentityMap`: original-to-imported identity mappings used for writes.
+- `Diagnostics`: warnings and informational diagnostics.
+- `Status`: `Imported`, `NoOp`, or `Failed`.
+
+**Validation rules**:
+
+- Failed imports leave no partial definitions, resources, resource versions, or activation entries.
+- No-op import is valid when all snapshot content already exists with identical content.
+- Successful import preserves snapshot relationships after remapping.
+
+## Identity Mapping
+
+Original-to-imported identifier relationship.
+
+**Fields**:
+
+- `EntityKind`: definition, definition version, resource, resource version, or activation entry.
+- `OriginalId`: identifier from the snapshot.
+- `ImportedId`: identifier used in the target store.
+- `Reason`: `Preserved`, `ReusedIdentical`, or `RemappedCollision`.
+
+**Validation rules**:
+
+- Remapped definition identifiers update resource `DefinitionId` and lineage references.
+- Remapped resource identifiers update resource versions and activation entries.
+- Mapping output is deterministic for the same snapshot and target-store state.
+
+## Portability Diagnostic
+
+Structured diagnostic emitted by export, validation, preview, and import.
+
+**Fields**:
+
+- `Code`: stable machine-readable code.
+- `Severity`: `Info`, `Warning`, or `Error`.
+- `Path`: optional snapshot/request path.
+- `Message`: human-readable explanation.
+
+**Common codes**:
+
+- `missing-definition`
+- `missing-definition-version`
+- `missing-resource`
+- `missing-resource-version`
+- `duplicate-snapshot-identity`
+- `unresolved-definition-reference`
+- `unresolved-resource-reference`
+- `divergent-identity-collision`
+- `unsupported-snapshot-format`
+- `malformed-snapshot`
+- `skipped-activation-entry`
+
+## State Transitions
+
+```text
+Export request
+  -> Resolve explicit scope
+  -> Read exact provider snapshots
+  -> Validate snapshot references
+  -> Return snapshot + skipped activation diagnostics
+
+Snapshot import preview
+  -> Validate snapshot shape
+  -> Compare target identities
+  -> Reuse identical content
+  -> Fail divergent collisions in strict mode
+  -> Plan deterministic mappings in remap mode
+  -> Return non-mutating preview
+
+Snapshot write import
+  -> Run same validation/planning as preview
+  -> Provider applies planned snapshot atomically
+  -> Return import result
+```

--- a/specs/013-portability-primitives/plan.md
+++ b/specs/013-portability-primitives/plan.md
@@ -44,10 +44,14 @@ Start Phase 4 with explicit SDK portability primitives for exporting and importi
 
 ```text
 specs/013-portability-primitives/
++-- spec.md
 +-- plan.md
 +-- research.md
 +-- data-model.md
 +-- quickstart.md
++-- tasks.md
++-- checklists/
+|   +-- requirements.md
 +-- contracts/
 |   +-- portability-primitives.md
 ```

--- a/specs/013-portability-primitives/plan.md
+++ b/specs/013-portability-primitives/plan.md
@@ -9,14 +9,14 @@ Start Phase 4 with explicit SDK portability primitives for exporting and importi
 
 ## Technical Context
 
-**Language/Version**: C# latest, .NET 8.0 / 9.0 / 10.0 multi-targeting  
-**Primary Dependencies**: Existing core SDK, resource definition/resource version abstractions, in-memory store, SQLite JSON provider, xUnit test stack; no new dependencies  
-**Storage**: Existing resource definitions, resource versions, and activation state; no schema migration planned for SQLite JSON or in-memory stores  
-**Testing**: `dotnet test Aster.sln`, focused portability service tests, in-memory and SQLite JSON round-trip tests, invalid snapshot/collision tests, `dotnet build Aster.sln /m:1`, `git diff --check`  
-**Target Platform**: .NET SDK/library consumers and local test environment  
-**Project Type**: SDK/library with provider packages and tests  
-**Performance Goals**: Export and preview are linear in selected definitions, selected resource versions, and activation entries; import performs validation and identity-map planning before writes  
-**Constraints**: Strict import by default; explicit deterministic remap mode; all-or-nothing import; exact definition/resource version identity preservation when no collision exists; no recipes, lifecycle hooks, live sync, migrations, runtime scanning, provider registries, public SQL, or public `IQueryable<Resource>`  
+**Language/Version**: C# latest, .NET 8.0 / 9.0 / 10.0 multi-targeting
+**Primary Dependencies**: Existing core SDK, resource definition/resource version abstractions, in-memory store, SQLite JSON provider, xUnit test stack; no new dependencies
+**Storage**: Existing resource definitions, resource versions, and activation state; no schema migration planned for SQLite JSON or in-memory stores
+**Testing**: `dotnet test Aster.sln`, focused portability service tests, in-memory and SQLite JSON round-trip tests, invalid snapshot/collision tests, `dotnet build Aster.sln /m:1`, `git diff --check`
+**Target Platform**: .NET SDK/library consumers and local test environment
+**Project Type**: SDK/library with provider packages and tests
+**Performance Goals**: Export and preview are linear in selected definitions, selected resource versions, and activation entries; import performs validation and identity-map planning before writes
+**Constraints**: Strict import by default; explicit deterministic remap mode; all-or-nothing import; exact definition/resource version identity preservation when no collision exists; no recipes, lifecycle hooks, live sync, migrations, runtime scanning, provider registries, public SQL, or public `IQueryable<Resource>`
 **Scale/Scope**: Core portability contracts and orchestration with in-memory and SQLite JSON provider support for deterministic SDK-to-SDK snapshot export/import
 
 ## Constitution Check

--- a/specs/013-portability-primitives/plan.md
+++ b/specs/013-portability-primitives/plan.md
@@ -1,0 +1,124 @@
+# Implementation Plan: Portability Primitives
+
+**Branch**: `013-portability-primitives` | **Date**: 2026-05-19 | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from `/specs/013-portability-primitives/spec.md`
+
+## Summary
+
+Start Phase 4 with explicit SDK portability primitives for exporting and importing definitions, resources, resource versions, and activation state. The design adds a public `IResourcePortabilityService` over a narrow provider-facing portability store contract so core can validate snapshots, plan deterministic identity mapping, and expose preview/write import results without leaking provider storage details. The first slice stays small: no recipes, lifecycle hooks, live sync, runtime scanning, provider registry, migration engine, public SQL, or public `IQueryable<Resource>`.
+
+## Technical Context
+
+**Language/Version**: C# latest, .NET 8.0 / 9.0 / 10.0 multi-targeting  
+**Primary Dependencies**: Existing core SDK, resource definition/resource version abstractions, in-memory store, SQLite JSON provider, xUnit test stack; no new dependencies  
+**Storage**: Existing resource definitions, resource versions, and activation state; no schema migration planned for SQLite JSON or in-memory stores  
+**Testing**: `dotnet test Aster.sln`, focused portability service tests, in-memory and SQLite JSON round-trip tests, invalid snapshot/collision tests, `dotnet build Aster.sln /m:1`, `git diff --check`  
+**Target Platform**: .NET SDK/library consumers and local test environment  
+**Project Type**: SDK/library with provider packages and tests  
+**Performance Goals**: Export and preview are linear in selected definitions, selected resource versions, and activation entries; import performs validation and identity-map planning before writes  
+**Constraints**: Strict import by default; explicit deterministic remap mode; all-or-nothing import; exact definition/resource version identity preservation when no collision exists; no recipes, lifecycle hooks, live sync, migrations, runtime scanning, provider registries, public SQL, or public `IQueryable<Resource>`  
+**Scale/Scope**: Core portability contracts and orchestration with in-memory and SQLite JSON provider support for deterministic SDK-to-SDK snapshot export/import
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+- **SDK-first/headless**: PASS - Adds SDK/library contracts only; no UI, CMS, or host coupling.
+- **Immutable versioning**: PASS - Export/import preserve resource version snapshots and do not rewrite historical versions.
+- **Channel activation**: PASS - Activation state remains separate and is represented as activation entries in snapshots.
+- **Typed/queryable**: PASS - Typed aspects and the portable query AST are unchanged; no public `IQueryable` or SQL surface.
+- **Provider agnostic**: PASS - Core service uses provider-facing portability contracts rather than direct SQLite or in-memory storage access.
+- **Simplicity first**: PASS - A small service plus a narrow store capability satisfies the current export/import need without a package repository or sync framework.
+- **Modern C# idioms**: PASS - Records, enums, collection expressions, nullable annotations, and async APIs fit the existing SDK style.
+- **Readability over cleverness**: PASS - Snapshot validation, scope resolution, and identity mapping are explicit workflows.
+- **Explicitness over magic**: PASS - Callers choose export scope, version scope, preview/import, and remap behavior explicitly.
+- **Abstractions justified**: PASS - A provider-facing portability store is required because current lifecycle APIs auto-version definitions and do not enumerate activation channels.
+- **Optimize for deletion**: PASS - Portability models and service are additive and isolated from querying and schema-version services.
+- **Composition over inheritance**: PASS - Uses services and records; no inheritance hierarchy.
+- **Intentional dependencies**: PASS - No new third-party dependencies.
+- **Operational simplicity**: PASS - No background processes, deployment changes, schema migrations, or external services.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/013-portability-primitives/
++-- plan.md
++-- research.md
++-- data-model.md
++-- quickstart.md
++-- contracts/
+|   +-- portability-primitives.md
++-- tasks.md
+```
+
+### Source Code (repository root)
+
+```text
+src/
++-- core/Aster.Core/
+|   +-- Abstractions/
+|   |   +-- portability service contract
+|   |   +-- provider-facing portability store contract
+|   +-- Models/Portability/
+|   |   +-- portable snapshot models
+|   |   +-- export/import request and result models
+|   |   +-- diagnostics and identity mapping models
+|   +-- Services/
+|   |   +-- portability service implementation
+|   +-- InMemory/
+|   |   +-- portability store support
+|   +-- Extensions/
+|       +-- DI registration update
++-- persistence/Aster.Persistence.SqliteJson/
+    +-- SQLite JSON portability store support
+
+test/
++-- Aster.Tests/
+    +-- Portability/
+    +-- InMemory/
+    +-- SqliteJson/
+```
+
+**Structure Decision**: Keep public portability contracts in `Aster.Core` because export/import is provider-agnostic SDK behavior. Add provider support in the existing in-memory and SQLite JSON stores because all-version definition enumeration, all-channel activation state, and atomic snapshot writes require provider-owned storage access.
+
+## Complexity Tracking
+
+No constitution violations.
+
+## Phase 0 Research Summary
+
+Research decisions are captured in [research.md](research.md). Key outcomes:
+
+- Add `IResourcePortabilityService` as the public workflow surface for export, validation, preview import, and write import.
+- Add a narrow provider-facing `IResourcePortabilityStore` for exact snapshot reads and all-or-nothing writes.
+- Use SDK-native snapshot records instead of external package formats or new dependencies.
+- Treat identical existing content as already satisfied; treat divergent content as a collision.
+- Keep import strict by default and require explicit remap mode.
+- Scope export through explicit definition/resource and resource-version modes.
+
+## Phase 1 Design Summary
+
+Design artifacts:
+
+- [data-model.md](data-model.md)
+- [contracts/portability-primitives.md](contracts/portability-primitives.md)
+- [quickstart.md](quickstart.md)
+
+## Post-Design Constitution Check
+
+- **SDK-first/headless**: PASS - Contracts remain host-agnostic and UI-free.
+- **Immutable versioning**: PASS - Snapshot import writes immutable snapshots and does not mutate previous versions.
+- **Channel activation**: PASS - Activation state remains an explicit separate snapshot collection.
+- **Typed/queryable**: PASS - No query API or typed aspect behavior changes.
+- **Provider agnostic**: PASS - Provider-specific work is behind an explicit portability store contract.
+- **Simplicity first**: PASS - No repository, recipe, hook, sync, or migration framework.
+- **Modern C# idioms**: PASS - Data records and async service methods match the existing codebase.
+- **Readability over cleverness**: PASS - Validation and identity mapping are modeled as direct data flows.
+- **Explicitness over magic**: PASS - No hidden discovery or automatic remapping.
+- **Abstractions justified**: PASS - The new store surface fills concrete read/write gaps in existing lifecycle APIs.
+- **Optimize for deletion**: PASS - Portability can be removed without changing query or schema-version surfaces.
+- **Composition over inheritance**: PASS - No inheritance introduced.
+- **Intentional dependencies**: PASS - No new dependencies.
+- **Operational simplicity**: PASS - Existing build/test workflow remains sufficient.

--- a/specs/013-portability-primitives/plan.md
+++ b/specs/013-portability-primitives/plan.md
@@ -50,7 +50,6 @@ specs/013-portability-primitives/
 +-- quickstart.md
 +-- contracts/
 |   +-- portability-primitives.md
-+-- tasks.md
 ```
 
 ### Source Code (repository root)

--- a/specs/013-portability-primitives/quickstart.md
+++ b/specs/013-portability-primitives/quickstart.md
@@ -1,0 +1,111 @@
+# Quickstart: Portability Primitives
+
+## Register Core Services
+
+```csharp
+services.AddAsterCore();
+```
+
+SQLite-backed hosts continue to register the provider after core:
+
+```csharp
+services.AddAsterCore();
+services.AddAsterSqliteJson(options =>
+{
+    options.ConnectionString = "Data Source=aster.db";
+});
+```
+
+## Export Selected Resources
+
+```csharp
+var portability = serviceProvider.GetRequiredService<IResourcePortabilityService>();
+
+var export = await portability.ExportAsync(new PortableSnapshotExportRequest
+{
+    ScopeMode = PortableExportScopeMode.SelectedResources,
+    ResourceIds = ["product-1", "product-2"],
+    ResourceVersionScope = PortableResourceVersionScope.AllVersions,
+});
+
+if (export.Diagnostics.Any(d => d.Severity == PortableDiagnosticSeverity.Error))
+{
+    foreach (var diagnostic in export.Diagnostics)
+        Console.WriteLine($"{diagnostic.Code}: {diagnostic.Message}");
+
+    return;
+}
+
+var snapshot = export.Snapshot;
+```
+
+The snapshot includes selected resource versions, referenced definition versions, and activation entries for exported versions. If an active version is omitted by scope, the export reports `skipped-activation-entry`.
+
+## Preview Import
+
+```csharp
+var preview = await portability.PreviewImportAsync(snapshot);
+
+foreach (var diagnostic in preview.Diagnostics)
+    Console.WriteLine($"{diagnostic.Severity} {diagnostic.Code}: {diagnostic.Message}");
+
+foreach (var mapping in preview.IdentityMap)
+    Console.WriteLine($"{mapping.EntityKind}: {mapping.OriginalId} -> {mapping.ImportedId} ({mapping.Reason})");
+```
+
+Default import behavior is strict. Identical existing content is treated as already satisfied. Divergent collisions fail before writing unless remap mode is selected.
+
+## Preview With Explicit Remapping
+
+```csharp
+var remapPreview = await portability.PreviewImportAsync(
+    snapshot,
+    new PortableImportOptions
+    {
+        CollisionMode = PortableImportCollisionMode.RemapDivergent,
+    });
+```
+
+The same snapshot and target state produce the same identity map during preview and write import.
+
+## Write Import
+
+```csharp
+var result = await portability.ImportAsync(
+    snapshot,
+    new PortableImportOptions
+    {
+        CollisionMode = PortableImportCollisionMode.RemapDivergent,
+    });
+
+if (result.Status == PortableImportStatus.Failed)
+{
+    foreach (var diagnostic in result.Diagnostics)
+        Console.WriteLine($"{diagnostic.Code}: {diagnostic.Message}");
+}
+```
+
+Write import is all-or-nothing. Failed imports leave no partial definitions, resources, versions, or activation entries.
+
+## Definition-Only Export
+
+```csharp
+var definitionExport = await portability.ExportAsync(new PortableSnapshotExportRequest
+{
+    ScopeMode = PortableExportScopeMode.DefinitionsOnly,
+    DefinitionIds = ["Product"],
+});
+```
+
+## Definition With Resources Export
+
+```csharp
+var fullDefinitionExport = await portability.ExportAsync(new PortableSnapshotExportRequest
+{
+    ScopeMode = PortableExportScopeMode.DefinitionWithResources,
+    DefinitionIds = ["Product"],
+    ResourceVersionScope = PortableResourceVersionScope.LatestOnly,
+});
+```
+
+This includes resources for the selected definitions, latest resource versions, referenced definition versions, and activation entries only for exported versions.

--- a/specs/013-portability-primitives/quickstart.md
+++ b/specs/013-portability-primitives/quickstart.md
@@ -49,6 +49,9 @@ var preview = await portability.PreviewImportAsync(snapshot);
 foreach (var diagnostic in preview.Diagnostics)
     Console.WriteLine($"{diagnostic.Severity} {diagnostic.Code}: {diagnostic.Message}");
 
+if (!preview.CanImport)
+    return;
+
 foreach (var mapping in preview.IdentityMap)
     Console.WriteLine($"{mapping.EntityKind}: {mapping.OriginalId} -> {mapping.ImportedId} ({mapping.Reason})");
 ```

--- a/specs/013-portability-primitives/research.md
+++ b/specs/013-portability-primitives/research.md
@@ -1,0 +1,105 @@
+# Research: Portability Primitives
+
+## Decision: Add A Public Portability Service
+
+**Decision**: Introduce `IResourcePortabilityService` as the public SDK workflow for export, snapshot validation, import preview, and write import.
+
+**Rationale**: Portability is a distinct SDK workflow that coordinates definitions, resources, activation state, validation, identity mapping, and diagnostics. Keeping it in a focused service avoids expanding `IResourceManager` and keeps import/export behavior discoverable.
+
+**Alternatives considered**:
+
+- Add export/import methods to `IResourceManager`. Rejected because the manager is resource lifecycle oriented and does not own definitions or snapshot validation.
+- Add static helper methods. Rejected because the workflow needs provider-backed collaborators and cancellation-aware async operations.
+- Build a recipe or hook framework first. Rejected because the spec explicitly defers recipes and lifecycle hooks.
+
+## Decision: Add A Narrow Provider-Facing Portability Store
+
+**Decision**: Add an explicit provider-facing `IResourcePortabilityStore` for snapshot enumeration, collision lookup, and all-or-nothing snapshot writes.
+
+**Rationale**: Existing lifecycle contracts intentionally hide storage details. They do not enumerate all definition versions, do not expose all activation channels, and `RegisterDefinitionAsync` auto-assigns definition versions rather than preserving arbitrary snapshot version numbers. A narrow portability store is justified by this concrete gap and keeps provider-specific storage access out of the public service implementation.
+
+**Alternatives considered**:
+
+- Use only `IResourceDefinitionStore`, `IResourceVersionReader`, and `IResourceVersionWriter`. Rejected because exact import of definition versions and complete activation export are not possible through those contracts.
+- Query provider storage via `IResourceQueryService`. Rejected because export/import is not a query concern and must not depend on provider query capabilities.
+- Add many small reader/writer interfaces. Rejected because one cohesive portability store is simpler for providers to implement and easier to delete later.
+
+## Decision: SDK-Native Snapshot Model
+
+**Decision**: Represent snapshots as SDK-native records containing format metadata, `ResourceDefinition` snapshots, `Resource` version snapshots, `ActivationState` entries, diagnostics, skipped activation entries, and identity mapping entries.
+
+**Rationale**: The first format is for SDK-to-SDK portability, not a long-term archival package standard. SDK-native records can use existing serialization behavior, avoid new dependencies, and remain easy to test.
+
+**Alternatives considered**:
+
+- Define a compressed package format. Rejected because compression, manifests, signing, and file transport are outside this slice.
+- Use provider-specific dump formats. Rejected because portability must be provider-agnostic.
+- Use external schema/document packages. Rejected because dependencies should remain intentional and no current requirement needs them.
+
+## Decision: Explicit Export Scope And Version Scope
+
+**Decision**: Export requests require explicit export scope: `definitions-only`, `selected-resources`, or `definition-with-resources`; resource exports also require explicit resource version scope: all versions, latest only, or specific versions.
+
+**Rationale**: Exporting an unintended whole store is a practical risk. Explicit modes make the package contents predictable and directly testable.
+
+**Alternatives considered**:
+
+- Always export all resources for selected definitions. Rejected because it can move more data than intended.
+- Always export only selected resources. Rejected because definition-with-resources is a valid operational workflow.
+- Always export all resource versions. Rejected because small packages and latest-only promotion are common needs.
+
+## Decision: Activation Entries Follow Exported Versions
+
+**Decision**: Include activation entries only for exported resource versions. If active versions are omitted by scope, report skipped activation entries.
+
+**Rationale**: This keeps partial-version exports valid and avoids dangling activation references. Reporting skipped entries makes the loss of activation context observable.
+
+**Alternatives considered**:
+
+- Fail export when active versions are omitted. Rejected because latest-only and specific-version exports should remain usable.
+- Automatically include active versions even when not selected. Rejected because it weakens explicit version scope.
+- Drop activation state silently. Rejected because activation is observable resource behavior.
+
+## Decision: Strict Import By Default
+
+**Decision**: Import uses strict collision handling by default. Deterministic remapping must be explicitly requested.
+
+**Rationale**: Remapping changes identities. Strict-by-default behavior is safer and aligns with explicitness over magic.
+
+**Alternatives considered**:
+
+- Remap automatically. Rejected because identity changes could surprise callers and hosts.
+- Require callers to choose strict/remap every time. Rejected because strict is a safe default and reduces boilerplate.
+
+## Decision: Identical Existing Content Is Already Satisfied
+
+**Decision**: If the target store already contains the same identifier and identical content, import treats that item as already satisfied. Divergent content is a collision.
+
+**Rationale**: This makes repeated imports idempotent for unchanged content while still failing closed when content differs.
+
+**Alternatives considered**:
+
+- Treat any existing identifier as a collision. Rejected because it makes idempotent import unnecessarily noisy.
+- Always remap existing identifiers in remap mode. Rejected because identical content should not create duplicate logical data.
+
+## Decision: Deterministic Remapping
+
+**Decision**: Deterministic replacement identifiers are derived from original identifiers, entity kind, and target-store collision state. They must not use wall-clock time or random IDs.
+
+**Rationale**: Preview and write import need to produce the same identity map for the same snapshot and target state. Determinism is also required for repeatable tests.
+
+**Alternatives considered**:
+
+- Use `IIdentityGenerator` for remapped IDs. Rejected because the default generator is random GUID-based and would make previews non-repeatable.
+- Let providers choose remapped IDs. Rejected because identity mapping must be consistent across providers.
+
+## Decision: All-Or-Nothing Write Import
+
+**Decision**: Write import validates and plans before writing, then asks the portability store to apply the planned snapshot atomically.
+
+**Rationale**: The spec requires failed imports to leave no partial data. Providers own their transaction or staging strategy: SQLite can use a transaction; in-memory can stage copies before replacing state.
+
+**Alternatives considered**:
+
+- Write incrementally through existing lifecycle APIs. Rejected because partial writes would be possible and definition versions could be renumbered.
+- Add rollback logic in the service. Rejected because rollback is provider-specific and less reliable than provider-owned atomic apply.

--- a/specs/013-portability-primitives/spec.md
+++ b/specs/013-portability-primitives/spec.md
@@ -1,8 +1,8 @@
 # Feature Specification: Portability Primitives
 
-**Feature Branch**: `013-portability-primitives`  
-**Created**: 2026-05-19  
-**Status**: Draft  
+**Feature Branch**: `013-portability-primitives`
+**Created**: 2026-05-19
+**Status**: Draft
 **Input**: User description: "Start Phase 4 with deterministic export/import primitives for definitions and resources. Export definition and resource snapshots with stable references. Import with deterministic ID remapping and collision diagnostics. Keep recipes and host lifecycle hooks separate follow-up slices."
 
 ## Clarifications

--- a/specs/013-portability-primitives/spec.md
+++ b/specs/013-portability-primitives/spec.md
@@ -1,0 +1,161 @@
+# Feature Specification: Portability Primitives
+
+**Feature Branch**: `013-portability-primitives`  
+**Created**: 2026-05-19  
+**Status**: Draft  
+**Input**: User description: "Start Phase 4 with deterministic export/import primitives for definitions and resources. Export definition and resource snapshots with stable references. Import with deterministic ID remapping and collision diagnostics. Keep recipes and host lifecycle hooks separate follow-up slices."
+
+## Clarifications
+
+### Session 2026-05-19
+
+- Q: How should import treat an incoming identifier that already exists in the target store with identical content? → A: Identical existing content is reused/no-op; divergent content is a collision.
+- Q: When exporting by definition, should the snapshot include all resources for that definition or only explicitly selected resources? → A: Support both modes; caller must choose resource scope explicitly.
+- Q: Which versions of selected resources should export include? → A: Caller chooses all versions, latest only, or specific versions.
+- Q: How should activation state be handled when selected resource versions omit active versions? → A: Include only activation entries for exported versions and report skipped entries.
+- Q: What should the default import behavior be when divergent identifier collisions are detected? → A: Strict by default; caller must opt into deterministic remapping.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Export A Portable Snapshot (Priority: P1)
+
+As an SDK user, I want to export selected resource definitions and resources into a portable snapshot so I can move content between stores without depending on provider-specific storage.
+
+**Why this priority**: Export is the foundation for portability. Without a self-contained snapshot, import behavior cannot be tested or trusted.
+
+**Independent Test**: Create definition versions, resources, resource versions, and activations; export a selected scope; verify the snapshot contains the requested data plus all references required to understand it.
+
+**Acceptance Scenarios**:
+
+1. **Given** definitions and resources exist in a store, **When** the caller exports selected definitions without selecting resources, **Then** the snapshot contains those definition versions with stable identifiers and version numbers.
+2. **Given** resources are selected for export, **When** the snapshot is created, **Then** it contains resource versions according to the caller's all-versions, latest-only, or specific-versions selection and the definition versions those resource versions reference.
+3. **Given** a caller chooses definition-with-resources scope, **When** the snapshot is created, **Then** it includes resources for the selected definitions and the definition versions those resources reference.
+4. **Given** exported resource versions have activation channels, **When** the snapshot is created, **Then** activation state for exported versions is included.
+5. **Given** active resource versions are omitted by the selected resource version scope, **When** the snapshot is created, **Then** activation entries for omitted versions are skipped and reported.
+6. **Given** an export scope references missing data, **When** export is requested, **Then** the caller receives structured diagnostics and no partial snapshot is reported as complete.
+
+---
+
+### User Story 2 - Import With Deterministic Identity Mapping (Priority: P2)
+
+As an SDK user, I want to import a portable snapshot into another store with predictable identity mapping so imported definitions and resources remain internally consistent even when target identifiers collide.
+
+**Why this priority**: Portability is only useful if imports are repeatable, explainable, and safe when the target store already contains data.
+
+**Independent Test**: Export a snapshot, import it into an empty store and into a store with colliding identifiers, and verify the imported data preserves relationships through a deterministic original-to-imported identity map.
+
+**Acceptance Scenarios**:
+
+1. **Given** a valid snapshot and an empty target store, **When** the snapshot is imported, **Then** definitions, resources, versions, and activation state are recreated with their original identifiers when no collision exists.
+2. **Given** the target store already contains one or more divergent identifiers from the snapshot, **When** import runs in explicit remap mode, **Then** colliding incoming identifiers are mapped to deterministic replacement identifiers and all internal references use the replacement identifiers consistently.
+3. **Given** the same snapshot and same target state, **When** remap import is repeated as a preview, **Then** the same identity map and diagnostics are produced.
+4. **Given** the target store contains a matching identifier with identical content, **When** import is requested, **Then** the import treats that item as already satisfied and does not create duplicate data.
+5. **Given** the target store contains a conflicting identifier and the caller has not explicitly allowed remapping, **When** import is requested, **Then** the import fails before writing data and reports the collision.
+
+---
+
+### User Story 3 - Preview Import Diagnostics Before Writing (Priority: P3)
+
+As a host application, I want to preview import results and diagnostics before writing to the target store so users can decide whether to proceed, remap, or fix the package.
+
+**Why this priority**: Import can affect many definitions and resources. A preview gives hosts a safe integration point without requiring lifecycle hooks in this slice.
+
+**Independent Test**: Run import preview against valid, colliding, and invalid snapshots; verify diagnostics, counts, and identity mappings are returned without changing the target store.
+
+**Acceptance Scenarios**:
+
+1. **Given** a valid snapshot, **When** import preview is requested, **Then** the caller receives counts for definitions, resources, resource versions, activation entries, and planned identity mappings.
+2. **Given** a snapshot contains unresolved references, **When** import preview is requested, **Then** diagnostics identify the missing or invalid references.
+3. **Given** import preview completes, **When** the target store is inspected, **Then** no definitions, resources, versions, or activations have been written.
+
+---
+
+### Edge Cases
+
+- The export scope includes a resource whose recorded definition version is missing.
+- The export scope includes a resource with unknown definition lineage.
+- The caller exports only definitions, with no resources.
+- The caller exports specific resources for a definition that has many other resources.
+- The caller exports a definition-with-resources scope for one or more selected definitions.
+- The caller exports only latest resource versions while older versions exist.
+- The caller exports a specific subset of resource versions for a resource with many versions.
+- The caller exports a specific resource version subset that omits active versions in one or more activation channels.
+- Multiple resource versions in the same export reference different definition versions.
+- The target store already contains a definition identifier from the snapshot with different version content.
+- The target store already contains a resource identifier from the snapshot.
+- The target store already contains an identifier from the snapshot with identical content.
+- The target store contains divergent identifier collisions and the caller did not explicitly choose remap mode.
+- The snapshot contains duplicate identifiers or duplicate version numbers.
+- The snapshot references activation state for a resource version that is not present in the snapshot.
+- A remapped definition identifier must also update all resource lineage references in the imported data.
+- A remapped resource identifier must also update all resource versions and activation entries in the imported data.
+- An import is attempted from an unsupported or malformed snapshot shape.
+- An import preview succeeds, but the target store changes before the write import is attempted.
+
+### Constitution Alignment *(mandatory)*
+
+- **Simplicity**: The slice defines portable snapshots, validation, deterministic identity mapping, preview, and write import only. It excludes recipes, host lifecycle hooks, live sync, external storage adapters, package signing, data transforms, and migration engines.
+- **Explicitness**: Callers choose export scope, resource inclusion mode, import mode, and whether an import is preview-only or writes data. Import is strict by default, and remapping must be explicitly selected. Collisions and remapping are reported explicitly.
+- **Dependencies**: None.
+- **Operational Impact**: Existing provider setup remains unchanged. Portability uses existing definition and resource stores and adds no background processes or deployment infrastructure.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The system MUST provide a way to export selected resource definitions and resources into a portable snapshot.
+- **FR-002**: Exported snapshots MUST include stable identifiers and version numbers for exported definitions, resources, resource versions, and activation state.
+- **FR-003**: Export scope MUST let callers explicitly choose definitions-only, selected-resources, or definition-with-resources export modes.
+- **FR-004**: Resource export scope MUST let callers explicitly choose all versions, latest only, or specific versions for included resources.
+- **FR-005**: Exporting resources MUST include the definition versions referenced by those exported resource versions, even when those definitions were not explicitly selected.
+- **FR-006**: Export MUST preserve resource definition lineage for each resource version.
+- **FR-007**: Export MUST preserve all exported resource versions without rewriting historical versions.
+- **FR-008**: Export MUST preserve activation channel membership for exported resource versions.
+- **FR-009**: Export MUST skip activation entries that reference omitted resource versions and MUST report those skipped activation entries.
+- **FR-010**: Export MUST fail with structured diagnostics when required referenced data is missing.
+- **FR-011**: The system MUST provide a way to validate a snapshot before writing it to a target store.
+- **FR-012**: Snapshot validation MUST detect duplicate identifiers, duplicate version numbers within the same logical entity, unresolved definition references, unresolved resource references, and malformed snapshot content.
+- **FR-013**: The system MUST provide an import preview that returns planned counts, identity mappings, and diagnostics without writing to the target store.
+- **FR-014**: The system MUST provide a write import that recreates valid snapshot content in the target store.
+- **FR-015**: Import MUST preserve relationships between definitions, resources, resource versions, lineage references, and activation state.
+- **FR-016**: Import MUST preserve original identifiers when no target-store collision exists.
+- **FR-017**: Import MUST treat an existing target-store item with the same identifier and identical content as already satisfied, without creating duplicate data.
+- **FR-018**: Import MUST detect collisions between snapshot identifiers and target-store identifiers when the existing target-store content differs from the snapshot content.
+- **FR-019**: Import MUST fail before writing data when divergent collisions exist and remapping is not explicitly allowed.
+- **FR-020**: Import MUST use strict collision handling by default.
+- **FR-021**: Import SHOULD support an explicit remap mode that maps colliding incoming identifiers to deterministic replacement identifiers.
+- **FR-022**: Deterministic remapping MUST produce the same original-to-imported identity map for the same snapshot and target-store state.
+- **FR-023**: Deterministic remapping MUST update all internal references in imported data consistently.
+- **FR-024**: Import results MUST report the original identifier, imported identifier, entity kind, and collision reason for every remapped or failed identity.
+- **FR-025**: Import MUST be all-or-nothing for a single requested snapshot; failed imports MUST NOT leave partial imported definitions, resources, versions, or activation entries.
+- **FR-026**: Import preview and write import MUST report diagnostics using stable machine-readable codes and human-readable messages.
+- **FR-027**: The snapshot format MUST include a format version so future portability changes can be detected safely.
+- **FR-028**: The feature MUST NOT introduce recipes, host lifecycle hooks, live synchronization, runtime scanning, provider registries, migration engines, public SQL, or public `IQueryable<Resource>`.
+
+### Key Entities *(include if feature involves data)*
+
+- **Portable Snapshot**: A self-contained export package containing format metadata, definitions, resources, resource versions, activation state, and stable references between them.
+- **Export Scope**: The caller-selected definitions-only, selected-resources, or definition-with-resources mode that determines which definitions and resources are included in a snapshot.
+- **Resource Version Scope**: The caller-selected all-versions, latest-only, or specific-versions mode that determines which versions of included resources are exported.
+- **Import Request**: A caller-initiated operation that validates or writes a snapshot into a target store.
+- **Import Preview**: A non-mutating result that describes planned imported content, identity mappings, and diagnostics.
+- **Identity Mapping**: The original-to-imported identifier relationship for definitions, resources, resource versions, and activation references.
+- **Collision Diagnostic**: A structured report explaining why a snapshot identity conflicts with target-store data or cannot be imported.
+
+### Assumptions
+
+- Portability operates on existing definition and resource stores rather than introducing a separate package repository.
+- The first snapshot format is intended for SDK-to-SDK portability, not long-term archival guarantees.
+- Export/import includes activation channel state because activation is part of observable resource behavior.
+- Deterministic remapping is based on snapshot content and target-store state, not on wall-clock time or random identity generation.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: A caller can export a store containing multiple definition versions, multiple resource versions, and activation state, then inspect a self-contained snapshot that preserves all required references and reports skipped activation entries.
+- **SC-002**: A caller can import a valid snapshot into an empty target store and observe equivalent definitions, resources, versions, lineage, and activation state.
+- **SC-003**: A caller can preview import into a target store with identical existing content and divergent identifier collisions, receiving no-op reuse decisions, deterministic identity mappings, and collision diagnostics without changing the target store.
+- **SC-004**: Repeating import preview with the same snapshot and target-store state produces the same identity mapping and diagnostics.
+- **SC-005**: Importing an invalid or conflicting snapshot without remapping leaves the target store unchanged and reports stable diagnostic codes.
+- **SC-006**: Existing resource lifecycle, schema-version, query, and provider tests continue to pass without new infrastructure.

--- a/specs/013-portability-primitives/tasks.md
+++ b/specs/013-portability-primitives/tasks.md
@@ -25,7 +25,7 @@
 
 - [ ] T006 Add `PortableSnapshot`, `PortableSnapshotExportRequest`, and export scope enums in `src/core/Aster.Core/Models/Portability/PortableSnapshot.cs`
 - [ ] T007 Add `PortableDiagnostic`, `PortableDiagnosticSeverity`, and diagnostic code constants in `src/core/Aster.Core/Models/Portability/PortableDiagnostic.cs`
-- [ ] T008 Add `PortableImportOptions`, `PortableImportCollisionMode`, `PortableImportCounts`, `PortableIdentityMapping`, `PortableIdentityMappingReason`, and `PortableImportStatus` in `src/core/Aster.Core/Models/Portability/PortableImportModels.cs`
+- [ ] T008 Add `PortableImportOptions`, `PortableImportCollisionMode`, planned/actual import counts, `PortableIdentityMapping`, `PortableEntityKind`, `PortableIdentityMappingReason`, and `PortableImportStatus` in `src/core/Aster.Core/Models/Portability/PortableImportModels.cs`
 - [ ] T009 Add `PortableSnapshotExportResult`, `PortableSnapshotValidationResult`, `PortableImportPreview`, and `PortableImportResult` in `src/core/Aster.Core/Models/Portability/PortableResults.cs`
 - [ ] T010 Add `PortableStoreReadRequest`, `PortableStoreSnapshot`, and `PortableTargetState` in `src/core/Aster.Core/Models/Portability/PortableStoreModels.cs`
 - [ ] T011 Register the default portability service in `src/core/Aster.Core/Extensions/AsterCoreServiceCollectionExtensions.cs`

--- a/specs/013-portability-primitives/tasks.md
+++ b/specs/013-portability-primitives/tasks.md
@@ -1,0 +1,165 @@
+# Tasks: Portability Primitives
+
+**Input**: Design documents from `/specs/013-portability-primitives/`
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/, quickstart.md
+
+**Tests**: Tests are required by the feature specification's independent tests and success criteria.
+
+**Organization**: Tasks are grouped by user story so each story can be implemented and validated independently.
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Establish the portability model and service locations without changing provider behavior.
+
+- [ ] T001 Create portability model folder in `src/core/Aster.Core/Models/Portability/`
+- [ ] T002 Create portability test folder in `test/Aster.Tests/Portability/`
+- [ ] T003 [P] Add public `IResourcePortabilityService` interface in `src/core/Aster.Core/Abstractions/IResourcePortabilityService.cs`
+- [ ] T004 [P] Add provider-facing `IResourcePortabilityStore` interface in `src/core/Aster.Core/Abstractions/IResourcePortabilityStore.cs`
+- [ ] T005 Confirm no new package dependencies are required in `src/core/Aster.Core/Aster.Core.csproj`, `src/persistence/Aster.Persistence.SqliteJson/Aster.Persistence.SqliteJson.csproj`, and `test/Aster.Tests/Aster.Tests.csproj`
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Define shared contracts, diagnostics, and registration used by every portability story.
+
+- [ ] T006 Add `PortableSnapshot`, `PortableSnapshotExportRequest`, and export scope enums in `src/core/Aster.Core/Models/Portability/PortableSnapshot.cs`
+- [ ] T007 Add `PortableDiagnostic`, `PortableDiagnosticSeverity`, and diagnostic code constants in `src/core/Aster.Core/Models/Portability/PortableDiagnostic.cs`
+- [ ] T008 Add `PortableImportOptions`, `PortableImportCollisionMode`, `PortableImportCounts`, `PortableIdentityMapping`, `PortableIdentityMappingReason`, and `PortableImportStatus` in `src/core/Aster.Core/Models/Portability/PortableImportModels.cs`
+- [ ] T009 Add `PortableSnapshotExportResult`, `PortableSnapshotValidationResult`, `PortableImportPreview`, and `PortableImportResult` in `src/core/Aster.Core/Models/Portability/PortableResults.cs`
+- [ ] T010 Add `PortableStoreReadRequest`, `PortableStoreSnapshot`, and `PortableTargetState` in `src/core/Aster.Core/Models/Portability/PortableStoreModels.cs`
+- [ ] T011 Register the default portability service in `src/core/Aster.Core/Extensions/AsterCoreServiceCollectionExtensions.cs`
+
+**Checkpoint**: Shared contracts compile and user story work can begin.
+
+---
+
+## Phase 3: User Story 1 - Export A Portable Snapshot (Priority: P1) MVP
+
+**Goal**: Export selected definitions, resources, resource versions, and activation state into a self-contained portable snapshot.
+
+**Independent Test**: Create definitions, resources, versions, and activation state; export selected scopes; verify included content, required references, counts, and skipped activation diagnostics.
+
+### Tests for User Story 1
+
+- [ ] T012 [P] [US1] Add definition-only export tests in `test/Aster.Tests/Portability/PortabilityExportTests.cs`
+- [ ] T013 [P] [US1] Add selected-resource version scope export tests in `test/Aster.Tests/Portability/PortabilityExportTests.cs`
+- [ ] T014 [P] [US1] Add skipped activation diagnostic export tests in `test/Aster.Tests/Portability/PortabilityExportTests.cs`
+- [ ] T015 [P] [US1] Add SQLite JSON export round-trip tests in `test/Aster.Tests/SqliteJson/SqliteJsonPortabilityStoreTests.cs`
+
+### Implementation for User Story 1
+
+- [ ] T016 [US1] Implement export scope validation in `src/core/Aster.Core/Services/ResourcePortabilityService.cs`
+- [ ] T017 [US1] Implement snapshot export orchestration in `src/core/Aster.Core/Services/ResourcePortabilityService.cs`
+- [ ] T018 [US1] Implement in-memory snapshot reads in `src/core/Aster.Core/InMemory/InMemoryResourceStore.cs`
+- [ ] T019 [US1] Implement SQLite JSON snapshot reads in `src/persistence/Aster.Persistence.SqliteJson/SqliteJsonResourceStore.cs`
+- [ ] T020 [US1] Emit `skipped-activation-entry` diagnostics from export in `src/core/Aster.Core/Services/ResourcePortabilityService.cs`
+
+**Checkpoint**: User Story 1 exports valid snapshots and diagnostics independently.
+
+---
+
+## Phase 4: User Story 2 - Import With Deterministic Identity Mapping (Priority: P2)
+
+**Goal**: Import snapshots safely with preserved identifiers, identical-content reuse, strict collision failures, and deterministic remap mode.
+
+**Independent Test**: Import a snapshot into empty and colliding stores; verify relationships, identity map stability, no-op reuse, remap behavior, and all-or-nothing failure.
+
+### Tests for User Story 2
+
+- [ ] T021 [P] [US2] Add empty-store import tests in `test/Aster.Tests/Portability/PortabilityImportTests.cs`
+- [ ] T022 [P] [US2] Add identical-content no-op import tests in `test/Aster.Tests/Portability/PortabilityImportTests.cs`
+- [ ] T023 [P] [US2] Add strict divergent collision failure tests in `test/Aster.Tests/Portability/PortabilityImportTests.cs`
+- [ ] T024 [P] [US2] Add deterministic remap import tests in `test/Aster.Tests/Portability/PortabilityImportTests.cs`
+- [ ] T025 [P] [US2] Add SQLite JSON atomic import tests in `test/Aster.Tests/SqliteJson/SqliteJsonPortabilityStoreTests.cs`
+
+### Implementation for User Story 2
+
+- [ ] T026 [US2] Implement target-state comparison in `src/core/Aster.Core/Services/ResourcePortabilityService.cs`
+- [ ] T027 [US2] Implement deterministic identity remapping in `src/core/Aster.Core/Services/ResourcePortabilityService.cs`
+- [ ] T028 [US2] Implement relationship rewrites for remapped definitions, resources, resource versions, and activation state in `src/core/Aster.Core/Services/ResourcePortabilityService.cs`
+- [ ] T029 [US2] Implement in-memory atomic import apply in `src/core/Aster.Core/InMemory/InMemoryResourceStore.cs`
+- [ ] T030 [US2] Implement SQLite JSON atomic import apply in `src/persistence/Aster.Persistence.SqliteJson/SqliteJsonResourceStore.cs`
+
+**Checkpoint**: User Story 2 imports valid snapshots and rejects unsafe imports independently.
+
+---
+
+## Phase 5: User Story 3 - Preview Import Diagnostics Before Writing (Priority: P3)
+
+**Goal**: Preview import counts, identity mappings, and diagnostics without mutating target storage.
+
+**Independent Test**: Preview valid, colliding, and invalid snapshots; verify diagnostics and counts while target stores remain unchanged.
+
+### Tests for User Story 3
+
+- [ ] T031 [P] [US3] Add non-mutating preview tests in `test/Aster.Tests/Portability/PortabilityPreviewTests.cs`
+- [ ] T032 [P] [US3] Add invalid snapshot preview diagnostic tests in `test/Aster.Tests/Portability/PortabilityPreviewTests.cs`
+- [ ] T033 [P] [US3] Add preview identity-map determinism tests in `test/Aster.Tests/Portability/PortabilityPreviewTests.cs`
+
+### Implementation for User Story 3
+
+- [ ] T034 [US3] Implement snapshot validation in `src/core/Aster.Core/Services/ResourcePortabilityService.cs`
+- [ ] T035 [US3] Implement preview planning without provider writes in `src/core/Aster.Core/Services/ResourcePortabilityService.cs`
+- [ ] T036 [US3] Share preview planning with write import in `src/core/Aster.Core/Services/ResourcePortabilityService.cs`
+
+**Checkpoint**: User Story 3 previews imports without mutation.
+
+---
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+**Purpose**: Verify the complete portability slice and update public guidance.
+
+- [ ] T037 [P] Update `src/core/Aster.Core/README.md` with portability service usage
+- [ ] T038 [P] Update `src/persistence/Aster.Persistence.SqliteJson/README.md` with provider portability support notes
+- [ ] T039 Validate quickstart scenarios against implemented APIs in `specs/013-portability-primitives/quickstart.md`
+- [ ] T040 Run `dotnet test Aster.sln` and fix portability regressions
+- [ ] T041 Run `dotnet build Aster.sln /m:1`
+- [ ] T042 Run `git diff --check`
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies.
+- **Foundational (Phase 2)**: Depends on Setup and blocks all user stories.
+- **User Story 1 (Phase 3)**: Depends on Foundational and is the MVP.
+- **User Story 2 (Phase 4)**: Depends on Foundational; uses export fixtures from US1 tests when available.
+- **User Story 3 (Phase 5)**: Depends on Foundational; shares import planning with US2.
+- **Polish (Phase 6)**: Depends on completed target stories.
+
+### User Story Dependencies
+
+- **US1 Export A Portable Snapshot**: Can start after Foundational.
+- **US2 Import With Deterministic Identity Mapping**: Can start after Foundational, but full end-to-end validation benefits from US1 export fixtures.
+- **US3 Preview Import Diagnostics Before Writing**: Can start after Foundational and should share planning code with US2.
+
+### Parallel Opportunities
+
+- T003 and T004 can run in parallel after T001.
+- T006 through T010 can be split across model files after interfaces are placed.
+- US1 tests T012 through T015 can be drafted in parallel.
+- US2 tests T021 through T025 can be drafted in parallel.
+- US3 tests T031 through T033 can be drafted in parallel.
+- README updates T037 and T038 can run in parallel after implementation stabilizes.
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 Only)
+
+1. Complete Phase 1 setup.
+2. Complete Phase 2 shared contracts.
+3. Complete Phase 3 export implementation and tests.
+4. Validate with `dotnet test Aster.sln --filter PortabilityExport`.
+
+### Incremental Delivery
+
+1. Deliver export snapshots and skipped activation diagnostics.
+2. Add write import with strict and remap modes.
+3. Add preview diagnostics and share planning with write import.
+4. Run full build, test, and whitespace validation.

--- a/wiki/Roadmap.md
+++ b/wiki/Roadmap.md
@@ -2,7 +2,7 @@
 
 Aster is delivered in six phases. Each phase builds on the last, with clean extension points so earlier work is not thrown away.
 
-> **Current status:** Phase 3 in progress — Core SDK, in-memory engine, SQLite JSON persistence/querying, query capability discovery, preflight validation, typed query authoring helpers, provider authoring/conformance support, SQLite facet sorting, portable operators, SQLite date-like ranges, and explicit index projection contracts are available.
+> **Current status:** Phase 4 starting — Core SDK, in-memory engine, SQLite JSON persistence/querying, query capability discovery, preflight validation, typed query authoring helpers, provider authoring/conformance support, SQLite facet sorting, portable operators, SQLite date-like ranges, explicit index projection contracts, and explicit definition schema upgrade behavior are available.
 >
 > For the current implementation trail and next Spec Kit slices, see [`docs/ExecutionRoadmap.md`](../docs/ExecutionRoadmap.md).
 
@@ -14,8 +14,8 @@ Aster is delivered in six phases. Each phase builds on the last, with clean exte
 |---|---|---|
 | **1** | Core SDK & In-Memory Engine | Complete |
 | **2A** | SQLite JSON Persistence & Querying | Complete |
-| **3** | Query Capabilities & Typed Querying | In Progress |
-| **4** | Portability & Integration Hooks | Planned |
+| **3** | Query Capabilities & Typed Querying | Complete |
+| **4** | Portability & Integration Hooks | In Progress |
 | **5** | Multi-tenancy, Policies, Advanced Versioning | Planned |
 | **6** | Operational Hardening | Planned |
 
@@ -27,7 +27,8 @@ Aster is delivered in six phases. Each phase builds on the last, with clean exte
 | **009 Portable Operator Expansion** | Landed | Add operators such as `NotEquals`, `In`, `StartsWith`, and facet value presence with provider capabilities and conformance coverage. |
 | **010 SQLite Date-Like Facet Ranges** | Landed | Close the remaining SQLite date-like range capability gap with explicit serialization rules. |
 | **011 Explicit Indexing Model** | Landed | Introduce intentional index projection contracts without a hidden planner or runtime scanning. |
-| **012 Definition Schema Versions & Upgrade Flow** | Next | Make long-lived resource schema versioning and upgrade behavior explicit. |
+| **012 Definition Schema Versions & Upgrade Flow** | Landed | Make long-lived resource schema versioning and upgrade behavior explicit. |
+| **013 Portability Primitives** | Next | Add deterministic export/import primitives for definitions and resources. |
 
 ---
 


### PR DESCRIPTION
## Summary
- add Spec Kit specification, clarifications, and checklist for portability primitives
- add planning artifacts for deterministic export/import, strict-by-default import, explicit remapping, and activation diagnostics
- update roadmap and agent context for the 013 slice

## Validation
- git diff --check