### PR TITLE
Add portability import preview validation

### DIFF
--- a/specs/013-portability-primitives/contracts/portability-primitives.md
+++ b/specs/013-portability-primitives/contracts/portability-primitives.md
@@ -239,18 +239,16 @@ public sealed record PortableIdentityMapping
 
 Required diagnostic codes include:
 
-- `missing-definition`
-- `missing-definition-version`
-- `missing-resource`
-- `missing-resource-version`
+- `invalid-export-scope`
+- `skipped-activation-entry`
+- `unsupported-format-version`
+- `missing-definition-reference`
+- `missing-resource-reference`
 - `duplicate-snapshot-identity`
-- `unresolved-definition-reference`
-- `unresolved-resource-reference`
 - `divergent-identity-collision`
 - `invalid-import-options`
-- `unsupported-snapshot-format`
 - `malformed-snapshot`
-- `skipped-activation-entry`
+- `import-apply-failed`
 
 ## Provider-Facing Store Contract
 

--- a/specs/013-portability-primitives/data-model.md
+++ b/specs/013-portability-primitives/data-model.md
@@ -148,18 +148,16 @@ Structured diagnostic emitted by export, validation, preview, and import.
 
 **Common codes**:
 
-- `missing-definition`
-- `missing-definition-version`
-- `missing-resource`
-- `missing-resource-version`
+- `invalid-export-scope`
+- `skipped-activation-entry`
+- `unsupported-format-version`
+- `missing-definition-reference`
+- `missing-resource-reference`
 - `duplicate-snapshot-identity`
-- `unresolved-definition-reference`
-- `unresolved-resource-reference`
 - `divergent-identity-collision`
 - `invalid-import-options`
-- `unsupported-snapshot-format`
 - `malformed-snapshot`
-- `skipped-activation-entry`
+- `import-apply-failed`
 
 ## State Transitions
 

--- a/specs/013-portability-primitives/tasks.md
+++ b/specs/013-portability-primitives/tasks.md
@@ -93,15 +93,15 @@
 
 ### Tests for User Story 3
 
-- [ ] T031 [P] [US3] Add non-mutating preview tests in `test/Aster.Tests/Portability/PortabilityPreviewTests.cs`
-- [ ] T032 [P] [US3] Add invalid snapshot preview diagnostic tests in `test/Aster.Tests/Portability/PortabilityPreviewTests.cs`
-- [ ] T033 [P] [US3] Add preview identity-map determinism tests in `test/Aster.Tests/Portability/PortabilityPreviewTests.cs`
+- [X] T031 [P] [US3] Add non-mutating preview tests in `test/Aster.Tests/Portability/PortabilityPreviewTests.cs`
+- [X] T032 [P] [US3] Add invalid snapshot preview diagnostic tests in `test/Aster.Tests/Portability/PortabilityPreviewTests.cs`
+- [X] T033 [P] [US3] Add preview identity-map determinism tests in `test/Aster.Tests/Portability/PortabilityPreviewTests.cs`
 
 ### Implementation for User Story 3
 
-- [ ] T034 [US3] Implement snapshot validation in `src/core/Aster.Core/Services/ResourcePortabilityService.cs`
-- [ ] T035 [US3] Implement preview planning without provider writes in `src/core/Aster.Core/Services/ResourcePortabilityService.cs`
-- [ ] T036 [US3] Share preview planning with write import in `src/core/Aster.Core/Services/ResourcePortabilityService.cs`
+- [X] T034 [US3] Implement snapshot validation in `src/core/Aster.Core/Services/ResourcePortabilityService.cs`
+- [X] T035 [US3] Implement preview planning without provider writes in `src/core/Aster.Core/Services/ResourcePortabilityService.cs`
+- [X] T036 [US3] Share preview planning with write import in `src/core/Aster.Core/Services/ResourcePortabilityService.cs`
 
 **Checkpoint**: User Story 3 previews imports without mutation.
 

--- a/src/core/Aster.Core/Models/Portability/PortableDiagnostic.cs
+++ b/src/core/Aster.Core/Models/Portability/PortableDiagnostic.cs
@@ -93,6 +93,11 @@ public static class PortableDiagnosticCodes
     public const string InvalidImportOptions = "invalid-import-options";
 
     /// <summary>
+    /// Snapshot shape is malformed before reference or collision validation can safely proceed.
+    /// </summary>
+    public const string MalformedSnapshot = "malformed-snapshot";
+
+    /// <summary>
     /// Import behavior is not implemented yet.
     /// </summary>
     public const string ImportNotImplemented = "import-not-implemented";

--- a/src/core/Aster.Core/Services/ResourcePortabilityService.cs
+++ b/src/core/Aster.Core/Services/ResourcePortabilityService.cs
@@ -166,7 +166,6 @@ public sealed class ResourcePortabilityService : IResourcePortabilityService
         cancellationToken.ThrowIfCancellationRequested();
 
         var diagnostics = ValidateSnapshot(snapshot);
-        diagnostics.AddRange(ValidateSnapshotIdentityUniqueness(snapshot));
         diagnostics.AddRange(ValidateImportOptions(options));
         if (diagnostics.Any(static diagnostic => diagnostic.Severity == PortableDiagnosticSeverity.Error))
             return ImportPlan.Failed(diagnostics);
@@ -520,6 +519,9 @@ public sealed class ResourcePortabilityService : IResourcePortabilityService
     private static List<PortableDiagnostic> ValidateSnapshot(PortableSnapshot snapshot)
     {
         var diagnostics = new List<PortableDiagnostic>();
+        var validDefinitions = new List<ResourceDefinition>();
+        var validResources = new List<Resource>();
+        var validActivationStates = new List<ActivationState>();
 
         if (snapshot.FormatVersion != PortableSnapshot.CurrentFormatVersion)
         {
@@ -532,11 +534,160 @@ public sealed class ResourcePortabilityService : IResourcePortabilityService
             });
         }
 
-        var definitionVersions = snapshot.Definitions
+        var definitions = snapshot.Definitions;
+        var resources = snapshot.Resources;
+        var activationStates = snapshot.ActivationStates;
+
+        if (definitions is null)
+        {
+            diagnostics.Add(MalformedSnapshot("definitions", "Snapshot definitions collection cannot be null."));
+            definitions = [];
+        }
+
+        if (resources is null)
+        {
+            diagnostics.Add(MalformedSnapshot("resources", "Snapshot resources collection cannot be null."));
+            resources = [];
+        }
+
+        if (activationStates is null)
+        {
+            diagnostics.Add(MalformedSnapshot("activationStates", "Snapshot activation states collection cannot be null."));
+            activationStates = [];
+        }
+
+        for (var i = 0; i < definitions.Count; i++)
+        {
+            var definition = definitions[i];
+            if (definition is null)
+            {
+                diagnostics.Add(MalformedSnapshot($"definitions/{i}", "Snapshot definition entry cannot be null."));
+                continue;
+            }
+
+            var isMalformed = false;
+            if (string.IsNullOrWhiteSpace(definition.DefinitionId))
+            {
+                diagnostics.Add(MalformedSnapshot($"definitions/{i}/definitionId", "Snapshot definition ID is required."));
+                isMalformed = true;
+            }
+
+            if (string.IsNullOrWhiteSpace(definition.Id))
+            {
+                diagnostics.Add(MalformedSnapshot($"definitions/{i}/id", "Snapshot definition version ID is required."));
+                isMalformed = true;
+            }
+
+            if (definition.Version <= 0)
+            {
+                diagnostics.Add(MalformedSnapshot($"definitions/{i}/version", "Snapshot definition version must be greater than zero."));
+                isMalformed = true;
+            }
+
+            if (definition.AspectDefinitions is null)
+            {
+                diagnostics.Add(MalformedSnapshot($"definitions/{i}/aspectDefinitions", "Snapshot definition aspect definitions collection cannot be null."));
+                isMalformed = true;
+            }
+
+            if (!isMalformed)
+                validDefinitions.Add(definition);
+        }
+
+        for (var i = 0; i < resources.Count; i++)
+        {
+            var resource = resources[i];
+            if (resource is null)
+            {
+                diagnostics.Add(MalformedSnapshot($"resources/{i}", "Snapshot resource entry cannot be null."));
+                continue;
+            }
+
+            var isMalformed = false;
+            if (string.IsNullOrWhiteSpace(resource.ResourceId))
+            {
+                diagnostics.Add(MalformedSnapshot($"resources/{i}/resourceId", "Snapshot resource ID is required."));
+                isMalformed = true;
+            }
+
+            if (string.IsNullOrWhiteSpace(resource.Id))
+            {
+                diagnostics.Add(MalformedSnapshot($"resources/{i}/id", "Snapshot resource version ID is required."));
+                isMalformed = true;
+            }
+
+            if (string.IsNullOrWhiteSpace(resource.DefinitionId))
+            {
+                diagnostics.Add(MalformedSnapshot($"resources/{i}/definitionId", "Snapshot resource definition ID is required."));
+                isMalformed = true;
+            }
+
+            if (resource.DefinitionVersion <= 0)
+            {
+                diagnostics.Add(MalformedSnapshot($"resources/{i}/definitionVersion", "Snapshot resource definition version must be greater than zero when present."));
+                isMalformed = true;
+            }
+
+            if (resource.Version <= 0)
+            {
+                diagnostics.Add(MalformedSnapshot($"resources/{i}/version", "Snapshot resource version must be greater than zero."));
+                isMalformed = true;
+            }
+
+            if (resource.Aspects is null)
+            {
+                diagnostics.Add(MalformedSnapshot($"resources/{i}/aspects", "Snapshot resource aspects collection cannot be null."));
+                isMalformed = true;
+            }
+
+            if (!isMalformed)
+                validResources.Add(resource);
+        }
+
+        for (var i = 0; i < activationStates.Count; i++)
+        {
+            var activationState = activationStates[i];
+            if (activationState is null)
+            {
+                diagnostics.Add(MalformedSnapshot($"activationStates/{i}", "Snapshot activation state entry cannot be null."));
+                continue;
+            }
+
+            var isMalformed = false;
+            if (string.IsNullOrWhiteSpace(activationState.ResourceId))
+            {
+                diagnostics.Add(MalformedSnapshot($"activationStates/{i}/resourceId", "Snapshot activation state resource ID is required."));
+                isMalformed = true;
+            }
+
+            if (string.IsNullOrWhiteSpace(activationState.Channel))
+            {
+                diagnostics.Add(MalformedSnapshot($"activationStates/{i}/channel", "Snapshot activation state channel is required."));
+                isMalformed = true;
+            }
+
+            if (activationState.ActiveVersions is null)
+            {
+                diagnostics.Add(MalformedSnapshot($"activationStates/{i}/activeVersions", "Snapshot activation state active versions collection cannot be null."));
+                isMalformed = true;
+            }
+            else if (activationState.ActiveVersions.Any(static version => version <= 0))
+            {
+                diagnostics.Add(MalformedSnapshot($"activationStates/{i}/activeVersions", "Snapshot activation state active versions must be greater than zero."));
+                isMalformed = true;
+            }
+
+            if (!isMalformed)
+                validActivationStates.Add(activationState);
+        }
+
+        diagnostics.AddRange(ValidateSnapshotIdentityUniqueness(validDefinitions, validResources, validActivationStates));
+
+        var definitionVersions = validDefinitions
             .Select(static definition => (definition.DefinitionId, definition.Version))
             .ToHashSet();
 
-        foreach (var resource in snapshot.Resources)
+        foreach (var resource in validResources)
         {
             if (resource.DefinitionVersion is null)
                 continue;
@@ -553,11 +704,11 @@ public sealed class ResourcePortabilityService : IResourcePortabilityService
             }
         }
 
-        var resourceVersions = snapshot.Resources
+        var resourceVersions = validResources
             .Select(static resource => (resource.ResourceId, resource.Version))
             .ToHashSet();
 
-        foreach (var activationState in snapshot.ActivationStates)
+        foreach (var activationState in validActivationStates)
         {
             foreach (var version in activationState.ActiveVersions)
             {
@@ -577,24 +728,27 @@ public sealed class ResourcePortabilityService : IResourcePortabilityService
         return diagnostics;
     }
 
-    private static List<PortableDiagnostic> ValidateSnapshotIdentityUniqueness(PortableSnapshot snapshot)
+    private static List<PortableDiagnostic> ValidateSnapshotIdentityUniqueness(
+        IReadOnlyList<ResourceDefinition> definitions,
+        IReadOnlyList<Resource> resources,
+        IReadOnlyList<ActivationState> activationStates)
     {
         var diagnostics = new List<PortableDiagnostic>();
 
         diagnostics.AddRange(FindDuplicateKeys(
-            snapshot.Definitions.Select(static definition => DefinitionVersionId(definition)),
+            definitions.Select(static definition => DefinitionVersionId(definition)),
             "definitions",
             "Snapshot contains duplicate definition version identities."));
         diagnostics.AddRange(FindDuplicateKeys(
-            snapshot.Resources.Select(static resource => ResourceVersionId(resource)),
+            resources.Select(static resource => ResourceVersionId(resource)),
             "resources",
             "Snapshot contains duplicate resource version identities."));
         diagnostics.AddRange(FindDuplicateKeys(
-            snapshot.Resources.Select(static resource => resource.Id),
+            resources.Select(static resource => resource.Id),
             "resources/id",
             "Snapshot contains duplicate version-specific resource IDs."));
         diagnostics.AddRange(FindDuplicateKeys(
-            snapshot.ActivationStates.Select(static state => ActivationEntryId(state)),
+            activationStates.Select(static state => ActivationEntryId(state)),
             "activationStates",
             "Snapshot contains duplicate activation state identities."));
 
@@ -692,6 +846,15 @@ public sealed class ResourcePortabilityService : IResourcePortabilityService
         new()
         {
             Code = PortableDiagnosticCodes.InvalidExportScope,
+            Severity = PortableDiagnosticSeverity.Error,
+            Path = path,
+            Message = message,
+        };
+
+    private static PortableDiagnostic MalformedSnapshot(string path, string message) =>
+        new()
+        {
+            Code = PortableDiagnosticCodes.MalformedSnapshot,
             Severity = PortableDiagnosticSeverity.Error,
             Path = path,
             Message = message,

--- a/test/Aster.Tests/Portability/PortabilityPreviewTests.cs
+++ b/test/Aster.Tests/Portability/PortabilityPreviewTests.cs
@@ -1,0 +1,196 @@
+using Aster.Core.Abstractions;
+using Aster.Core.Extensions;
+using Aster.Core.Models.Definitions;
+using Aster.Core.Models.Instances;
+using Aster.Core.Models.Portability;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Aster.Tests.Portability;
+
+public sealed class PortabilityPreviewTests : IDisposable
+{
+    private readonly ServiceProvider provider;
+    private readonly IResourceDefinitionStore definitionStore;
+    private readonly IResourceManager manager;
+    private readonly IResourcePortabilityService portability;
+
+    public PortabilityPreviewTests()
+    {
+        provider = new ServiceCollection()
+            .AddAsterCore()
+            .BuildServiceProvider();
+
+        definitionStore = provider.GetRequiredService<IResourceDefinitionStore>();
+        manager = provider.GetRequiredService<IResourceManager>();
+        portability = provider.GetRequiredService<IResourcePortabilityService>();
+    }
+
+    public void Dispose() => provider.Dispose();
+
+    [Fact]
+    public async Task PreviewImportAsync_ValidSnapshot_ReturnsPlannedCountsAndDoesNotMutateStore()
+    {
+        var snapshot = CreateSnapshot();
+
+        var preview = await portability.PreviewImportAsync(snapshot);
+
+        Assert.True(preview.CanImport);
+        Assert.Empty(preview.Diagnostics);
+        Assert.Equal(1, preview.Counts.Definitions);
+        Assert.Equal(1, preview.Counts.Resources);
+        Assert.Equal(1, preview.Counts.ResourceVersions);
+        Assert.Equal(1, preview.Counts.ActivationEntries);
+        Assert.Contains(
+            preview.IdentityMap,
+            static mapping =>
+                mapping.EntityKind == PortableEntityKind.DefinitionVersion
+                && mapping.SourceId == """["Product",1]"""
+                && mapping.TargetId == """["Product",1]"""
+                && mapping.Reason == PortableIdentityMappingReason.Preserved);
+
+        Assert.Null(await definitionStore.GetDefinitionAsync("Product"));
+        Assert.Null(await manager.GetLatestVersionAsync("product-1"));
+        Assert.Empty(await manager.GetActiveVersionsAsync("product-1", "Published"));
+    }
+
+    [Fact]
+    public async Task PreviewImportAsync_UnresolvedReferences_ReturnsDiagnosticsWithoutMutation()
+    {
+        var snapshot = CreateSnapshot() with
+        {
+            Definitions = [],
+            ActivationStates =
+            [
+                new ActivationState
+                {
+                    ResourceId = "product-1",
+                    Channel = "Published",
+                    ActiveVersions = [1, 2],
+                    LastUpdated = new DateTime(2026, 1, 2, 3, 5, 5, DateTimeKind.Utc),
+                },
+            ],
+        };
+
+        var preview = await portability.PreviewImportAsync(snapshot);
+
+        Assert.False(preview.CanImport);
+        Assert.Empty(preview.IdentityMap);
+        Assert.Contains(preview.Diagnostics, static diagnostic => diagnostic.Code == PortableDiagnosticCodes.MissingDefinitionReference);
+        Assert.Contains(preview.Diagnostics, static diagnostic => diagnostic.Code == PortableDiagnosticCodes.MissingResourceReference);
+        Assert.Null(await manager.GetLatestVersionAsync("product-1"));
+    }
+
+    [Fact]
+    public async Task PreviewImportAsync_DuplicateSnapshotIdentity_ReturnsDiagnosticBeforePlanningWrites()
+    {
+        var snapshot = CreateSnapshot();
+        snapshot = snapshot with
+        {
+            Resources =
+            [
+                snapshot.Resources[0],
+                snapshot.Resources[0] with { Id = "product-1-v1-copy" },
+            ],
+            ActivationStates = [],
+        };
+
+        var preview = await portability.PreviewImportAsync(snapshot);
+
+        Assert.False(preview.CanImport);
+        var diagnostic = Assert.Single(
+            preview.Diagnostics,
+            static diagnostic => diagnostic.Code == PortableDiagnosticCodes.DuplicateSnapshotIdentity);
+        Assert.Equal("""resources/["product-1",1]""", diagnostic.Path);
+        Assert.Equal(0, preview.Counts.ResourceVersions);
+        Assert.Empty(preview.IdentityMap);
+    }
+
+    [Fact]
+    public async Task PreviewImportAsync_RemapDivergentCollision_ProducesDeterministicIdentityMapWithoutMutation()
+    {
+        await portability.ImportAsync(CreateSnapshotWithResourceOwner("target-owner"));
+        var snapshot = CreateSnapshot();
+        var options = new PortableImportOptions { CollisionMode = PortableImportCollisionMode.RemapDivergent };
+
+        var first = await portability.PreviewImportAsync(snapshot, options);
+        var second = await portability.PreviewImportAsync(snapshot, options);
+
+        Assert.True(first.CanImport);
+        Assert.Equal(
+            first.IdentityMap.Select(static mapping => (mapping.EntityKind, mapping.SourceId, mapping.TargetId, mapping.Reason)),
+            second.IdentityMap.Select(static mapping => (mapping.EntityKind, mapping.SourceId, mapping.TargetId, mapping.Reason)));
+        Assert.Equal(
+            first.Diagnostics.Select(static diagnostic => (diagnostic.Code, diagnostic.Severity, diagnostic.Path, diagnostic.Message)),
+            second.Diagnostics.Select(static diagnostic => (diagnostic.Code, diagnostic.Severity, diagnostic.Path, diagnostic.Message)));
+        Assert.Contains(
+            first.IdentityMap,
+            static mapping =>
+                mapping.EntityKind == PortableEntityKind.ResourceVersion
+                && mapping.SourceId == """["product-1",1]"""
+                && mapping.TargetId == """["product-1__imported",1]"""
+                && mapping.Reason == PortableIdentityMappingReason.RemappedDivergent);
+        Assert.Contains(
+            first.IdentityMap,
+            static mapping =>
+                mapping.EntityKind == PortableEntityKind.ActivationEntry
+                && mapping.SourceId == """["product-1","Published"]"""
+                && mapping.TargetId == """["product-1__imported","Published"]"""
+                && mapping.Reason == PortableIdentityMappingReason.RemappedDivergent);
+        Assert.Null(await manager.GetLatestVersionAsync("product-1__imported"));
+        Assert.Empty(await manager.GetActiveVersionsAsync("product-1__imported", "Published"));
+    }
+
+    private static PortableSnapshot CreateSnapshot()
+    {
+        var created = new DateTime(2026, 1, 2, 3, 4, 5, DateTimeKind.Utc);
+
+        return new PortableSnapshot
+        {
+            FormatVersion = PortableSnapshot.CurrentFormatVersion,
+            Definitions =
+            [
+                new ResourceDefinition
+                {
+                    DefinitionId = "Product",
+                    Id = "product-definition-v1",
+                    Version = 1,
+                },
+            ],
+            Resources =
+            [
+                new Resource
+                {
+                    ResourceId = "product-1",
+                    Id = "product-1-v1",
+                    DefinitionId = "Product",
+                    DefinitionVersion = 1,
+                    Version = 1,
+                    Created = created,
+                },
+            ],
+            ActivationStates =
+            [
+                new ActivationState
+                {
+                    ResourceId = "product-1",
+                    Channel = "Published",
+                    ActiveVersions = [1],
+                    LastUpdated = created.AddMinutes(1),
+                },
+            ],
+        };
+    }
+
+    private static PortableSnapshot CreateSnapshotWithResourceOwner(string owner)
+    {
+        var snapshot = CreateSnapshot();
+
+        return snapshot with
+        {
+            Resources =
+            [
+                snapshot.Resources[0] with { Owner = owner },
+            ],
+        };
+    }
+}

--- a/test/Aster.Tests/Portability/PortabilityPreviewTests.cs
+++ b/test/Aster.Tests/Portability/PortabilityPreviewTests.cs
@@ -7,7 +7,7 @@ using Microsoft.Extensions.DependencyInjection;
 
 namespace Aster.Tests.Portability;
 
-public sealed class PortabilityPreviewTests : IDisposable
+public sealed class PortabilityPreviewTests : IAsyncDisposable
 {
     private readonly ServiceProvider provider;
     private readonly IResourceDefinitionStore definitionStore;
@@ -25,7 +25,7 @@ public sealed class PortabilityPreviewTests : IDisposable
         portability = provider.GetRequiredService<IResourcePortabilityService>();
     }
 
-    public void Dispose() => provider.Dispose();
+    public ValueTask DisposeAsync() => provider.DisposeAsync();
 
     [Fact]
     public async Task PreviewImportAsync_ValidSnapshot_ReturnsPlannedCountsAndDoesNotMutateStore()

--- a/test/Aster.Tests/Portability/PortabilityValidationTests.cs
+++ b/test/Aster.Tests/Portability/PortabilityValidationTests.cs
@@ -1,5 +1,6 @@
 using Aster.Core.Abstractions;
 using Aster.Core.Extensions;
+using Aster.Core.Models.Definitions;
 using Aster.Core.Models.Instances;
 using Aster.Core.Models.Portability;
 using Microsoft.Extensions.DependencyInjection;
@@ -35,5 +36,70 @@ public sealed class PortabilityValidationTests
         var diagnostic = Assert.Single(result.Diagnostics);
         Assert.Equal(PortableDiagnosticCodes.MissingResourceReference, diagnostic.Code);
         Assert.Equal(PortableDiagnosticSeverity.Error, diagnostic.Severity);
+    }
+
+    [Fact]
+    public async Task ValidateAsync_DuplicateDefinitionVersion_ReturnsDuplicateIdentityError()
+    {
+        await using var provider = new ServiceCollection()
+            .AddAsterCore()
+            .BuildServiceProvider();
+        var portability = provider.GetRequiredService<IResourcePortabilityService>();
+
+        var result = await portability.ValidateAsync(new PortableSnapshot
+        {
+            FormatVersion = PortableSnapshot.CurrentFormatVersion,
+            Definitions =
+            [
+                new ResourceDefinition
+                {
+                    DefinitionId = "Product",
+                    Id = "product-definition-v1",
+                    Version = 1,
+                },
+                new ResourceDefinition
+                {
+                    DefinitionId = "Product",
+                    Id = "product-definition-v1-copy",
+                    Version = 1,
+                },
+            ],
+        });
+
+        Assert.False(result.IsValid);
+        var diagnostic = Assert.Single(result.Diagnostics);
+        Assert.Equal(PortableDiagnosticCodes.DuplicateSnapshotIdentity, diagnostic.Code);
+        Assert.Equal("""definitions/["Product",1]""", diagnostic.Path);
+    }
+
+    [Fact]
+    public async Task ValidateAsync_MalformedResource_ReturnsMalformedSnapshotError()
+    {
+        await using var provider = new ServiceCollection()
+            .AddAsterCore()
+            .BuildServiceProvider();
+        var portability = provider.GetRequiredService<IResourcePortabilityService>();
+
+        var result = await portability.ValidateAsync(new PortableSnapshot
+        {
+            FormatVersion = PortableSnapshot.CurrentFormatVersion,
+            Resources =
+            [
+                new Resource
+                {
+                    ResourceId = "",
+                    Id = "product-1-v1",
+                    DefinitionId = "Product",
+                    DefinitionVersion = 1,
+                    Version = 1,
+                    Created = new DateTime(2026, 1, 2, 3, 4, 5, DateTimeKind.Utc),
+                },
+            ],
+        });
+
+        Assert.False(result.IsValid);
+        var diagnostic = Assert.Single(result.Diagnostics);
+        Assert.Equal(PortableDiagnosticCodes.MalformedSnapshot, diagnostic.Code);
+        Assert.Equal("resources/0/resourceId", diagnostic.Path);
     }
 }


### PR DESCRIPTION
## Summary
- validate snapshot shape consistently before preview/import/validation flows
- add malformed snapshot diagnostics and preview-specific coverage
- update portability spec artifacts for preview diagnostics

## Validation
- dotnet test Aster.sln --no-restore --filter "FullyQualifiedName~Portability"
- dotnet test Aster.sln --no-restore
- dotnet build Aster.sln /m:1
- focused dotnet format --verify-no-changes
- git diff --check