### PR TITLE
Implement portability export MVP

### DIFF
--- a/specs/013-portability-primitives/tasks.md
+++ b/specs/013-portability-primitives/tasks.md
@@ -11,11 +11,11 @@
 
 **Purpose**: Establish the portability model and service locations without changing provider behavior.
 
-- [ ] T001 Create portability model folder in `src/core/Aster.Core/Models/Portability/`
-- [ ] T002 Create portability test folder in `test/Aster.Tests/Portability/`
-- [ ] T003 [P] Add public `IResourcePortabilityService` interface in `src/core/Aster.Core/Abstractions/IResourcePortabilityService.cs`
-- [ ] T004 [P] Add provider-facing `IResourcePortabilityStore` interface in `src/core/Aster.Core/Abstractions/IResourcePortabilityStore.cs`
-- [ ] T005 Confirm no new package dependencies are required in `src/core/Aster.Core/Aster.Core.csproj`, `src/persistence/Aster.Persistence.SqliteJson/Aster.Persistence.SqliteJson.csproj`, and `test/Aster.Tests/Aster.Tests.csproj`
+- [X] T001 Create portability model folder in `src/core/Aster.Core/Models/Portability/`
+- [X] T002 Create portability test folder in `test/Aster.Tests/Portability/`
+- [X] T003 [P] Add public `IResourcePortabilityService` interface in `src/core/Aster.Core/Abstractions/IResourcePortabilityService.cs`
+- [X] T004 [P] Add provider-facing `IResourcePortabilityStore` interface in `src/core/Aster.Core/Abstractions/IResourcePortabilityStore.cs`
+- [X] T005 Confirm no new package dependencies are required in `src/core/Aster.Core/Aster.Core.csproj`, `src/persistence/Aster.Persistence.SqliteJson/Aster.Persistence.SqliteJson.csproj`, and `test/Aster.Tests/Aster.Tests.csproj`
 
 ---
 
@@ -23,12 +23,12 @@
 
 **Purpose**: Define shared contracts, diagnostics, and registration used by every portability story.
 
-- [ ] T006 Add `PortableSnapshot`, `PortableSnapshotExportRequest`, and export scope enums in `src/core/Aster.Core/Models/Portability/PortableSnapshot.cs`
-- [ ] T007 Add `PortableDiagnostic`, `PortableDiagnosticSeverity`, and diagnostic code constants in `src/core/Aster.Core/Models/Portability/PortableDiagnostic.cs`
-- [ ] T008 Add `PortableImportOptions`, `PortableImportCollisionMode`, planned/actual import counts, `PortableIdentityMapping`, `PortableEntityKind`, `PortableIdentityMappingReason`, and `PortableImportStatus` in `src/core/Aster.Core/Models/Portability/PortableImportModels.cs`
-- [ ] T009 Add `PortableSnapshotExportResult`, `PortableSnapshotValidationResult`, `PortableImportPreview`, and `PortableImportResult` in `src/core/Aster.Core/Models/Portability/PortableResults.cs`
-- [ ] T010 Add `PortableStoreReadRequest`, `PortableStoreSnapshot`, and `PortableTargetState` in `src/core/Aster.Core/Models/Portability/PortableStoreModels.cs`
-- [ ] T011 Register the default portability service in `src/core/Aster.Core/Extensions/AsterCoreServiceCollectionExtensions.cs`
+- [X] T006 Add `PortableSnapshot`, `PortableSnapshotExportRequest`, and export scope enums in `src/core/Aster.Core/Models/Portability/PortableSnapshot.cs`
+- [X] T007 Add `PortableDiagnostic`, `PortableDiagnosticSeverity`, and diagnostic code constants in `src/core/Aster.Core/Models/Portability/PortableDiagnostic.cs`
+- [X] T008 Add `PortableImportOptions`, `PortableImportCollisionMode`, planned/actual import counts, `PortableIdentityMapping`, `PortableEntityKind`, `PortableIdentityMappingReason`, and `PortableImportStatus` in `src/core/Aster.Core/Models/Portability/PortableImportModels.cs`
+- [X] T009 Add `PortableSnapshotExportResult`, `PortableSnapshotValidationResult`, `PortableImportPreview`, and `PortableImportResult` in `src/core/Aster.Core/Models/Portability/PortableResults.cs`
+- [X] T010 Add `PortableStoreReadRequest`, `PortableStoreSnapshot`, and `PortableTargetState` in `src/core/Aster.Core/Models/Portability/PortableStoreModels.cs`
+- [X] T011 Register the default portability service in `src/core/Aster.Core/Extensions/AsterCoreServiceCollectionExtensions.cs`
 
 **Checkpoint**: Shared contracts compile and user story work can begin.
 
@@ -42,18 +42,18 @@
 
 ### Tests for User Story 1
 
-- [ ] T012 [P] [US1] Add definition-only export tests in `test/Aster.Tests/Portability/PortabilityExportTests.cs`
-- [ ] T013 [P] [US1] Add selected-resource version scope export tests in `test/Aster.Tests/Portability/PortabilityExportTests.cs`
-- [ ] T014 [P] [US1] Add skipped activation diagnostic export tests in `test/Aster.Tests/Portability/PortabilityExportTests.cs`
-- [ ] T015 [P] [US1] Add SQLite JSON export round-trip tests in `test/Aster.Tests/SqliteJson/SqliteJsonPortabilityStoreTests.cs`
+- [X] T012 [P] [US1] Add definition-only export tests in `test/Aster.Tests/Portability/PortabilityExportTests.cs`
+- [X] T013 [P] [US1] Add selected-resource version scope export tests in `test/Aster.Tests/Portability/PortabilityExportTests.cs`
+- [X] T014 [P] [US1] Add skipped activation diagnostic export tests in `test/Aster.Tests/Portability/PortabilityExportTests.cs`
+- [X] T015 [P] [US1] Add SQLite JSON export round-trip tests in `test/Aster.Tests/SqliteJson/SqliteJsonPortabilityStoreTests.cs`
 
 ### Implementation for User Story 1
 
-- [ ] T016 [US1] Implement export scope validation in `src/core/Aster.Core/Services/ResourcePortabilityService.cs`
-- [ ] T017 [US1] Implement snapshot export orchestration in `src/core/Aster.Core/Services/ResourcePortabilityService.cs`
-- [ ] T018 [US1] Implement in-memory snapshot reads in `src/core/Aster.Core/InMemory/InMemoryResourceStore.cs`
-- [ ] T019 [US1] Implement SQLite JSON snapshot reads in `src/persistence/Aster.Persistence.SqliteJson/SqliteJsonResourceStore.cs`
-- [ ] T020 [US1] Emit `skipped-activation-entry` diagnostics from export in `src/core/Aster.Core/Services/ResourcePortabilityService.cs`
+- [X] T016 [US1] Implement export scope validation in `src/core/Aster.Core/Services/ResourcePortabilityService.cs`
+- [X] T017 [US1] Implement snapshot export orchestration in `src/core/Aster.Core/Services/ResourcePortabilityService.cs`
+- [X] T018 [US1] Implement in-memory snapshot reads in `src/core/Aster.Core/InMemory/InMemoryResourceStore.cs`
+- [X] T019 [US1] Implement SQLite JSON snapshot reads in `src/persistence/Aster.Persistence.SqliteJson/SqliteJsonResourceStore.cs`
+- [X] T020 [US1] Emit `skipped-activation-entry` diagnostics from export in `src/core/Aster.Core/Services/ResourcePortabilityService.cs`
 
 **Checkpoint**: User Story 1 exports valid snapshots and diagnostics independently.
 

--- a/src/core/Aster.Core/Abstractions/IResourcePortabilityService.cs
+++ b/src/core/Aster.Core/Abstractions/IResourcePortabilityService.cs
@@ -1,0 +1,39 @@
+using Aster.Core.Models.Portability;
+
+namespace Aster.Core.Abstractions;
+
+/// <summary>
+/// Exports, validates, previews, and imports portable Aster snapshots.
+/// </summary>
+public interface IResourcePortabilityService
+{
+    /// <summary>
+    /// Exports a portable snapshot for the requested explicit scope.
+    /// </summary>
+    ValueTask<PortableSnapshotExportResult> ExportAsync(
+        PortableSnapshotExportRequest request,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Validates snapshot structure and relationships before import.
+    /// </summary>
+    ValueTask<PortableSnapshotValidationResult> ValidateAsync(
+        PortableSnapshot snapshot,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Previews an import without mutating the target store.
+    /// </summary>
+    ValueTask<PortableImportPreview> PreviewImportAsync(
+        PortableSnapshot snapshot,
+        PortableImportOptions? options = null,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Imports a snapshot as an all-or-nothing operation.
+    /// </summary>
+    ValueTask<PortableImportResult> ImportAsync(
+        PortableSnapshot snapshot,
+        PortableImportOptions? options = null,
+        CancellationToken cancellationToken = default);
+}

--- a/src/core/Aster.Core/Abstractions/IResourcePortabilityStore.cs
+++ b/src/core/Aster.Core/Abstractions/IResourcePortabilityStore.cs
@@ -1,0 +1,16 @@
+using Aster.Core.Models.Portability;
+
+namespace Aster.Core.Abstractions;
+
+/// <summary>
+/// Provider-facing storage contract used by portability orchestration.
+/// </summary>
+public interface IResourcePortabilityStore
+{
+    /// <summary>
+    /// Reads the definitions, resources, and activation state needed for an export request.
+    /// </summary>
+    ValueTask<PortableStoreSnapshot> ReadSnapshotAsync(
+        PortableStoreReadRequest request,
+        CancellationToken cancellationToken = default);
+}

--- a/src/core/Aster.Core/Extensions/AsterCoreServiceCollectionExtensions.cs
+++ b/src/core/Aster.Core/Extensions/AsterCoreServiceCollectionExtensions.cs
@@ -63,12 +63,15 @@ public static class AsterCoreServiceCollectionExtensions
         services.AddSingleton<InMemoryResourceStore>();
         services.AddSingleton<IResourceVersionReader>(sp => sp.GetRequiredService<InMemoryResourceStore>());
         services.AddSingleton<IResourceVersionWriter>(sp => sp.GetRequiredService<InMemoryResourceStore>());
+        services.AddSingleton<InMemoryPortabilityStore>();
+        services.AddSingleton<IResourcePortabilityStore>(sp => sp.GetRequiredService<InMemoryPortabilityStore>());
 
         // Resource manager
         services.AddSingleton<InMemoryResourceManager>();
         services.AddSingleton<DefaultResourceManager>();
         services.AddSingleton<IResourceManager>(sp => sp.GetRequiredService<DefaultResourceManager>());
         services.AddSingleton<IResourceSchemaVersionService, ResourceSchemaVersionService>();
+        services.AddSingleton<IResourcePortabilityService, ResourcePortabilityService>();
 
         // Query service
         services.AddSingleton<InMemoryQueryService>();

--- a/src/core/Aster.Core/InMemory/InMemoryPortabilityStore.cs
+++ b/src/core/Aster.Core/InMemory/InMemoryPortabilityStore.cs
@@ -137,30 +137,31 @@ public sealed class InMemoryPortabilityStore : IResourcePortabilityStore
         var activationStates = new List<ActivationState>();
         var skippedEntries = new List<SkippedActivationEntry>();
 
-        foreach (var (resourceId, channelActivations) in resourceStore.Activations)
+        foreach (var (resourceId, resourceActivationStates) in resourceStore.ActivationStates.OrderBy(static item => item.Key, StringComparer.Ordinal))
         {
             cancellationToken.ThrowIfCancellationRequested();
 
             if (!includedVersions.TryGetValue(resourceId, out var includedResourceVersions))
                 continue;
 
-            Dictionary<string, HashSet<int>> channels;
-            lock (channelActivations)
-                channels = channelActivations.ToDictionary(static item => item.Key, static item => item.Value.ToHashSet(), StringComparer.Ordinal);
+            var states = resourceActivationStates
+                .OrderBy(static item => item.Key, StringComparer.Ordinal)
+                .Select(static item => item.Value)
+                .ToList();
 
-            foreach (var (channel, activeVersions) in channels.OrderBy(static item => item.Key, StringComparer.Ordinal))
+            foreach (var state in states)
             {
-                var includedActiveVersions = activeVersions
+                var includedActiveVersions = state.ActiveVersions
                     .Where(includedResourceVersions.Contains)
                     .Order()
                     .ToList();
 
-                foreach (var skippedVersion in activeVersions.Except(includedActiveVersions).Order())
+                foreach (var skippedVersion in state.ActiveVersions.Except(includedActiveVersions).Order())
                 {
                     skippedEntries.Add(new SkippedActivationEntry
                     {
                         ResourceId = resourceId,
-                        Channel = channel,
+                        Channel = state.Channel,
                         Version = skippedVersion,
                         Reason = SkippedActivationReason.ExcludedByResourceVersionScope,
                     });
@@ -169,13 +170,7 @@ public sealed class InMemoryPortabilityStore : IResourcePortabilityStore
                 if (includedActiveVersions.Count == 0)
                     continue;
 
-                activationStates.Add(new ActivationState
-                {
-                    ResourceId = resourceId,
-                    Channel = channel,
-                    ActiveVersions = includedActiveVersions,
-                    LastUpdated = DateTime.UtcNow,
-                });
+                activationStates.Add(state with { ActiveVersions = includedActiveVersions });
             }
         }
 

--- a/src/core/Aster.Core/InMemory/InMemoryPortabilityStore.cs
+++ b/src/core/Aster.Core/InMemory/InMemoryPortabilityStore.cs
@@ -1,0 +1,201 @@
+using Aster.Core.Abstractions;
+using Aster.Core.Models.Definitions;
+using Aster.Core.Models.Instances;
+using Aster.Core.Models.Portability;
+
+namespace Aster.Core.InMemory;
+
+/// <summary>
+/// In-memory portability snapshot reader over the existing definition and resource stores.
+/// </summary>
+public sealed class InMemoryPortabilityStore : IResourcePortabilityStore
+{
+    private readonly InMemoryResourceDefinitionStore definitionStore;
+    private readonly InMemoryResourceStore resourceStore;
+
+    /// <summary>
+    /// Initializes a new instance of <see cref="InMemoryPortabilityStore"/>.
+    /// </summary>
+    public InMemoryPortabilityStore(
+        InMemoryResourceDefinitionStore definitionStore,
+        InMemoryResourceStore resourceStore)
+    {
+        ArgumentNullException.ThrowIfNull(definitionStore);
+        ArgumentNullException.ThrowIfNull(resourceStore);
+
+        this.definitionStore = definitionStore;
+        this.resourceStore = resourceStore;
+    }
+
+    /// <inheritdoc />
+    public ValueTask<PortableStoreSnapshot> ReadSnapshotAsync(
+        PortableStoreReadRequest request,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        var resources = SelectResources(request.ExportRequest, cancellationToken);
+        var definitions = SelectDefinitions(request.ExportRequest, resources, cancellationToken);
+        var (activationStates, skippedActivationEntries) = SelectActivationStates(resources, cancellationToken);
+
+        return ValueTask.FromResult(new PortableStoreSnapshot
+        {
+            Definitions = definitions,
+            Resources = resources,
+            ActivationStates = activationStates,
+            SkippedActivationEntries = skippedActivationEntries,
+        });
+    }
+
+    private List<ResourceDefinition> SelectDefinitions(
+        PortableSnapshotExportRequest request,
+        IReadOnlyCollection<Resource> resources,
+        CancellationToken cancellationToken)
+    {
+        var definitionVersions = new Dictionary<(string DefinitionId, int Version), ResourceDefinition>();
+
+        if (request.ScopeMode is PortableExportScopeMode.DefinitionsOnly or PortableExportScopeMode.DefinitionWithResources)
+        {
+            foreach (var definitionId in request.DefinitionIds)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+
+                foreach (var definition in definitionStore.GetDefinitionVersions(definitionId))
+                    definitionVersions[(definition.DefinitionId, definition.Version)] = definition;
+            }
+        }
+
+        foreach (var resource in resources)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            if (resource.DefinitionVersion is null)
+                continue;
+
+            var definition = definitionStore.GetDefinitionVersion(resource.DefinitionId, resource.DefinitionVersion.Value);
+            if (definition is not null)
+                definitionVersions[(definition.DefinitionId, definition.Version)] = definition;
+        }
+
+        return definitionVersions.Values
+            .OrderBy(static definition => definition.DefinitionId, StringComparer.Ordinal)
+            .ThenBy(static definition => definition.Version)
+            .ToList();
+    }
+
+    private List<Resource> SelectResources(
+        PortableSnapshotExportRequest request,
+        CancellationToken cancellationToken)
+    {
+        var resourceIds = request.ScopeMode switch
+        {
+            PortableExportScopeMode.DefinitionsOnly => [],
+            PortableExportScopeMode.SelectedResources => request.ResourceVersionScope == PortableResourceVersionScope.SpecificVersions
+                ? request.SpecificResourceVersions.Select(static reference => reference.ResourceId).ToHashSet(StringComparer.Ordinal)
+                : request.ResourceIds,
+            PortableExportScopeMode.DefinitionWithResources => request.DefinitionIds
+                .SelectMany(resourceStore.GetResourceIdsForDefinition)
+                .ToHashSet(StringComparer.Ordinal),
+            _ => [],
+        };
+
+        var specificVersions = request.SpecificResourceVersions.ToHashSet();
+        var resources = new List<Resource>();
+
+        foreach (var resourceId in resourceIds)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var versions = resourceStore.TryGetVersions(resourceId);
+            if (versions is null)
+                continue;
+
+            List<Resource> snapshot;
+            lock (versions)
+                snapshot = [.. versions];
+
+            resources.AddRange(SelectVersions(snapshot, request.ResourceVersionScope, specificVersions));
+        }
+
+        return resources
+            .OrderBy(static resource => resource.ResourceId, StringComparer.Ordinal)
+            .ThenBy(static resource => resource.Version)
+            .ToList();
+    }
+
+    private (List<ActivationState> ActivationStates, List<SkippedActivationEntry> SkippedActivationEntries) SelectActivationStates(
+        IReadOnlyCollection<Resource> resources,
+        CancellationToken cancellationToken)
+    {
+        var includedVersions = resources
+            .GroupBy(static resource => resource.ResourceId, StringComparer.Ordinal)
+            .ToDictionary(
+                static group => group.Key,
+                static group => group.Select(static resource => resource.Version).ToHashSet(),
+                StringComparer.Ordinal);
+
+        var activationStates = new List<ActivationState>();
+        var skippedEntries = new List<SkippedActivationEntry>();
+
+        foreach (var (resourceId, channelActivations) in resourceStore.Activations)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            if (!includedVersions.TryGetValue(resourceId, out var includedResourceVersions))
+                continue;
+
+            Dictionary<string, HashSet<int>> channels;
+            lock (channelActivations)
+                channels = channelActivations.ToDictionary(static item => item.Key, static item => item.Value.ToHashSet(), StringComparer.Ordinal);
+
+            foreach (var (channel, activeVersions) in channels.OrderBy(static item => item.Key, StringComparer.Ordinal))
+            {
+                var includedActiveVersions = activeVersions
+                    .Where(includedResourceVersions.Contains)
+                    .Order()
+                    .ToList();
+
+                foreach (var skippedVersion in activeVersions.Except(includedActiveVersions).Order())
+                {
+                    skippedEntries.Add(new SkippedActivationEntry
+                    {
+                        ResourceId = resourceId,
+                        Channel = channel,
+                        Version = skippedVersion,
+                        Reason = SkippedActivationReason.ExcludedByResourceVersionScope,
+                    });
+                }
+
+                if (includedActiveVersions.Count == 0)
+                    continue;
+
+                activationStates.Add(new ActivationState
+                {
+                    ResourceId = resourceId,
+                    Channel = channel,
+                    ActiveVersions = includedActiveVersions,
+                    LastUpdated = DateTime.UtcNow,
+                });
+            }
+        }
+
+        return (activationStates, skippedEntries);
+    }
+
+    private static IEnumerable<Resource> SelectVersions(
+        IReadOnlyList<Resource> versions,
+        PortableResourceVersionScope versionScope,
+        IReadOnlySet<ResourceVersionReference> specificVersions) =>
+        versionScope switch
+        {
+            PortableResourceVersionScope.AllVersions => versions,
+            PortableResourceVersionScope.LatestOnly => versions.Count > 0 ? [versions[^1]] : [],
+            PortableResourceVersionScope.SpecificVersions => versions
+                .Where(version => specificVersions.Contains(new ResourceVersionReference
+                {
+                    ResourceId = version.ResourceId,
+                    Version = version.Version,
+                })),
+            _ => [],
+        };
+}

--- a/src/core/Aster.Core/InMemory/InMemoryResourceDefinitionStore.cs
+++ b/src/core/Aster.Core/InMemory/InMemoryResourceDefinitionStore.cs
@@ -92,6 +92,34 @@ public sealed partial class InMemoryResourceDefinitionStore : IResourceDefinitio
         return ValueTask.FromResult<IEnumerable<ResourceDefinition>>(latest);
     }
 
+    /// <summary>
+    /// Returns all versions for a definition.
+    /// </summary>
+    internal IReadOnlyList<ResourceDefinition> GetDefinitionVersions(string definitionId)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(definitionId);
+
+        if (!definitions.TryGetValue(definitionId, out var versions))
+            return [];
+
+        lock (versions)
+            return [.. versions];
+    }
+
+    /// <summary>
+    /// Returns a specific definition version.
+    /// </summary>
+    internal ResourceDefinition? GetDefinitionVersion(string definitionId, int version)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(definitionId);
+
+        if (!definitions.TryGetValue(definitionId, out var versions))
+            return null;
+
+        lock (versions)
+            return versions.FirstOrDefault(definition => definition.Version == version);
+    }
+
     // ──────────────────────────────────────────────────────────────────────────
     // Structured log methods (source generated)
     // ──────────────────────────────────────────────────────────────────────────

--- a/src/core/Aster.Core/InMemory/InMemoryResourceManager.cs
+++ b/src/core/Aster.Core/InMemory/InMemoryResourceManager.cs
@@ -334,9 +334,7 @@ public sealed partial class InMemoryResourceManager : IResourceManager, IResourc
         ArgumentException.ThrowIfNullOrWhiteSpace(channel);
         ArgumentNullException.ThrowIfNull(state);
 
-        // Activation state is already updated in memory by ActivateAsync / DeactivateAsync;
-        // this method exists as the provider-agnostic persistence hook (no-op for in-memory).
-        return ValueTask.FromResult(state);
+        return store.UpdateActivationAsync(resourceId, channel, state, cancellationToken);
     }
 
     // ──────────────────────────────────────────────────────────────────────────

--- a/src/core/Aster.Core/InMemory/InMemoryResourceStore.cs
+++ b/src/core/Aster.Core/InMemory/InMemoryResourceStore.cs
@@ -88,6 +88,7 @@ public sealed class InMemoryResourceStore : IResourceVersionReader, IResourceVer
         ArgumentException.ThrowIfNullOrWhiteSpace(resourceId);
         ArgumentException.ThrowIfNullOrWhiteSpace(channel);
         ArgumentNullException.ThrowIfNull(state);
+        cancellationToken.ThrowIfCancellationRequested();
 
         var channelActivations = GetOrAddActivations(resourceId);
         lock (channelActivations)

--- a/src/core/Aster.Core/InMemory/InMemoryResourceStore.cs
+++ b/src/core/Aster.Core/InMemory/InMemoryResourceStore.cs
@@ -27,6 +27,12 @@ public sealed class InMemoryResourceStore : IResourceVersionReader, IResourceVer
         new(StringComparer.Ordinal);
 
     /// <summary>
+    /// Last persisted activation state keyed by <c>ResourceId</c> → channel name.
+    /// </summary>
+    internal readonly ConcurrentDictionary<string, ConcurrentDictionary<string, ActivationState>> ActivationStates =
+        new(StringComparer.Ordinal);
+
+    /// <summary>
     /// Returns the ordered version list for a resource, or <see langword="null"/> if it does not exist.
     /// The caller must <c>lock</c> the returned list when reading or mutating.
     /// </summary>
@@ -86,6 +92,11 @@ public sealed class InMemoryResourceStore : IResourceVersionReader, IResourceVer
         var channelActivations = GetOrAddActivations(resourceId);
         lock (channelActivations)
             channelActivations[channel] = state.ActiveVersions.ToHashSet();
+
+        var states = ActivationStates.GetOrAdd(
+            resourceId,
+            _ => new ConcurrentDictionary<string, ActivationState>(StringComparer.Ordinal));
+        states[channel] = state;
 
         return ValueTask.FromResult(state);
     }

--- a/src/core/Aster.Core/Models/Portability/PortableDiagnostic.cs
+++ b/src/core/Aster.Core/Models/Portability/PortableDiagnostic.cs
@@ -73,6 +73,11 @@ public static class PortableDiagnosticCodes
     public const string MissingDefinitionReference = "missing-definition-reference";
 
     /// <summary>
+    /// Snapshot references a missing resource version.
+    /// </summary>
+    public const string MissingResourceReference = "missing-resource-reference";
+
+    /// <summary>
     /// Import behavior is not implemented yet.
     /// </summary>
     public const string ImportNotImplemented = "import-not-implemented";

--- a/src/core/Aster.Core/Models/Portability/PortableDiagnostic.cs
+++ b/src/core/Aster.Core/Models/Portability/PortableDiagnostic.cs
@@ -1,0 +1,79 @@
+namespace Aster.Core.Models.Portability;
+
+/// <summary>
+/// Diagnostic emitted by portability validation, export, preview, or import.
+/// </summary>
+public sealed record PortableDiagnostic
+{
+    /// <summary>
+    /// Stable machine-readable diagnostic code.
+    /// </summary>
+    public required string Code { get; init; }
+
+    /// <summary>
+    /// Diagnostic severity.
+    /// </summary>
+    public required PortableDiagnosticSeverity Severity { get; init; }
+
+    /// <summary>
+    /// Optional location within the snapshot or request.
+    /// </summary>
+    public string? Path { get; init; }
+
+    /// <summary>
+    /// Human-readable diagnostic detail.
+    /// </summary>
+    public required string Message { get; init; }
+}
+
+/// <summary>
+/// Diagnostic severity for portability operations.
+/// </summary>
+public enum PortableDiagnosticSeverity
+{
+    /// <summary>
+    /// Informational diagnostic.
+    /// </summary>
+    Info,
+
+    /// <summary>
+    /// Warning diagnostic.
+    /// </summary>
+    Warning,
+
+    /// <summary>
+    /// Error diagnostic.
+    /// </summary>
+    Error,
+}
+
+/// <summary>
+/// Stable portability diagnostic codes.
+/// </summary>
+public static class PortableDiagnosticCodes
+{
+    /// <summary>
+    /// Export request scope is invalid or incomplete.
+    /// </summary>
+    public const string InvalidExportScope = "invalid-export-scope";
+
+    /// <summary>
+    /// Exported activation entry references a resource version excluded by the requested scope.
+    /// </summary>
+    public const string SkippedActivationEntry = "skipped-activation-entry";
+
+    /// <summary>
+    /// Snapshot format version is not supported.
+    /// </summary>
+    public const string UnsupportedFormatVersion = "unsupported-format-version";
+
+    /// <summary>
+    /// Snapshot references a missing definition version.
+    /// </summary>
+    public const string MissingDefinitionReference = "missing-definition-reference";
+
+    /// <summary>
+    /// Import behavior is not implemented yet.
+    /// </summary>
+    public const string ImportNotImplemented = "import-not-implemented";
+}

--- a/src/core/Aster.Core/Models/Portability/PortableImportModels.cs
+++ b/src/core/Aster.Core/Models/Portability/PortableImportModels.cs
@@ -1,0 +1,153 @@
+namespace Aster.Core.Models.Portability;
+
+/// <summary>
+/// Import options for portable snapshots.
+/// </summary>
+public sealed class PortableImportOptions
+{
+    /// <summary>
+    /// Collision handling mode.
+    /// </summary>
+    public PortableImportCollisionMode CollisionMode { get; set; } = PortableImportCollisionMode.Strict;
+}
+
+/// <summary>
+/// Collision handling mode for import.
+/// </summary>
+public enum PortableImportCollisionMode
+{
+    /// <summary>
+    /// Fail before writing when divergent collisions exist.
+    /// </summary>
+    Strict,
+
+    /// <summary>
+    /// Deterministically remap divergent items.
+    /// </summary>
+    RemapDivergent,
+}
+
+/// <summary>
+/// Planned import counts.
+/// </summary>
+public sealed record PortablePlannedImportCounts
+{
+    /// <summary>Definition versions planned for import.</summary>
+    public int Definitions { get; init; }
+
+    /// <summary>Logical resources planned for import.</summary>
+    public int Resources { get; init; }
+
+    /// <summary>Resource versions planned for import.</summary>
+    public int ResourceVersions { get; init; }
+
+    /// <summary>Activation entries planned for import.</summary>
+    public int ActivationEntries { get; init; }
+
+    /// <summary>Items expected to be reused because existing content is identical.</summary>
+    public int ReusedIdenticalItems { get; init; }
+
+    /// <summary>Items expected to be remapped.</summary>
+    public int RemappedItems { get; init; }
+}
+
+/// <summary>
+/// Actual import counts.
+/// </summary>
+public sealed record PortableActualImportCounts
+{
+    /// <summary>Definition versions imported.</summary>
+    public int Definitions { get; init; }
+
+    /// <summary>Logical resources imported.</summary>
+    public int Resources { get; init; }
+
+    /// <summary>Resource versions imported.</summary>
+    public int ResourceVersions { get; init; }
+
+    /// <summary>Activation entries imported.</summary>
+    public int ActivationEntries { get; init; }
+
+    /// <summary>Items reused because existing content was identical.</summary>
+    public int ReusedIdenticalItems { get; init; }
+
+    /// <summary>Items remapped.</summary>
+    public int RemappedItems { get; init; }
+}
+
+/// <summary>
+/// Identity mapping produced by preview or import.
+/// </summary>
+public sealed record PortableIdentityMapping
+{
+    /// <summary>
+    /// Mapped entity kind.
+    /// </summary>
+    public required PortableEntityKind EntityKind { get; init; }
+
+    /// <summary>
+    /// Source identity from the snapshot.
+    /// </summary>
+    public required string SourceId { get; init; }
+
+    /// <summary>
+    /// Target identity after import planning.
+    /// </summary>
+    public required string TargetId { get; init; }
+
+    /// <summary>
+    /// Reason for this mapping.
+    /// </summary>
+    public required PortableIdentityMappingReason Reason { get; init; }
+}
+
+/// <summary>
+/// Portable entity kind.
+/// </summary>
+public enum PortableEntityKind
+{
+    /// <summary>Logical definition.</summary>
+    Definition,
+
+    /// <summary>Definition version.</summary>
+    DefinitionVersion,
+
+    /// <summary>Logical resource.</summary>
+    Resource,
+
+    /// <summary>Resource version.</summary>
+    ResourceVersion,
+
+    /// <summary>Activation entry.</summary>
+    ActivationEntry,
+}
+
+/// <summary>
+/// Identity mapping reason.
+/// </summary>
+public enum PortableIdentityMappingReason
+{
+    /// <summary>Identity is preserved.</summary>
+    Preserved,
+
+    /// <summary>Existing identical content is reused.</summary>
+    ReusedIdentical,
+
+    /// <summary>Identity was remapped to avoid a divergent collision.</summary>
+    RemappedDivergent,
+}
+
+/// <summary>
+/// Import status.
+/// </summary>
+public enum PortableImportStatus
+{
+    /// <summary>Snapshot was imported.</summary>
+    Imported,
+
+    /// <summary>Import was a no-op because all content already existed identically.</summary>
+    NoOp,
+
+    /// <summary>Import failed before writing.</summary>
+    Failed,
+}

--- a/src/core/Aster.Core/Models/Portability/PortableResults.cs
+++ b/src/core/Aster.Core/Models/Portability/PortableResults.cs
@@ -1,0 +1,90 @@
+namespace Aster.Core.Models.Portability;
+
+/// <summary>
+/// Export result containing the snapshot and any diagnostics.
+/// </summary>
+public sealed record PortableSnapshotExportResult
+{
+    /// <summary>
+    /// Exported snapshot, or <see langword="null"/> when export failed validation.
+    /// </summary>
+    public PortableSnapshot? Snapshot { get; init; }
+
+    /// <summary>
+    /// Diagnostics emitted during export.
+    /// </summary>
+    public IReadOnlyList<PortableDiagnostic> Diagnostics { get; init; } = [];
+
+    /// <summary>
+    /// Activation entries excluded because their resource versions were not exported.
+    /// </summary>
+    public IReadOnlyList<SkippedActivationEntry> SkippedActivationEntries { get; init; } = [];
+}
+
+/// <summary>
+/// Snapshot validation result.
+/// </summary>
+public sealed record PortableSnapshotValidationResult
+{
+    /// <summary>
+    /// Whether the snapshot is valid.
+    /// </summary>
+    public required bool IsValid { get; init; }
+
+    /// <summary>
+    /// Validation diagnostics.
+    /// </summary>
+    public IReadOnlyList<PortableDiagnostic> Diagnostics { get; init; } = [];
+}
+
+/// <summary>
+/// Non-mutating import preview result.
+/// </summary>
+public sealed record PortableImportPreview
+{
+    /// <summary>
+    /// Whether the snapshot can be imported.
+    /// </summary>
+    public required bool CanImport { get; init; }
+
+    /// <summary>
+    /// Planned import counts.
+    /// </summary>
+    public required PortablePlannedImportCounts Counts { get; init; }
+
+    /// <summary>
+    /// Planned identity mappings.
+    /// </summary>
+    public IReadOnlyList<PortableIdentityMapping> IdentityMap { get; init; } = [];
+
+    /// <summary>
+    /// Preview diagnostics.
+    /// </summary>
+    public IReadOnlyList<PortableDiagnostic> Diagnostics { get; init; } = [];
+}
+
+/// <summary>
+/// Import result.
+/// </summary>
+public sealed record PortableImportResult
+{
+    /// <summary>
+    /// Import status.
+    /// </summary>
+    public required PortableImportStatus Status { get; init; }
+
+    /// <summary>
+    /// Actual import counts.
+    /// </summary>
+    public required PortableActualImportCounts Counts { get; init; }
+
+    /// <summary>
+    /// Actual identity mappings.
+    /// </summary>
+    public IReadOnlyList<PortableIdentityMapping> IdentityMap { get; init; } = [];
+
+    /// <summary>
+    /// Import diagnostics.
+    /// </summary>
+    public IReadOnlyList<PortableDiagnostic> Diagnostics { get; init; } = [];
+}

--- a/src/core/Aster.Core/Models/Portability/PortableSnapshot.cs
+++ b/src/core/Aster.Core/Models/Portability/PortableSnapshot.cs
@@ -1,0 +1,124 @@
+using Aster.Core.Models.Definitions;
+using Aster.Core.Models.Instances;
+
+namespace Aster.Core.Models.Portability;
+
+/// <summary>
+/// Self-contained portable representation of selected Aster data.
+/// </summary>
+public sealed record PortableSnapshot
+{
+    /// <summary>
+    /// Initial supported snapshot format version.
+    /// </summary>
+    public const int CurrentFormatVersion = 1;
+
+    /// <summary>
+    /// Snapshot format version.
+    /// </summary>
+    public required int FormatVersion { get; init; }
+
+    /// <summary>
+    /// Definition versions included in the snapshot.
+    /// </summary>
+    public IReadOnlyList<ResourceDefinition> Definitions { get; init; } = [];
+
+    /// <summary>
+    /// Resource versions included in the snapshot.
+    /// </summary>
+    public IReadOnlyList<Resource> Resources { get; init; } = [];
+
+    /// <summary>
+    /// Activation state entries whose referenced resource versions are included.
+    /// </summary>
+    public IReadOnlyList<ActivationState> ActivationStates { get; init; } = [];
+}
+
+/// <summary>
+/// Explicit export request.
+/// </summary>
+public sealed class PortableSnapshotExportRequest
+{
+    /// <summary>
+    /// Requested export scope.
+    /// </summary>
+    public PortableExportScopeMode ScopeMode { get; set; }
+
+    /// <summary>
+    /// Definition IDs used by definition-scoped export modes.
+    /// </summary>
+    public HashSet<string> DefinitionIds { get; set; } = new(StringComparer.Ordinal);
+
+    /// <summary>
+    /// Resource IDs used by selected-resource export mode.
+    /// </summary>
+    public HashSet<string> ResourceIds { get; set; } = new(StringComparer.Ordinal);
+
+    /// <summary>
+    /// Resource version selection behavior.
+    /// </summary>
+    public PortableResourceVersionScope ResourceVersionScope { get; set; } = PortableResourceVersionScope.AllVersions;
+
+    /// <summary>
+    /// Specific resource versions used when <see cref="ResourceVersionScope"/> is <see cref="PortableResourceVersionScope.SpecificVersions"/>.
+    /// </summary>
+    public HashSet<ResourceVersionReference> SpecificResourceVersions { get; set; } = [];
+}
+
+/// <summary>
+/// Reference to one resource version.
+/// </summary>
+public sealed record ResourceVersionReference
+{
+    /// <summary>
+    /// Logical resource identifier.
+    /// </summary>
+    public required string ResourceId { get; init; }
+
+    /// <summary>
+    /// Resource version number.
+    /// </summary>
+    public required int Version { get; init; }
+}
+
+/// <summary>
+/// Export scope mode.
+/// </summary>
+public enum PortableExportScopeMode
+{
+    /// <summary>
+    /// Export selected definition versions only.
+    /// </summary>
+    DefinitionsOnly,
+
+    /// <summary>
+    /// Export selected resources.
+    /// </summary>
+    SelectedResources,
+
+    /// <summary>
+    /// Export selected definitions and resources using those definitions.
+    /// </summary>
+    DefinitionWithResources,
+}
+
+/// <summary>
+/// Resource version selection behavior for export.
+/// </summary>
+public enum PortableResourceVersionScope
+{
+    /// <summary>
+    /// Include every selected resource version.
+    /// </summary>
+    AllVersions,
+
+    /// <summary>
+    /// Include only the latest selected resource version.
+    /// </summary>
+    LatestOnly,
+
+    /// <summary>
+    /// Include only explicitly named resource versions.
+    /// </summary>
+    SpecificVersions,
+}

--- a/src/core/Aster.Core/Models/Portability/PortableStoreModels.cs
+++ b/src/core/Aster.Core/Models/Portability/PortableStoreModels.cs
@@ -1,0 +1,99 @@
+using Aster.Core.Models.Definitions;
+using Aster.Core.Models.Instances;
+
+namespace Aster.Core.Models.Portability;
+
+/// <summary>
+/// Provider-facing snapshot read request.
+/// </summary>
+public sealed record PortableStoreReadRequest
+{
+    /// <summary>
+    /// Validated export request.
+    /// </summary>
+    public required PortableSnapshotExportRequest ExportRequest { get; init; }
+}
+
+/// <summary>
+/// Provider-facing snapshot read result.
+/// </summary>
+public sealed record PortableStoreSnapshot
+{
+    /// <summary>
+    /// Definition versions read from storage.
+    /// </summary>
+    public IReadOnlyList<ResourceDefinition> Definitions { get; init; } = [];
+
+    /// <summary>
+    /// Resource versions read from storage.
+    /// </summary>
+    public IReadOnlyList<Resource> Resources { get; init; } = [];
+
+    /// <summary>
+    /// Activation states whose referenced resource versions are present.
+    /// </summary>
+    public IReadOnlyList<ActivationState> ActivationStates { get; init; } = [];
+
+    /// <summary>
+    /// Activation entries skipped because referenced resource versions were excluded.
+    /// </summary>
+    public IReadOnlyList<SkippedActivationEntry> SkippedActivationEntries { get; init; } = [];
+}
+
+/// <summary>
+/// Provider-facing target state for import planning.
+/// </summary>
+public sealed record PortableTargetState
+{
+    /// <summary>
+    /// Existing definition versions.
+    /// </summary>
+    public IReadOnlyList<ResourceDefinition> Definitions { get; init; } = [];
+
+    /// <summary>
+    /// Existing resource versions.
+    /// </summary>
+    public IReadOnlyList<Resource> Resources { get; init; } = [];
+
+    /// <summary>
+    /// Existing activation states.
+    /// </summary>
+    public IReadOnlyList<ActivationState> ActivationStates { get; init; } = [];
+}
+
+/// <summary>
+/// Reason an activation entry was skipped during export.
+/// </summary>
+public enum SkippedActivationReason
+{
+    /// <summary>
+    /// Activation references a resource version excluded by the export scope.
+    /// </summary>
+    ExcludedByResourceVersionScope,
+}
+
+/// <summary>
+/// Activation entry skipped during export.
+/// </summary>
+public sealed record SkippedActivationEntry
+{
+    /// <summary>
+    /// Logical resource identifier.
+    /// </summary>
+    public required string ResourceId { get; init; }
+
+    /// <summary>
+    /// Activation channel.
+    /// </summary>
+    public required string Channel { get; init; }
+
+    /// <summary>
+    /// Resource version referenced by the activation entry.
+    /// </summary>
+    public required int Version { get; init; }
+
+    /// <summary>
+    /// Skip reason.
+    /// </summary>
+    public required SkippedActivationReason Reason { get; init; }
+}

--- a/src/core/Aster.Core/Services/ResourcePortabilityService.cs
+++ b/src/core/Aster.Core/Services/ResourcePortabilityService.cs
@@ -141,6 +141,15 @@ public sealed class ResourcePortabilityService : IResourcePortabilityService
             diagnostics.Add(InvalidExportScope("resourceVersionScope", "Resource version scope must be a defined value."));
         }
 
+        if (request.ResourceVersionScope == PortableResourceVersionScope.SpecificVersions
+            && request.ScopeMode != PortableExportScopeMode.DefinitionsOnly
+            && request.SpecificResourceVersions.Count == 0)
+        {
+            diagnostics.Add(InvalidExportScope(
+                "specificResourceVersions",
+                "Specific resource version exports require at least one resource/version reference."));
+        }
+
         switch (request.ScopeMode)
         {
             case PortableExportScopeMode.DefinitionsOnly:
@@ -155,16 +164,8 @@ public sealed class ResourcePortabilityService : IResourcePortabilityService
                 break;
 
             case PortableExportScopeMode.SelectedResources:
-                if (request.ResourceVersionScope == PortableResourceVersionScope.SpecificVersions)
-                {
-                    if (request.SpecificResourceVersions.Count == 0)
-                    {
-                        diagnostics.Add(InvalidExportScope(
-                            "specificResourceVersions",
-                            "Specific resource version exports require at least one resource/version reference."));
-                    }
-                }
-                else if (request.ResourceIds.Count == 0)
+                if (request.ResourceVersionScope != PortableResourceVersionScope.SpecificVersions
+                    && request.ResourceIds.Count == 0)
                 {
                     diagnostics.Add(InvalidExportScope(
                         "resourceIds",

--- a/src/core/Aster.Core/Services/ResourcePortabilityService.cs
+++ b/src/core/Aster.Core/Services/ResourcePortabilityService.cs
@@ -213,6 +213,27 @@ public sealed class ResourcePortabilityService : IResourcePortabilityService
             }
         }
 
+        var resourceVersions = snapshot.Resources
+            .Select(static resource => (resource.ResourceId, resource.Version))
+            .ToHashSet();
+
+        foreach (var activationState in snapshot.ActivationStates)
+        {
+            foreach (var version in activationState.ActiveVersions)
+            {
+                if (resourceVersions.Contains((activationState.ResourceId, version)))
+                    continue;
+
+                diagnostics.Add(new PortableDiagnostic
+                {
+                    Code = PortableDiagnosticCodes.MissingResourceReference,
+                    Severity = PortableDiagnosticSeverity.Error,
+                    Path = $"activationStates/{activationState.ResourceId}/{activationState.Channel}/{version}",
+                    Message = $"Activation entry for resource '{activationState.ResourceId}' version {version} in channel '{activationState.Channel}' references a missing resource version.",
+                });
+            }
+        }
+
         return diagnostics;
     }
 

--- a/src/core/Aster.Core/Services/ResourcePortabilityService.cs
+++ b/src/core/Aster.Core/Services/ResourcePortabilityService.cs
@@ -1,0 +1,227 @@
+using Aster.Core.Abstractions;
+using Aster.Core.Models.Instances;
+using Aster.Core.Models.Portability;
+
+namespace Aster.Core.Services;
+
+/// <summary>
+/// Default portability orchestration over provider-facing snapshot primitives.
+/// </summary>
+public sealed class ResourcePortabilityService : IResourcePortabilityService
+{
+    private readonly IResourcePortabilityStore portabilityStore;
+
+    /// <summary>
+    /// Initializes a new instance of <see cref="ResourcePortabilityService"/>.
+    /// </summary>
+    public ResourcePortabilityService(IResourcePortabilityStore portabilityStore)
+    {
+        ArgumentNullException.ThrowIfNull(portabilityStore);
+        this.portabilityStore = portabilityStore;
+    }
+
+    /// <inheritdoc />
+    public async ValueTask<PortableSnapshotExportResult> ExportAsync(
+        PortableSnapshotExportRequest request,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        var diagnostics = ValidateExportRequest(request);
+        if (diagnostics.Any(static d => d.Severity == PortableDiagnosticSeverity.Error))
+            return new PortableSnapshotExportResult { Diagnostics = diagnostics };
+
+        var storeSnapshot = await portabilityStore.ReadSnapshotAsync(
+            new PortableStoreReadRequest { ExportRequest = request },
+            cancellationToken);
+
+        var skippedActivationDiagnostics = storeSnapshot.SkippedActivationEntries
+            .Select(static entry => new PortableDiagnostic
+            {
+                Code = PortableDiagnosticCodes.SkippedActivationEntry,
+                Severity = PortableDiagnosticSeverity.Warning,
+                Path = $"activationStates/{entry.ResourceId}/{entry.Channel}/{entry.Version}",
+                Message = $"Activation entry for resource '{entry.ResourceId}' version {entry.Version} in channel '{entry.Channel}' was skipped because that resource version is outside the export scope.",
+            })
+            .ToList();
+
+        var snapshot = new PortableSnapshot
+        {
+            FormatVersion = PortableSnapshot.CurrentFormatVersion,
+            Definitions = storeSnapshot.Definitions,
+            Resources = storeSnapshot.Resources,
+            ActivationStates = storeSnapshot.ActivationStates,
+        };
+
+        return new PortableSnapshotExportResult
+        {
+            Snapshot = snapshot,
+            Diagnostics = diagnostics.Concat(skippedActivationDiagnostics).ToList(),
+            SkippedActivationEntries = storeSnapshot.SkippedActivationEntries,
+        };
+    }
+
+    /// <inheritdoc />
+    public ValueTask<PortableSnapshotValidationResult> ValidateAsync(
+        PortableSnapshot snapshot,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(snapshot);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var diagnostics = ValidateSnapshot(snapshot);
+        return ValueTask.FromResult(new PortableSnapshotValidationResult
+        {
+            IsValid = diagnostics.All(static d => d.Severity != PortableDiagnosticSeverity.Error),
+            Diagnostics = diagnostics,
+        });
+    }
+
+    /// <inheritdoc />
+    public ValueTask<PortableImportPreview> PreviewImportAsync(
+        PortableSnapshot snapshot,
+        PortableImportOptions? options = null,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(snapshot);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        return ValueTask.FromResult(new PortableImportPreview
+        {
+            CanImport = false,
+            Counts = new PortablePlannedImportCounts(),
+            Diagnostics =
+            [
+                new PortableDiagnostic
+                {
+                    Code = PortableDiagnosticCodes.ImportNotImplemented,
+                    Severity = PortableDiagnosticSeverity.Error,
+                    Message = "Snapshot import preview is not implemented in this export-focused slice.",
+                },
+            ],
+        });
+    }
+
+    /// <inheritdoc />
+    public ValueTask<PortableImportResult> ImportAsync(
+        PortableSnapshot snapshot,
+        PortableImportOptions? options = null,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(snapshot);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        return ValueTask.FromResult(new PortableImportResult
+        {
+            Status = PortableImportStatus.Failed,
+            Counts = new PortableActualImportCounts(),
+            Diagnostics =
+            [
+                new PortableDiagnostic
+                {
+                    Code = PortableDiagnosticCodes.ImportNotImplemented,
+                    Severity = PortableDiagnosticSeverity.Error,
+                    Message = "Snapshot import is not implemented in this export-focused slice.",
+                },
+            ],
+        });
+    }
+
+    private static List<PortableDiagnostic> ValidateExportRequest(PortableSnapshotExportRequest request)
+    {
+        var diagnostics = new List<PortableDiagnostic>();
+
+        if (!Enum.IsDefined(request.ScopeMode))
+        {
+            diagnostics.Add(InvalidExportScope("scopeMode", "Export scope mode must be a defined value."));
+        }
+
+        if (!Enum.IsDefined(request.ResourceVersionScope))
+        {
+            diagnostics.Add(InvalidExportScope("resourceVersionScope", "Resource version scope must be a defined value."));
+        }
+
+        switch (request.ScopeMode)
+        {
+            case PortableExportScopeMode.DefinitionsOnly:
+            case PortableExportScopeMode.DefinitionWithResources:
+                if (request.DefinitionIds.Count == 0)
+                {
+                    diagnostics.Add(InvalidExportScope(
+                        "definitionIds",
+                        "Definition-scoped exports require at least one definition ID."));
+                }
+
+                break;
+
+            case PortableExportScopeMode.SelectedResources:
+                if (request.ResourceVersionScope == PortableResourceVersionScope.SpecificVersions)
+                {
+                    if (request.SpecificResourceVersions.Count == 0)
+                    {
+                        diagnostics.Add(InvalidExportScope(
+                            "specificResourceVersions",
+                            "Specific resource version exports require at least one resource/version reference."));
+                    }
+                }
+                else if (request.ResourceIds.Count == 0)
+                {
+                    diagnostics.Add(InvalidExportScope(
+                        "resourceIds",
+                        "Selected resource exports require at least one resource ID."));
+                }
+
+                break;
+        }
+
+        return diagnostics;
+    }
+
+    private static List<PortableDiagnostic> ValidateSnapshot(PortableSnapshot snapshot)
+    {
+        var diagnostics = new List<PortableDiagnostic>();
+
+        if (snapshot.FormatVersion != PortableSnapshot.CurrentFormatVersion)
+        {
+            diagnostics.Add(new PortableDiagnostic
+            {
+                Code = PortableDiagnosticCodes.UnsupportedFormatVersion,
+                Severity = PortableDiagnosticSeverity.Error,
+                Path = "formatVersion",
+                Message = $"Snapshot format version {snapshot.FormatVersion} is not supported.",
+            });
+        }
+
+        var definitionVersions = snapshot.Definitions
+            .Select(static definition => (definition.DefinitionId, definition.Version))
+            .ToHashSet();
+
+        foreach (var resource in snapshot.Resources)
+        {
+            if (resource.DefinitionVersion is null)
+                continue;
+
+            if (!definitionVersions.Contains((resource.DefinitionId, resource.DefinitionVersion.Value)))
+            {
+                diagnostics.Add(new PortableDiagnostic
+                {
+                    Code = PortableDiagnosticCodes.MissingDefinitionReference,
+                    Severity = PortableDiagnosticSeverity.Error,
+                    Path = $"resources/{resource.ResourceId}/{resource.Version}/definitionVersion",
+                    Message = $"Resource '{resource.ResourceId}' version {resource.Version} references missing definition '{resource.DefinitionId}' version {resource.DefinitionVersion}.",
+                });
+            }
+        }
+
+        return diagnostics;
+    }
+
+    private static PortableDiagnostic InvalidExportScope(string path, string message) =>
+        new()
+        {
+            Code = PortableDiagnosticCodes.InvalidExportScope,
+            Severity = PortableDiagnosticSeverity.Error,
+            Path = path,
+            Message = message,
+        };
+}

--- a/src/persistence/Aster.Persistence.SqliteJson/SqliteJsonAsterServiceCollectionExtensions.cs
+++ b/src/persistence/Aster.Persistence.SqliteJson/SqliteJsonAsterServiceCollectionExtensions.cs
@@ -32,6 +32,7 @@ public static class SqliteJsonAsterServiceCollectionExtensions
         services.AddSingleton<IResourceDefinitionStore>(sp => sp.GetRequiredService<SqliteJsonResourceStore>());
         services.AddSingleton<IResourceVersionReader>(sp => sp.GetRequiredService<SqliteJsonResourceStore>());
         services.AddSingleton<IResourceVersionWriter>(sp => sp.GetRequiredService<SqliteJsonResourceStore>());
+        services.AddSingleton<IResourcePortabilityStore>(sp => sp.GetRequiredService<SqliteJsonResourceStore>());
         services.AddSingleton<IResourceQueryService>(sp => sp.GetRequiredService<SqliteJsonQueryService>());
         services.AddSingleton<IResourceQueryProviderIdentity>(sp => sp.GetRequiredService<SqliteJsonQueryProviderIdentity>());
         services.AddSingleton<IResourceQueryCapabilitiesProvider>(sp => sp.GetRequiredService<SqliteJsonQueryCapabilitiesProvider>());

--- a/src/persistence/Aster.Persistence.SqliteJson/SqliteJsonResourceStore.cs
+++ b/src/persistence/Aster.Persistence.SqliteJson/SqliteJsonResourceStore.cs
@@ -17,6 +17,8 @@ public sealed class SqliteJsonResourceStore :
     IResourceVersionWriter,
     IResourcePortabilityStore
 {
+    private const int MaxSqliteParametersPerQuery = 500;
+
     private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web);
 
     private readonly string connectionString;
@@ -240,7 +242,9 @@ public sealed class SqliteJsonResourceStore :
             request.ExportRequest,
             await ReadScopedResourceVersionsAsync(request.ExportRequest, cancellationToken));
         var definitions = await SelectDefinitionsAsync(request.ExportRequest, resources, cancellationToken);
-        var activationStates = await ReadAllActivationStatesAsync(cancellationToken);
+        var activationStates = await ReadScopedActivationStatesAsync(
+            resources.Select(static resource => resource.ResourceId).ToHashSet(StringComparer.Ordinal),
+            cancellationToken);
         var (includedActivationStates, skippedActivationEntries) = SelectActivationStates(resources, activationStates);
 
         return new PortableStoreSnapshot
@@ -290,14 +294,14 @@ public sealed class SqliteJsonResourceStore :
         IReadOnlyCollection<Resource> resources,
         CancellationToken cancellationToken)
     {
-        var allDefinitions = await ReadAllDefinitionVersionsAsync(cancellationToken);
-        var allDefinitionsByVersion = allDefinitions.ToDictionary(
+        var scopedDefinitions = await ReadScopedDefinitionVersionsAsync(request, resources, cancellationToken);
+        var scopedDefinitionsByVersion = scopedDefinitions.ToDictionary(
             static definition => (definition.DefinitionId, definition.Version));
         var definitions = new Dictionary<(string DefinitionId, int Version), ResourceDefinition>();
 
         if (request.ScopeMode is PortableExportScopeMode.DefinitionsOnly or PortableExportScopeMode.DefinitionWithResources)
         {
-            foreach (var definition in allDefinitions.Where(definition => request.DefinitionIds.Contains(definition.DefinitionId)))
+            foreach (var definition in scopedDefinitions.Where(definition => request.DefinitionIds.Contains(definition.DefinitionId)))
                 definitions[(definition.DefinitionId, definition.Version)] = definition;
         }
 
@@ -306,7 +310,7 @@ public sealed class SqliteJsonResourceStore :
             if (resource.DefinitionVersion is null)
                 continue;
 
-            if (allDefinitionsByVersion.TryGetValue((resource.DefinitionId, resource.DefinitionVersion.Value), out var definition))
+            if (scopedDefinitionsByVersion.TryGetValue((resource.DefinitionId, resource.DefinitionVersion.Value), out var definition))
                 definitions[(definition.DefinitionId, definition.Version)] = definition;
         }
 
@@ -316,31 +320,47 @@ public sealed class SqliteJsonResourceStore :
             .ToList();
     }
 
-    private async Task<List<ResourceDefinition>> ReadAllDefinitionVersionsAsync(CancellationToken cancellationToken)
+    private async Task<List<ResourceDefinition>> ReadScopedDefinitionVersionsAsync(
+        PortableSnapshotExportRequest request,
+        IReadOnlyCollection<Resource> resources,
+        CancellationToken cancellationToken)
     {
-        await using var connection = await OpenConnectionAsync(cancellationToken);
-        await using var command = connection.CreateCommand();
-        command.CommandText = """
-            SELECT payload
-            FROM resource_definitions
-            ORDER BY definition_id, version;
-            """;
+        var fullDefinitionIds = request.ScopeMode is PortableExportScopeMode.DefinitionsOnly or PortableExportScopeMode.DefinitionWithResources
+            ? request.DefinitionIds
+            : [];
+        var referencedDefinitionVersions = resources
+            .Where(static resource => resource.DefinitionVersion is not null)
+            .Select(static resource => (resource.DefinitionId, Version: resource.DefinitionVersion!.Value))
+            .ToHashSet();
+        var definitionIds = fullDefinitionIds
+            .Concat(referencedDefinitionVersions.Select(static reference => reference.DefinitionId))
+            .ToHashSet(StringComparer.Ordinal);
 
-        return await ReadPayloadsAsync<ResourceDefinition>(command, cancellationToken);
+        var definitions = await ReadPayloadsByTextIdsAsync<ResourceDefinition>(
+            tableName: "resource_definitions",
+            columnName: "definition_id",
+            ids: definitionIds,
+            orderBy: "definition_id, version",
+            cancellationToken);
+
+        return definitions
+            .Where(definition =>
+                fullDefinitionIds.Contains(definition.DefinitionId)
+                || referencedDefinitionVersions.Contains((definition.DefinitionId, definition.Version)))
+            .OrderBy(static definition => definition.DefinitionId, StringComparer.Ordinal)
+            .ThenBy(static definition => definition.Version)
+            .ToList();
     }
 
-    private async Task<List<ActivationState>> ReadAllActivationStatesAsync(CancellationToken cancellationToken)
-    {
-        await using var connection = await OpenConnectionAsync(cancellationToken);
-        await using var command = connection.CreateCommand();
-        command.CommandText = """
-            SELECT payload
-            FROM activation_states
-            ORDER BY resource_id, channel;
-            """;
-
-        return await ReadPayloadsAsync<ActivationState>(command, cancellationToken);
-    }
+    private async Task<List<ActivationState>> ReadScopedActivationStatesAsync(
+        IReadOnlyCollection<string> resourceIds,
+        CancellationToken cancellationToken) =>
+        await ReadPayloadsByTextIdsAsync<ActivationState>(
+            tableName: "activation_states",
+            columnName: "resource_id",
+            ids: resourceIds,
+            orderBy: "resource_id, channel",
+            cancellationToken);
 
     private async Task<List<Resource>> ReadScopedResourceVersionsAsync(
         PortableSnapshotExportRequest request,
@@ -358,17 +378,17 @@ public sealed class SqliteJsonResourceStore :
         if (ids.Count == 0)
             return [];
 
-        await using var connection = await OpenConnectionAsync(cancellationToken);
-        await using var command = connection.CreateCommand();
-        var parameterNames = AddTextParameters(command, "id", ids);
-        command.CommandText = $"""
-            SELECT payload
-            FROM resource_versions
-            WHERE {columnName} IN ({string.Join(", ", parameterNames)})
-            ORDER BY resource_id, version;
-            """;
+        var resources = await ReadPayloadsByTextIdsAsync<Resource>(
+            tableName: "resource_versions",
+            columnName,
+            ids,
+            orderBy: "resource_id, version",
+            cancellationToken);
 
-        return await ReadPayloadsAsync<Resource>(command, cancellationToken);
+        return resources
+            .OrderBy(static resource => resource.ResourceId, StringComparer.Ordinal)
+            .ThenBy(static resource => resource.Version)
+            .ToList();
     }
 
     private static List<Resource> SelectResourceVersions(
@@ -479,6 +499,35 @@ public sealed class SqliteJsonResourceStore :
         }
 
         return parameterNames;
+    }
+
+    private async Task<List<T>> ReadPayloadsByTextIdsAsync<T>(
+        string tableName,
+        string columnName,
+        IReadOnlyCollection<string> ids,
+        string orderBy,
+        CancellationToken cancellationToken)
+    {
+        var results = new List<T>();
+        if (ids.Count == 0)
+            return results;
+
+        await using var connection = await OpenConnectionAsync(cancellationToken);
+        foreach (var batch in ids.Order(StringComparer.Ordinal).Chunk(MaxSqliteParametersPerQuery))
+        {
+            await using var command = connection.CreateCommand();
+            var parameterNames = AddTextParameters(command, "id", batch);
+            command.CommandText = $"""
+                SELECT payload
+                FROM {tableName}
+                WHERE {columnName} IN ({string.Join(", ", parameterNames)})
+                ORDER BY {orderBy};
+                """;
+
+            results.AddRange(await ReadPayloadsAsync<T>(command, cancellationToken));
+        }
+
+        return results;
     }
 
     private async Task<IEnumerable<Resource>> ReadActiveVersionsAsync(

--- a/src/persistence/Aster.Persistence.SqliteJson/SqliteJsonResourceStore.cs
+++ b/src/persistence/Aster.Persistence.SqliteJson/SqliteJsonResourceStore.cs
@@ -2,6 +2,7 @@ using System.Text.Json;
 using Aster.Core.Abstractions;
 using Aster.Core.Models.Definitions;
 using Aster.Core.Models.Instances;
+using Aster.Core.Models.Portability;
 using Aster.Core.Models.Querying;
 using Microsoft.Data.Sqlite;
 
@@ -13,7 +14,8 @@ namespace Aster.Persistence.SqliteJson;
 public sealed class SqliteJsonResourceStore :
     IResourceDefinitionStore,
     IResourceVersionReader,
-    IResourceVersionWriter
+    IResourceVersionWriter,
+    IResourcePortabilityStore
 {
     private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web);
 
@@ -219,6 +221,29 @@ public sealed class SqliteJsonResourceStore :
         };
     }
 
+    /// <inheritdoc />
+    public async ValueTask<PortableStoreSnapshot> ReadSnapshotAsync(
+        PortableStoreReadRequest request,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        var resources = SelectResources(
+            request.ExportRequest,
+            (await ReadAllVersionsAsync(cancellationToken)).ToList());
+        var definitions = await SelectDefinitionsAsync(request.ExportRequest, resources, cancellationToken);
+        var activationStates = await ReadAllActivationStatesAsync(cancellationToken);
+        var (includedActivationStates, skippedActivationEntries) = SelectActivationStates(resources, activationStates);
+
+        return new PortableStoreSnapshot
+        {
+            Definitions = definitions,
+            Resources = resources,
+            ActivationStates = includedActivationStates,
+            SkippedActivationEntries = skippedActivationEntries,
+        };
+    }
+
     private async Task<IEnumerable<Resource>> ReadLatestVersionsAsync(CancellationToken cancellationToken)
     {
         await using var connection = await OpenConnectionAsync(cancellationToken);
@@ -251,6 +276,157 @@ public sealed class SqliteJsonResourceStore :
 
         return await ReadPayloadsAsync<Resource>(command, cancellationToken);
     }
+
+    private async Task<List<ResourceDefinition>> SelectDefinitionsAsync(
+        PortableSnapshotExportRequest request,
+        IReadOnlyCollection<Resource> resources,
+        CancellationToken cancellationToken)
+    {
+        var allDefinitions = await ReadAllDefinitionVersionsAsync(cancellationToken);
+        var definitions = new Dictionary<(string DefinitionId, int Version), ResourceDefinition>();
+
+        if (request.ScopeMode is PortableExportScopeMode.DefinitionsOnly or PortableExportScopeMode.DefinitionWithResources)
+        {
+            foreach (var definition in allDefinitions.Where(definition => request.DefinitionIds.Contains(definition.DefinitionId)))
+                definitions[(definition.DefinitionId, definition.Version)] = definition;
+        }
+
+        foreach (var resource in resources)
+        {
+            if (resource.DefinitionVersion is null)
+                continue;
+
+            var definition = allDefinitions.FirstOrDefault(candidate =>
+                string.Equals(candidate.DefinitionId, resource.DefinitionId, StringComparison.Ordinal)
+                && candidate.Version == resource.DefinitionVersion.Value);
+
+            if (definition is not null)
+                definitions[(definition.DefinitionId, definition.Version)] = definition;
+        }
+
+        return definitions.Values
+            .OrderBy(static definition => definition.DefinitionId, StringComparer.Ordinal)
+            .ThenBy(static definition => definition.Version)
+            .ToList();
+    }
+
+    private async Task<List<ResourceDefinition>> ReadAllDefinitionVersionsAsync(CancellationToken cancellationToken)
+    {
+        await using var connection = await OpenConnectionAsync(cancellationToken);
+        await using var command = connection.CreateCommand();
+        command.CommandText = """
+            SELECT payload
+            FROM resource_definitions
+            ORDER BY definition_id, version;
+            """;
+
+        return await ReadPayloadsAsync<ResourceDefinition>(command, cancellationToken);
+    }
+
+    private async Task<List<ActivationState>> ReadAllActivationStatesAsync(CancellationToken cancellationToken)
+    {
+        await using var connection = await OpenConnectionAsync(cancellationToken);
+        await using var command = connection.CreateCommand();
+        command.CommandText = """
+            SELECT payload
+            FROM activation_states
+            ORDER BY resource_id, channel;
+            """;
+
+        return await ReadPayloadsAsync<ActivationState>(command, cancellationToken);
+    }
+
+    private static List<Resource> SelectResources(
+        PortableSnapshotExportRequest request,
+        IReadOnlyCollection<Resource> allResources)
+    {
+        var resourceIds = request.ScopeMode switch
+        {
+            PortableExportScopeMode.DefinitionsOnly => [],
+            PortableExportScopeMode.SelectedResources => request.ResourceVersionScope == PortableResourceVersionScope.SpecificVersions
+                ? request.SpecificResourceVersions.Select(static reference => reference.ResourceId).ToHashSet(StringComparer.Ordinal)
+                : request.ResourceIds,
+            PortableExportScopeMode.DefinitionWithResources => allResources
+                .Where(resource => request.DefinitionIds.Contains(resource.DefinitionId))
+                .Select(static resource => resource.ResourceId)
+                .ToHashSet(StringComparer.Ordinal),
+            _ => [],
+        };
+
+        var specificVersions = request.SpecificResourceVersions.ToHashSet();
+
+        return allResources
+            .Where(resource => resourceIds.Contains(resource.ResourceId))
+            .GroupBy(static resource => resource.ResourceId, StringComparer.Ordinal)
+            .SelectMany(group => SelectVersions(
+                group.OrderBy(static resource => resource.Version).ToList(),
+                request.ResourceVersionScope,
+                specificVersions))
+            .OrderBy(static resource => resource.ResourceId, StringComparer.Ordinal)
+            .ThenBy(static resource => resource.Version)
+            .ToList();
+    }
+
+    private static (List<ActivationState> ActivationStates, List<SkippedActivationEntry> SkippedActivationEntries) SelectActivationStates(
+        IReadOnlyCollection<Resource> resources,
+        IReadOnlyCollection<ActivationState> activationStates)
+    {
+        var includedVersions = resources
+            .GroupBy(static resource => resource.ResourceId, StringComparer.Ordinal)
+            .ToDictionary(
+                static group => group.Key,
+                static group => group.Select(static resource => resource.Version).ToHashSet(),
+                StringComparer.Ordinal);
+
+        var includedStates = new List<ActivationState>();
+        var skippedEntries = new List<SkippedActivationEntry>();
+
+        foreach (var state in activationStates)
+        {
+            if (!includedVersions.TryGetValue(state.ResourceId, out var includedResourceVersions))
+                continue;
+
+            var includedActiveVersions = state.ActiveVersions
+                .Where(includedResourceVersions.Contains)
+                .Order()
+                .ToList();
+
+            foreach (var skippedVersion in state.ActiveVersions.Except(includedActiveVersions).Order())
+            {
+                skippedEntries.Add(new SkippedActivationEntry
+                {
+                    ResourceId = state.ResourceId,
+                    Channel = state.Channel,
+                    Version = skippedVersion,
+                    Reason = SkippedActivationReason.ExcludedByResourceVersionScope,
+                });
+            }
+
+            if (includedActiveVersions.Count == 0)
+                continue;
+
+            includedStates.Add(state with { ActiveVersions = includedActiveVersions });
+        }
+
+        return (includedStates, skippedEntries);
+    }
+
+    private static IEnumerable<Resource> SelectVersions(
+        IReadOnlyList<Resource> versions,
+        PortableResourceVersionScope versionScope,
+        IReadOnlySet<ResourceVersionReference> specificVersions) =>
+        versionScope switch
+        {
+            PortableResourceVersionScope.AllVersions => versions,
+            PortableResourceVersionScope.LatestOnly => versions.Count > 0 ? [versions[^1]] : [],
+            PortableResourceVersionScope.SpecificVersions => versions
+                .Where(version => specificVersions.Contains(new ResourceVersionReference
+                {
+                    ResourceId = version.ResourceId,
+                    Version = version.Version,
+                })),
+            _ => [],
+        };
 
     private async Task<IEnumerable<Resource>> ReadActiveVersionsAsync(
         string? channel,

--- a/src/persistence/Aster.Persistence.SqliteJson/SqliteJsonResourceStore.cs
+++ b/src/persistence/Aster.Persistence.SqliteJson/SqliteJsonResourceStore.cs
@@ -228,9 +228,17 @@ public sealed class SqliteJsonResourceStore :
     {
         ArgumentNullException.ThrowIfNull(request);
 
-        var resources = SelectResources(
+        if (request.ExportRequest.ScopeMode == PortableExportScopeMode.DefinitionsOnly)
+        {
+            return new PortableStoreSnapshot
+            {
+                Definitions = await SelectDefinitionsAsync(request.ExportRequest, [], cancellationToken),
+            };
+        }
+
+        var resources = SelectResourceVersions(
             request.ExportRequest,
-            (await ReadAllVersionsAsync(cancellationToken)).ToList());
+            await ReadScopedResourceVersionsAsync(request.ExportRequest, cancellationToken));
         var definitions = await SelectDefinitionsAsync(request.ExportRequest, resources, cancellationToken);
         var activationStates = await ReadAllActivationStatesAsync(cancellationToken);
         var (includedActivationStates, skippedActivationEntries) = SelectActivationStates(resources, activationStates);
@@ -283,6 +291,8 @@ public sealed class SqliteJsonResourceStore :
         CancellationToken cancellationToken)
     {
         var allDefinitions = await ReadAllDefinitionVersionsAsync(cancellationToken);
+        var allDefinitionsByVersion = allDefinitions.ToDictionary(
+            static definition => (definition.DefinitionId, definition.Version));
         var definitions = new Dictionary<(string DefinitionId, int Version), ResourceDefinition>();
 
         if (request.ScopeMode is PortableExportScopeMode.DefinitionsOnly or PortableExportScopeMode.DefinitionWithResources)
@@ -296,11 +306,7 @@ public sealed class SqliteJsonResourceStore :
             if (resource.DefinitionVersion is null)
                 continue;
 
-            var definition = allDefinitions.FirstOrDefault(candidate =>
-                string.Equals(candidate.DefinitionId, resource.DefinitionId, StringComparison.Ordinal)
-                && candidate.Version == resource.DefinitionVersion.Value);
-
-            if (definition is not null)
+            if (allDefinitionsByVersion.TryGetValue((resource.DefinitionId, resource.DefinitionVersion.Value), out var definition))
                 definitions[(definition.DefinitionId, definition.Version)] = definition;
         }
 
@@ -336,9 +342,38 @@ public sealed class SqliteJsonResourceStore :
         return await ReadPayloadsAsync<ActivationState>(command, cancellationToken);
     }
 
-    private static List<Resource> SelectResources(
+    private async Task<List<Resource>> ReadScopedResourceVersionsAsync(
         PortableSnapshotExportRequest request,
-        IReadOnlyCollection<Resource> allResources)
+        CancellationToken cancellationToken)
+    {
+        var (columnName, ids) = request.ScopeMode switch
+        {
+            PortableExportScopeMode.DefinitionWithResources => ("definition_id", request.DefinitionIds),
+            PortableExportScopeMode.SelectedResources => ("resource_id", request.ResourceVersionScope == PortableResourceVersionScope.SpecificVersions
+                ? request.SpecificResourceVersions.Select(static reference => reference.ResourceId).ToHashSet(StringComparer.Ordinal)
+                : request.ResourceIds),
+            _ => ("resource_id", []),
+        };
+
+        if (ids.Count == 0)
+            return [];
+
+        await using var connection = await OpenConnectionAsync(cancellationToken);
+        await using var command = connection.CreateCommand();
+        var parameterNames = AddTextParameters(command, "id", ids);
+        command.CommandText = $"""
+            SELECT payload
+            FROM resource_versions
+            WHERE {columnName} IN ({string.Join(", ", parameterNames)})
+            ORDER BY resource_id, version;
+            """;
+
+        return await ReadPayloadsAsync<Resource>(command, cancellationToken);
+    }
+
+    private static List<Resource> SelectResourceVersions(
+        PortableSnapshotExportRequest request,
+        IReadOnlyCollection<Resource> scopedResources)
     {
         var resourceIds = request.ScopeMode switch
         {
@@ -346,7 +381,7 @@ public sealed class SqliteJsonResourceStore :
             PortableExportScopeMode.SelectedResources => request.ResourceVersionScope == PortableResourceVersionScope.SpecificVersions
                 ? request.SpecificResourceVersions.Select(static reference => reference.ResourceId).ToHashSet(StringComparer.Ordinal)
                 : request.ResourceIds,
-            PortableExportScopeMode.DefinitionWithResources => allResources
+            PortableExportScopeMode.DefinitionWithResources => scopedResources
                 .Where(resource => request.DefinitionIds.Contains(resource.DefinitionId))
                 .Select(static resource => resource.ResourceId)
                 .ToHashSet(StringComparer.Ordinal),
@@ -355,7 +390,7 @@ public sealed class SqliteJsonResourceStore :
 
         var specificVersions = request.SpecificResourceVersions.ToHashSet();
 
-        return allResources
+        return scopedResources
             .Where(resource => resourceIds.Contains(resource.ResourceId))
             .GroupBy(static resource => resource.ResourceId, StringComparer.Ordinal)
             .SelectMany(group => SelectVersions(
@@ -427,6 +462,24 @@ public sealed class SqliteJsonResourceStore :
                 })),
             _ => [],
         };
+
+    private static List<string> AddTextParameters(
+        SqliteCommand command,
+        string parameterPrefix,
+        IEnumerable<string> values)
+    {
+        var parameterNames = new List<string>();
+        var index = 0;
+
+        foreach (var value in values.Order(StringComparer.Ordinal))
+        {
+            var parameterName = $"${parameterPrefix}{index++}";
+            command.Parameters.AddWithValue(parameterName, value);
+            parameterNames.Add(parameterName);
+        }
+
+        return parameterNames;
+    }
 
     private async Task<IEnumerable<Resource>> ReadActiveVersionsAsync(
         string? channel,

--- a/src/persistence/Aster.Persistence.SqliteJson/SqliteJsonResourceStore.cs
+++ b/src/persistence/Aster.Persistence.SqliteJson/SqliteJsonResourceStore.cs
@@ -366,6 +366,12 @@ public sealed class SqliteJsonResourceStore :
         PortableSnapshotExportRequest request,
         CancellationToken cancellationToken)
     {
+        if (request.ScopeMode == PortableExportScopeMode.SelectedResources
+            && request.ResourceVersionScope == PortableResourceVersionScope.SpecificVersions)
+        {
+            return await ReadSpecificResourceVersionsAsync(request.SpecificResourceVersions, cancellationToken);
+        }
+
         var (columnName, ids) = request.ScopeMode switch
         {
             PortableExportScopeMode.DefinitionWithResources => ("definition_id", request.DefinitionIds),
@@ -386,6 +392,38 @@ public sealed class SqliteJsonResourceStore :
             cancellationToken);
 
         return resources
+            .OrderBy(static resource => resource.ResourceId, StringComparer.Ordinal)
+            .ThenBy(static resource => resource.Version)
+            .ToList();
+    }
+
+    private async Task<List<Resource>> ReadSpecificResourceVersionsAsync(
+        IReadOnlyCollection<ResourceVersionReference> references,
+        CancellationToken cancellationToken)
+    {
+        if (references.Count == 0)
+            return [];
+
+        var results = new List<Resource>();
+        await using var connection = await OpenConnectionAsync(cancellationToken);
+        foreach (var batch in references
+            .OrderBy(static reference => reference.ResourceId, StringComparer.Ordinal)
+            .ThenBy(static reference => reference.Version)
+            .Chunk(MaxSqliteParametersPerQuery / 2))
+        {
+            await using var command = connection.CreateCommand();
+            var predicates = AddResourceVersionPredicates(command, batch);
+            command.CommandText = $"""
+                SELECT payload
+                FROM resource_versions
+                WHERE {string.Join(" OR ", predicates)}
+                ORDER BY resource_id, version;
+                """;
+
+            results.AddRange(await ReadPayloadsAsync<Resource>(command, cancellationToken));
+        }
+
+        return results
             .OrderBy(static resource => resource.ResourceId, StringComparer.Ordinal)
             .ThenBy(static resource => resource.Version)
             .ToList();
@@ -499,6 +537,24 @@ public sealed class SqliteJsonResourceStore :
         }
 
         return parameterNames;
+    }
+
+    private static List<string> AddResourceVersionPredicates(
+        SqliteCommand command,
+        IReadOnlyList<ResourceVersionReference> references)
+    {
+        var predicates = new List<string>();
+
+        for (var index = 0; index < references.Count; index++)
+        {
+            var resourceIdParameter = $"$resourceId{index}";
+            var versionParameter = $"$version{index}";
+            command.Parameters.AddWithValue(resourceIdParameter, references[index].ResourceId);
+            command.Parameters.AddWithValue(versionParameter, references[index].Version);
+            predicates.Add($"(resource_id = {resourceIdParameter} AND version = {versionParameter})");
+        }
+
+        return predicates;
     }
 
     private async Task<List<T>> ReadPayloadsByTextIdsAsync<T>(

--- a/test/Aster.Tests/Portability/PortabilityExportTests.cs
+++ b/test/Aster.Tests/Portability/PortabilityExportTests.cs
@@ -28,6 +28,22 @@ public sealed class PortabilityExportTests : IDisposable
     public void Dispose() => provider.Dispose();
 
     [Fact]
+    public async Task ExportAsync_DefinitionWithResourcesSpecificVersionsWithoutVersions_ReturnsInvalidScopeDiagnostic()
+    {
+        var result = await portability.ExportAsync(new PortableSnapshotExportRequest
+        {
+            ScopeMode = PortableExportScopeMode.DefinitionWithResources,
+            DefinitionIds = ["Product"],
+            ResourceVersionScope = PortableResourceVersionScope.SpecificVersions,
+        });
+
+        Assert.Null(result.Snapshot);
+        var diagnostic = Assert.Single(result.Diagnostics);
+        Assert.Equal(PortableDiagnosticCodes.InvalidExportScope, diagnostic.Code);
+        Assert.Equal("specificResourceVersions", diagnostic.Path);
+    }
+
+    [Fact]
     public async Task ExportAsync_DefinitionsOnly_IncludesAllSelectedDefinitionVersions()
     {
         await RegisterDefinitionVersionsAsync("Product", count: 2);

--- a/test/Aster.Tests/Portability/PortabilityExportTests.cs
+++ b/test/Aster.Tests/Portability/PortabilityExportTests.cs
@@ -97,7 +97,8 @@ public sealed class PortabilityExportTests : IDisposable
     {
         await RegisterDefinitionVersionsAsync("Product", count: 1);
         var (v1, v2) = await CreateTwoVersionResourceAsync();
-        await ActivateVersionsAsync(v1.ResourceId, "Preview", [v1.Version, v2.Version]);
+        var lastUpdated = DateTime.UtcNow.AddMinutes(-5);
+        await ActivateVersionsAsync(v1.ResourceId, "Preview", [v1.Version, v2.Version], lastUpdated);
 
         var result = await portability.ExportAsync(new PortableSnapshotExportRequest
         {
@@ -118,6 +119,7 @@ public sealed class PortabilityExportTests : IDisposable
 
         var state = Assert.Single(result.Snapshot.ActivationStates);
         Assert.Equal([v2.Version], state.ActiveVersions);
+        Assert.Equal(lastUpdated, state.LastUpdated);
     }
 
     [Fact]
@@ -162,7 +164,11 @@ public sealed class PortabilityExportTests : IDisposable
         return (v1, v2);
     }
 
-    private async Task ActivateVersionsAsync(string resourceId, string channel, IReadOnlyList<int> versions)
+    private async Task ActivateVersionsAsync(
+        string resourceId,
+        string channel,
+        IReadOnlyList<int> versions,
+        DateTime? lastUpdated = null)
     {
         var writer = provider.GetRequiredService<IResourceVersionWriter>();
         await writer.UpdateActivationAsync(resourceId, channel, new ActivationState
@@ -170,7 +176,7 @@ public sealed class PortabilityExportTests : IDisposable
             ResourceId = resourceId,
             Channel = channel,
             ActiveVersions = versions,
-            LastUpdated = DateTime.UtcNow,
+            LastUpdated = lastUpdated ?? DateTime.UtcNow,
         });
     }
 }

--- a/test/Aster.Tests/Portability/PortabilityExportTests.cs
+++ b/test/Aster.Tests/Portability/PortabilityExportTests.cs
@@ -1,0 +1,176 @@
+using Aster.Core.Abstractions;
+using Aster.Core.Definitions;
+using Aster.Core.Extensions;
+using Aster.Core.Models.Instances;
+using Aster.Core.Models.Portability;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Aster.Tests.Portability;
+
+public sealed class PortabilityExportTests : IDisposable
+{
+    private readonly ServiceProvider provider;
+    private readonly IResourceDefinitionStore definitionStore;
+    private readonly IResourceManager manager;
+    private readonly IResourcePortabilityService portability;
+
+    public PortabilityExportTests()
+    {
+        provider = new ServiceCollection()
+            .AddAsterCore()
+            .BuildServiceProvider();
+
+        definitionStore = provider.GetRequiredService<IResourceDefinitionStore>();
+        manager = provider.GetRequiredService<IResourceManager>();
+        portability = provider.GetRequiredService<IResourcePortabilityService>();
+    }
+
+    public void Dispose() => provider.Dispose();
+
+    [Fact]
+    public async Task ExportAsync_DefinitionsOnly_IncludesAllSelectedDefinitionVersions()
+    {
+        await RegisterDefinitionVersionsAsync("Product", count: 2);
+        await RegisterDefinitionVersionsAsync("Order", count: 1);
+
+        var result = await portability.ExportAsync(new PortableSnapshotExportRequest
+        {
+            ScopeMode = PortableExportScopeMode.DefinitionsOnly,
+            DefinitionIds = ["Product"],
+        });
+
+        Assert.NotNull(result.Snapshot);
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal([1, 2], result.Snapshot.Definitions.Select(static definition => definition.Version).ToList());
+        Assert.All(result.Snapshot.Definitions, static definition => Assert.Equal("Product", definition.DefinitionId));
+        Assert.Empty(result.Snapshot.Resources);
+        Assert.Empty(result.Snapshot.ActivationStates);
+    }
+
+    [Fact]
+    public async Task ExportAsync_SelectedResourceLatestOnly_IncludesLatestVersionAndReferencedDefinition()
+    {
+        await RegisterDefinitionVersionsAsync("Product", count: 1);
+        var (v1, v2) = await CreateTwoVersionResourceAsync();
+
+        var result = await portability.ExportAsync(new PortableSnapshotExportRequest
+        {
+            ScopeMode = PortableExportScopeMode.SelectedResources,
+            ResourceIds = [v1.ResourceId],
+            ResourceVersionScope = PortableResourceVersionScope.LatestOnly,
+        });
+
+        Assert.NotNull(result.Snapshot);
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal([v2.Version], result.Snapshot.Resources.Select(static resource => resource.Version).ToList());
+        Assert.Single(result.Snapshot.Definitions);
+        Assert.Equal(v2.DefinitionVersion, result.Snapshot.Definitions[0].Version);
+    }
+
+    [Fact]
+    public async Task ExportAsync_SelectedResourceSpecificVersions_IncludesOnlyRequestedVersions()
+    {
+        await RegisterDefinitionVersionsAsync("Product", count: 1);
+        var (v1, _) = await CreateTwoVersionResourceAsync();
+
+        var result = await portability.ExportAsync(new PortableSnapshotExportRequest
+        {
+            ScopeMode = PortableExportScopeMode.SelectedResources,
+            ResourceVersionScope = PortableResourceVersionScope.SpecificVersions,
+            SpecificResourceVersions =
+            [
+                new ResourceVersionReference
+                {
+                    ResourceId = v1.ResourceId,
+                    Version = 1,
+                },
+            ],
+        });
+
+        Assert.NotNull(result.Snapshot);
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal([1], result.Snapshot.Resources.Select(static resource => resource.Version).ToList());
+    }
+
+    [Fact]
+    public async Task ExportAsync_LatestOnly_SkipsActivationEntriesForExcludedVersions()
+    {
+        await RegisterDefinitionVersionsAsync("Product", count: 1);
+        var (v1, v2) = await CreateTwoVersionResourceAsync();
+        await ActivateVersionsAsync(v1.ResourceId, "Preview", [v1.Version, v2.Version]);
+
+        var result = await portability.ExportAsync(new PortableSnapshotExportRequest
+        {
+            ScopeMode = PortableExportScopeMode.SelectedResources,
+            ResourceIds = [v1.ResourceId],
+            ResourceVersionScope = PortableResourceVersionScope.LatestOnly,
+        });
+
+        Assert.NotNull(result.Snapshot);
+        var diagnostic = Assert.Single(result.Diagnostics);
+        Assert.Equal(PortableDiagnosticCodes.SkippedActivationEntry, diagnostic.Code);
+        Assert.Equal(PortableDiagnosticSeverity.Warning, diagnostic.Severity);
+
+        var skippedEntry = Assert.Single(result.SkippedActivationEntries);
+        Assert.Equal(v1.ResourceId, skippedEntry.ResourceId);
+        Assert.Equal(v1.Version, skippedEntry.Version);
+        Assert.Equal("Preview", skippedEntry.Channel);
+
+        var state = Assert.Single(result.Snapshot.ActivationStates);
+        Assert.Equal([v2.Version], state.ActiveVersions);
+    }
+
+    [Fact]
+    public async Task ExportAsync_DefinitionWithResources_IncludesMatchingResourcesOnly()
+    {
+        await RegisterDefinitionVersionsAsync("Product", count: 1);
+        await RegisterDefinitionVersionsAsync("Order", count: 1);
+        var product = await manager.CreateAsync("Product", new CreateResourceRequest());
+        await manager.CreateAsync("Order", new CreateResourceRequest());
+
+        var result = await portability.ExportAsync(new PortableSnapshotExportRequest
+        {
+            ScopeMode = PortableExportScopeMode.DefinitionWithResources,
+            DefinitionIds = ["Product"],
+            ResourceVersionScope = PortableResourceVersionScope.AllVersions,
+        });
+
+        Assert.NotNull(result.Snapshot);
+        Assert.Empty(result.Diagnostics);
+        var resource = Assert.Single(result.Snapshot.Resources);
+        Assert.Equal(product.ResourceId, resource.ResourceId);
+        Assert.All(result.Snapshot.Definitions, static definition => Assert.Equal("Product", definition.DefinitionId));
+    }
+
+    private async Task RegisterDefinitionVersionsAsync(string definitionId, int count)
+    {
+        for (var i = 0; i < count; i++)
+        {
+            await definitionStore.RegisterDefinitionAsync(new ResourceDefinitionBuilder()
+                .WithDefinitionId(definitionId)
+                .Build());
+        }
+    }
+
+    private async Task<(Resource V1, Resource V2)> CreateTwoVersionResourceAsync()
+    {
+        var v1 = await manager.CreateAsync("Product", new CreateResourceRequest());
+        var v2 = await manager.UpdateAsync(v1.ResourceId, new UpdateResourceRequest
+        {
+            BaseVersion = v1.Version,
+        });
+        return (v1, v2);
+    }
+
+    private async Task ActivateVersionsAsync(string resourceId, string channel, IReadOnlyList<int> versions)
+    {
+        var writer = provider.GetRequiredService<IResourceVersionWriter>();
+        await writer.UpdateActivationAsync(resourceId, channel, new ActivationState
+        {
+            ResourceId = resourceId,
+            Channel = channel,
+            ActiveVersions = versions,
+            LastUpdated = DateTime.UtcNow,
+        });
+    }
+}

--- a/test/Aster.Tests/Portability/PortabilityValidationTests.cs
+++ b/test/Aster.Tests/Portability/PortabilityValidationTests.cs
@@ -1,0 +1,39 @@
+using Aster.Core.Abstractions;
+using Aster.Core.Extensions;
+using Aster.Core.Models.Instances;
+using Aster.Core.Models.Portability;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Aster.Tests.Portability;
+
+public sealed class PortabilityValidationTests
+{
+    [Fact]
+    public async Task ValidateAsync_ActivationStateReferencesMissingResourceVersion_ReturnsError()
+    {
+        await using var provider = new ServiceCollection()
+            .AddAsterCore()
+            .BuildServiceProvider();
+        var portability = provider.GetRequiredService<IResourcePortabilityService>();
+
+        var result = await portability.ValidateAsync(new PortableSnapshot
+        {
+            FormatVersion = PortableSnapshot.CurrentFormatVersion,
+            ActivationStates =
+            [
+                new ActivationState
+                {
+                    ResourceId = "missing-resource",
+                    Channel = "Published",
+                    ActiveVersions = [1],
+                    LastUpdated = DateTime.UtcNow,
+                },
+            ],
+        });
+
+        Assert.False(result.IsValid);
+        var diagnostic = Assert.Single(result.Diagnostics);
+        Assert.Equal(PortableDiagnosticCodes.MissingResourceReference, diagnostic.Code);
+        Assert.Equal(PortableDiagnosticSeverity.Error, diagnostic.Severity);
+    }
+}

--- a/test/Aster.Tests/SqliteJson/SqliteJsonPortabilityStoreTests.cs
+++ b/test/Aster.Tests/SqliteJson/SqliteJsonPortabilityStoreTests.cs
@@ -53,6 +53,43 @@ public sealed class SqliteJsonPortabilityStoreTests : IDisposable
         Assert.Equal([1, 2], activationState.ActiveVersions);
     }
 
+    [Fact]
+    public async Task ExportAsync_SpecificVersionsWithSqlite_ExportsOnlyRequestedVersion()
+    {
+        await using var provider = CreateServiceProvider();
+        var definitionStore = provider.GetRequiredService<IResourceDefinitionStore>();
+        var manager = provider.GetRequiredService<IResourceManager>();
+        var portability = provider.GetRequiredService<IResourcePortabilityService>();
+
+        await definitionStore.RegisterDefinitionAsync(new ResourceDefinitionBuilder()
+            .WithDefinitionId("Product")
+            .Build());
+        var v1 = await manager.CreateAsync("Product", new CreateResourceRequest());
+        await manager.UpdateAsync(v1.ResourceId, new UpdateResourceRequest
+        {
+            BaseVersion = v1.Version,
+        });
+
+        var result = await portability.ExportAsync(new PortableSnapshotExportRequest
+        {
+            ScopeMode = PortableExportScopeMode.SelectedResources,
+            ResourceVersionScope = PortableResourceVersionScope.SpecificVersions,
+            SpecificResourceVersions =
+            [
+                new ResourceVersionReference
+                {
+                    ResourceId = v1.ResourceId,
+                    Version = v1.Version,
+                },
+            ],
+        });
+
+        Assert.NotNull(result.Snapshot);
+        var resource = Assert.Single(result.Snapshot.Resources);
+        Assert.Equal(v1.ResourceId, resource.ResourceId);
+        Assert.Equal(v1.Version, resource.Version);
+    }
+
     private ServiceProvider CreateServiceProvider()
     {
         var services = new ServiceCollection();

--- a/test/Aster.Tests/SqliteJson/SqliteJsonPortabilityStoreTests.cs
+++ b/test/Aster.Tests/SqliteJson/SqliteJsonPortabilityStoreTests.cs
@@ -1,0 +1,92 @@
+using Aster.Core.Abstractions;
+using Aster.Core.Definitions;
+using Aster.Core.Extensions;
+using Aster.Core.Models.Instances;
+using Aster.Core.Models.Portability;
+using Aster.Persistence.SqliteJson;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Aster.Tests.SqliteJson;
+
+public sealed class SqliteJsonPortabilityStoreTests : IDisposable
+{
+    private readonly string databasePath =
+        Path.Combine(Path.GetTempPath(), $"aster-portability-{Guid.NewGuid():N}.db");
+
+    public void Dispose()
+    {
+        TryDelete(databasePath);
+        TryDelete($"{databasePath}-shm");
+        TryDelete($"{databasePath}-wal");
+    }
+
+    [Fact]
+    public async Task ExportAsync_UsesSqlitePortabilityStoreRegisteredAfterAsterCore()
+    {
+        await using var provider = CreateServiceProvider();
+        var definitionStore = provider.GetRequiredService<IResourceDefinitionStore>();
+        var manager = provider.GetRequiredService<IResourceManager>();
+        var portability = provider.GetRequiredService<IResourcePortabilityService>();
+
+        await definitionStore.RegisterDefinitionAsync(new ResourceDefinitionBuilder()
+            .WithDefinitionId("Product")
+            .Build());
+        var v1 = await manager.CreateAsync("Product", new CreateResourceRequest());
+        var v2 = await manager.UpdateAsync(v1.ResourceId, new UpdateResourceRequest
+        {
+            BaseVersion = v1.Version,
+        });
+        await UpdateActivationAsync(provider, v1.ResourceId, [v1.Version, v2.Version]);
+
+        var result = await portability.ExportAsync(new PortableSnapshotExportRequest
+        {
+            ScopeMode = PortableExportScopeMode.SelectedResources,
+            ResourceIds = [v1.ResourceId],
+            ResourceVersionScope = PortableResourceVersionScope.AllVersions,
+        });
+
+        Assert.NotNull(result.Snapshot);
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal([1, 2], result.Snapshot.Resources.Select(static resource => resource.Version).ToList());
+        Assert.Single(result.Snapshot.Definitions);
+        var activationState = Assert.Single(result.Snapshot.ActivationStates);
+        Assert.Equal([1, 2], activationState.ActiveVersions);
+    }
+
+    private ServiceProvider CreateServiceProvider()
+    {
+        var services = new ServiceCollection();
+        services.AddAsterCore();
+        services.AddAsterSqliteJson(options =>
+        {
+            options.ConnectionString = $"Data Source={databasePath}";
+        });
+
+        return services.BuildServiceProvider();
+    }
+
+    private static async Task UpdateActivationAsync(
+        IServiceProvider provider,
+        string resourceId,
+        IReadOnlyList<int> versions)
+    {
+        var writer = provider.GetRequiredService<IResourceVersionWriter>();
+        await writer.UpdateActivationAsync(resourceId, "Published", new ActivationState
+        {
+            ResourceId = resourceId,
+            Channel = "Published",
+            ActiveVersions = versions,
+            LastUpdated = DateTime.UtcNow,
+        });
+    }
+
+    private static void TryDelete(string path)
+    {
+        try
+        {
+            File.Delete(path);
+        }
+        catch (IOException) { }
+        catch (UnauthorizedAccessException) { }
+    }
+}


### PR DESCRIPTION
## Summary
- add portability service/store contracts and snapshot/result models
- register default portability service with in-memory and SQLite JSON snapshot readers
- implement explicit export scopes, definition/resource inclusion, and skipped activation diagnostics
- add in-memory and SQLite export coverage, and mark Spec Kit tasks T001-T020 complete

## Validation
- dotnet test Aster.sln
- dotnet build Aster.sln /m:1
- git diff --check
- dotnet format Aster.sln --verify-no-changes --verbosity minimal --include <changed files>