### PR TITLE
Implement deterministic portability remapping

### DIFF
--- a/specs/013-portability-primitives/contracts/portability-primitives.md
+++ b/specs/013-portability-primitives/contracts/portability-primitives.md
@@ -116,6 +116,9 @@ Rules:
 - Divergent existing content is a collision.
 - Strict mode fails before writing when divergent collisions exist.
 - Remap mode maps divergent collisions to deterministic replacement identifiers.
+- Remap mode reports divergent collisions as warnings and writes remapped content when no error diagnostics remain.
+- Remapping a definition updates imported resource lineage references.
+- Remapping a resource updates imported resource versions and activation entries together.
 - Preview import is non-mutating.
 - Write import is all-or-nothing.
 
@@ -226,8 +229,8 @@ public enum PortableIdentityMappingReason
 public sealed record PortableIdentityMapping
 {
     public required PortableEntityKind EntityKind { get; init; }
-    public required string OriginalId { get; init; }
-    public required string ImportedId { get; init; }
+    public required string SourceId { get; init; }
+    public required string TargetId { get; init; }
     public required PortableIdentityMappingReason Reason { get; init; }
 }
 ```

--- a/specs/013-portability-primitives/contracts/portability-primitives.md
+++ b/specs/013-portability-primitives/contracts/portability-primitives.md
@@ -247,6 +247,7 @@ Required diagnostic codes include:
 - `unresolved-definition-reference`
 - `unresolved-resource-reference`
 - `divergent-identity-collision`
+- `invalid-import-options`
 - `unsupported-snapshot-format`
 - `malformed-snapshot`
 - `skipped-activation-entry`

--- a/specs/013-portability-primitives/data-model.md
+++ b/specs/013-portability-primitives/data-model.md
@@ -109,9 +109,9 @@ Original-to-imported identifier relationship.
 **Fields**:
 
 - `EntityKind`: `Definition`, `DefinitionVersion`, `Resource`, `ResourceVersion`, or `ActivationEntry`.
-- `OriginalId`: identifier from the snapshot.
-- `ImportedId`: identifier used in the target store.
-- `Reason`: `Preserved`, `ReusedIdentical`, or `RemappedCollision`.
+- `SourceId`: identifier from the snapshot.
+- `TargetId`: identifier used in the target store.
+- `Reason`: `Preserved`, `ReusedIdentical`, `RemappedDivergent`, or `CollidedDivergent`.
 
 **Validation rules**:
 

--- a/specs/013-portability-primitives/data-model.md
+++ b/specs/013-portability-primitives/data-model.md
@@ -156,6 +156,7 @@ Structured diagnostic emitted by export, validation, preview, and import.
 - `unresolved-definition-reference`
 - `unresolved-resource-reference`
 - `divergent-identity-collision`
+- `invalid-import-options`
 - `unsupported-snapshot-format`
 - `malformed-snapshot`
 - `skipped-activation-entry`

--- a/specs/013-portability-primitives/quickstart.md
+++ b/specs/013-portability-primitives/quickstart.md
@@ -53,7 +53,7 @@ if (!preview.CanImport)
     return;
 
 foreach (var mapping in preview.IdentityMap)
-    Console.WriteLine($"{mapping.EntityKind}: {mapping.OriginalId} -> {mapping.ImportedId} ({mapping.Reason})");
+    Console.WriteLine($"{mapping.EntityKind}: {mapping.SourceId} -> {mapping.TargetId} ({mapping.Reason})");
 ```
 
 Default import behavior is strict. Identical existing content is treated as already satisfied. Divergent collisions fail before writing unless remap mode is selected.
@@ -70,6 +70,7 @@ var remapPreview = await portability.PreviewImportAsync(
 ```
 
 The same snapshot and target state produce the same identity map during preview and write import.
+Definition remaps update imported resource lineage references. Resource remaps update imported resource versions and activation entries together.
 
 ## Write Import
 

--- a/specs/013-portability-primitives/tasks.md
+++ b/specs/013-portability-primitives/tasks.md
@@ -70,14 +70,14 @@
 - [X] T021 [P] [US2] Add empty-store import tests in `test/Aster.Tests/Portability/PortabilityImportTests.cs`
 - [X] T022 [P] [US2] Add identical-content no-op import tests in `test/Aster.Tests/Portability/PortabilityImportTests.cs`
 - [X] T023 [P] [US2] Add strict divergent collision failure tests in `test/Aster.Tests/Portability/PortabilityImportTests.cs`
-- [ ] T024 [P] [US2] Add deterministic remap import tests in `test/Aster.Tests/Portability/PortabilityImportTests.cs`
+- [X] T024 [P] [US2] Add deterministic remap import tests in `test/Aster.Tests/Portability/PortabilityImportTests.cs`
 - [X] T025 [P] [US2] Add SQLite JSON atomic import tests in `test/Aster.Tests/SqliteJson/SqliteJsonPortabilityStoreTests.cs`
 
 ### Implementation for User Story 2
 
 - [X] T026 [US2] Implement target-state comparison in `src/core/Aster.Core/Services/ResourcePortabilityService.cs`
-- [ ] T027 [US2] Implement deterministic identity remapping in `src/core/Aster.Core/Services/ResourcePortabilityService.cs`
-- [ ] T028 [US2] Implement relationship rewrites for remapped definitions, resources, resource versions, and activation state in `src/core/Aster.Core/Services/ResourcePortabilityService.cs`
+- [X] T027 [US2] Implement deterministic identity remapping in `src/core/Aster.Core/Services/ResourcePortabilityService.cs`
+- [X] T028 [US2] Implement relationship rewrites for remapped definitions, resources, resource versions, and activation state in `src/core/Aster.Core/Services/ResourcePortabilityService.cs`
 - [X] T029 [US2] Implement in-memory atomic import apply in `src/core/Aster.Core/InMemory/InMemoryResourceStore.cs`
 - [X] T030 [US2] Implement SQLite JSON atomic import apply in `src/persistence/Aster.Persistence.SqliteJson/SqliteJsonResourceStore.cs`
 

--- a/src/core/Aster.Core/Models/Portability/PortableDiagnostic.cs
+++ b/src/core/Aster.Core/Models/Portability/PortableDiagnostic.cs
@@ -93,7 +93,7 @@ public static class PortableDiagnosticCodes
     public const string ImportNotImplemented = "import-not-implemented";
 
     /// <summary>
-    /// RemapDivergent import handling is not implemented yet.
+    /// RemapDivergent import handling is unavailable for a portability operation.
     /// </summary>
     public const string RemapDivergentNotImplemented = "remap-divergent-not-implemented";
 

--- a/src/core/Aster.Core/Models/Portability/PortableDiagnostic.cs
+++ b/src/core/Aster.Core/Models/Portability/PortableDiagnostic.cs
@@ -93,11 +93,6 @@ public static class PortableDiagnosticCodes
     public const string ImportNotImplemented = "import-not-implemented";
 
     /// <summary>
-    /// RemapDivergent import handling is unavailable for a portability operation.
-    /// </summary>
-    public const string RemapDivergentNotImplemented = "remap-divergent-not-implemented";
-
-    /// <summary>
     /// Planned import writes failed during provider apply.
     /// </summary>
     public const string ImportApplyFailed = "import-apply-failed";

--- a/src/core/Aster.Core/Models/Portability/PortableDiagnostic.cs
+++ b/src/core/Aster.Core/Models/Portability/PortableDiagnostic.cs
@@ -88,6 +88,11 @@ public static class PortableDiagnosticCodes
     public const string DivergentIdentityCollision = "divergent-identity-collision";
 
     /// <summary>
+    /// Import options are invalid or unsupported.
+    /// </summary>
+    public const string InvalidImportOptions = "invalid-import-options";
+
+    /// <summary>
     /// Import behavior is not implemented yet.
     /// </summary>
     public const string ImportNotImplemented = "import-not-implemented";

--- a/src/core/Aster.Core/Services/ResourcePortabilityService.cs
+++ b/src/core/Aster.Core/Services/ResourcePortabilityService.cs
@@ -167,6 +167,7 @@ public sealed class ResourcePortabilityService : IResourcePortabilityService
 
         var diagnostics = ValidateSnapshot(snapshot);
         diagnostics.AddRange(ValidateSnapshotIdentityUniqueness(snapshot));
+        diagnostics.AddRange(ValidateImportOptions(options));
         if (diagnostics.Any(static diagnostic => diagnostic.Severity == PortableDiagnosticSeverity.Error))
             return ImportPlan.Failed(diagnostics);
 
@@ -200,6 +201,8 @@ public sealed class ResourcePortabilityService : IResourcePortabilityService
             remappedCollisionDiagnostics.Add(new RemappedCollisionDiagnostic(
                 PortableEntityKind.DefinitionVersion,
                 definition.DefinitionId,
+                definition.Version,
+                null,
                 $"definitions/{definition.DefinitionId}/{definition.Version}",
                 $"Definition '{definition.DefinitionId}' version {definition.Version} already exists with different content."));
         }
@@ -233,6 +236,8 @@ public sealed class ResourcePortabilityService : IResourcePortabilityService
             remappedCollisionDiagnostics.Add(new RemappedCollisionDiagnostic(
                 PortableEntityKind.ResourceVersion,
                 resource.ResourceId,
+                resource.Version,
+                null,
                 $"resources/{resource.ResourceId}/{resource.Version}",
                 $"Resource '{resource.ResourceId}' version {resource.Version} already exists with different content."));
         }
@@ -258,6 +263,8 @@ public sealed class ResourcePortabilityService : IResourcePortabilityService
             remappedCollisionDiagnostics.Add(new RemappedCollisionDiagnostic(
                 PortableEntityKind.ActivationEntry,
                 state.ResourceId,
+                null,
+                state.Channel,
                 $"activationStates/{state.ResourceId}/{state.Channel}",
                 $"Activation state for resource '{state.ResourceId}' channel '{state.Channel}' already exists with different content."));
         }
@@ -279,9 +286,7 @@ public sealed class ResourcePortabilityService : IResourcePortabilityService
             RemappedCollision(
                 diagnostic.Path,
                 diagnostic.Message,
-                diagnostic.EntityKind == PortableEntityKind.DefinitionVersion
-                    ? definitionIdMap[diagnostic.SourceLogicalId]
-                    : resourceIdMap[diagnostic.SourceLogicalId])));
+                RemappedCollisionTargetId(diagnostic, definitionIdMap, resourceIdMap))));
 
         var plannedDefinitions = new List<ResourceDefinition>();
         var plannedResources = new List<Resource>();
@@ -459,6 +464,24 @@ public sealed class ResourcePortabilityService : IResourcePortabilityService
         return diagnostics;
     }
 
+    private static List<PortableDiagnostic> ValidateImportOptions(PortableImportOptions options)
+    {
+        var diagnostics = new List<PortableDiagnostic>();
+
+        if (!Enum.IsDefined(options.CollisionMode))
+        {
+            diagnostics.Add(new PortableDiagnostic
+            {
+                Code = PortableDiagnosticCodes.InvalidImportOptions,
+                Severity = PortableDiagnosticSeverity.Error,
+                Path = "collisionMode",
+                Message = "Import collision mode must be a defined value.",
+            });
+        }
+
+        return diagnostics;
+    }
+
     private static List<PortableDiagnostic> ValidateSnapshot(PortableSnapshot snapshot)
     {
         var diagnostics = new List<PortableDiagnostic>();
@@ -612,6 +635,24 @@ public sealed class ResourcePortabilityService : IResourcePortabilityService
         return candidate;
     }
 
+    private static string RemappedCollisionTargetId(
+        RemappedCollisionDiagnostic diagnostic,
+        IReadOnlyDictionary<string, string> definitionIdMap,
+        IReadOnlyDictionary<string, string> resourceIdMap) =>
+        diagnostic.EntityKind switch
+        {
+            PortableEntityKind.DefinitionVersion => JsonSerializer.Serialize(
+                new object[] { definitionIdMap[diagnostic.SourceLogicalId], diagnostic.Version!.Value },
+                JsonOptions),
+            PortableEntityKind.ResourceVersion => JsonSerializer.Serialize(
+                new object[] { resourceIdMap[diagnostic.SourceLogicalId], diagnostic.Version!.Value },
+                JsonOptions),
+            PortableEntityKind.ActivationEntry => JsonSerializer.Serialize(
+                new object[] { resourceIdMap[diagnostic.SourceLogicalId], diagnostic.Channel! },
+                JsonOptions),
+            _ => throw new InvalidOperationException($"Unsupported remapped collision entity kind '{diagnostic.EntityKind}'."),
+        };
+
     private static PortableDiagnostic InvalidExportScope(string path, string message) =>
         new()
         {
@@ -739,6 +780,8 @@ public sealed class ResourcePortabilityService : IResourcePortabilityService
     private sealed record RemappedCollisionDiagnostic(
         PortableEntityKind EntityKind,
         string SourceLogicalId,
+        int? Version,
+        string? Channel,
         string Path,
         string Message);
 

--- a/src/core/Aster.Core/Services/ResourcePortabilityService.cs
+++ b/src/core/Aster.Core/Services/ResourcePortabilityService.cs
@@ -173,6 +173,7 @@ public sealed class ResourcePortabilityService : IResourcePortabilityService
 
         var targetState = await portabilityStore.ReadTargetStateAsync(snapshot, cancellationToken);
         var identityMap = new List<PortableIdentityMapping>();
+        var strictFailureIdentityMap = new List<PortableIdentityMapping>();
         var existingDefinitions = targetState.Definitions.ToDictionary(static definition => (definition.DefinitionId, definition.Version));
         var existingResources = targetState.Resources.ToDictionary(static resource => (resource.ResourceId, resource.Version));
         var existingActivationStates = targetState.ActivationStates.ToDictionary(static state => (state.ResourceId, state.Channel));
@@ -185,12 +186,25 @@ public sealed class ResourcePortabilityService : IResourcePortabilityService
             cancellationToken.ThrowIfCancellationRequested();
 
             var key = (definition.DefinitionId, definition.Version);
-            if (!existingDefinitions.TryGetValue(key, out var existing) || ContentEquals(definition, existing))
+            if (!existingDefinitions.TryGetValue(key, out var existing))
+            {
+                if (options.CollisionMode == PortableImportCollisionMode.Strict)
+                    strictFailureIdentityMap.Add(Preserved(PortableEntityKind.DefinitionVersion, DefinitionVersionId(definition)));
+
                 continue;
+            }
+
+            if (ContentEquals(definition, existing))
+            {
+                if (options.CollisionMode == PortableImportCollisionMode.Strict)
+                    strictFailureIdentityMap.Add(Reused(PortableEntityKind.DefinitionVersion, DefinitionVersionId(definition)));
+
+                continue;
+            }
 
             if (options.CollisionMode == PortableImportCollisionMode.Strict)
             {
-                identityMap.Add(Collided(PortableEntityKind.DefinitionVersion, DefinitionVersionId(definition)));
+                strictFailureIdentityMap.Add(Collided(PortableEntityKind.DefinitionVersion, DefinitionVersionId(definition)));
                 diagnostics.Add(DivergentCollision(
                     $"definitions/{definition.DefinitionId}/{definition.Version}",
                     $"Definition '{definition.DefinitionId}' version {definition.Version} already exists with different content."));
@@ -213,10 +227,18 @@ public sealed class ResourcePortabilityService : IResourcePortabilityService
 
             var key = (resource.ResourceId, resource.Version);
             if (!existingResources.TryGetValue(key, out var existing))
+            {
+                if (options.CollisionMode == PortableImportCollisionMode.Strict)
+                    strictFailureIdentityMap.Add(Preserved(PortableEntityKind.ResourceVersion, ResourceVersionId(resource)));
+
                 continue;
+            }
 
             if (ContentEquals(resource, existing))
             {
+                if (options.CollisionMode == PortableImportCollisionMode.Strict)
+                    strictFailureIdentityMap.Add(Reused(PortableEntityKind.ResourceVersion, ResourceVersionId(resource)));
+
                 if (definitionIdsToRemap.Contains(resource.DefinitionId))
                     resourceIdsToRemap.Add(resource.ResourceId);
 
@@ -225,7 +247,7 @@ public sealed class ResourcePortabilityService : IResourcePortabilityService
 
             if (options.CollisionMode == PortableImportCollisionMode.Strict)
             {
-                identityMap.Add(Collided(PortableEntityKind.ResourceVersion, ResourceVersionId(resource)));
+                strictFailureIdentityMap.Add(Collided(PortableEntityKind.ResourceVersion, ResourceVersionId(resource)));
                 diagnostics.Add(DivergentCollision(
                     $"resources/{resource.ResourceId}/{resource.Version}",
                     $"Resource '{resource.ResourceId}' version {resource.Version} already exists with different content."));
@@ -247,12 +269,25 @@ public sealed class ResourcePortabilityService : IResourcePortabilityService
             cancellationToken.ThrowIfCancellationRequested();
 
             var key = (state.ResourceId, state.Channel);
-            if (!existingActivationStates.TryGetValue(key, out var existing) || ContentEquals(state, existing))
+            if (!existingActivationStates.TryGetValue(key, out var existing))
+            {
+                if (options.CollisionMode == PortableImportCollisionMode.Strict)
+                    strictFailureIdentityMap.Add(Preserved(PortableEntityKind.ActivationEntry, ActivationEntryId(state)));
+
                 continue;
+            }
+
+            if (ContentEquals(state, existing))
+            {
+                if (options.CollisionMode == PortableImportCollisionMode.Strict)
+                    strictFailureIdentityMap.Add(Reused(PortableEntityKind.ActivationEntry, ActivationEntryId(state)));
+
+                continue;
+            }
 
             if (options.CollisionMode == PortableImportCollisionMode.Strict)
             {
-                identityMap.Add(Collided(PortableEntityKind.ActivationEntry, ActivationEntryId(state)));
+                strictFailureIdentityMap.Add(Collided(PortableEntityKind.ActivationEntry, ActivationEntryId(state)));
                 diagnostics.Add(DivergentCollision(
                     $"activationStates/{state.ResourceId}/{state.Channel}",
                     $"Activation state for resource '{state.ResourceId}' channel '{state.Channel}' already exists with different content."));
@@ -270,7 +305,7 @@ public sealed class ResourcePortabilityService : IResourcePortabilityService
         }
 
         if (diagnostics.Any(static diagnostic => diagnostic.Severity == PortableDiagnosticSeverity.Error))
-            return ImportPlan.Failed(diagnostics, identityMap);
+            return ImportPlan.Failed(diagnostics, strictFailureIdentityMap);
 
         var definitionIdMap = BuildRemappedIdMap(
             definitionIdsToRemap,

--- a/src/core/Aster.Core/Services/ResourcePortabilityService.cs
+++ b/src/core/Aster.Core/Services/ResourcePortabilityService.cs
@@ -171,95 +171,208 @@ public sealed class ResourcePortabilityService : IResourcePortabilityService
             return ImportPlan.Failed(diagnostics);
 
         var targetState = await portabilityStore.ReadTargetStateAsync(snapshot, cancellationToken);
-        var plannedDefinitions = new List<ResourceDefinition>();
-        var plannedResources = new List<Resource>();
-        var plannedActivationStates = new List<ActivationState>();
         var identityMap = new List<PortableIdentityMapping>();
-        var reusedIdenticalItems = 0;
-
         var existingDefinitions = targetState.Definitions.ToDictionary(static definition => (definition.DefinitionId, definition.Version));
+        var existingResources = targetState.Resources.ToDictionary(static resource => (resource.ResourceId, resource.Version));
+        var existingActivationStates = targetState.ActivationStates.ToDictionary(static state => (state.ResourceId, state.Channel));
+        var definitionIdsToRemap = new HashSet<string>(StringComparer.Ordinal);
+        var resourceIdsToRemap = new HashSet<string>(StringComparer.Ordinal);
+        var remappedCollisionDiagnostics = new List<RemappedCollisionDiagnostic>();
+
         foreach (var definition in snapshot.Definitions)
         {
             cancellationToken.ThrowIfCancellationRequested();
 
             var key = (definition.DefinitionId, definition.Version);
-            if (!existingDefinitions.TryGetValue(key, out var existing))
+            if (!existingDefinitions.TryGetValue(key, out var existing) || ContentEquals(definition, existing))
+                continue;
+
+            if (options.CollisionMode == PortableImportCollisionMode.Strict)
             {
-                plannedDefinitions.Add(definition);
-                identityMap.Add(Preserved(PortableEntityKind.DefinitionVersion, DefinitionVersionId(definition)));
+                identityMap.Add(Collided(PortableEntityKind.DefinitionVersion, DefinitionVersionId(definition)));
+                diagnostics.Add(DivergentCollision(
+                    $"definitions/{definition.DefinitionId}/{definition.Version}",
+                    $"Definition '{definition.DefinitionId}' version {definition.Version} already exists with different content."));
                 continue;
             }
 
-            if (ContentEquals(definition, existing))
-            {
-                reusedIdenticalItems++;
-                identityMap.Add(Reused(PortableEntityKind.DefinitionVersion, DefinitionVersionId(definition)));
-                continue;
-            }
-
-            identityMap.Add(Collided(PortableEntityKind.DefinitionVersion, DefinitionVersionId(definition)));
-            diagnostics.Add(DivergentCollision(
+            definitionIdsToRemap.Add(definition.DefinitionId);
+            remappedCollisionDiagnostics.Add(new RemappedCollisionDiagnostic(
+                PortableEntityKind.DefinitionVersion,
+                definition.DefinitionId,
                 $"definitions/{definition.DefinitionId}/{definition.Version}",
-                $"Definition '{definition.DefinitionId}' version {definition.Version} already exists with different content.",
-                options.CollisionMode));
+                $"Definition '{definition.DefinitionId}' version {definition.Version} already exists with different content."));
         }
 
-        var existingResources = targetState.Resources.ToDictionary(static resource => (resource.ResourceId, resource.Version));
         foreach (var resource in snapshot.Resources)
         {
             cancellationToken.ThrowIfCancellationRequested();
 
             var key = (resource.ResourceId, resource.Version);
             if (!existingResources.TryGetValue(key, out var existing))
-            {
-                plannedResources.Add(resource);
-                identityMap.Add(Preserved(PortableEntityKind.ResourceVersion, ResourceVersionId(resource)));
                 continue;
-            }
 
             if (ContentEquals(resource, existing))
             {
-                reusedIdenticalItems++;
-                identityMap.Add(Reused(PortableEntityKind.ResourceVersion, ResourceVersionId(resource)));
+                if (definitionIdsToRemap.Contains(resource.DefinitionId))
+                    resourceIdsToRemap.Add(resource.ResourceId);
+
                 continue;
             }
 
-            identityMap.Add(Collided(PortableEntityKind.ResourceVersion, ResourceVersionId(resource)));
-            diagnostics.Add(DivergentCollision(
+            if (options.CollisionMode == PortableImportCollisionMode.Strict)
+            {
+                identityMap.Add(Collided(PortableEntityKind.ResourceVersion, ResourceVersionId(resource)));
+                diagnostics.Add(DivergentCollision(
+                    $"resources/{resource.ResourceId}/{resource.Version}",
+                    $"Resource '{resource.ResourceId}' version {resource.Version} already exists with different content."));
+                continue;
+            }
+
+            resourceIdsToRemap.Add(resource.ResourceId);
+            remappedCollisionDiagnostics.Add(new RemappedCollisionDiagnostic(
+                PortableEntityKind.ResourceVersion,
+                resource.ResourceId,
                 $"resources/{resource.ResourceId}/{resource.Version}",
-                $"Resource '{resource.ResourceId}' version {resource.Version} already exists with different content.",
-                options.CollisionMode));
+                $"Resource '{resource.ResourceId}' version {resource.Version} already exists with different content."));
         }
 
-        var existingActivationStates = targetState.ActivationStates.ToDictionary(static state => (state.ResourceId, state.Channel));
         foreach (var state in snapshot.ActivationStates)
         {
             cancellationToken.ThrowIfCancellationRequested();
 
             var key = (state.ResourceId, state.Channel);
-            if (!existingActivationStates.TryGetValue(key, out var existing))
+            if (!existingActivationStates.TryGetValue(key, out var existing) || ContentEquals(state, existing))
+                continue;
+
+            if (options.CollisionMode == PortableImportCollisionMode.Strict)
+            {
+                identityMap.Add(Collided(PortableEntityKind.ActivationEntry, ActivationEntryId(state)));
+                diagnostics.Add(DivergentCollision(
+                    $"activationStates/{state.ResourceId}/{state.Channel}",
+                    $"Activation state for resource '{state.ResourceId}' channel '{state.Channel}' already exists with different content."));
+                continue;
+            }
+
+            resourceIdsToRemap.Add(state.ResourceId);
+            remappedCollisionDiagnostics.Add(new RemappedCollisionDiagnostic(
+                PortableEntityKind.ActivationEntry,
+                state.ResourceId,
+                $"activationStates/{state.ResourceId}/{state.Channel}",
+                $"Activation state for resource '{state.ResourceId}' channel '{state.Channel}' already exists with different content."));
+        }
+
+        if (diagnostics.Any(static diagnostic => diagnostic.Severity == PortableDiagnosticSeverity.Error))
+            return ImportPlan.Failed(diagnostics, identityMap);
+
+        var definitionIdMap = BuildRemappedIdMap(
+            definitionIdsToRemap,
+            targetState.Definitions.Select(static definition => definition.DefinitionId),
+            snapshot.Definitions.Select(static definition => definition.DefinitionId));
+        var resourceIdMap = BuildRemappedIdMap(
+            resourceIdsToRemap,
+            targetState.Resources.Select(static resource => resource.ResourceId)
+                .Concat(targetState.ActivationStates.Select(static state => state.ResourceId)),
+            snapshot.Resources.Select(static resource => resource.ResourceId));
+
+        diagnostics.AddRange(remappedCollisionDiagnostics.Select(diagnostic =>
+            RemappedCollision(
+                diagnostic.Path,
+                diagnostic.Message,
+                diagnostic.EntityKind == PortableEntityKind.DefinitionVersion
+                    ? definitionIdMap[diagnostic.SourceLogicalId]
+                    : resourceIdMap[diagnostic.SourceLogicalId])));
+
+        var plannedDefinitions = new List<ResourceDefinition>();
+        var plannedResources = new List<Resource>();
+        var plannedActivationStates = new List<ActivationState>();
+        var reusedIdenticalItems = 0;
+
+        foreach (var definition in snapshot.Definitions)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            if (definitionIdMap.TryGetValue(definition.DefinitionId, out var targetDefinitionId))
+            {
+                var remappedDefinition = definition with { DefinitionId = targetDefinitionId };
+                plannedDefinitions.Add(remappedDefinition);
+                identityMap.Add(Remapped(
+                    PortableEntityKind.DefinitionVersion,
+                    DefinitionVersionId(definition),
+                    DefinitionVersionId(remappedDefinition)));
+                continue;
+            }
+
+            var key = (definition.DefinitionId, definition.Version);
+            if (!existingDefinitions.TryGetValue(key, out _))
+            {
+                plannedDefinitions.Add(definition);
+                identityMap.Add(Preserved(PortableEntityKind.DefinitionVersion, DefinitionVersionId(definition)));
+                continue;
+            }
+
+            reusedIdenticalItems++;
+            identityMap.Add(Reused(PortableEntityKind.DefinitionVersion, DefinitionVersionId(definition)));
+        }
+
+        foreach (var resource in snapshot.Resources)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var remappedResource = resource with
+            {
+                ResourceId = resourceIdMap.GetValueOrDefault(resource.ResourceId, resource.ResourceId),
+                DefinitionId = definitionIdMap.GetValueOrDefault(resource.DefinitionId, resource.DefinitionId),
+            };
+
+            if (resourceIdMap.ContainsKey(resource.ResourceId))
+            {
+                plannedResources.Add(remappedResource);
+                identityMap.Add(Remapped(
+                    PortableEntityKind.ResourceVersion,
+                    ResourceVersionId(resource),
+                    ResourceVersionId(remappedResource)));
+                continue;
+            }
+
+            var key = (resource.ResourceId, resource.Version);
+            if (!existingResources.TryGetValue(key, out _))
+            {
+                plannedResources.Add(remappedResource);
+                identityMap.Add(Preserved(PortableEntityKind.ResourceVersion, ResourceVersionId(resource)));
+                continue;
+            }
+
+            reusedIdenticalItems++;
+            identityMap.Add(Reused(PortableEntityKind.ResourceVersion, ResourceVersionId(resource)));
+        }
+
+        foreach (var state in snapshot.ActivationStates)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            if (resourceIdMap.TryGetValue(state.ResourceId, out var targetResourceId))
+            {
+                var remappedState = state with { ResourceId = targetResourceId };
+                plannedActivationStates.Add(remappedState);
+                identityMap.Add(Remapped(
+                    PortableEntityKind.ActivationEntry,
+                    ActivationEntryId(state),
+                    ActivationEntryId(remappedState)));
+                continue;
+            }
+
+            var key = (state.ResourceId, state.Channel);
+            if (!existingActivationStates.TryGetValue(key, out _))
             {
                 plannedActivationStates.Add(state);
                 identityMap.Add(Preserved(PortableEntityKind.ActivationEntry, ActivationEntryId(state)));
                 continue;
             }
 
-            if (ContentEquals(state, existing))
-            {
-                reusedIdenticalItems++;
-                identityMap.Add(Reused(PortableEntityKind.ActivationEntry, ActivationEntryId(state)));
-                continue;
-            }
-
-            identityMap.Add(Collided(PortableEntityKind.ActivationEntry, ActivationEntryId(state)));
-            diagnostics.Add(DivergentCollision(
-                $"activationStates/{state.ResourceId}/{state.Channel}",
-                $"Activation state for resource '{state.ResourceId}' channel '{state.Channel}' already exists with different content.",
-                options.CollisionMode));
+            reusedIdenticalItems++;
+            identityMap.Add(Reused(PortableEntityKind.ActivationEntry, ActivationEntryId(state)));
         }
-
-        if (diagnostics.Any(static diagnostic => diagnostic.Severity == PortableDiagnosticSeverity.Error))
-            return ImportPlan.Failed(diagnostics, identityMap);
 
         var plannedSnapshot = new PortableSnapshot
         {
@@ -275,6 +388,7 @@ public sealed class ResourcePortabilityService : IResourcePortabilityService
             ResourceVersions = plannedResources.Count,
             ActivationEntries = plannedActivationStates.Count,
             ReusedIdenticalItems = reusedIdenticalItems,
+            RemappedItems = identityMap.Count(static mapping => mapping.Reason == PortableIdentityMappingReason.RemappedDivergent),
         };
         var actualCounts = new PortableActualImportCounts
         {
@@ -283,6 +397,7 @@ public sealed class ResourcePortabilityService : IResourcePortabilityService
             ResourceVersions = plannedCounts.ResourceVersions,
             ActivationEntries = plannedCounts.ActivationEntries,
             ReusedIdenticalItems = plannedCounts.ReusedIdenticalItems,
+            RemappedItems = plannedCounts.RemappedItems,
         };
 
         return new ImportPlan(
@@ -443,25 +558,59 @@ public sealed class ResourcePortabilityService : IResourcePortabilityService
                 Message = $"{message} Duplicate key: '{group.Key}'.",
             });
 
-    private static PortableDiagnostic DivergentCollision(
-        string path,
-        string message,
-        PortableImportCollisionMode collisionMode) =>
-        collisionMode == PortableImportCollisionMode.Strict
-            ? new PortableDiagnostic
-            {
-                Code = PortableDiagnosticCodes.DivergentIdentityCollision,
-                Severity = PortableDiagnosticSeverity.Error,
-                Path = path,
-                Message = message,
-            }
-            : new PortableDiagnostic
-            {
-                Code = PortableDiagnosticCodes.RemapDivergentNotImplemented,
-                Severity = PortableDiagnosticSeverity.Error,
-                Path = path,
-                Message = $"{message} RemapDivergent import is planned for the next import slice.",
-            };
+    private static PortableDiagnostic DivergentCollision(string path, string message) =>
+        new()
+        {
+            Code = PortableDiagnosticCodes.DivergentIdentityCollision,
+            Severity = PortableDiagnosticSeverity.Error,
+            Path = path,
+            Message = message,
+        };
+
+    private static PortableDiagnostic RemappedCollision(string path, string message, string targetId) =>
+        new()
+        {
+            Code = PortableDiagnosticCodes.DivergentIdentityCollision,
+            Severity = PortableDiagnosticSeverity.Warning,
+            Path = path,
+            Message = $"{message} Incoming content will be remapped to '{targetId}'.",
+        };
+
+    private static IReadOnlyDictionary<string, string> BuildRemappedIdMap(
+        IEnumerable<string> sourceIds,
+        IEnumerable<string> targetReservedIds,
+        IEnumerable<string> snapshotReservedIds)
+    {
+        var sourceSet = sourceIds.ToHashSet(StringComparer.Ordinal);
+        var reservedIds = targetReservedIds
+            .Concat(snapshotReservedIds.Where(id => !sourceSet.Contains(id)))
+            .ToHashSet(StringComparer.Ordinal);
+        var map = new Dictionary<string, string>(StringComparer.Ordinal);
+
+        foreach (var sourceId in sourceSet.OrderBy(static id => id, StringComparer.Ordinal))
+        {
+            var targetId = CreateRemappedId(sourceId, reservedIds);
+            reservedIds.Add(targetId);
+            map[sourceId] = targetId;
+        }
+
+        return map;
+    }
+
+    private static string CreateRemappedId(string sourceId, ISet<string> reservedIds)
+    {
+        var baseId = $"{sourceId}__imported";
+        var candidate = baseId;
+        var suffix = 2;
+
+        while (reservedIds.Contains(candidate))
+        {
+            candidate = $"{baseId}{suffix}";
+            suffix++;
+        }
+
+        return candidate;
+    }
 
     private static PortableDiagnostic InvalidExportScope(string path, string message) =>
         new()
@@ -569,6 +718,15 @@ public sealed class ResourcePortabilityService : IResourcePortabilityService
             Reason = PortableIdentityMappingReason.CollidedDivergent,
         };
 
+    private static PortableIdentityMapping Remapped(PortableEntityKind entityKind, string sourceId, string targetId) =>
+        new()
+        {
+            EntityKind = entityKind,
+            SourceId = sourceId,
+            TargetId = targetId,
+            Reason = PortableIdentityMappingReason.RemappedDivergent,
+        };
+
     private static string DefinitionVersionId(ResourceDefinition definition) =>
         JsonSerializer.Serialize(new object[] { definition.DefinitionId, definition.Version }, JsonOptions);
 
@@ -577,6 +735,12 @@ public sealed class ResourcePortabilityService : IResourcePortabilityService
 
     private static string ActivationEntryId(ActivationState state) =>
         JsonSerializer.Serialize(new object[] { state.ResourceId, state.Channel }, JsonOptions);
+
+    private sealed record RemappedCollisionDiagnostic(
+        PortableEntityKind EntityKind,
+        string SourceLogicalId,
+        string Path,
+        string Message);
 
     private sealed record ImportPlan(
         PortableSnapshot PlannedSnapshot,

--- a/test/Aster.Tests/Portability/PortabilityImportTests.cs
+++ b/test/Aster.Tests/Portability/PortabilityImportTests.cs
@@ -117,10 +117,25 @@ public sealed class PortabilityImportTests : IDisposable
         var mapping = Assert.Single(
             result.IdentityMap,
             static mapping => mapping.Reason == PortableIdentityMappingReason.CollidedDivergent);
+        Assert.Equal(3, result.IdentityMap.Count);
         Assert.Equal(PortableEntityKind.DefinitionVersion, mapping.EntityKind);
         Assert.Equal("""["Product",1]""", mapping.SourceId);
         Assert.Equal("""["Product",1]""", mapping.TargetId);
         Assert.Equal(PortableIdentityMappingReason.CollidedDivergent, mapping.Reason);
+        Assert.Contains(
+            result.IdentityMap,
+            static mapping =>
+                mapping.EntityKind == PortableEntityKind.ResourceVersion
+                && mapping.SourceId == """["product-1",1]"""
+                && mapping.TargetId == """["product-1",1]"""
+                && mapping.Reason == PortableIdentityMappingReason.Preserved);
+        Assert.Contains(
+            result.IdentityMap,
+            static mapping =>
+                mapping.EntityKind == PortableEntityKind.ActivationEntry
+                && mapping.SourceId == """["product-1","Published"]"""
+                && mapping.TargetId == """["product-1","Published"]"""
+                && mapping.Reason == PortableIdentityMappingReason.Preserved);
         Assert.Null(await manager.GetLatestVersionAsync("product-1"));
     }
 

--- a/test/Aster.Tests/Portability/PortabilityImportTests.cs
+++ b/test/Aster.Tests/Portability/PortabilityImportTests.cs
@@ -144,6 +144,7 @@ public sealed class PortabilityImportTests : IDisposable
         var diagnostic = Assert.Single(result.Diagnostics);
         Assert.Equal(PortableDiagnosticCodes.DivergentIdentityCollision, diagnostic.Code);
         Assert.Equal(PortableDiagnosticSeverity.Warning, diagnostic.Severity);
+        Assert.Contains("""["Product__imported",1]""", diagnostic.Message, StringComparison.Ordinal);
         var mapping = Assert.Single(
             result.IdentityMap,
             static mapping => mapping.Reason == PortableIdentityMappingReason.RemappedDivergent);
@@ -202,6 +203,19 @@ public sealed class PortabilityImportTests : IDisposable
         Assert.Null(remappedResource.Owner);
         var activeVersion = Assert.Single(activeRemappedVersions);
         Assert.Equal(1, activeVersion.Version);
+    }
+
+    [Fact]
+    public async Task PreviewImportAsync_UndefinedCollisionMode_FailsWithInvalidImportOptionsDiagnostic()
+    {
+        var result = await portability.PreviewImportAsync(
+            CreateSnapshot(),
+            new PortableImportOptions { CollisionMode = (PortableImportCollisionMode)999 });
+
+        Assert.False(result.CanImport);
+        var diagnostic = Assert.Single(result.Diagnostics);
+        Assert.Equal(PortableDiagnosticCodes.InvalidImportOptions, diagnostic.Code);
+        Assert.Equal("collisionMode", diagnostic.Path);
     }
 
     [Fact]

--- a/test/Aster.Tests/Portability/PortabilityImportTests.cs
+++ b/test/Aster.Tests/Portability/PortabilityImportTests.cs
@@ -125,7 +125,7 @@ public sealed class PortabilityImportTests : IDisposable
     }
 
     [Fact]
-    public async Task ImportAsync_RemapDivergentDefinitionCollision_UsesDedicatedDeferredDiagnostic()
+    public async Task ImportAsync_RemapDivergentDefinitionCollision_RewritesDefinitionLineage()
     {
         await definitionStore.RegisterDefinitionAsync(new ResourceDefinitionBuilder()
             .WithDefinitionId("Product")
@@ -136,9 +136,88 @@ public sealed class PortabilityImportTests : IDisposable
             snapshot,
             new PortableImportOptions { CollisionMode = PortableImportCollisionMode.RemapDivergent });
 
-        Assert.Equal(PortableImportStatus.Failed, result.Status);
+        Assert.Equal(PortableImportStatus.Imported, result.Status);
+        Assert.Equal(1, result.Counts.Definitions);
+        Assert.Equal(1, result.Counts.ResourceVersions);
+        Assert.Equal(1, result.Counts.ActivationEntries);
+        Assert.Equal(1, result.Counts.RemappedItems);
         var diagnostic = Assert.Single(result.Diagnostics);
-        Assert.Equal(PortableDiagnosticCodes.RemapDivergentNotImplemented, diagnostic.Code);
+        Assert.Equal(PortableDiagnosticCodes.DivergentIdentityCollision, diagnostic.Code);
+        Assert.Equal(PortableDiagnosticSeverity.Warning, diagnostic.Severity);
+        var mapping = Assert.Single(
+            result.IdentityMap,
+            static mapping => mapping.Reason == PortableIdentityMappingReason.RemappedDivergent);
+        Assert.Equal(PortableEntityKind.DefinitionVersion, mapping.EntityKind);
+        Assert.Equal("""["Product",1]""", mapping.SourceId);
+        Assert.Equal("""["Product__imported",1]""", mapping.TargetId);
+
+        var remappedDefinition = await definitionStore.GetDefinitionAsync("Product__imported");
+        var importedResource = await manager.GetLatestVersionAsync("product-1");
+
+        Assert.NotNull(remappedDefinition);
+        Assert.Equal(1, remappedDefinition.Version);
+        Assert.NotNull(importedResource);
+        Assert.Equal("Product__imported", importedResource.DefinitionId);
+    }
+
+    [Fact]
+    public async Task ImportAsync_RemapDivergentResourceCollision_RewritesResourceAndActivationState()
+    {
+        var targetSnapshot = CreateSnapshotWithResourceOwner("target-owner");
+        await portability.ImportAsync(targetSnapshot);
+        var snapshot = CreateSnapshot();
+
+        var result = await portability.ImportAsync(
+            snapshot,
+            new PortableImportOptions { CollisionMode = PortableImportCollisionMode.RemapDivergent });
+
+        Assert.Equal(PortableImportStatus.Imported, result.Status);
+        Assert.Equal(0, result.Counts.Definitions);
+        Assert.Equal(1, result.Counts.ResourceVersions);
+        Assert.Equal(1, result.Counts.ActivationEntries);
+        Assert.Equal(1, result.Counts.ReusedIdenticalItems);
+        Assert.Equal(2, result.Counts.RemappedItems);
+        Assert.Contains(
+            result.IdentityMap,
+            static mapping =>
+                mapping.EntityKind == PortableEntityKind.ResourceVersion
+                && mapping.SourceId == """["product-1",1]"""
+                && mapping.TargetId == """["product-1__imported",1]"""
+                && mapping.Reason == PortableIdentityMappingReason.RemappedDivergent);
+        Assert.Contains(
+            result.IdentityMap,
+            static mapping =>
+                mapping.EntityKind == PortableEntityKind.ActivationEntry
+                && mapping.SourceId == """["product-1","Published"]"""
+                && mapping.TargetId == """["product-1__imported","Published"]"""
+                && mapping.Reason == PortableIdentityMappingReason.RemappedDivergent);
+
+        var originalResource = await manager.GetLatestVersionAsync("product-1");
+        var remappedResource = await manager.GetLatestVersionAsync("product-1__imported");
+        var activeRemappedVersions = (await manager.GetActiveVersionsAsync("product-1__imported", "Published")).ToList();
+
+        Assert.NotNull(originalResource);
+        Assert.Equal("target-owner", originalResource.Owner);
+        Assert.NotNull(remappedResource);
+        Assert.Null(remappedResource.Owner);
+        var activeVersion = Assert.Single(activeRemappedVersions);
+        Assert.Equal(1, activeVersion.Version);
+    }
+
+    [Fact]
+    public async Task PreviewImportAsync_RemapDivergentCollision_ProducesDeterministicIdentityMap()
+    {
+        await portability.ImportAsync(CreateSnapshotWithResourceOwner("target-owner"));
+        var snapshot = CreateSnapshot();
+        var options = new PortableImportOptions { CollisionMode = PortableImportCollisionMode.RemapDivergent };
+
+        var first = await portability.PreviewImportAsync(snapshot, options);
+        var second = await portability.PreviewImportAsync(snapshot, options);
+
+        Assert.True(first.CanImport);
+        Assert.Equal(
+            first.IdentityMap.Select(static mapping => (mapping.EntityKind, mapping.SourceId, mapping.TargetId, mapping.Reason)),
+            second.IdentityMap.Select(static mapping => (mapping.EntityKind, mapping.SourceId, mapping.TargetId, mapping.Reason)));
     }
 
     [Fact]
@@ -370,6 +449,19 @@ public sealed class PortabilityImportTests : IDisposable
                 {
                     ActiveVersions = activeVersions,
                 },
+            ],
+        };
+    }
+
+    private static PortableSnapshot CreateSnapshotWithResourceOwner(string owner)
+    {
+        var snapshot = CreateSnapshot();
+
+        return snapshot with
+        {
+            Resources =
+            [
+                snapshot.Resources[0] with { Owner = owner },
             ],
         };
     }


### PR DESCRIPTION
## Summary
- implement deterministic RemapDivergent import planning for portability snapshots
- rewrite remapped definition lineage, resource versions, and activation entries consistently
- add remap import and deterministic preview coverage
- update portability spec artifacts for the completed US2 remap tasks

## Validation
- dotnet test Aster.sln --no-restore
- dotnet build Aster.sln /m:1
- dotnet format Aster.sln --verify-no-changes --include src/core/Aster.Core/Services/ResourcePortabilityService.cs src/core/Aster.Core/Models/Portability/PortableDiagnostic.cs test/Aster.Tests/Portability/PortabilityImportTests.cs specs/013-portability-primitives/tasks.md specs/013-portability-primitives/contracts/portability-primitives.md specs/013-portability-primitives/quickstart.md specs/013-portability-primitives/data-model.md
- git diff --check

Note: full repo-wide dotnet format currently reports unrelated existing whitespace issues in query files.