### PR TITLE
Implement strict portability import

### DIFF
--- a/specs/013-portability-primitives/contracts/portability-primitives.md
+++ b/specs/013-portability-primitives/contracts/portability-primitives.md
@@ -219,7 +219,8 @@ public enum PortableIdentityMappingReason
 {
     Preserved,
     ReusedIdentical,
-    RemappedCollision,
+    RemappedDivergent,
+    CollidedDivergent,
 }
 
 public sealed record PortableIdentityMapping

--- a/specs/013-portability-primitives/tasks.md
+++ b/specs/013-portability-primitives/tasks.md
@@ -67,19 +67,19 @@
 
 ### Tests for User Story 2
 
-- [ ] T021 [P] [US2] Add empty-store import tests in `test/Aster.Tests/Portability/PortabilityImportTests.cs`
-- [ ] T022 [P] [US2] Add identical-content no-op import tests in `test/Aster.Tests/Portability/PortabilityImportTests.cs`
-- [ ] T023 [P] [US2] Add strict divergent collision failure tests in `test/Aster.Tests/Portability/PortabilityImportTests.cs`
+- [X] T021 [P] [US2] Add empty-store import tests in `test/Aster.Tests/Portability/PortabilityImportTests.cs`
+- [X] T022 [P] [US2] Add identical-content no-op import tests in `test/Aster.Tests/Portability/PortabilityImportTests.cs`
+- [X] T023 [P] [US2] Add strict divergent collision failure tests in `test/Aster.Tests/Portability/PortabilityImportTests.cs`
 - [ ] T024 [P] [US2] Add deterministic remap import tests in `test/Aster.Tests/Portability/PortabilityImportTests.cs`
-- [ ] T025 [P] [US2] Add SQLite JSON atomic import tests in `test/Aster.Tests/SqliteJson/SqliteJsonPortabilityStoreTests.cs`
+- [X] T025 [P] [US2] Add SQLite JSON atomic import tests in `test/Aster.Tests/SqliteJson/SqliteJsonPortabilityStoreTests.cs`
 
 ### Implementation for User Story 2
 
-- [ ] T026 [US2] Implement target-state comparison in `src/core/Aster.Core/Services/ResourcePortabilityService.cs`
+- [X] T026 [US2] Implement target-state comparison in `src/core/Aster.Core/Services/ResourcePortabilityService.cs`
 - [ ] T027 [US2] Implement deterministic identity remapping in `src/core/Aster.Core/Services/ResourcePortabilityService.cs`
 - [ ] T028 [US2] Implement relationship rewrites for remapped definitions, resources, resource versions, and activation state in `src/core/Aster.Core/Services/ResourcePortabilityService.cs`
-- [ ] T029 [US2] Implement in-memory atomic import apply in `src/core/Aster.Core/InMemory/InMemoryResourceStore.cs`
-- [ ] T030 [US2] Implement SQLite JSON atomic import apply in `src/persistence/Aster.Persistence.SqliteJson/SqliteJsonResourceStore.cs`
+- [X] T029 [US2] Implement in-memory atomic import apply in `src/core/Aster.Core/InMemory/InMemoryResourceStore.cs`
+- [X] T030 [US2] Implement SQLite JSON atomic import apply in `src/persistence/Aster.Persistence.SqliteJson/SqliteJsonResourceStore.cs`
 
 **Checkpoint**: User Story 2 imports valid snapshots and rejects unsafe imports independently.
 

--- a/src/core/Aster.Core/Abstractions/IResourcePortabilityStore.cs
+++ b/src/core/Aster.Core/Abstractions/IResourcePortabilityStore.cs
@@ -13,4 +13,18 @@ public interface IResourcePortabilityStore
     ValueTask<PortableStoreSnapshot> ReadSnapshotAsync(
         PortableStoreReadRequest request,
         CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Reads existing target content that could collide with a snapshot import.
+    /// </summary>
+    ValueTask<PortableTargetState> ReadTargetStateAsync(
+        PortableSnapshot snapshot,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Applies a planned import snapshot atomically.
+    /// </summary>
+    ValueTask ApplyImportAsync(
+        PortableSnapshot plannedSnapshot,
+        CancellationToken cancellationToken = default);
 }

--- a/src/core/Aster.Core/InMemory/InMemoryPortabilityStore.cs
+++ b/src/core/Aster.Core/InMemory/InMemoryPortabilityStore.cs
@@ -109,29 +109,60 @@ public sealed class InMemoryPortabilityStore : IResourcePortabilityStore
         ArgumentNullException.ThrowIfNull(plannedSnapshot);
         cancellationToken.ThrowIfCancellationRequested();
 
-        foreach (var definition in plannedSnapshot.Definitions
-            .OrderBy(static definition => definition.DefinitionId, StringComparer.Ordinal)
-            .ThenBy(static definition => definition.Version))
-        {
-            cancellationToken.ThrowIfCancellationRequested();
-            definitionStore.ImportDefinitionVersion(definition);
-        }
+        var appliedDefinitions = new List<ResourceDefinition>();
+        var appliedResources = new List<Resource>();
+        var appliedActivationStates = new List<(ActivationState State, ActivationState? PreviousState)>();
 
-        foreach (var resource in plannedSnapshot.Resources
-            .OrderBy(static resource => resource.ResourceId, StringComparer.Ordinal)
-            .ThenBy(static resource => resource.Version))
+        try
         {
-            cancellationToken.ThrowIfCancellationRequested();
-            resourceStore.ImportVersion(resource);
-        }
+            foreach (var definition in plannedSnapshot.Definitions
+                .OrderBy(static definition => definition.DefinitionId, StringComparer.Ordinal)
+                .ThenBy(static definition => definition.Version))
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                definitionStore.ImportDefinitionVersion(definition);
+                appliedDefinitions.Add(definition);
+            }
 
-        foreach (var state in plannedSnapshot.ActivationStates
-            .OrderBy(static state => state.ResourceId, StringComparer.Ordinal)
-            .ThenBy(static state => state.Channel, StringComparer.Ordinal))
-        {
-            cancellationToken.ThrowIfCancellationRequested();
-            await resourceStore.UpdateActivationAsync(state.ResourceId, state.Channel, state, cancellationToken);
+            foreach (var resource in plannedSnapshot.Resources
+                .OrderBy(static resource => resource.ResourceId, StringComparer.Ordinal)
+                .ThenBy(static resource => resource.Version))
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                resourceStore.ImportVersion(resource);
+                appliedResources.Add(resource);
+            }
+
+            foreach (var state in plannedSnapshot.ActivationStates
+                .OrderBy(static state => state.ResourceId, StringComparer.Ordinal)
+                .ThenBy(static state => state.Channel, StringComparer.Ordinal))
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                var previous = resourceStore.GetActivationState(state.ResourceId, state.Channel);
+                await resourceStore.UpdateActivationAsync(state.ResourceId, state.Channel, state, CancellationToken.None);
+                appliedActivationStates.Add((state, previous));
+            }
         }
+        catch
+        {
+            RollBackAppliedChanges(appliedDefinitions, appliedResources, appliedActivationStates);
+            throw;
+        }
+    }
+
+    private void RollBackAppliedChanges(
+        IReadOnlyList<ResourceDefinition> appliedDefinitions,
+        IReadOnlyList<Resource> appliedResources,
+        IReadOnlyList<(ActivationState State, ActivationState? PreviousState)> appliedActivationStates)
+    {
+        foreach (var (state, previousState) in appliedActivationStates.Reverse())
+            resourceStore.RestoreActivationState(state.ResourceId, state.Channel, previousState);
+
+        foreach (var resource in appliedResources.Reverse())
+            resourceStore.RemoveImportedVersion(resource);
+
+        foreach (var definition in appliedDefinitions.Reverse())
+            definitionStore.RemoveImportedDefinitionVersion(definition);
     }
 
     private List<ResourceDefinition> SelectDefinitions(

--- a/src/core/Aster.Core/InMemory/InMemoryPortabilityStore.cs
+++ b/src/core/Aster.Core/InMemory/InMemoryPortabilityStore.cs
@@ -47,6 +47,90 @@ public sealed class InMemoryPortabilityStore : IResourcePortabilityStore
         });
     }
 
+    /// <inheritdoc />
+    public ValueTask<PortableTargetState> ReadTargetStateAsync(
+        PortableSnapshot snapshot,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(snapshot);
+
+        var definitions = new List<ResourceDefinition>();
+        foreach (var definition in snapshot.Definitions)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var existing = definitionStore.GetDefinitionVersion(definition.DefinitionId, definition.Version);
+            if (existing is not null)
+                definitions.Add(existing);
+        }
+
+        var resources = new List<Resource>();
+        foreach (var resource in snapshot.Resources)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var versions = resourceStore.TryGetVersions(resource.ResourceId);
+            if (versions is null)
+                continue;
+
+            lock (versions)
+            {
+                var existing = versions.FirstOrDefault(candidate => candidate.Version == resource.Version);
+                if (existing is not null)
+                    resources.Add(existing);
+            }
+        }
+
+        var activationStates = new List<ActivationState>();
+        foreach (var state in snapshot.ActivationStates)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            if (resourceStore.ActivationStates.TryGetValue(state.ResourceId, out var states)
+                && states.TryGetValue(state.Channel, out var existing))
+            {
+                activationStates.Add(existing);
+            }
+        }
+
+        return ValueTask.FromResult(new PortableTargetState
+        {
+            Definitions = definitions,
+            Resources = resources,
+            ActivationStates = activationStates,
+        });
+    }
+
+    /// <inheritdoc />
+    public async ValueTask ApplyImportAsync(
+        PortableSnapshot plannedSnapshot,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(plannedSnapshot);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        foreach (var definition in plannedSnapshot.Definitions
+            .OrderBy(static definition => definition.DefinitionId, StringComparer.Ordinal)
+            .ThenBy(static definition => definition.Version))
+        {
+            definitionStore.ImportDefinitionVersion(definition);
+        }
+
+        foreach (var resource in plannedSnapshot.Resources
+            .OrderBy(static resource => resource.ResourceId, StringComparer.Ordinal)
+            .ThenBy(static resource => resource.Version))
+        {
+            await resourceStore.SaveVersionAsync(resource, CancellationToken.None);
+        }
+
+        foreach (var state in plannedSnapshot.ActivationStates
+            .OrderBy(static state => state.ResourceId, StringComparer.Ordinal)
+            .ThenBy(static state => state.Channel, StringComparer.Ordinal))
+        {
+            await resourceStore.UpdateActivationAsync(state.ResourceId, state.Channel, state, CancellationToken.None);
+        }
+    }
+
     private List<ResourceDefinition> SelectDefinitions(
         PortableSnapshotExportRequest request,
         IReadOnlyCollection<Resource> resources,

--- a/src/core/Aster.Core/InMemory/InMemoryPortabilityStore.cs
+++ b/src/core/Aster.Core/InMemory/InMemoryPortabilityStore.cs
@@ -113,6 +113,7 @@ public sealed class InMemoryPortabilityStore : IResourcePortabilityStore
             .OrderBy(static definition => definition.DefinitionId, StringComparer.Ordinal)
             .ThenBy(static definition => definition.Version))
         {
+            cancellationToken.ThrowIfCancellationRequested();
             definitionStore.ImportDefinitionVersion(definition);
         }
 
@@ -120,14 +121,16 @@ public sealed class InMemoryPortabilityStore : IResourcePortabilityStore
             .OrderBy(static resource => resource.ResourceId, StringComparer.Ordinal)
             .ThenBy(static resource => resource.Version))
         {
-            await resourceStore.SaveVersionAsync(resource, CancellationToken.None);
+            cancellationToken.ThrowIfCancellationRequested();
+            resourceStore.ImportVersion(resource);
         }
 
         foreach (var state in plannedSnapshot.ActivationStates
             .OrderBy(static state => state.ResourceId, StringComparer.Ordinal)
             .ThenBy(static state => state.Channel, StringComparer.Ordinal))
         {
-            await resourceStore.UpdateActivationAsync(state.ResourceId, state.Channel, state, CancellationToken.None);
+            cancellationToken.ThrowIfCancellationRequested();
+            await resourceStore.UpdateActivationAsync(state.ResourceId, state.Channel, state, cancellationToken);
         }
     }
 

--- a/src/core/Aster.Core/InMemory/InMemoryPortabilityStore.cs
+++ b/src/core/Aster.Core/InMemory/InMemoryPortabilityStore.cs
@@ -139,7 +139,7 @@ public sealed class InMemoryPortabilityStore : IResourcePortabilityStore
             {
                 cancellationToken.ThrowIfCancellationRequested();
                 var previous = resourceStore.GetActivationState(state.ResourceId, state.Channel);
-                await resourceStore.UpdateActivationAsync(state.ResourceId, state.Channel, state, CancellationToken.None);
+                await resourceStore.UpdateActivationAsync(state.ResourceId, state.Channel, state, cancellationToken);
                 appliedActivationStates.Add((state, previous));
             }
         }

--- a/src/core/Aster.Core/InMemory/InMemoryResourceDefinitionStore.cs
+++ b/src/core/Aster.Core/InMemory/InMemoryResourceDefinitionStore.cs
@@ -120,6 +120,18 @@ public sealed partial class InMemoryResourceDefinitionStore : IResourceDefinitio
             return versions.FirstOrDefault(definition => definition.Version == version);
     }
 
+    /// <summary>
+    /// Imports an exact definition version.
+    /// </summary>
+    internal void ImportDefinitionVersion(ResourceDefinition definition)
+    {
+        ArgumentNullException.ThrowIfNull(definition);
+
+        var versions = definitions.GetOrAdd(definition.DefinitionId, _ => []);
+        lock (versions)
+            versions.Add(definition);
+    }
+
     // ──────────────────────────────────────────────────────────────────────────
     // Structured log methods (source generated)
     // ──────────────────────────────────────────────────────────────────────────

--- a/src/core/Aster.Core/InMemory/InMemoryResourceDefinitionStore.cs
+++ b/src/core/Aster.Core/InMemory/InMemoryResourceDefinitionStore.cs
@@ -141,6 +141,22 @@ public sealed partial class InMemoryResourceDefinitionStore : IResourceDefinitio
         }
     }
 
+    /// <summary>
+    /// Removes an imported definition version during rollback.
+    /// </summary>
+    internal void RemoveImportedDefinitionVersion(ResourceDefinition definition)
+    {
+        ArgumentNullException.ThrowIfNull(definition);
+
+        if (!definitions.TryGetValue(definition.DefinitionId, out var versions))
+            return;
+
+        lock (versions)
+            versions.RemoveAll(existing =>
+                existing.Version == definition.Version
+                && string.Equals(existing.Id, definition.Id, StringComparison.Ordinal));
+    }
+
     // ──────────────────────────────────────────────────────────────────────────
     // Structured log methods (source generated)
     // ──────────────────────────────────────────────────────────────────────────

--- a/src/core/Aster.Core/InMemory/InMemoryResourceDefinitionStore.cs
+++ b/src/core/Aster.Core/InMemory/InMemoryResourceDefinitionStore.cs
@@ -66,7 +66,7 @@ public sealed partial class InMemoryResourceDefinitionStore : IResourceDefinitio
 
         lock (versions)
         {
-            int nextVersion = versions.Count + 1;
+            int nextVersion = versions.Count > 0 ? versions[^1].Version + 1 : 1;
             var versionedDefinition = definition with { Version = nextVersion };
             versions.Add(versionedDefinition);
             LogDefinitionRegistered(definition.DefinitionId, nextVersion);

--- a/src/core/Aster.Core/InMemory/InMemoryResourceDefinitionStore.cs
+++ b/src/core/Aster.Core/InMemory/InMemoryResourceDefinitionStore.cs
@@ -129,7 +129,16 @@ public sealed partial class InMemoryResourceDefinitionStore : IResourceDefinitio
 
         var versions = definitions.GetOrAdd(definition.DefinitionId, _ => []);
         lock (versions)
-            versions.Add(definition);
+        {
+            var insertIndex = versions.FindIndex(existing => existing.Version >= definition.Version);
+            if (insertIndex >= 0 && versions[insertIndex].Version == definition.Version)
+                throw new InvalidOperationException($"Definition '{definition.DefinitionId}' version {definition.Version} already exists.");
+
+            if (insertIndex < 0)
+                versions.Add(definition);
+            else
+                versions.Insert(insertIndex, definition);
+        }
     }
 
     // ──────────────────────────────────────────────────────────────────────────

--- a/src/core/Aster.Core/InMemory/InMemoryResourceStore.cs
+++ b/src/core/Aster.Core/InMemory/InMemoryResourceStore.cs
@@ -66,6 +66,58 @@ public sealed class InMemoryResourceStore : IResourceVersionReader, IResourceVer
         }
     }
 
+    /// <summary>
+    /// Removes an imported resource version during rollback.
+    /// </summary>
+    internal void RemoveImportedVersion(Resource resource)
+    {
+        ArgumentNullException.ThrowIfNull(resource);
+
+        if (!Versions.TryGetValue(resource.ResourceId, out var versions))
+            return;
+
+        lock (versions)
+            versions.RemoveAll(existing =>
+                existing.Version == resource.Version
+                && string.Equals(existing.Id, resource.Id, StringComparison.Ordinal));
+    }
+
+    /// <summary>
+    /// Returns the persisted activation state for a resource/channel pair.
+    /// </summary>
+    internal ActivationState? GetActivationState(string resourceId, string channel) =>
+        ActivationStates.TryGetValue(resourceId, out var states)
+        && states.TryGetValue(channel, out var state)
+            ? state
+            : null;
+
+    /// <summary>
+    /// Restores a persisted activation state, or removes it when <paramref name="state"/> is <see langword="null"/>.
+    /// </summary>
+    internal void RestoreActivationState(string resourceId, string channel, ActivationState? state)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(resourceId);
+        ArgumentException.ThrowIfNullOrWhiteSpace(channel);
+
+        var channelActivations = GetOrAddActivations(resourceId);
+        lock (channelActivations)
+        {
+            if (state is null)
+                channelActivations.TryRemove(channel, out _);
+            else
+                channelActivations[channel] = state.ActiveVersions.ToHashSet();
+        }
+
+        var states = ActivationStates.GetOrAdd(
+            resourceId,
+            _ => new ConcurrentDictionary<string, ActivationState>(StringComparer.Ordinal));
+
+        if (state is null)
+            states.Remove(channel, out _);
+        else
+            states[channel] = state;
+    }
+
     /// <inheritdoc />
     public ValueTask<IEnumerable<Resource>> ReadVersionsAsync(
         ResourceVersionReadRequest request,

--- a/src/core/Aster.Core/InMemory/InMemoryResourceStore.cs
+++ b/src/core/Aster.Core/InMemory/InMemoryResourceStore.cs
@@ -45,6 +45,27 @@ public sealed class InMemoryResourceStore : IResourceVersionReader, IResourceVer
     internal ConcurrentDictionary<string, HashSet<int>> GetOrAddActivations(string resourceId) =>
         Activations.GetOrAdd(resourceId, _ => new ConcurrentDictionary<string, HashSet<int>>(StringComparer.Ordinal));
 
+    /// <summary>
+    /// Imports an exact resource version while preserving version ordering.
+    /// </summary>
+    internal void ImportVersion(Resource resource)
+    {
+        ArgumentNullException.ThrowIfNull(resource);
+
+        var versions = Versions.GetOrAdd(resource.ResourceId, _ => []);
+        lock (versions)
+        {
+            var insertIndex = versions.FindIndex(existing => existing.Version >= resource.Version);
+            if (insertIndex >= 0 && versions[insertIndex].Version == resource.Version)
+                throw new InvalidOperationException($"Resource '{resource.ResourceId}' version {resource.Version} already exists.");
+
+            if (insertIndex < 0)
+                versions.Add(resource);
+            else
+                versions.Insert(insertIndex, resource);
+        }
+    }
+
     /// <inheritdoc />
     public ValueTask<IEnumerable<Resource>> ReadVersionsAsync(
         ResourceVersionReadRequest request,

--- a/src/core/Aster.Core/InMemory/InMemoryResourceStore.cs
+++ b/src/core/Aster.Core/InMemory/InMemoryResourceStore.cs
@@ -113,7 +113,7 @@ public sealed class InMemoryResourceStore : IResourceVersionReader, IResourceVer
             _ => new ConcurrentDictionary<string, ActivationState>(StringComparer.Ordinal));
 
         if (state is null)
-            states.Remove(channel, out _);
+            states.TryRemove(channel, out _);
         else
             states[channel] = state;
     }

--- a/src/core/Aster.Core/Models/Portability/PortableDiagnostic.cs
+++ b/src/core/Aster.Core/Models/Portability/PortableDiagnostic.cs
@@ -96,4 +96,9 @@ public static class PortableDiagnosticCodes
     /// RemapDivergent import handling is not implemented yet.
     /// </summary>
     public const string RemapDivergentNotImplemented = "remap-divergent-not-implemented";
+
+    /// <summary>
+    /// Planned import writes failed during provider apply.
+    /// </summary>
+    public const string ImportApplyFailed = "import-apply-failed";
 }

--- a/src/core/Aster.Core/Models/Portability/PortableDiagnostic.cs
+++ b/src/core/Aster.Core/Models/Portability/PortableDiagnostic.cs
@@ -78,6 +78,16 @@ public static class PortableDiagnosticCodes
     public const string MissingResourceReference = "missing-resource-reference";
 
     /// <summary>
+    /// Snapshot contains duplicate identities.
+    /// </summary>
+    public const string DuplicateSnapshotIdentity = "duplicate-snapshot-identity";
+
+    /// <summary>
+    /// Snapshot content collides with divergent target content.
+    /// </summary>
+    public const string DivergentIdentityCollision = "divergent-identity-collision";
+
+    /// <summary>
     /// Import behavior is not implemented yet.
     /// </summary>
     public const string ImportNotImplemented = "import-not-implemented";

--- a/src/core/Aster.Core/Models/Portability/PortableDiagnostic.cs
+++ b/src/core/Aster.Core/Models/Portability/PortableDiagnostic.cs
@@ -91,4 +91,9 @@ public static class PortableDiagnosticCodes
     /// Import behavior is not implemented yet.
     /// </summary>
     public const string ImportNotImplemented = "import-not-implemented";
+
+    /// <summary>
+    /// RemapDivergent import handling is not implemented yet.
+    /// </summary>
+    public const string RemapDivergentNotImplemented = "remap-divergent-not-implemented";
 }

--- a/src/core/Aster.Core/Models/Portability/PortableImportModels.cs
+++ b/src/core/Aster.Core/Models/Portability/PortableImportModels.cs
@@ -135,6 +135,9 @@ public enum PortableIdentityMappingReason
 
     /// <summary>Identity was remapped to avoid a divergent collision.</summary>
     RemappedDivergent,
+
+    /// <summary>Identity collided with existing divergent content.</summary>
+    CollidedDivergent,
 }
 
 /// <summary>

--- a/src/core/Aster.Core/Services/ResourcePortabilityService.cs
+++ b/src/core/Aster.Core/Services/ResourcePortabilityService.cs
@@ -180,6 +180,8 @@ public sealed class ResourcePortabilityService : IResourcePortabilityService
         var existingDefinitions = targetState.Definitions.ToDictionary(static definition => (definition.DefinitionId, definition.Version));
         foreach (var definition in snapshot.Definitions)
         {
+            cancellationToken.ThrowIfCancellationRequested();
+
             var key = (definition.DefinitionId, definition.Version);
             if (!existingDefinitions.TryGetValue(key, out var existing))
             {
@@ -205,6 +207,8 @@ public sealed class ResourcePortabilityService : IResourcePortabilityService
         var existingResources = targetState.Resources.ToDictionary(static resource => (resource.ResourceId, resource.Version));
         foreach (var resource in snapshot.Resources)
         {
+            cancellationToken.ThrowIfCancellationRequested();
+
             var key = (resource.ResourceId, resource.Version);
             if (!existingResources.TryGetValue(key, out var existing))
             {
@@ -230,6 +234,8 @@ public sealed class ResourcePortabilityService : IResourcePortabilityService
         var existingActivationStates = targetState.ActivationStates.ToDictionary(static state => (state.ResourceId, state.Channel));
         foreach (var state in snapshot.ActivationStates)
         {
+            cancellationToken.ThrowIfCancellationRequested();
+
             var key = (state.ResourceId, state.Channel);
             if (!existingActivationStates.TryGetValue(key, out var existing))
             {
@@ -554,13 +560,13 @@ public sealed class ResourcePortabilityService : IResourcePortabilityService
         };
 
     private static string DefinitionVersionId(ResourceDefinition definition) =>
-        $"{definition.DefinitionId}:{definition.Version}";
+        JsonSerializer.Serialize(new object[] { definition.DefinitionId, definition.Version }, JsonOptions);
 
     private static string ResourceVersionId(Resource resource) =>
-        $"{resource.ResourceId}:{resource.Version}";
+        JsonSerializer.Serialize(new object[] { resource.ResourceId, resource.Version }, JsonOptions);
 
     private static string ActivationEntryId(ActivationState state) =>
-        $"{state.ResourceId}:{state.Channel}";
+        JsonSerializer.Serialize(new object[] { state.ResourceId, state.Channel }, JsonOptions);
 
     private sealed record ImportPlan(
         PortableSnapshot PlannedSnapshot,

--- a/src/core/Aster.Core/Services/ResourcePortabilityService.cs
+++ b/src/core/Aster.Core/Services/ResourcePortabilityService.cs
@@ -123,7 +123,31 @@ public sealed class ResourcePortabilityService : IResourcePortabilityService
         }
 
         if (plan.HasWrites)
-            await portabilityStore.ApplyImportAsync(plan.PlannedSnapshot, cancellationToken);
+        {
+            try
+            {
+                await portabilityStore.ApplyImportAsync(plan.PlannedSnapshot, cancellationToken);
+            }
+            catch (Exception exception) when (exception is not OperationCanceledException)
+            {
+                return new PortableImportResult
+                {
+                    Status = PortableImportStatus.Failed,
+                    Counts = new PortableActualImportCounts(),
+                    IdentityMap = plan.IdentityMap,
+                    Diagnostics =
+                    [
+                        .. plan.Diagnostics,
+                        new PortableDiagnostic
+                        {
+                            Code = PortableDiagnosticCodes.ImportApplyFailed,
+                            Severity = PortableDiagnosticSeverity.Error,
+                            Message = $"Import apply failed after planning completed: {exception.Message}",
+                        },
+                    ],
+                };
+            }
+        }
 
         return new PortableImportResult
         {

--- a/src/core/Aster.Core/Services/ResourcePortabilityService.cs
+++ b/src/core/Aster.Core/Services/ResourcePortabilityService.cs
@@ -473,7 +473,7 @@ public sealed class ResourcePortabilityService : IResourcePortabilityService
         string.Equals(left.ResourceId, right.ResourceId, StringComparison.Ordinal)
         && string.Equals(left.Channel, right.Channel, StringComparison.Ordinal)
         && left.LastUpdated == right.LastUpdated
-        && left.ActiveVersions.Order().SequenceEqual(right.ActiveVersions.Order());
+        && left.ActiveVersions.Distinct().Order().SequenceEqual(right.ActiveVersions.Distinct().Order());
 
     private static bool DictionaryContentEquals<TValue>(
         IReadOnlyDictionary<string, TValue> left,

--- a/src/core/Aster.Core/Services/ResourcePortabilityService.cs
+++ b/src/core/Aster.Core/Services/ResourcePortabilityService.cs
@@ -385,7 +385,7 @@ public sealed class ResourcePortabilityService : IResourcePortabilityService
             "Snapshot contains duplicate resource version identities."));
         diagnostics.AddRange(FindDuplicateKeys(
             snapshot.Resources.Select(static resource => resource.Id),
-            "resources",
+            "resources/id",
             "Snapshot contains duplicate version-specific resource IDs."));
         diagnostics.AddRange(FindDuplicateKeys(
             snapshot.ActivationStates.Select(static state => ActivationEntryId(state)),

--- a/src/core/Aster.Core/Services/ResourcePortabilityService.cs
+++ b/src/core/Aster.Core/Services/ResourcePortabilityService.cs
@@ -526,8 +526,18 @@ public sealed class ResourcePortabilityService : IResourcePortabilityService
 
     private static bool JsonContentEquals<T>(T left, T right)
     {
-        var leftNode = JsonSerializer.SerializeToNode(left, JsonOptions);
-        var rightNode = JsonSerializer.SerializeToNode(right, JsonOptions);
+        JsonNode? leftNode;
+        JsonNode? rightNode;
+
+        try
+        {
+            leftNode = JsonSerializer.SerializeToNode(left, JsonOptions);
+            rightNode = JsonSerializer.SerializeToNode(right, JsonOptions);
+        }
+        catch (Exception ex) when (ex is JsonException or NotSupportedException)
+        {
+            return false;
+        }
 
         return JsonNode.DeepEquals(leftNode, rightNode);
     }

--- a/src/core/Aster.Core/Services/ResourcePortabilityService.cs
+++ b/src/core/Aster.Core/Services/ResourcePortabilityService.cs
@@ -1,4 +1,6 @@
+using System.Text.Json;
 using Aster.Core.Abstractions;
+using Aster.Core.Models.Definitions;
 using Aster.Core.Models.Instances;
 using Aster.Core.Models.Portability;
 
@@ -9,6 +11,8 @@ namespace Aster.Core.Services;
 /// </summary>
 public sealed class ResourcePortabilityService : IResourcePortabilityService
 {
+    private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web);
+
     private readonly IResourcePortabilityStore portabilityStore;
 
     /// <summary>
@@ -78,53 +82,181 @@ public sealed class ResourcePortabilityService : IResourcePortabilityService
     }
 
     /// <inheritdoc />
-    public ValueTask<PortableImportPreview> PreviewImportAsync(
+    public async ValueTask<PortableImportPreview> PreviewImportAsync(
         PortableSnapshot snapshot,
         PortableImportOptions? options = null,
         CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(snapshot);
-        cancellationToken.ThrowIfCancellationRequested();
+        options ??= new PortableImportOptions();
 
-        return ValueTask.FromResult(new PortableImportPreview
+        var plan = await BuildImportPlanAsync(snapshot, options, cancellationToken);
+        return new PortableImportPreview
         {
-            CanImport = false,
-            Counts = new PortablePlannedImportCounts(),
-            Diagnostics =
-            [
-                new PortableDiagnostic
-                {
-                    Code = PortableDiagnosticCodes.ImportNotImplemented,
-                    Severity = PortableDiagnosticSeverity.Error,
-                    Message = "Snapshot import preview is not implemented in this export-focused slice.",
-                },
-            ],
-        });
+            CanImport = plan.Diagnostics.All(static diagnostic => diagnostic.Severity != PortableDiagnosticSeverity.Error),
+            Counts = plan.PlannedCounts,
+            IdentityMap = plan.IdentityMap,
+            Diagnostics = plan.Diagnostics,
+        };
     }
 
     /// <inheritdoc />
-    public ValueTask<PortableImportResult> ImportAsync(
+    public async ValueTask<PortableImportResult> ImportAsync(
         PortableSnapshot snapshot,
         PortableImportOptions? options = null,
         CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(snapshot);
+        options ??= new PortableImportOptions();
+
+        var plan = await BuildImportPlanAsync(snapshot, options, cancellationToken);
+        if (plan.Diagnostics.Any(static diagnostic => diagnostic.Severity == PortableDiagnosticSeverity.Error))
+        {
+            return new PortableImportResult
+            {
+                Status = PortableImportStatus.Failed,
+                Counts = new PortableActualImportCounts(),
+                IdentityMap = plan.IdentityMap,
+                Diagnostics = plan.Diagnostics,
+            };
+        }
+
+        if (plan.HasWrites)
+            await portabilityStore.ApplyImportAsync(plan.PlannedSnapshot, cancellationToken);
+
+        return new PortableImportResult
+        {
+            Status = plan.HasWrites ? PortableImportStatus.Imported : PortableImportStatus.NoOp,
+            Counts = plan.ActualCounts,
+            IdentityMap = plan.IdentityMap,
+            Diagnostics = plan.Diagnostics,
+        };
+    }
+
+    private async ValueTask<ImportPlan> BuildImportPlanAsync(
+        PortableSnapshot snapshot,
+        PortableImportOptions options,
+        CancellationToken cancellationToken)
+    {
         cancellationToken.ThrowIfCancellationRequested();
 
-        return ValueTask.FromResult(new PortableImportResult
+        var diagnostics = ValidateSnapshot(snapshot);
+        diagnostics.AddRange(ValidateSnapshotIdentityUniqueness(snapshot));
+        if (diagnostics.Any(static diagnostic => diagnostic.Severity == PortableDiagnosticSeverity.Error))
+            return ImportPlan.Failed(diagnostics);
+
+        var targetState = await portabilityStore.ReadTargetStateAsync(snapshot, cancellationToken);
+        var plannedDefinitions = new List<ResourceDefinition>();
+        var plannedResources = new List<Resource>();
+        var plannedActivationStates = new List<ActivationState>();
+        var identityMap = new List<PortableIdentityMapping>();
+        var reusedIdenticalItems = 0;
+
+        var existingDefinitions = targetState.Definitions.ToDictionary(static definition => (definition.DefinitionId, definition.Version));
+        foreach (var definition in snapshot.Definitions)
         {
-            Status = PortableImportStatus.Failed,
-            Counts = new PortableActualImportCounts(),
-            Diagnostics =
-            [
-                new PortableDiagnostic
-                {
-                    Code = PortableDiagnosticCodes.ImportNotImplemented,
-                    Severity = PortableDiagnosticSeverity.Error,
-                    Message = "Snapshot import is not implemented in this export-focused slice.",
-                },
-            ],
-        });
+            var key = (definition.DefinitionId, definition.Version);
+            if (!existingDefinitions.TryGetValue(key, out var existing))
+            {
+                plannedDefinitions.Add(definition);
+                identityMap.Add(Preserved(PortableEntityKind.DefinitionVersion, DefinitionVersionId(definition)));
+                continue;
+            }
+
+            if (ContentEquals(definition, existing))
+            {
+                reusedIdenticalItems++;
+                identityMap.Add(Reused(PortableEntityKind.DefinitionVersion, DefinitionVersionId(definition)));
+                continue;
+            }
+
+            diagnostics.Add(DivergentCollision(
+                $"definitions/{definition.DefinitionId}/{definition.Version}",
+                $"Definition '{definition.DefinitionId}' version {definition.Version} already exists with different content.",
+                options.CollisionMode));
+        }
+
+        var existingResources = targetState.Resources.ToDictionary(static resource => (resource.ResourceId, resource.Version));
+        foreach (var resource in snapshot.Resources)
+        {
+            var key = (resource.ResourceId, resource.Version);
+            if (!existingResources.TryGetValue(key, out var existing))
+            {
+                plannedResources.Add(resource);
+                identityMap.Add(Preserved(PortableEntityKind.ResourceVersion, ResourceVersionId(resource)));
+                continue;
+            }
+
+            if (ContentEquals(resource, existing))
+            {
+                reusedIdenticalItems++;
+                identityMap.Add(Reused(PortableEntityKind.ResourceVersion, ResourceVersionId(resource)));
+                continue;
+            }
+
+            diagnostics.Add(DivergentCollision(
+                $"resources/{resource.ResourceId}/{resource.Version}",
+                $"Resource '{resource.ResourceId}' version {resource.Version} already exists with different content.",
+                options.CollisionMode));
+        }
+
+        var existingActivationStates = targetState.ActivationStates.ToDictionary(static state => (state.ResourceId, state.Channel));
+        foreach (var state in snapshot.ActivationStates)
+        {
+            var key = (state.ResourceId, state.Channel);
+            if (!existingActivationStates.TryGetValue(key, out var existing))
+            {
+                plannedActivationStates.Add(state);
+                identityMap.Add(Preserved(PortableEntityKind.ActivationEntry, ActivationEntryId(state)));
+                continue;
+            }
+
+            if (ContentEquals(state, existing))
+            {
+                reusedIdenticalItems++;
+                identityMap.Add(Reused(PortableEntityKind.ActivationEntry, ActivationEntryId(state)));
+                continue;
+            }
+
+            diagnostics.Add(DivergentCollision(
+                $"activationStates/{state.ResourceId}/{state.Channel}",
+                $"Activation state for resource '{state.ResourceId}' channel '{state.Channel}' already exists with different content.",
+                options.CollisionMode));
+        }
+
+        if (diagnostics.Any(static diagnostic => diagnostic.Severity == PortableDiagnosticSeverity.Error))
+            return ImportPlan.Failed(diagnostics, identityMap);
+
+        var plannedSnapshot = new PortableSnapshot
+        {
+            FormatVersion = PortableSnapshot.CurrentFormatVersion,
+            Definitions = plannedDefinitions,
+            Resources = plannedResources,
+            ActivationStates = plannedActivationStates,
+        };
+        var plannedCounts = new PortablePlannedImportCounts
+        {
+            Definitions = plannedDefinitions.Count,
+            Resources = plannedResources.Select(static resource => resource.ResourceId).Distinct(StringComparer.Ordinal).Count(),
+            ResourceVersions = plannedResources.Count,
+            ActivationEntries = plannedActivationStates.Count,
+            ReusedIdenticalItems = reusedIdenticalItems,
+        };
+        var actualCounts = new PortableActualImportCounts
+        {
+            Definitions = plannedCounts.Definitions,
+            Resources = plannedCounts.Resources,
+            ResourceVersions = plannedCounts.ResourceVersions,
+            ActivationEntries = plannedCounts.ActivationEntries,
+            ReusedIdenticalItems = plannedCounts.ReusedIdenticalItems,
+        };
+
+        return new ImportPlan(
+            plannedSnapshot,
+            plannedCounts,
+            actualCounts,
+            identityMap,
+            diagnostics);
     }
 
     private static List<PortableDiagnostic> ValidateExportRequest(PortableSnapshotExportRequest request)
@@ -238,6 +370,65 @@ public sealed class ResourcePortabilityService : IResourcePortabilityService
         return diagnostics;
     }
 
+    private static List<PortableDiagnostic> ValidateSnapshotIdentityUniqueness(PortableSnapshot snapshot)
+    {
+        var diagnostics = new List<PortableDiagnostic>();
+
+        diagnostics.AddRange(FindDuplicateKeys(
+            snapshot.Definitions.Select(static definition => DefinitionVersionId(definition)),
+            "definitions",
+            "Snapshot contains duplicate definition version identities."));
+        diagnostics.AddRange(FindDuplicateKeys(
+            snapshot.Resources.Select(static resource => ResourceVersionId(resource)),
+            "resources",
+            "Snapshot contains duplicate resource version identities."));
+        diagnostics.AddRange(FindDuplicateKeys(
+            snapshot.Resources.Select(static resource => resource.Id),
+            "resources",
+            "Snapshot contains duplicate version-specific resource IDs."));
+        diagnostics.AddRange(FindDuplicateKeys(
+            snapshot.ActivationStates.Select(static state => ActivationEntryId(state)),
+            "activationStates",
+            "Snapshot contains duplicate activation state identities."));
+
+        return diagnostics;
+    }
+
+    private static IEnumerable<PortableDiagnostic> FindDuplicateKeys(
+        IEnumerable<string> keys,
+        string path,
+        string message) =>
+        keys
+            .GroupBy(static key => key, StringComparer.Ordinal)
+            .Where(static group => group.Count() > 1)
+            .Select(group => new PortableDiagnostic
+            {
+                Code = PortableDiagnosticCodes.DuplicateSnapshotIdentity,
+                Severity = PortableDiagnosticSeverity.Error,
+                Path = $"{path}/{group.Key}",
+                Message = $"{message} Duplicate key: '{group.Key}'.",
+            });
+
+    private static PortableDiagnostic DivergentCollision(
+        string path,
+        string message,
+        PortableImportCollisionMode collisionMode) =>
+        collisionMode == PortableImportCollisionMode.Strict
+            ? new PortableDiagnostic
+            {
+                Code = PortableDiagnosticCodes.DivergentIdentityCollision,
+                Severity = PortableDiagnosticSeverity.Error,
+                Path = path,
+                Message = message,
+            }
+            : new PortableDiagnostic
+            {
+                Code = PortableDiagnosticCodes.ImportNotImplemented,
+                Severity = PortableDiagnosticSeverity.Error,
+                Path = path,
+                Message = $"{message} RemapDivergent import is planned for the next import slice.",
+            };
+
     private static PortableDiagnostic InvalidExportScope(string path, string message) =>
         new()
         {
@@ -246,4 +437,60 @@ public sealed class ResourcePortabilityService : IResourcePortabilityService
             Path = path,
             Message = message,
         };
+
+    private static bool ContentEquals<T>(T left, T right) =>
+        string.Equals(
+            JsonSerializer.Serialize(left, JsonOptions),
+            JsonSerializer.Serialize(right, JsonOptions),
+            StringComparison.Ordinal);
+
+    private static PortableIdentityMapping Preserved(PortableEntityKind entityKind, string id) =>
+        new()
+        {
+            EntityKind = entityKind,
+            SourceId = id,
+            TargetId = id,
+            Reason = PortableIdentityMappingReason.Preserved,
+        };
+
+    private static PortableIdentityMapping Reused(PortableEntityKind entityKind, string id) =>
+        new()
+        {
+            EntityKind = entityKind,
+            SourceId = id,
+            TargetId = id,
+            Reason = PortableIdentityMappingReason.ReusedIdentical,
+        };
+
+    private static string DefinitionVersionId(ResourceDefinition definition) =>
+        $"{definition.DefinitionId}:{definition.Version}";
+
+    private static string ResourceVersionId(Resource resource) =>
+        $"{resource.ResourceId}:{resource.Version}";
+
+    private static string ActivationEntryId(ActivationState state) =>
+        $"{state.ResourceId}:{state.Channel}";
+
+    private sealed record ImportPlan(
+        PortableSnapshot PlannedSnapshot,
+        PortablePlannedImportCounts PlannedCounts,
+        PortableActualImportCounts ActualCounts,
+        IReadOnlyList<PortableIdentityMapping> IdentityMap,
+        IReadOnlyList<PortableDiagnostic> Diagnostics)
+    {
+        public bool HasWrites =>
+            PlannedCounts.Definitions > 0
+            || PlannedCounts.ResourceVersions > 0
+            || PlannedCounts.ActivationEntries > 0;
+
+        public static ImportPlan Failed(
+            IReadOnlyList<PortableDiagnostic> diagnostics,
+            IReadOnlyList<PortableIdentityMapping>? identityMap = null) =>
+            new(
+                new PortableSnapshot { FormatVersion = PortableSnapshot.CurrentFormatVersion },
+                new PortablePlannedImportCounts(),
+                new PortableActualImportCounts(),
+                identityMap ?? [],
+                diagnostics);
+    }
 }

--- a/src/core/Aster.Core/Services/ResourcePortabilityService.cs
+++ b/src/core/Aster.Core/Services/ResourcePortabilityService.cs
@@ -171,6 +171,7 @@ public sealed class ResourcePortabilityService : IResourcePortabilityService
                 continue;
             }
 
+            identityMap.Add(Collided(PortableEntityKind.DefinitionVersion, DefinitionVersionId(definition)));
             diagnostics.Add(DivergentCollision(
                 $"definitions/{definition.DefinitionId}/{definition.Version}",
                 $"Definition '{definition.DefinitionId}' version {definition.Version} already exists with different content.",
@@ -195,6 +196,7 @@ public sealed class ResourcePortabilityService : IResourcePortabilityService
                 continue;
             }
 
+            identityMap.Add(Collided(PortableEntityKind.ResourceVersion, ResourceVersionId(resource)));
             diagnostics.Add(DivergentCollision(
                 $"resources/{resource.ResourceId}/{resource.Version}",
                 $"Resource '{resource.ResourceId}' version {resource.Version} already exists with different content.",
@@ -219,6 +221,7 @@ public sealed class ResourcePortabilityService : IResourcePortabilityService
                 continue;
             }
 
+            identityMap.Add(Collided(PortableEntityKind.ActivationEntry, ActivationEntryId(state)));
             diagnostics.Add(DivergentCollision(
                 $"activationStates/{state.ResourceId}/{state.Channel}",
                 $"Activation state for resource '{state.ResourceId}' channel '{state.Channel}' already exists with different content.",
@@ -515,6 +518,15 @@ public sealed class ResourcePortabilityService : IResourcePortabilityService
             SourceId = id,
             TargetId = id,
             Reason = PortableIdentityMappingReason.ReusedIdentical,
+        };
+
+    private static PortableIdentityMapping Collided(PortableEntityKind entityKind, string id) =>
+        new()
+        {
+            EntityKind = entityKind,
+            SourceId = id,
+            TargetId = id,
+            Reason = PortableIdentityMappingReason.CollidedDivergent,
         };
 
     private static string DefinitionVersionId(ResourceDefinition definition) =>

--- a/src/core/Aster.Core/Services/ResourcePortabilityService.cs
+++ b/src/core/Aster.Core/Services/ResourcePortabilityService.cs
@@ -1,4 +1,5 @@
 using System.Text.Json;
+using System.Text.Json.Nodes;
 using Aster.Core.Abstractions;
 using Aster.Core.Models.Definitions;
 using Aster.Core.Models.Instances;
@@ -423,7 +424,7 @@ public sealed class ResourcePortabilityService : IResourcePortabilityService
             }
             : new PortableDiagnostic
             {
-                Code = PortableDiagnosticCodes.ImportNotImplemented,
+                Code = PortableDiagnosticCodes.RemapDivergentNotImplemented,
                 Severity = PortableDiagnosticSeverity.Error,
                 Path = path,
                 Message = $"{message} RemapDivergent import is planned for the next import slice.",
@@ -439,10 +440,64 @@ public sealed class ResourcePortabilityService : IResourcePortabilityService
         };
 
     private static bool ContentEquals<T>(T left, T right) =>
-        string.Equals(
-            JsonSerializer.Serialize(left, JsonOptions),
-            JsonSerializer.Serialize(right, JsonOptions),
-            StringComparison.Ordinal);
+        (left, right) switch
+        {
+            (ResourceDefinition leftDefinition, ResourceDefinition rightDefinition) => ContentEquals(leftDefinition, rightDefinition),
+            (Resource leftResource, Resource rightResource) => ContentEquals(leftResource, rightResource),
+            (ActivationState leftState, ActivationState rightState) => ContentEquals(leftState, rightState),
+            _ => JsonContentEquals(left, right),
+        };
+
+    private static bool ContentEquals(ResourceDefinition left, ResourceDefinition right) =>
+        string.Equals(left.DefinitionId, right.DefinitionId, StringComparison.Ordinal)
+        && string.Equals(left.Id, right.Id, StringComparison.Ordinal)
+        && left.Version == right.Version
+        && left.IsSingleton == right.IsSingleton
+        && DictionaryContentEquals(left.AspectDefinitions, right.AspectDefinitions);
+
+    private static bool ContentEquals(Resource left, Resource right) =>
+        string.Equals(left.ResourceId, right.ResourceId, StringComparison.Ordinal)
+        && string.Equals(left.Id, right.Id, StringComparison.Ordinal)
+        && string.Equals(left.DefinitionId, right.DefinitionId, StringComparison.Ordinal)
+        && left.DefinitionVersion == right.DefinitionVersion
+        && left.Version == right.Version
+        && left.Created == right.Created
+        && string.Equals(left.Owner, right.Owner, StringComparison.Ordinal)
+        && string.Equals(left.Hash, right.Hash, StringComparison.Ordinal)
+        && DictionaryContentEquals(left.Aspects, right.Aspects);
+
+    private static bool ContentEquals(ActivationState left, ActivationState right) =>
+        string.Equals(left.ResourceId, right.ResourceId, StringComparison.Ordinal)
+        && string.Equals(left.Channel, right.Channel, StringComparison.Ordinal)
+        && left.LastUpdated == right.LastUpdated
+        && left.ActiveVersions.Order().SequenceEqual(right.ActiveVersions.Order());
+
+    private static bool DictionaryContentEquals<TValue>(
+        IReadOnlyDictionary<string, TValue> left,
+        IReadOnlyDictionary<string, TValue> right)
+    {
+        if (left.Count != right.Count)
+            return false;
+
+        foreach (var (key, leftValue) in left.OrderBy(static pair => pair.Key, StringComparer.Ordinal))
+        {
+            if (!right.TryGetValue(key, out var rightValue))
+                return false;
+
+            if (!JsonContentEquals(leftValue, rightValue))
+                return false;
+        }
+
+        return true;
+    }
+
+    private static bool JsonContentEquals<T>(T left, T right)
+    {
+        var leftNode = JsonSerializer.SerializeToNode(left, JsonOptions);
+        var rightNode = JsonSerializer.SerializeToNode(right, JsonOptions);
+
+        return JsonNode.DeepEquals(leftNode, rightNode);
+    }
 
     private static PortableIdentityMapping Preserved(PortableEntityKind entityKind, string id) =>
         new()

--- a/src/persistence/Aster.Persistence.SqliteJson/SqliteJsonResourceStore.cs
+++ b/src/persistence/Aster.Persistence.SqliteJson/SqliteJsonResourceStore.cs
@@ -90,7 +90,7 @@ public sealed class SqliteJsonResourceStore :
         ArgumentNullException.ThrowIfNull(definition);
 
         await using var connection = await OpenConnectionAsync(cancellationToken);
-        await using var transaction = await connection.BeginTransactionAsync(cancellationToken);
+        await using var transaction = (SqliteTransaction)await connection.BeginTransactionAsync(cancellationToken);
 
         var nextVersion = await GetNextDefinitionVersionAsync(connection, definition.DefinitionId, cancellationToken);
         var versionedDefinition = definition with { Version = nextVersion };
@@ -256,6 +256,72 @@ public sealed class SqliteJsonResourceStore :
         };
     }
 
+    /// <inheritdoc />
+    public async ValueTask<PortableTargetState> ReadTargetStateAsync(
+        PortableSnapshot snapshot,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(snapshot);
+
+        var definitions = await ReadTargetDefinitionVersionsAsync(snapshot, cancellationToken);
+        var resources = await ReadSpecificResourceVersionsAsync(
+            snapshot.Resources
+                .Select(static resource => new ResourceVersionReference
+                {
+                    ResourceId = resource.ResourceId,
+                    Version = resource.Version,
+                })
+                .ToHashSet(),
+            cancellationToken);
+        var activationStates = await ReadScopedActivationStatesAsync(
+            snapshot.ActivationStates
+                .Select(static state => state.ResourceId)
+                .ToHashSet(StringComparer.Ordinal),
+            cancellationToken);
+        var activationKeys = snapshot.ActivationStates
+            .Select(static state => (state.ResourceId, state.Channel))
+            .ToHashSet();
+
+        return new PortableTargetState
+        {
+            Definitions = definitions,
+            Resources = resources,
+            ActivationStates = activationStates
+                .Where(state => activationKeys.Contains((state.ResourceId, state.Channel)))
+                .ToList(),
+        };
+    }
+
+    /// <inheritdoc />
+    public async ValueTask ApplyImportAsync(
+        PortableSnapshot plannedSnapshot,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(plannedSnapshot);
+
+        await using var connection = await OpenConnectionAsync(cancellationToken);
+        await using var transaction = (SqliteTransaction)await connection.BeginTransactionAsync(cancellationToken);
+
+        try
+        {
+            foreach (var definition in plannedSnapshot.Definitions)
+                await InsertDefinitionAsync(connection, transaction, definition, cancellationToken);
+
+            foreach (var resource in plannedSnapshot.Resources)
+                await InsertResourceAsync(connection, transaction, resource, cancellationToken);
+
+            foreach (var state in plannedSnapshot.ActivationStates)
+                await InsertActivationStateAsync(connection, transaction, state, cancellationToken);
+
+            await transaction.CommitAsync(cancellationToken);
+        }
+        catch
+        {
+            await transaction.RollbackAsync(CancellationToken.None);
+            throw;
+        }
+    }
+
     private async Task<IEnumerable<Resource>> ReadLatestVersionsAsync(CancellationToken cancellationToken)
     {
         await using var connection = await OpenConnectionAsync(cancellationToken);
@@ -349,6 +415,33 @@ public sealed class SqliteJsonResourceStore :
                 || referencedDefinitionVersions.Contains((definition.DefinitionId, definition.Version)))
             .OrderBy(static definition => definition.DefinitionId, StringComparer.Ordinal)
             .ThenBy(static definition => definition.Version)
+            .ToList();
+    }
+
+    private async Task<List<ResourceDefinition>> ReadTargetDefinitionVersionsAsync(
+        PortableSnapshot snapshot,
+        CancellationToken cancellationToken)
+    {
+        var definitionIds = snapshot.Definitions
+            .Select(static definition => definition.DefinitionId)
+            .Concat(snapshot.Resources.Select(static resource => resource.DefinitionId))
+            .ToHashSet(StringComparer.Ordinal);
+        var definitionVersions = snapshot.Definitions
+            .Select(static definition => (definition.DefinitionId, definition.Version))
+            .Concat(snapshot.Resources
+                .Where(static resource => resource.DefinitionVersion is not null)
+                .Select(static resource => (resource.DefinitionId, resource.DefinitionVersion!.Value)))
+            .ToHashSet();
+
+        var definitions = await ReadPayloadsByTextIdsAsync<ResourceDefinition>(
+            tableName: "resource_definitions",
+            columnName: "definition_id",
+            ids: definitionIds,
+            orderBy: "definition_id, version",
+            cancellationToken);
+
+        return definitions
+            .Where(definition => definitionVersions.Contains((definition.DefinitionId, definition.Version)))
             .ToList();
     }
 
@@ -643,6 +736,90 @@ public sealed class SqliteJsonResourceStore :
         }
 
         return active;
+    }
+
+    private async Task InsertDefinitionAsync(
+        SqliteConnection connection,
+        SqliteTransaction transaction,
+        ResourceDefinition definition,
+        CancellationToken cancellationToken)
+    {
+        await using var command = connection.CreateCommand();
+        command.Transaction = transaction;
+        command.CommandText = """
+            INSERT INTO resource_definitions (definition_id, version, id, payload)
+            VALUES ($definitionId, $version, $id, $payload);
+            """;
+        command.Parameters.AddWithValue("$definitionId", definition.DefinitionId);
+        command.Parameters.AddWithValue("$version", definition.Version);
+        command.Parameters.AddWithValue("$id", definition.Id);
+        command.Parameters.AddWithValue("$payload", Serialize(definition));
+
+        await command.ExecuteNonQueryAsync(cancellationToken);
+    }
+
+    private async Task InsertResourceAsync(
+        SqliteConnection connection,
+        SqliteTransaction transaction,
+        Resource resource,
+        CancellationToken cancellationToken)
+    {
+        await using var command = connection.CreateCommand();
+        command.Transaction = transaction;
+        command.CommandText = """
+            INSERT INTO resource_versions (
+                resource_id,
+                version,
+                id,
+                definition_id,
+                definition_version,
+                created,
+                owner,
+                hash,
+                payload
+            )
+            VALUES (
+                $resourceId,
+                $version,
+                $id,
+                $definitionId,
+                $definitionVersion,
+                $created,
+                $owner,
+                $hash,
+                $payload
+            );
+            """;
+        command.Parameters.AddWithValue("$resourceId", resource.ResourceId);
+        command.Parameters.AddWithValue("$version", resource.Version);
+        command.Parameters.AddWithValue("$id", resource.Id);
+        command.Parameters.AddWithValue("$definitionId", resource.DefinitionId);
+        command.Parameters.AddWithValue("$definitionVersion", (object?)resource.DefinitionVersion ?? DBNull.Value);
+        command.Parameters.AddWithValue("$created", resource.Created.ToUniversalTime().ToString("O"));
+        command.Parameters.AddWithValue("$owner", (object?)resource.Owner ?? DBNull.Value);
+        command.Parameters.AddWithValue("$hash", (object?)resource.Hash ?? DBNull.Value);
+        command.Parameters.AddWithValue("$payload", Serialize(resource));
+
+        await command.ExecuteNonQueryAsync(cancellationToken);
+    }
+
+    private async Task InsertActivationStateAsync(
+        SqliteConnection connection,
+        SqliteTransaction transaction,
+        ActivationState state,
+        CancellationToken cancellationToken)
+    {
+        await using var command = connection.CreateCommand();
+        command.Transaction = transaction;
+        command.CommandText = """
+            INSERT INTO activation_states (resource_id, channel, payload)
+            VALUES ($resourceId, $channel, $payload);
+            """;
+        command.Parameters.AddWithValue("$resourceId", state.ResourceId);
+        command.Parameters.AddWithValue("$channel", state.Channel);
+        command.Parameters.AddWithValue("$payload", Serialize(state));
+
+        await command.ExecuteNonQueryAsync(cancellationToken);
     }
 
     private async Task<SqliteConnection> OpenConnectionAsync(CancellationToken cancellationToken)

--- a/src/persistence/Aster.Persistence.SqliteJson/SqliteJsonResourceStore.cs
+++ b/src/persistence/Aster.Persistence.SqliteJson/SqliteJsonResourceStore.cs
@@ -273,22 +273,13 @@ public sealed class SqliteJsonResourceStore :
                 })
                 .ToHashSet(),
             cancellationToken);
-        var activationStates = await ReadScopedActivationStatesAsync(
-            snapshot.ActivationStates
-                .Select(static state => state.ResourceId)
-                .ToHashSet(StringComparer.Ordinal),
-            cancellationToken);
-        var activationKeys = snapshot.ActivationStates
-            .Select(static state => (state.ResourceId, state.Channel))
-            .ToHashSet();
+        var activationStates = await ReadSpecificActivationStatesAsync(snapshot.ActivationStates, cancellationToken);
 
         return new PortableTargetState
         {
             Definitions = definitions,
             Resources = resources,
-            ActivationStates = activationStates
-                .Where(state => activationKeys.Contains((state.ResourceId, state.Channel)))
-                .ToList(),
+            ActivationStates = activationStates,
         };
     }
 
@@ -422,26 +413,72 @@ public sealed class SqliteJsonResourceStore :
         PortableSnapshot snapshot,
         CancellationToken cancellationToken)
     {
-        var definitionIds = snapshot.Definitions
-            .Select(static definition => definition.DefinitionId)
-            .Concat(snapshot.Resources.Select(static resource => resource.DefinitionId))
-            .ToHashSet(StringComparer.Ordinal);
         var definitionVersions = snapshot.Definitions
-            .Select(static definition => (definition.DefinitionId, definition.Version))
+            .Select(static definition => (definition.DefinitionId, Version: definition.Version))
             .Concat(snapshot.Resources
                 .Where(static resource => resource.DefinitionVersion is not null)
-                .Select(static resource => (resource.DefinitionId, resource.DefinitionVersion!.Value)))
+                .Select(static resource => (resource.DefinitionId, Version: resource.DefinitionVersion!.Value)))
             .ToHashSet();
 
-        var definitions = await ReadPayloadsByTextIdsAsync<ResourceDefinition>(
-            tableName: "resource_definitions",
-            columnName: "definition_id",
-            ids: definitionIds,
-            orderBy: "definition_id, version",
-            cancellationToken);
+        if (definitionVersions.Count == 0)
+            return [];
 
-        return definitions
-            .Where(definition => definitionVersions.Contains((definition.DefinitionId, definition.Version)))
+        var results = new List<ResourceDefinition>();
+        await using var connection = await OpenConnectionAsync(cancellationToken);
+        foreach (var batch in definitionVersions
+            .OrderBy(static reference => reference.DefinitionId, StringComparer.Ordinal)
+            .ThenBy(static reference => reference.Version)
+            .Chunk(MaxSqliteParametersPerQuery / 2))
+        {
+            await using var command = connection.CreateCommand();
+            var predicates = AddDefinitionVersionPredicates(command, batch);
+            command.CommandText = $"""
+                SELECT payload
+                FROM resource_definitions
+                WHERE {string.Join(" OR ", predicates)}
+                ORDER BY definition_id, version;
+                """;
+
+            results.AddRange(await ReadPayloadsAsync<ResourceDefinition>(command, cancellationToken));
+        }
+
+        return results
+            .OrderBy(static definition => definition.DefinitionId, StringComparer.Ordinal)
+            .ThenBy(static definition => definition.Version)
+            .ToList();
+    }
+
+    private async Task<List<ActivationState>> ReadSpecificActivationStatesAsync(
+        IReadOnlyCollection<ActivationState> activationStates,
+        CancellationToken cancellationToken)
+    {
+        if (activationStates.Count == 0)
+            return [];
+
+        var results = new List<ActivationState>();
+        await using var connection = await OpenConnectionAsync(cancellationToken);
+        foreach (var batch in activationStates
+            .Select(static state => (state.ResourceId, state.Channel))
+            .Distinct()
+            .OrderBy(static reference => reference.ResourceId, StringComparer.Ordinal)
+            .ThenBy(static reference => reference.Channel, StringComparer.Ordinal)
+            .Chunk(MaxSqliteParametersPerQuery / 2))
+        {
+            await using var command = connection.CreateCommand();
+            var predicates = AddActivationStatePredicates(command, batch);
+            command.CommandText = $"""
+                SELECT payload
+                FROM activation_states
+                WHERE {string.Join(" OR ", predicates)}
+                ORDER BY resource_id, channel;
+                """;
+
+            results.AddRange(await ReadPayloadsAsync<ActivationState>(command, cancellationToken));
+        }
+
+        return results
+            .OrderBy(static state => state.ResourceId, StringComparer.Ordinal)
+            .ThenBy(static state => state.Channel, StringComparer.Ordinal)
             .ToList();
     }
 
@@ -645,6 +682,42 @@ public sealed class SqliteJsonResourceStore :
             command.Parameters.AddWithValue(resourceIdParameter, references[index].ResourceId);
             command.Parameters.AddWithValue(versionParameter, references[index].Version);
             predicates.Add($"(resource_id = {resourceIdParameter} AND version = {versionParameter})");
+        }
+
+        return predicates;
+    }
+
+    private static List<string> AddDefinitionVersionPredicates(
+        SqliteCommand command,
+        IReadOnlyList<(string DefinitionId, int Version)> references)
+    {
+        var predicates = new List<string>();
+
+        for (var index = 0; index < references.Count; index++)
+        {
+            var definitionIdParameter = $"$definitionId{index}";
+            var versionParameter = $"$definitionVersion{index}";
+            command.Parameters.AddWithValue(definitionIdParameter, references[index].DefinitionId);
+            command.Parameters.AddWithValue(versionParameter, references[index].Version);
+            predicates.Add($"(definition_id = {definitionIdParameter} AND version = {versionParameter})");
+        }
+
+        return predicates;
+    }
+
+    private static List<string> AddActivationStatePredicates(
+        SqliteCommand command,
+        IReadOnlyList<(string ResourceId, string Channel)> references)
+    {
+        var predicates = new List<string>();
+
+        for (var index = 0; index < references.Count; index++)
+        {
+            var resourceIdParameter = $"$activationResourceId{index}";
+            var channelParameter = $"$activationChannel{index}";
+            command.Parameters.AddWithValue(resourceIdParameter, references[index].ResourceId);
+            command.Parameters.AddWithValue(channelParameter, references[index].Channel);
+            predicates.Add($"(resource_id = {resourceIdParameter} AND channel = {channelParameter})");
         }
 
         return predicates;

--- a/test/Aster.Tests/Portability/PortabilityImportTests.cs
+++ b/test/Aster.Tests/Portability/PortabilityImportTests.cs
@@ -144,7 +144,20 @@ public sealed class PortabilityImportTests : IDisposable
     [Fact]
     public async Task PreviewImportAsync_UnsupportedJsonAspectValue_FailsWithDivergentCollisionDiagnostic()
     {
-        var snapshot = CreateSnapshot();
+        var baseSnapshot = CreateSnapshot();
+        var snapshot = baseSnapshot with
+        {
+            Resources =
+            [
+                baseSnapshot.Resources[0] with
+                {
+                    Aspects = new Dictionary<string, object>
+                    {
+                        ["unsupported"] = "ok",
+                    },
+                },
+            ],
+        };
         await portability.ImportAsync(snapshot);
         var unsupportedSnapshot = snapshot with
         {

--- a/test/Aster.Tests/Portability/PortabilityImportTests.cs
+++ b/test/Aster.Tests/Portability/PortabilityImportTests.cs
@@ -71,6 +71,36 @@ public sealed class PortabilityImportTests : IDisposable
     }
 
     [Fact]
+    public async Task ImportAsync_IdenticalActivationStateWithDifferentVersionOrder_ReturnsNoOp()
+    {
+        var snapshot = CreateSnapshotWithTwoActiveVersions([1, 2]);
+        await portability.ImportAsync(snapshot);
+
+        var result = await portability.ImportAsync(CreateSnapshotWithTwoActiveVersions([2, 1]));
+
+        Assert.Equal(PortableImportStatus.NoOp, result.Status);
+        Assert.Equal(0, result.Counts.Definitions);
+        Assert.Equal(0, result.Counts.ResourceVersions);
+        Assert.Equal(0, result.Counts.ActivationEntries);
+        Assert.Equal(4, result.Counts.ReusedIdenticalItems);
+    }
+
+    [Fact]
+    public async Task ImportAsync_InMemoryStoreImportsVersionsOutOfOrder_PreservesLatestVersionInvariant()
+    {
+        await portability.ImportAsync(CreateVersionedSnapshot(definitionVersion: 2, resourceVersion: 2));
+        await portability.ImportAsync(CreateVersionedSnapshot(definitionVersion: 1, resourceVersion: 1));
+
+        var latestDefinition = await definitionStore.GetDefinitionAsync("Product");
+        var latestResource = await manager.GetLatestVersionAsync("product-ordered");
+
+        Assert.NotNull(latestDefinition);
+        Assert.Equal(2, latestDefinition.Version);
+        Assert.NotNull(latestResource);
+        Assert.Equal(2, latestResource.Version);
+    }
+
+    [Fact]
     public async Task ImportAsync_StrictDivergentDefinitionCollision_FailsWithoutWritingResources()
     {
         await definitionStore.RegisterDefinitionAsync(new ResourceDefinitionBuilder()
@@ -84,6 +114,23 @@ public sealed class PortabilityImportTests : IDisposable
         var diagnostic = Assert.Single(result.Diagnostics);
         Assert.Equal(PortableDiagnosticCodes.DivergentIdentityCollision, diagnostic.Code);
         Assert.Null(await manager.GetLatestVersionAsync("product-1"));
+    }
+
+    [Fact]
+    public async Task ImportAsync_RemapDivergentDefinitionCollision_UsesDedicatedDeferredDiagnostic()
+    {
+        await definitionStore.RegisterDefinitionAsync(new ResourceDefinitionBuilder()
+            .WithDefinitionId("Product")
+            .Build());
+        var snapshot = CreateSnapshot();
+
+        var result = await portability.ImportAsync(
+            snapshot,
+            new PortableImportOptions { CollisionMode = PortableImportCollisionMode.RemapDivergent });
+
+        Assert.Equal(PortableImportStatus.Failed, result.Status);
+        var diagnostic = Assert.Single(result.Diagnostics);
+        Assert.Equal(PortableDiagnosticCodes.RemapDivergentNotImplemented, diagnostic.Code);
     }
 
     private static PortableSnapshot CreateSnapshot()
@@ -122,6 +169,67 @@ public sealed class PortabilityImportTests : IDisposable
                     Channel = "Published",
                     ActiveVersions = [1],
                     LastUpdated = created.AddMinutes(1),
+                },
+            ],
+        };
+    }
+
+    private static PortableSnapshot CreateSnapshotWithTwoActiveVersions(IReadOnlyList<int> activeVersions)
+    {
+        var snapshot = CreateSnapshot();
+        var v2Created = new DateTime(2026, 1, 3, 3, 4, 5, DateTimeKind.Utc);
+
+        return snapshot with
+        {
+            Resources =
+            [
+                snapshot.Resources[0],
+                new Resource
+                {
+                    ResourceId = "product-1",
+                    Id = "product-1-v2",
+                    DefinitionId = "Product",
+                    DefinitionVersion = 1,
+                    Version = 2,
+                    Created = v2Created,
+                },
+            ],
+            ActivationStates =
+            [
+                snapshot.ActivationStates[0] with
+                {
+                    ActiveVersions = activeVersions,
+                },
+            ],
+        };
+    }
+
+    private static PortableSnapshot CreateVersionedSnapshot(int definitionVersion, int resourceVersion)
+    {
+        var created = new DateTime(2026, 1, 2, 3, 4, 5, DateTimeKind.Utc).AddDays(resourceVersion);
+
+        return new PortableSnapshot
+        {
+            FormatVersion = PortableSnapshot.CurrentFormatVersion,
+            Definitions =
+            [
+                new ResourceDefinition
+                {
+                    DefinitionId = "Product",
+                    Id = $"product-definition-v{definitionVersion}",
+                    Version = definitionVersion,
+                },
+            ],
+            Resources =
+            [
+                new Resource
+                {
+                    ResourceId = "product-ordered",
+                    Id = $"product-ordered-v{resourceVersion}",
+                    DefinitionId = "Product",
+                    DefinitionVersion = definitionVersion,
+                    Version = resourceVersion,
+                    Created = created,
                 },
             ],
         };

--- a/test/Aster.Tests/Portability/PortabilityImportTests.cs
+++ b/test/Aster.Tests/Portability/PortabilityImportTests.cs
@@ -133,6 +133,42 @@ public sealed class PortabilityImportTests : IDisposable
         Assert.Equal(PortableDiagnosticCodes.RemapDivergentNotImplemented, diagnostic.Code);
     }
 
+    [Fact]
+    public async Task PreviewImportAsync_DuplicateVersionSpecificResourceIds_UsesExplicitIdPath()
+    {
+        var snapshot = CreateSnapshot() with
+        {
+            Resources =
+            [
+                new Resource
+                {
+                    ResourceId = "product-1",
+                    Id = "duplicate-version-id",
+                    DefinitionId = "Product",
+                    DefinitionVersion = 1,
+                    Version = 1,
+                    Created = new DateTime(2026, 1, 2, 3, 4, 5, DateTimeKind.Utc),
+                },
+                new Resource
+                {
+                    ResourceId = "product-2",
+                    Id = "duplicate-version-id",
+                    DefinitionId = "Product",
+                    DefinitionVersion = 1,
+                    Version = 1,
+                    Created = new DateTime(2026, 1, 3, 3, 4, 5, DateTimeKind.Utc),
+                },
+            ],
+            ActivationStates = [],
+        };
+
+        var result = await portability.PreviewImportAsync(snapshot);
+
+        Assert.False(result.CanImport);
+        var diagnostic = Assert.Single(result.Diagnostics, static diagnostic => diagnostic.Code == PortableDiagnosticCodes.DuplicateSnapshotIdentity);
+        Assert.Equal("resources/id/duplicate-version-id", diagnostic.Path);
+    }
+
     private static PortableSnapshot CreateSnapshot()
     {
         var created = new DateTime(2026, 1, 2, 3, 4, 5, DateTimeKind.Utc);

--- a/test/Aster.Tests/Portability/PortabilityImportTests.cs
+++ b/test/Aster.Tests/Portability/PortabilityImportTests.cs
@@ -52,7 +52,7 @@ public sealed class PortabilityImportTests : IDisposable
         Assert.NotNull(exported.Snapshot);
         Assert.Equal(snapshot.Definitions.Select(static definition => (definition.DefinitionId, definition.Id, definition.Version)), exported.Snapshot.Definitions.Select(static definition => (definition.DefinitionId, definition.Id, definition.Version)));
         Assert.Equal(snapshot.Resources.Select(static resource => (resource.ResourceId, resource.Id, resource.DefinitionId, resource.DefinitionVersion, resource.Version)), exported.Snapshot.Resources.Select(static resource => (resource.ResourceId, resource.Id, resource.DefinitionId, resource.DefinitionVersion, resource.Version)));
-        Assert.Equal(snapshot.ActivationStates.Select(static state => (state.ResourceId, state.Channel, state.LastUpdated, Versions: state.ActiveVersions.ToArray())), exported.Snapshot.ActivationStates.Select(static state => (state.ResourceId, state.Channel, state.LastUpdated, Versions: state.ActiveVersions.ToArray())));
+        Assert.Equal(snapshot.ActivationStates.Select(static state => (state.ResourceId, state.Channel, state.LastUpdated, Versions: string.Join(",", state.ActiveVersions))), exported.Snapshot.ActivationStates.Select(static state => (state.ResourceId, state.Channel, state.LastUpdated, Versions: string.Join(",", state.ActiveVersions))));
     }
 
     [Fact]

--- a/test/Aster.Tests/Portability/PortabilityImportTests.cs
+++ b/test/Aster.Tests/Portability/PortabilityImportTests.cs
@@ -113,6 +113,13 @@ public sealed class PortabilityImportTests : IDisposable
         Assert.Equal(PortableImportStatus.Failed, result.Status);
         var diagnostic = Assert.Single(result.Diagnostics);
         Assert.Equal(PortableDiagnosticCodes.DivergentIdentityCollision, diagnostic.Code);
+        var mapping = Assert.Single(
+            result.IdentityMap,
+            static mapping => mapping.Reason == PortableIdentityMappingReason.CollidedDivergent);
+        Assert.Equal(PortableEntityKind.DefinitionVersion, mapping.EntityKind);
+        Assert.Equal("Product:1", mapping.SourceId);
+        Assert.Equal("Product:1", mapping.TargetId);
+        Assert.Equal(PortableIdentityMappingReason.CollidedDivergent, mapping.Reason);
         Assert.Null(await manager.GetLatestVersionAsync("product-1"));
     }
 

--- a/test/Aster.Tests/Portability/PortabilityImportTests.cs
+++ b/test/Aster.Tests/Portability/PortabilityImportTests.cs
@@ -4,6 +4,7 @@ using Aster.Core.Extensions;
 using Aster.Core.Models.Definitions;
 using Aster.Core.Models.Instances;
 using Aster.Core.Models.Portability;
+using Aster.Core.Services;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Aster.Tests.Portability;
@@ -249,6 +250,20 @@ public sealed class PortabilityImportTests : IDisposable
         Assert.Equal(11, latest.Version);
     }
 
+    [Fact]
+    public async Task ImportAsync_ApplyFailure_ReturnsFailedResultWithDiagnostic()
+    {
+        var service = new ResourcePortabilityService(new ThrowingApplyPortabilityStore());
+
+        var result = await service.ImportAsync(CreateSnapshot());
+
+        Assert.Equal(PortableImportStatus.Failed, result.Status);
+        Assert.Equal(0, result.Counts.Definitions);
+        var diagnostic = Assert.Single(result.Diagnostics);
+        Assert.Equal(PortableDiagnosticCodes.ImportApplyFailed, diagnostic.Code);
+        Assert.Contains("simulated apply race", diagnostic.Message, StringComparison.Ordinal);
+    }
+
     private static PortableSnapshot CreateSnapshot()
     {
         var created = new DateTime(2026, 1, 2, 3, 4, 5, DateTimeKind.Utc);
@@ -349,5 +364,23 @@ public sealed class PortabilityImportTests : IDisposable
                 },
             ],
         };
+    }
+
+    private sealed class ThrowingApplyPortabilityStore : IResourcePortabilityStore
+    {
+        public ValueTask<PortableStoreSnapshot> ReadSnapshotAsync(
+            PortableStoreReadRequest request,
+            CancellationToken cancellationToken = default) =>
+            ValueTask.FromResult(new PortableStoreSnapshot());
+
+        public ValueTask<PortableTargetState> ReadTargetStateAsync(
+            PortableSnapshot snapshot,
+            CancellationToken cancellationToken = default) =>
+            ValueTask.FromResult(new PortableTargetState());
+
+        public ValueTask ApplyImportAsync(
+            PortableSnapshot plannedSnapshot,
+            CancellationToken cancellationToken = default) =>
+            throw new InvalidOperationException("simulated apply race");
     }
 }

--- a/test/Aster.Tests/Portability/PortabilityImportTests.cs
+++ b/test/Aster.Tests/Portability/PortabilityImportTests.cs
@@ -76,7 +76,7 @@ public sealed class PortabilityImportTests : IDisposable
         var snapshot = CreateSnapshotWithTwoActiveVersions([1, 2]);
         await portability.ImportAsync(snapshot);
 
-        var result = await portability.ImportAsync(CreateSnapshotWithTwoActiveVersions([2, 1]));
+        var result = await portability.ImportAsync(CreateSnapshotWithTwoActiveVersions([2, 1, 1]));
 
         Assert.Equal(PortableImportStatus.NoOp, result.Status);
         Assert.Equal(0, result.Counts.Definitions);

--- a/test/Aster.Tests/Portability/PortabilityImportTests.cs
+++ b/test/Aster.Tests/Portability/PortabilityImportTests.cs
@@ -214,6 +214,34 @@ public sealed class PortabilityImportTests : IDisposable
         Assert.Null(await manager.GetLatestVersionAsync("rollback-product-1"));
     }
 
+    [Fact]
+    public async Task RegisterDefinitionAsync_AfterHighVersionImport_UsesNextHighestVersion()
+    {
+        var store = provider.GetRequiredService<IResourcePortabilityStore>();
+        await store.ApplyImportAsync(new PortableSnapshot
+        {
+            FormatVersion = PortableSnapshot.CurrentFormatVersion,
+            Definitions =
+            [
+                new ResourceDefinition
+                {
+                    DefinitionId = "VersionedProduct",
+                    Id = "versioned-product-definition-v10",
+                    Version = 10,
+                },
+            ],
+        });
+
+        await definitionStore.RegisterDefinitionAsync(new ResourceDefinitionBuilder()
+            .WithDefinitionId("VersionedProduct")
+            .Build());
+
+        var latest = await definitionStore.GetDefinitionAsync("VersionedProduct");
+
+        Assert.NotNull(latest);
+        Assert.Equal(11, latest.Version);
+    }
+
     private static PortableSnapshot CreateSnapshot()
     {
         var created = new DateTime(2026, 1, 2, 3, 4, 5, DateTimeKind.Utc);

--- a/test/Aster.Tests/Portability/PortabilityImportTests.cs
+++ b/test/Aster.Tests/Portability/PortabilityImportTests.cs
@@ -142,6 +142,32 @@ public sealed class PortabilityImportTests : IDisposable
     }
 
     [Fact]
+    public async Task PreviewImportAsync_UnsupportedJsonAspectValue_FailsWithDivergentCollisionDiagnostic()
+    {
+        var snapshot = CreateSnapshot();
+        await portability.ImportAsync(snapshot);
+        var unsupportedSnapshot = snapshot with
+        {
+            Resources =
+            [
+                snapshot.Resources[0] with
+                {
+                    Aspects = new Dictionary<string, object>
+                    {
+                        ["unsupported"] = new UnsupportedJsonAspect { Handle = new IntPtr(1) },
+                    },
+                },
+            ],
+        };
+
+        var result = await portability.PreviewImportAsync(unsupportedSnapshot);
+
+        Assert.False(result.CanImport);
+        var diagnostic = Assert.Single(result.Diagnostics);
+        Assert.Equal(PortableDiagnosticCodes.DivergentIdentityCollision, diagnostic.Code);
+    }
+
+    [Fact]
     public async Task PreviewImportAsync_DuplicateVersionSpecificResourceIds_UsesExplicitIdPath()
     {
         var snapshot = CreateSnapshot() with
@@ -382,5 +408,10 @@ public sealed class PortabilityImportTests : IDisposable
             PortableSnapshot plannedSnapshot,
             CancellationToken cancellationToken = default) =>
             throw new InvalidOperationException("simulated apply race");
+    }
+
+    private sealed class UnsupportedJsonAspect
+    {
+        public IntPtr Handle { get; init; }
     }
 }

--- a/test/Aster.Tests/Portability/PortabilityImportTests.cs
+++ b/test/Aster.Tests/Portability/PortabilityImportTests.cs
@@ -169,6 +169,51 @@ public sealed class PortabilityImportTests : IDisposable
         Assert.Equal("resources/id/duplicate-version-id", diagnostic.Path);
     }
 
+    [Fact]
+    public async Task ApplyImportAsync_InMemoryFailure_RollsBackPreviouslyAppliedItems()
+    {
+        var store = provider.GetRequiredService<IResourcePortabilityStore>();
+        var snapshot = new PortableSnapshot
+        {
+            FormatVersion = PortableSnapshot.CurrentFormatVersion,
+            Definitions =
+            [
+                new ResourceDefinition
+                {
+                    DefinitionId = "RollbackProduct",
+                    Id = "rollback-product-definition-v1",
+                    Version = 1,
+                },
+            ],
+            Resources =
+            [
+                new Resource
+                {
+                    ResourceId = "rollback-product-1",
+                    Id = "rollback-product-1-v1",
+                    DefinitionId = "RollbackProduct",
+                    DefinitionVersion = 1,
+                    Version = 1,
+                    Created = new DateTime(2026, 1, 2, 3, 4, 5, DateTimeKind.Utc),
+                },
+                new Resource
+                {
+                    ResourceId = "rollback-product-1",
+                    Id = "rollback-product-1-v1-duplicate",
+                    DefinitionId = "RollbackProduct",
+                    DefinitionVersion = 1,
+                    Version = 1,
+                    Created = new DateTime(2026, 1, 3, 3, 4, 5, DateTimeKind.Utc),
+                },
+            ],
+        };
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() => store.ApplyImportAsync(snapshot).AsTask());
+
+        Assert.Null(await definitionStore.GetDefinitionAsync("RollbackProduct"));
+        Assert.Null(await manager.GetLatestVersionAsync("rollback-product-1"));
+    }
+
     private static PortableSnapshot CreateSnapshot()
     {
         var created = new DateTime(2026, 1, 2, 3, 4, 5, DateTimeKind.Utc);

--- a/test/Aster.Tests/Portability/PortabilityImportTests.cs
+++ b/test/Aster.Tests/Portability/PortabilityImportTests.cs
@@ -1,0 +1,129 @@
+using Aster.Core.Abstractions;
+using Aster.Core.Definitions;
+using Aster.Core.Extensions;
+using Aster.Core.Models.Definitions;
+using Aster.Core.Models.Instances;
+using Aster.Core.Models.Portability;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Aster.Tests.Portability;
+
+public sealed class PortabilityImportTests : IDisposable
+{
+    private readonly ServiceProvider provider;
+    private readonly IResourceDefinitionStore definitionStore;
+    private readonly IResourceManager manager;
+    private readonly IResourcePortabilityService portability;
+
+    public PortabilityImportTests()
+    {
+        provider = new ServiceCollection()
+            .AddAsterCore()
+            .BuildServiceProvider();
+
+        definitionStore = provider.GetRequiredService<IResourceDefinitionStore>();
+        manager = provider.GetRequiredService<IResourceManager>();
+        portability = provider.GetRequiredService<IResourcePortabilityService>();
+    }
+
+    public void Dispose() => provider.Dispose();
+
+    [Fact]
+    public async Task ImportAsync_EmptyStore_PreservesDefinitionsResourcesAndActivationState()
+    {
+        var snapshot = CreateSnapshot();
+
+        var result = await portability.ImportAsync(snapshot);
+
+        Assert.Equal(PortableImportStatus.Imported, result.Status);
+        Assert.Equal(1, result.Counts.Definitions);
+        Assert.Equal(1, result.Counts.Resources);
+        Assert.Equal(1, result.Counts.ResourceVersions);
+        Assert.Equal(1, result.Counts.ActivationEntries);
+
+        var exported = await portability.ExportAsync(new PortableSnapshotExportRequest
+        {
+            ScopeMode = PortableExportScopeMode.SelectedResources,
+            ResourceIds = ["product-1"],
+            ResourceVersionScope = PortableResourceVersionScope.AllVersions,
+        });
+
+        Assert.NotNull(exported.Snapshot);
+        Assert.Equal(snapshot.Definitions.Select(static definition => (definition.DefinitionId, definition.Id, definition.Version)), exported.Snapshot.Definitions.Select(static definition => (definition.DefinitionId, definition.Id, definition.Version)));
+        Assert.Equal(snapshot.Resources.Select(static resource => (resource.ResourceId, resource.Id, resource.DefinitionId, resource.DefinitionVersion, resource.Version)), exported.Snapshot.Resources.Select(static resource => (resource.ResourceId, resource.Id, resource.DefinitionId, resource.DefinitionVersion, resource.Version)));
+        Assert.Equal(snapshot.ActivationStates.Select(static state => (state.ResourceId, state.Channel, state.LastUpdated, Versions: state.ActiveVersions.ToArray())), exported.Snapshot.ActivationStates.Select(static state => (state.ResourceId, state.Channel, state.LastUpdated, Versions: state.ActiveVersions.ToArray())));
+    }
+
+    [Fact]
+    public async Task ImportAsync_IdenticalContentAlreadyExists_ReturnsNoOp()
+    {
+        var snapshot = CreateSnapshot();
+        await portability.ImportAsync(snapshot);
+
+        var result = await portability.ImportAsync(snapshot);
+
+        Assert.Equal(PortableImportStatus.NoOp, result.Status);
+        Assert.Equal(0, result.Counts.Definitions);
+        Assert.Equal(0, result.Counts.ResourceVersions);
+        Assert.Equal(0, result.Counts.ActivationEntries);
+        Assert.Equal(3, result.Counts.ReusedIdenticalItems);
+        Assert.All(result.IdentityMap, static mapping => Assert.Equal(PortableIdentityMappingReason.ReusedIdentical, mapping.Reason));
+    }
+
+    [Fact]
+    public async Task ImportAsync_StrictDivergentDefinitionCollision_FailsWithoutWritingResources()
+    {
+        await definitionStore.RegisterDefinitionAsync(new ResourceDefinitionBuilder()
+            .WithDefinitionId("Product")
+            .Build());
+        var snapshot = CreateSnapshot();
+
+        var result = await portability.ImportAsync(snapshot);
+
+        Assert.Equal(PortableImportStatus.Failed, result.Status);
+        var diagnostic = Assert.Single(result.Diagnostics);
+        Assert.Equal(PortableDiagnosticCodes.DivergentIdentityCollision, diagnostic.Code);
+        Assert.Null(await manager.GetLatestVersionAsync("product-1"));
+    }
+
+    private static PortableSnapshot CreateSnapshot()
+    {
+        var created = new DateTime(2026, 1, 2, 3, 4, 5, DateTimeKind.Utc);
+
+        return new PortableSnapshot
+        {
+            FormatVersion = PortableSnapshot.CurrentFormatVersion,
+            Definitions =
+            [
+                new ResourceDefinition
+                {
+                    DefinitionId = "Product",
+                    Id = "product-definition-v1",
+                    Version = 1,
+                },
+            ],
+            Resources =
+            [
+                new Resource
+                {
+                    ResourceId = "product-1",
+                    Id = "product-1-v1",
+                    DefinitionId = "Product",
+                    DefinitionVersion = 1,
+                    Version = 1,
+                    Created = created,
+                },
+            ],
+            ActivationStates =
+            [
+                new ActivationState
+                {
+                    ResourceId = "product-1",
+                    Channel = "Published",
+                    ActiveVersions = [1],
+                    LastUpdated = created.AddMinutes(1),
+                },
+            ],
+        };
+    }
+}

--- a/test/Aster.Tests/Portability/PortabilityImportTests.cs
+++ b/test/Aster.Tests/Portability/PortabilityImportTests.cs
@@ -118,8 +118,8 @@ public sealed class PortabilityImportTests : IDisposable
             result.IdentityMap,
             static mapping => mapping.Reason == PortableIdentityMappingReason.CollidedDivergent);
         Assert.Equal(PortableEntityKind.DefinitionVersion, mapping.EntityKind);
-        Assert.Equal("Product:1", mapping.SourceId);
-        Assert.Equal("Product:1", mapping.TargetId);
+        Assert.Equal("""["Product",1]""", mapping.SourceId);
+        Assert.Equal("""["Product",1]""", mapping.TargetId);
         Assert.Equal(PortableIdentityMappingReason.CollidedDivergent, mapping.Reason);
         Assert.Null(await manager.GetLatestVersionAsync("product-1"));
     }

--- a/test/Aster.Tests/SqliteJson/SqliteJsonPortabilityStoreTests.cs
+++ b/test/Aster.Tests/SqliteJson/SqliteJsonPortabilityStoreTests.cs
@@ -90,6 +90,28 @@ public sealed class SqliteJsonPortabilityStoreTests : IDisposable
         Assert.Equal(v1.Version, resource.Version);
     }
 
+    [Fact]
+    public async Task ImportAsync_WithSqlite_PersistsSnapshotForLaterExport()
+    {
+        await using var provider = CreateServiceProvider();
+        var portability = provider.GetRequiredService<IResourcePortabilityService>();
+        var snapshot = CreateSnapshot();
+
+        var import = await portability.ImportAsync(snapshot);
+        var export = await portability.ExportAsync(new PortableSnapshotExportRequest
+        {
+            ScopeMode = PortableExportScopeMode.SelectedResources,
+            ResourceIds = ["sqlite-product-1"],
+            ResourceVersionScope = PortableResourceVersionScope.AllVersions,
+        });
+
+        Assert.Equal(PortableImportStatus.Imported, import.Status);
+        Assert.NotNull(export.Snapshot);
+        Assert.Equal(snapshot.Definitions.Select(static definition => (definition.DefinitionId, definition.Id, definition.Version)), export.Snapshot.Definitions.Select(static definition => (definition.DefinitionId, definition.Id, definition.Version)));
+        Assert.Equal(snapshot.Resources.Select(static resource => (resource.ResourceId, resource.Id, resource.DefinitionId, resource.DefinitionVersion, resource.Version)), export.Snapshot.Resources.Select(static resource => (resource.ResourceId, resource.Id, resource.DefinitionId, resource.DefinitionVersion, resource.Version)));
+        Assert.Equal(snapshot.ActivationStates.Select(static state => (state.ResourceId, state.Channel, state.LastUpdated, Versions: state.ActiveVersions.ToArray())), export.Snapshot.ActivationStates.Select(static state => (state.ResourceId, state.Channel, state.LastUpdated, Versions: state.ActiveVersions.ToArray())));
+    }
+
     private ServiceProvider CreateServiceProvider()
     {
         var services = new ServiceCollection();
@@ -115,6 +137,47 @@ public sealed class SqliteJsonPortabilityStoreTests : IDisposable
             ActiveVersions = versions,
             LastUpdated = DateTime.UtcNow,
         });
+    }
+
+    private static PortableSnapshot CreateSnapshot()
+    {
+        var created = new DateTime(2026, 2, 3, 4, 5, 6, DateTimeKind.Utc);
+
+        return new PortableSnapshot
+        {
+            FormatVersion = PortableSnapshot.CurrentFormatVersion,
+            Definitions =
+            [
+                new()
+                {
+                    DefinitionId = "SqliteProduct",
+                    Id = "sqlite-product-definition-v1",
+                    Version = 1,
+                },
+            ],
+            Resources =
+            [
+                new()
+                {
+                    ResourceId = "sqlite-product-1",
+                    Id = "sqlite-product-1-v1",
+                    DefinitionId = "SqliteProduct",
+                    DefinitionVersion = 1,
+                    Version = 1,
+                    Created = created,
+                },
+            ],
+            ActivationStates =
+            [
+                new()
+                {
+                    ResourceId = "sqlite-product-1",
+                    Channel = "Published",
+                    ActiveVersions = [1],
+                    LastUpdated = created.AddMinutes(1),
+                },
+            ],
+        };
     }
 
     private static void TryDelete(string path)

--- a/test/Aster.Tests/SqliteJson/SqliteJsonPortabilityStoreTests.cs
+++ b/test/Aster.Tests/SqliteJson/SqliteJsonPortabilityStoreTests.cs
@@ -116,7 +116,7 @@ public sealed class SqliteJsonPortabilityStoreTests : IDisposable
         Assert.NotNull(export.Snapshot);
         Assert.Equal(snapshot.Definitions.Select(static definition => (definition.DefinitionId, definition.Id, definition.Version)), export.Snapshot.Definitions.Select(static definition => (definition.DefinitionId, definition.Id, definition.Version)));
         Assert.Equal(snapshot.Resources.Select(static resource => (resource.ResourceId, resource.Id, resource.DefinitionId, resource.DefinitionVersion, resource.Version)), export.Snapshot.Resources.Select(static resource => (resource.ResourceId, resource.Id, resource.DefinitionId, resource.DefinitionVersion, resource.Version)));
-        Assert.Equal(snapshot.ActivationStates.Select(static state => (state.ResourceId, state.Channel, state.LastUpdated, Versions: state.ActiveVersions.ToArray())), export.Snapshot.ActivationStates.Select(static state => (state.ResourceId, state.Channel, state.LastUpdated, Versions: state.ActiveVersions.ToArray())));
+        Assert.Equal(snapshot.ActivationStates.Select(static state => (state.ResourceId, state.Channel, state.LastUpdated, Versions: string.Join(",", state.ActiveVersions))), export.Snapshot.ActivationStates.Select(static state => (state.ResourceId, state.Channel, state.LastUpdated, Versions: string.Join(",", state.ActiveVersions))));
     }
 
     private ServiceProvider CreateServiceProvider()

--- a/test/Aster.Tests/SqliteJson/SqliteJsonPortabilityStoreTests.cs
+++ b/test/Aster.Tests/SqliteJson/SqliteJsonPortabilityStoreTests.cs
@@ -93,12 +93,19 @@ public sealed class SqliteJsonPortabilityStoreTests : IDisposable
     [Fact]
     public async Task ImportAsync_WithSqlite_PersistsSnapshotForLaterExport()
     {
-        await using var provider = CreateServiceProvider();
-        var portability = provider.GetRequiredService<IResourcePortabilityService>();
         var snapshot = CreateSnapshot();
+        PortableImportResult import;
 
-        var import = await portability.ImportAsync(snapshot);
-        var export = await portability.ExportAsync(new PortableSnapshotExportRequest
+        await using (var importProvider = CreateServiceProvider())
+        {
+            var portability = importProvider.GetRequiredService<IResourcePortabilityService>();
+            import = await portability.ImportAsync(snapshot);
+        }
+
+        await using var exportProvider = CreateServiceProvider();
+        var exportPortability = exportProvider.GetRequiredService<IResourcePortabilityService>();
+
+        var export = await exportPortability.ExportAsync(new PortableSnapshotExportRequest
         {
             ScopeMode = PortableExportScopeMode.SelectedResources,
             ResourceIds = ["sqlite-product-1"],


### PR DESCRIPTION
## Summary
- add target-state and atomic apply hooks to the portability store contract
- implement strict import planning, no-op reuse, divergent collision diagnostics, and write import execution
- add in-memory and SQLite provider import apply paths
- add strict import tests for empty stores, identical reuse, strict collision failure, and SQLite persistence

## Validation
- dotnet test Aster.sln
- dotnet build Aster.sln /m:1
- git diff --check
- dotnet format Aster.sln --verify-no-changes --verbosity minimal --include <changed files>

## Notes
- RemapDivergent identity mapping remains intentionally deferred to the next import slice.