### PR TITLE
Add explicit tenant scoping

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,4 @@
 {
-  "featureDir": "specs/014-host-lifecycle-hooks"
+  "featureDir": "specs/015-tenant-scoping",
+  "feature_directory": "specs/015-tenant-scoping"
 }

--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,4 +1,3 @@
 {
-  "featureDir": "specs/015-tenant-scoping",
-  "feature_directory": "specs/015-tenant-scoping"
+  "featureDir": "specs/015-tenant-scoping"
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 <!-- SPECKIT START -->
 For additional context about technologies to be used, project structure,
-shell commands, and other important information, read `specs/014-host-lifecycle-hooks/plan.md`.
+shell commands, and other important information, read `specs/015-tenant-scoping/plan.md`.
 <!-- SPECKIT END -->
 
 ## Active Technologies
@@ -14,8 +14,11 @@ shell commands, and other important information, read `specs/014-host-lifecycle-
 - Existing resource definitions, resource versions, and activation state; no schema migration planned for SQLite JSON or in-memory stores (013-portability-primitives)
 - C# latest, .NET 8.0 / 9.0 / 10.0 multi-targeting + Existing core SDK, resource manager/store abstractions, resource schema-version service, portability service, SQLite JSON provider, xUnit test stack; no new dependencies (014-host-lifecycle-hooks)
 - Existing resource definitions, resource versions, activation state, and portable snapshots; no schema migration or persisted hook state (014-host-lifecycle-hooks)
+- C# latest, .NET 8.0 / 9.0 / 10.0 multi-targeting + Existing core SDK, in-memory store, SQLite JSON provider, resource manager/store abstractions, query capability/validation stack, portability service, lifecycle hook dispatcher, xUnit test stack; no new dependencies (015-tenant-scoping)
+- Existing resource definitions, resource versions, activation state, and portable snapshots extended with tenant scope metadata; no automatic migration policy or external storage service (015-tenant-scoping)
 
 ## Recent Changes
+- 015-tenant-scoping: Added explicit tenant boundary planning for definitions, resources, activation state, queries, schema upgrades, portability, and lifecycle hooks; no automatic migration policy or tenant registry
 - 014-host-lifecycle-hooks: Added explicit host lifecycle hook planning over save, activation, deactivation, export, preview import, and write import; no schema migration or persisted hook state
 - 013-portability-primitives: Added deterministic export/import portability planning over existing definitions, resources, and activation state; no schema migration planned
 - 012-definition-schema-upgrades: Added definition schema version and explicit upgrade flow planning; no schema migration or automatic data rewrite

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ For tenant-aware hosts, pass a `TenantScope` explicitly:
 
 ```csharp
 var tenant = TenantScope.FromTenantId("tenant-a");
-await definitionStore.RegisterDefinitionAsync(definition, tenant);
+await definitionStore.RegisterDefinitionAsync(definition, tenant, CancellationToken.None);
 ```
 
 ### 3. Create a Resource

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 It provides a headless, backend-agnostic foundation for attaching reusable, cross-cutting capabilities (Tags, Owner, RBAC, Scheduling, …) to any resource type — without hard-coding every entity from scratch.
 
-> **Status:** Phase 4 in progress — Core SDK, in-memory engine, SQLite JSON persistence/querying, query capability discovery, preflight validation, typed query helpers, provider conformance support, portable operators, SQLite date-like ranges, explicit index projection contracts, definition schema upgrades, and portability primitives are available. See [Roadmap](#roadmap) for future phases.
+> **Status:** Phase 5 starting — Core SDK, in-memory engine, SQLite JSON persistence/querying, query capability discovery, preflight validation, typed query helpers, provider conformance support, portable operators, SQLite date-like ranges, explicit index projection contracts, definition schema upgrades, portability primitives, host lifecycle hooks, and explicit tenant scoping are available. See [Roadmap](#roadmap) for future phases.
 
 ---
 
@@ -36,6 +36,7 @@ It provides a headless, backend-agnostic foundation for attaching reusable, cros
 | **Facet Definition** | A typed field declared inside an Aspect Definition (e.g. `Title: string`, `Amount: decimal`). |
 | **Facet Value** | The actual value of a facet on an aspect instance. |
 | **Activation Channel** | A named delivery context (e.g. `"Published"`, `"Staging"`). A resource version becomes _active_ when placed in a channel. Multiple channels and multiple simultaneously active versions are supported. |
+| **Tenant Scope** | An explicit opaque tenant boundary for definitions, resources, activation state, queries, schema upgrades, portability, and lifecycle hooks. Omitted scope resolves to the default single-tenant scope. |
 
 Resources follow an **append-only versioning model** — versions are never mutated. A version with no activation entry is implicitly a draft.
 
@@ -79,11 +80,19 @@ var definition = new ResourceDefinitionBuilder()
 await definitionStore.RegisterDefinitionAsync(definition);
 ```
 
+For tenant-aware hosts, pass a `TenantScope` explicitly:
+
+```csharp
+var tenant = TenantScope.FromTenantId("tenant-a");
+await definitionStore.RegisterDefinitionAsync(definition, tenant);
+```
+
 ### 3. Create a Resource
 
 ```csharp
 var resource = await manager.CreateAsync("Product", new CreateResourceRequest
 {
+    TenantScope = tenant, // omit for default single-tenant behavior
     InitialAspects = new Dictionary<string, object>
     {
         ["TitleAspect"] = new TitleAspect("Super Gadget"),
@@ -153,6 +162,7 @@ Use `IResourceQueryService` with a portable `ResourceQuery` AST:
 ```csharp
 var query = new ResourceQuery
 {
+    TenantScope = tenant,
     DefinitionId = "Product",
     Filter = new FacetValueFilter("TitleAspect", "Title", "Gadget", ComparisonOperator.Contains),
     Sorts = [new SortExpression("Created", SortDirection.Descending)],
@@ -286,7 +296,7 @@ specs/                       ← Feature specs (001-core-sdk-foundation, …)
 | **2A** | SQLite JSON Persistence & Querying | ✅ Complete |
 | **3** | Query Capabilities & Typed Querying | ✅ Complete |
 | **4** | Portability & Integration Hooks | 🚧 In Progress |
-| **5** | Multi-tenancy, Policies, Advanced Versioning | 📋 Planned |
+| **5** | Multi-tenancy, Policies, Advanced Versioning | 🚧 In Progress |
 | **6** | Operational Hardening (concurrency, perf, migrations) | 📋 Planned |
 
 See [`docs/Roadmap.md`](docs/Roadmap.md) and [`wiki/Roadmap.md`](wiki/Roadmap.md) for the full phase breakdown with epics and definitions of done.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 It provides a headless, backend-agnostic foundation for attaching reusable, cross-cutting capabilities (Tags, Owner, RBAC, Scheduling, …) to any resource type — without hard-coding every entity from scratch.
 
-> **Status:** Phase 5 starting — Core SDK, in-memory engine, SQLite JSON persistence/querying, query capability discovery, preflight validation, typed query helpers, provider conformance support, portable operators, SQLite date-like ranges, explicit index projection contracts, definition schema upgrades, portability primitives, host lifecycle hooks, and explicit tenant scoping are available. See [Roadmap](#roadmap) for future phases.
+> **Status:** Phase 5 in progress — Core SDK, in-memory engine, SQLite JSON persistence/querying, query capability discovery, preflight validation, typed query helpers, provider conformance support, portable operators, SQLite date-like ranges, explicit index projection contracts, definition schema upgrades, portability primitives, host lifecycle hooks, and explicit tenant scoping are available. See [Roadmap](#roadmap) for future phases.
 
 ---
 
@@ -295,7 +295,7 @@ specs/                       ← Feature specs (001-core-sdk-foundation, …)
 | **1** | Core SDK & In-Memory Engine | ✅ Complete |
 | **2A** | SQLite JSON Persistence & Querying | ✅ Complete |
 | **3** | Query Capabilities & Typed Querying | ✅ Complete |
-| **4** | Portability & Integration Hooks | 🚧 In Progress |
+| **4** | Portability & Integration Hooks | ✅ Core Complete |
 | **5** | Multi-tenancy, Policies, Advanced Versioning | 🚧 In Progress |
 | **6** | Operational Hardening (concurrency, perf, migrations) | 📋 Planned |
 

--- a/docs/ExecutionRoadmap.md
+++ b/docs/ExecutionRoadmap.md
@@ -1,14 +1,14 @@
 # Aster Execution Roadmap
 
-Last updated: 2026-05-20
+Last updated: 2026-05-24
 
 This roadmap tracks the implementation trail we have already cut through the repo and the next product slices that should stay small enough for Spec Kit-driven PRs. It is intentionally execution-oriented; the broader architecture narrative remains in `docs/Roadmap.md` and the wiki.
 
 ## Current Position
 
-Aster now has a working Core SDK, in-memory runtime, SQLite JSON persistence/querying, provider capability discovery, provider validation alignment, provider authoring ergonomics, a reusable provider conformance harness, SQLite facet sorting, portable operator expansion, SQLite date-like ranges, explicit provider-declared index projections, explicit definition schema upgrade behavior, and deterministic portability primitives.
+Aster now has a working Core SDK, in-memory runtime, SQLite JSON persistence/querying, provider capability discovery, provider validation alignment, provider authoring ergonomics, a reusable provider conformance harness, SQLite facet sorting, portable operator expansion, SQLite date-like ranges, explicit provider-declared index projections, explicit definition schema upgrade behavior, deterministic portability primitives, and explicit host lifecycle hooks.
 
-The active workstream is in **Phase 4: Portability & Integration Hooks**. The next useful slice is explicit host lifecycle hooks around save, activation, deactivation, and import/export, still without introducing recipes, live sync, migrations, planner behavior, runtime scanning, provider registries, public SQL, or `IQueryable<Resource>`.
+The Phase 4 core workstream is complete enough to defer optional recipes. The active workstream is now **Phase 5: Multi-tenancy, Policies, Advanced Versioning**, starting with explicit tenant-aware boundaries before policies or cross-tenant behavior are introduced.
 
 ## Landed Slices
 
@@ -27,25 +27,27 @@ The active workstream is in **Phase 4: Portability & Integration Hooks**. The ne
 | `011-explicit-indexing-model` | Landed | Provider-declared index projection contracts, validation, evaluation, capability discovery, and provider-authoring docs without physical indexes or query planning. |
 | `012-definition-schema-upgrades` | Landed | Explicit resource definition lineage, schema status inspection, append-only schema upgrades, and carried-forward data diagnostics. |
 | `013-portability-primitives` | Landed | Deterministic export/import primitives for definitions, resources, resource versions, activation state, strict validation, previews, identity mapping, remapping, and provider-backed atomic writes. |
+| `014-host-lifecycle-hooks` | Landed | Explicit before/after hooks for save, activation, deactivation, schema upgrades, export, preview import, and write import with deterministic ordering and fail-closed diagnostics. |
 
 ## Near-Term Roadmap
 
-### 014 — Host Lifecycle Hooks
+### 015 — Tenant Scoping
 
-**Goal:** Add explicit integration hooks around resource lifecycle and portability operations without hidden discovery or a recipe framework.
+**Goal:** Add explicit tenant-aware boundaries for definitions, resources, activation state, queries, schema upgrades, portability, and lifecycle hooks while preserving default single-tenant behavior.
 
 Candidate scope:
 
-- Before/after hooks for save, activation, deactivation, export, preview import, and write import.
-- Clear ordering, cancellation, failure semantics, and diagnostics.
-- Keep recipes, runtime scanning, live sync, and background job orchestration separate follow-up slices.
+- Stable tenant identity and default single-tenant scope.
+- Scoped definition/resource lifecycle, activation state, queries, schema upgrades, portability snapshots, and lifecycle hook contexts.
+- Fail-closed diagnostics for missing, invalid, ambiguous, or mismatched tenant scope.
+- Keep shared-definition inheritance, cross-tenant queries, authorization, policy engines, migrations, runtime scanning, provider registries, public SQL, and `IQueryable<Resource>` out of scope.
 
 ## Later Roadmap
 
 | Area | Intent |
 |---|---|
-| Host hooks | Lifecycle hooks around save, activation, deactivation, and import/export. |
-| Multi-tenancy | Tenant-aware definition scope and query boundaries. |
+| Optional recipes | Separate `Aster.Recipes` package for hosts that want recipe execution over portability primitives. |
+| Multi-tenancy extensions | Shared definitions, tenant hierarchy, and cross-tenant administrative workflows after explicit tenant boundaries exist. |
 | Policies | Retention, archival, soft-delete, and pruning policies. |
 | Operational hardening | Benchmarks, migration idempotency, concurrency hardening, and large-data test suites. |
 

--- a/docs/ExecutionRoadmap.md
+++ b/docs/ExecutionRoadmap.md
@@ -6,9 +6,9 @@ This roadmap tracks the implementation trail we have already cut through the rep
 
 ## Current Position
 
-Aster now has a working Core SDK, in-memory runtime, SQLite JSON persistence/querying, provider capability discovery, provider validation alignment, provider authoring ergonomics, a reusable provider conformance harness, SQLite facet sorting, portable operator expansion, SQLite date-like ranges, explicit provider-declared index projections, explicit definition schema upgrade behavior, deterministic portability primitives, and explicit host lifecycle hooks.
+Aster now has a working Core SDK, in-memory runtime, SQLite JSON persistence/querying, provider capability discovery, provider validation alignment, provider authoring ergonomics, a reusable provider conformance harness, SQLite facet sorting, portable operator expansion, SQLite date-like ranges, explicit provider-declared index projections, explicit definition schema upgrade behavior, deterministic portability primitives, explicit host lifecycle hooks, and explicit tenant scoping.
 
-The Phase 4 core workstream is complete enough to defer optional recipes. The active workstream is now **Phase 5: Multi-tenancy, Policies, Advanced Versioning**, starting with explicit tenant-aware boundaries before policies or cross-tenant behavior are introduced.
+The Phase 4 core workstream is complete enough to defer optional recipes. The active workstream is now **Phase 5: Multi-tenancy, Policies, Advanced Versioning**. Explicit tenant-aware boundaries have landed; policy foundations are the next small slice before cross-tenant behavior is introduced.
 
 ## Landed Slices
 
@@ -28,19 +28,21 @@ The Phase 4 core workstream is complete enough to defer optional recipes. The ac
 | `012-definition-schema-upgrades` | Landed | Explicit resource definition lineage, schema status inspection, append-only schema upgrades, and carried-forward data diagnostics. |
 | `013-portability-primitives` | Landed | Deterministic export/import primitives for definitions, resources, resource versions, activation state, strict validation, previews, identity mapping, remapping, and provider-backed atomic writes. |
 | `014-host-lifecycle-hooks` | Landed | Explicit before/after hooks for save, activation, deactivation, schema upgrades, export, preview import, and write import with deterministic ordering and fail-closed diagnostics. |
+| `015-tenant-scoping` | Landed | Explicit tenant boundaries for definitions, resources, activation state, queries, schema upgrades, portability snapshots, and lifecycle hook contexts with default single-tenant compatibility. |
 
 ## Near-Term Roadmap
 
-### 015 — Tenant Scoping
+### 016 — Policy Foundations
 
-**Goal:** Add explicit tenant-aware boundaries for definitions, resources, activation state, queries, schema upgrades, portability, and lifecycle hooks while preserving default single-tenant behavior.
+**Goal:** Introduce explicit policy contracts for retention, archival, soft-delete, and version pruning while preserving append-only resource history by default.
 
 Candidate scope:
 
-- Stable tenant identity and default single-tenant scope.
-- Scoped definition/resource lifecycle, activation state, queries, schema upgrades, portability snapshots, and lifecycle hook contexts.
-- Fail-closed diagnostics for missing, invalid, ambiguous, or mismatched tenant scope.
-- Keep shared-definition inheritance, cross-tenant queries, authorization, policy engines, migrations, runtime scanning, provider registries, public SQL, and `IQueryable<Resource>` out of scope.
+- Policy metadata models and validation diagnostics.
+- Explicit policy evaluation entry points for hosts and providers.
+- Soft-delete/archive markers that remain queryable through declared scopes.
+- Version pruning previews before destructive writes.
+- Keep background schedulers, hidden retention jobs, authorization policy engines, runtime scanning, provider registries, public SQL, and `IQueryable<Resource>` out of scope.
 
 ## Later Roadmap
 

--- a/specs/015-tenant-scoping/checklists/requirements.md
+++ b/specs/015-tenant-scoping/checklists/requirements.md
@@ -1,0 +1,34 @@
+# Specification Quality Checklist: Tenant Scoping
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning  
+**Created**: 2026-05-24  
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [X] No implementation details (languages, frameworks, APIs)
+- [X] Focused on user value and business needs
+- [X] Written for non-technical stakeholders
+- [X] All mandatory sections completed
+
+## Requirement Completeness
+
+- [X] No [NEEDS CLARIFICATION] markers remain
+- [X] Requirements are testable and unambiguous
+- [X] Success criteria are measurable
+- [X] Success criteria are technology-agnostic (no implementation details)
+- [X] All acceptance scenarios are defined
+- [X] Edge cases are identified
+- [X] Scope is clearly bounded
+- [X] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [X] All functional requirements have clear acceptance criteria
+- [X] User scenarios cover primary flows
+- [X] Feature meets measurable outcomes defined in Success Criteria
+- [X] No implementation details leak into specification
+
+## Notes
+
+- Ready for `/speckit-clarify` or `/speckit-plan`.

--- a/specs/015-tenant-scoping/contracts/tenant-scoping.md
+++ b/specs/015-tenant-scoping/contracts/tenant-scoping.md
@@ -1,0 +1,123 @@
+# Contract: Tenant Scoping
+
+This contract describes public SDK behavior for tenant-aware boundaries. Names are provisional for planning, but the behavior is normative.
+
+## Tenant Scope Model
+
+The SDK MUST expose a small tenant scope value that can be supplied to tenant-aware operations.
+
+Required behavior:
+
+- A missing tenant scope MUST resolve to the documented default single-tenant scope.
+- Explicit tenant IDs MUST be opaque exact-match values.
+- The SDK MUST reject null, empty, or whitespace tenant IDs.
+- The SDK MUST NOT case-fold, slugify, trim into a different identity, or otherwise normalize valid tenant IDs.
+- Tenant authorization and tenant existence checks are host responsibilities.
+
+Public API shape:
+
+- Existing request DTOs SHOULD gain optional tenant scope properties.
+- Existing method-style APIs without request DTOs SHOULD gain additive tenant-aware overloads.
+- Existing methods without tenant input MUST continue to target the default single-tenant scope.
+
+## Definition Store Behavior
+
+Definition registration and lookup MUST be scoped by the effective tenant.
+
+Required behavior:
+
+- Registering a definition appends a new version inside the effective tenant scope.
+- Looking up the latest definition by ID returns the latest version for that ID in the effective tenant only.
+- Looking up a specific definition version resolves `(tenant, definition ID, version)`.
+- Listing definitions returns latest definitions for the effective tenant only.
+- The same definition ID and version MAY exist in different tenants.
+
+Existing no-tenant calls MUST continue to operate on the default single-tenant scope.
+
+SQLite provider compatibility:
+
+- Fresh SQLite databases MUST store tenant metadata for definitions, resources, and activation state.
+- Existing pre-tenant SQLite databases MUST be treated as default-scope data after provider initialization.
+- The provider MUST NOT introduce a general migration framework for this slice.
+
+## Resource Manager Behavior
+
+Resource lifecycle operations MUST resolve an effective tenant before reading or writing data.
+
+Required behavior:
+
+- Create, update, get latest, get version, get versions, activate, deactivate, and get active versions operate inside one effective tenant.
+- Caller-supplied duplicate resource ID checks are tenant-scoped.
+- Optimistic concurrency checks are tenant-scoped.
+- A resource ID that exists in another tenant MUST behave as not found or out of scope for the current tenant.
+- The same resource ID MAY exist in different tenants.
+
+Existing no-tenant calls MUST continue to operate on the default single-tenant scope.
+
+## Query Behavior
+
+Portable queries MUST include or resolve one effective tenant scope.
+
+Required behavior:
+
+- Query execution filters by tenant before applying version scope, activation channel, predicates, sorting, skip, or take.
+- Provider capability declarations do not need a new provider registry or negotiation model.
+- Query validation MUST reject invalid tenant scope before execution.
+- Results MUST NOT include resources from another tenant.
+
+## Schema Upgrade Behavior
+
+Schema status and schema upgrade workflows MUST resolve definition lineage within the effective tenant.
+
+Required behavior:
+
+- Schema status compares the resource's recorded definition version to definitions in the same tenant.
+- Upgrade targets must exist in the same tenant.
+- Upgrade writes append a new resource version in the same tenant.
+- Cross-tenant definition lineage MUST fail closed.
+
+## Portability Behavior
+
+Export, validation, preview import, and write import MUST preserve tenant boundaries.
+
+Required behavior:
+
+- Export requests select data from exactly one effective tenant.
+- Snapshots MUST record source tenant identity.
+- Snapshots MUST NOT contain multiple source tenants.
+- Preview import and write import MUST target exactly one explicit tenant.
+- Import results and previews MUST report source and target tenant metadata.
+- Multi-tenant remapping is out of scope.
+
+## Lifecycle Hook Behavior
+
+Lifecycle hook contexts MUST expose the effective tenant scope for tenant-scoped operations.
+
+Required behavior:
+
+- Save, activation, deactivation, schema upgrade, export, preview import, and write import contexts include tenant scope.
+- Hooks observe the same effective tenant used by the underlying operation.
+- Hook rejection/failure semantics remain unchanged and apply only to the current tenant-scoped operation.
+
+## Compatibility
+
+The default single-tenant scope preserves existing behavior:
+
+- Existing callers that omit tenant scope use the default scope.
+- Existing tests and quickstart flows must not require tenant-specific input.
+- Adding explicit tenant-specific data must not change behavior of omitted-scope calls.
+
+## Out Of Scope
+
+This feature MUST NOT introduce:
+
+- shared-definition inheritance;
+- tenant hierarchy;
+- cross-tenant queries;
+- authorization or permission checks;
+- policy engines or retention rules;
+- migration engine or migration policy;
+- runtime scanning;
+- provider registry;
+- public raw SQL;
+- public `IQueryable<Resource>`.

--- a/specs/015-tenant-scoping/data-model.md
+++ b/specs/015-tenant-scoping/data-model.md
@@ -1,0 +1,164 @@
+# Data Model: Tenant Scoping
+
+## Tenant Scope
+
+Represents the effective boundary for tenant-aware SDK operations.
+
+Fields:
+
+- `TenantId`: Stable opaque tenant identifier.
+- `IsDefault`: Whether the scope represents the documented default single-tenant environment.
+
+Validation rules:
+
+- Tenant IDs must not be null, empty, or whitespace.
+- Valid tenant IDs are exact-match opaque values.
+- The SDK must not case-fold, trim into a different identity, slugify, or normalize valid tenant IDs.
+- Omitted tenant scope resolves to the default single-tenant scope.
+
+Relationships:
+
+- Applied to definition, resource, activation, query, schema upgrade, portability, and lifecycle hook operations.
+
+## Tenant-Scoped Definition
+
+Represents a resource definition resolved within one tenant scope.
+
+Fields:
+
+- `TenantScope`: Effective tenant boundary.
+- `DefinitionId`: Logical definition identifier.
+- `Version`: Definition version number.
+- Existing definition payload and metadata.
+
+Validation rules:
+
+- `(TenantScope, DefinitionId, Version)` is unique.
+- Latest-definition lookup is scoped by `(TenantScope, DefinitionId)`.
+- The same `DefinitionId` and `Version` may exist independently in different tenants.
+
+Relationships:
+
+- Tenant-scoped resources reference definition lineage inside the same tenant scope.
+
+## Tenant-Scoped Resource
+
+Represents a resource and its immutable versions resolved within one tenant scope.
+
+Fields:
+
+- `TenantScope`: Effective tenant boundary.
+- `ResourceId`: Logical resource identifier.
+- `Version`: Resource version number.
+- `DefinitionId`: Logical definition identifier inside the same tenant.
+- `DefinitionVersion`: Recorded definition version inside the same tenant.
+- Existing resource payload, aspects, metadata, and version fields.
+
+Validation rules:
+
+- `(TenantScope, ResourceId, Version)` is unique.
+- Caller-supplied duplicate `ResourceId` checks are scoped to the tenant.
+- Resource reads, updates, activations, and deactivations must not resolve resources from another tenant.
+- Existing optimistic concurrency remains scoped to the tenant's latest version for the resource.
+
+Relationships:
+
+- Activation state is resolved by tenant, resource ID, and channel.
+- Queries use tenant scope before applying filters, sorting, and paging.
+
+## Tenant-Scoped Activation State
+
+Represents channel activation records for one tenant-scoped resource.
+
+Fields:
+
+- `TenantScope`: Effective tenant boundary.
+- `ResourceId`: Logical resource identifier.
+- `Channel`: Activation channel.
+- Existing activation entries.
+
+Validation rules:
+
+- Activation and deactivation only affect records in the effective tenant.
+- The same `ResourceId` and `Channel` may exist independently in different tenants.
+
+## Tenant-Scoped Query
+
+Represents a portable resource query evaluated within one tenant boundary.
+
+Fields:
+
+- `TenantScope`: Optional explicit tenant scope; omitted means default single-tenant scope.
+- Existing query scope, activation channel, definition filter, predicates, sorting, and paging.
+
+Validation rules:
+
+- Query execution must resolve one effective tenant before reading candidate versions.
+- Query results must not include resources from another tenant.
+- Active-scope queries must apply tenant filtering before channel activation matching.
+
+## Tenant-Scoped Snapshot
+
+Represents a portable snapshot containing data from exactly one source tenant.
+
+Fields:
+
+- `SourceTenantScope`: Tenant identity recorded when the snapshot is exported.
+- Existing snapshot format version.
+- Tenant-scoped definition versions.
+- Tenant-scoped resource versions.
+- Tenant-scoped activation state.
+
+Validation rules:
+
+- A snapshot must contain data from exactly one source tenant.
+- Export requests use the effective tenant scope to select data.
+- Import preview and write import target exactly one explicit target tenant.
+- Imports report source and target tenant metadata.
+- Multi-source snapshot export and multi-target remapping are out of scope.
+
+## Tenant Scope Failure
+
+Represents fail-closed tenant-scope validation or mismatch.
+
+Fields:
+
+- `Code`: Stable failure code.
+- `Message`: Human-readable explanation.
+- `TenantId`: Tenant involved when available.
+- `TargetTenantId`: Import target tenant when applicable.
+
+Candidate codes:
+
+- `tenant-scope-invalid`
+- `tenant-scope-mismatch`
+- `tenant-scope-required`
+- `tenant-snapshot-multiple-tenants`
+
+Validation rules:
+
+- Invalid tenant IDs fail before data is read or written.
+- Cross-tenant target mismatches fail without exposing other-tenant payload data.
+
+## State Transitions
+
+```text
+No tenant input
+  -> Resolve default tenant scope
+  -> Execute operation in default scope
+
+Explicit tenant input
+  -> Validate tenant identifier
+  -> Resolve explicit tenant scope
+  -> Execute operation in explicit scope
+
+Export
+  -> Resolve effective tenant
+  -> Select scoped data
+  -> Emit snapshot with SourceTenantScope
+
+Import preview/write
+  -> Validate snapshot source tenant
+  -> Resolve explicit target tenant
+  -> Preview or write only within target tenant
+```

--- a/specs/015-tenant-scoping/plan.md
+++ b/specs/015-tenant-scoping/plan.md
@@ -1,0 +1,136 @@
+# Implementation Plan: Tenant Scoping
+
+**Branch**: `015-tenant-scoping` | **Date**: 2026-05-24 | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from `/specs/015-tenant-scoping/spec.md`
+
+## Summary
+
+Add explicit tenant-aware boundaries as the first Phase 5 slice. The plan introduces a small tenant scope model, threads optional tenant scope through request DTOs where they already exist, adds explicit tenant overloads for method-style APIs, partitions definition/resource/query/activation/schema/portability behavior by the effective tenant, and exposes the effective tenant to lifecycle hooks. Existing callers that omit tenant scope continue to use a documented default single-tenant scope. The slice intentionally avoids tenant hierarchy, shared-definition inheritance, cross-tenant queries, authorization, policy engines, migrations, runtime scanning, provider registries, public SQL, and public `IQueryable<Resource>`.
+
+## Technical Context
+
+**Language/Version**: C# latest, .NET 8.0 / 9.0 / 10.0 multi-targeting  
+**Primary Dependencies**: Existing core SDK, in-memory store, SQLite JSON provider, resource manager/store abstractions, query capability/validation stack, portability service, lifecycle hook dispatcher, xUnit test stack; no new dependencies  
+**Storage**: Existing resource definitions, resource versions, activation state, and portable snapshots extended with tenant scope metadata; SQLite initialization may perform minimal idempotent default-scope compatibility backfill for existing pre-tenant databases; no general migration policy or external storage service  
+**Testing**: `dotnet test Aster.sln`, focused tenant definition/resource/query/portability/lifecycle tests, SQLite JSON tenant isolation tests, existing single-tenant regression tests, `dotnet build Aster.sln /m:1`, `git diff --check`  
+**Target Platform**: .NET SDK/library consumers and local test environment  
+**Project Type**: SDK/library with provider packages and tests  
+**Performance Goals**: Default single-tenant operations remain equivalent except for cheap tenant-scope resolution; tenant filtering is applied before query predicates and should not require scanning other tenants in provider-backed execution  
+**Constraints**: Explicit operation input determines tenant scope; request DTOs carry tenant scope where they already exist; method-style APIs receive additive tenant overloads; omitted scope always maps to the default single-tenant scope; tenant IDs are opaque exact-match values; identities are tenant-scoped; snapshots contain one source tenant and import into one explicit target tenant; no tenant hierarchy, shared definitions, authorization, policy engine, migration framework, runtime scanning, provider registry, public SQL, or public `IQueryable<Resource>`  
+**Scale/Scope**: Current core SDK plus in-memory and SQLite JSON provider support for tenant-isolated definitions, resources, activation state, queries, schema upgrades, portability, and lifecycle hook contexts
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+- **SDK-first/headless**: PASS - Adds SDK/library scope contracts only; no UI, CMS, host framework, or authorization coupling.
+- **Immutable versioning**: PASS - Tenant scope partitions append-only versions but does not mutate historical snapshots.
+- **Channel activation**: PASS - Activation remains separate from resource payloads and is partitioned by tenant plus channel.
+- **Typed/queryable**: PASS - Typed aspects and portable query AST remain the public query surface; no public SQL or `IQueryable<Resource>`.
+- **Provider agnostic**: PASS - Core models and service contracts carry tenant scope while provider packages handle provider-specific storage filtering.
+- **Simplicity first**: PASS - One explicit tenant scope and one default scope satisfy current requirements without tenant hierarchy or policy infrastructure.
+- **Modern C# idioms**: PASS - Records, nullable annotations, collection expressions, and async APIs fit the existing SDK style.
+- **Readability over cleverness**: PASS - Tenant scope is visible on request models and contexts rather than hidden behind ambient state.
+- **Explicitness over magic**: PASS - No runtime scanning, implicit tenant discovery, or hidden host context.
+- **Abstractions justified**: PASS - A tenant scope value and scoped request semantics solve demonstrated isolation requirements across existing operations.
+- **Optimize for deletion**: PASS - Tenant metadata is additive and localized to request/snapshot/context boundaries and provider filters.
+- **Composition over inheritance**: PASS - Uses composed scope values and request data; no inheritance hierarchy.
+- **Intentional dependencies**: PASS - No new third-party dependencies.
+- **Operational simplicity**: PASS - No external services, background jobs, migration runner, or deployment-time tenant provisioning.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/015-tenant-scoping/
++-- spec.md
++-- plan.md
++-- research.md
++-- data-model.md
++-- quickstart.md
++-- checklists/
+|   +-- requirements.md
++-- contracts/
+    +-- tenant-scoping.md
+```
+
+### Source Code (repository root)
+
+```text
+src/
++-- core/Aster.Core/
+|   +-- Abstractions/
+|   |   +-- tenant-aware request/store contracts
+|   +-- Models/Tenancy/
+|   |   +-- tenant scope value model and default scope constants
+|   +-- Models/Querying/
+|   |   +-- query tenant scope metadata
+|   +-- Models/Portability/
+|   |   +-- snapshot source tenant and import target tenant metadata
+|   +-- Models/Lifecycle/
+|   |   +-- tenant scope on lifecycle hook contexts
+|   +-- InMemory/
+|   |   +-- tenant-partitioned definition/resource/portability/query behavior
+|   +-- Services/
+|       +-- tenant-aware resource manager, schema upgrade, portability, and hook context creation
+|
++-- persistence/Aster.Persistence.SqliteJson/
+|   +-- tenant-aware SQLite storage and query filtering
+|
++-- apps/Aster.Web/
+    +-- default-scope compatibility updates only if needed
+
+test/
++-- Aster.Tests/
+    +-- Tenancy/
+    +-- InMemory/
+    +-- Querying/
+    +-- Portability/
+    +-- Lifecycle/
+    +-- SqliteJson/
+```
+
+**Structure Decision**: Keep tenant scope in `Aster.Core` because it is a provider-agnostic SDK boundary required by definitions, lifecycle operations, querying, portability, and hooks. Provider packages implement tenant-aware persistence/filtering behind existing provider abstractions. Do not add a tenant service, registry, authorization layer, policy package, or new dependency.
+
+## Complexity Tracking
+
+No constitution violations.
+
+## Phase 0 Research Summary
+
+Research decisions are captured in [research.md](research.md). Key outcomes:
+
+- Use explicit request-level tenant scope over ambient context.
+- Preserve compatibility through a named default single-tenant scope.
+- Use request DTO tenant fields where request DTOs already exist and additive overloads for method-style APIs.
+- Treat tenant identifiers as opaque exact-match values.
+- Make definition and resource identities unique within tenant scope.
+- Keep snapshots single-source-tenant and imports single-target-tenant.
+- Validate tenant scope centrally and fail closed before reading or writing scoped data.
+- Keep provider work explicit and local; SQLite may perform minimal default-scope compatibility bootstrap, but no migration framework, registry, planner, or policy framework is introduced.
+
+## Phase 1 Design Summary
+
+Design artifacts:
+
+- [data-model.md](data-model.md)
+- [contracts/tenant-scoping.md](contracts/tenant-scoping.md)
+- [quickstart.md](quickstart.md)
+
+## Post-Design Constitution Check
+
+- **SDK-first/headless**: PASS - Design remains SDK-only and leaves tenant auth/policy decisions to hosts.
+- **Immutable versioning**: PASS - Tenant-scoped resources still append new immutable versions.
+- **Channel activation**: PASS - Activation entries are tenant-scoped while activation stays separate from payload data.
+- **Typed/queryable**: PASS - Query model gets tenant scope metadata without exposing SQL or `IQueryable`.
+- **Provider agnostic**: PASS - Core defines tenant semantics; providers translate them into local storage filters.
+- **Simplicity first**: PASS - Scope value plus request/context propagation is the smallest design that covers current workflows.
+- **Modern C# idioms**: PASS - Uses records and nullable-safe request properties consistent with existing code.
+- **Readability over cleverness**: PASS - Tenant resolution is explicit and testable at operation boundaries.
+- **Explicitness over magic**: PASS - No ambient tenant context, runtime scanning, or convention-only discovery.
+- **Abstractions justified**: PASS - Tenant scope model is shared by multiple existing services and providers.
+- **Optimize for deletion**: PASS - Tenant-specific additions can be removed from request/snapshot/context fields and provider filters without unrelated framework teardown.
+- **Composition over inheritance**: PASS - Scope is composed into existing models; no base-service hierarchy.
+- **Intentional dependencies**: PASS - No new dependencies.
+- **Operational simplicity**: PASS - Existing build/test workflow remains sufficient; no migration engine or tenant provisioning service.

--- a/specs/015-tenant-scoping/quickstart.md
+++ b/specs/015-tenant-scoping/quickstart.md
@@ -31,8 +31,8 @@ Hosts that need tenant isolation pass a tenant scope explicitly:
 var tenantA = TenantScope.FromTenantId("tenant-a");
 var tenantB = TenantScope.FromTenantId("tenant-b");
 
-await definitionStore.RegisterDefinitionAsync(productDefinition, tenantA);
-await definitionStore.RegisterDefinitionAsync(productDefinition, tenantB);
+await definitionStore.RegisterDefinitionAsync(productDefinition, tenantA, CancellationToken.None);
+await definitionStore.RegisterDefinitionAsync(productDefinition, tenantB, CancellationToken.None);
 
 var productA = await manager.CreateAsync("Product", new CreateResourceRequest
 {
@@ -73,12 +73,14 @@ await manager.ActivateAsync(
     resourceId: "product-1",
     version: 1,
     channel: "Published",
-    tenantScope: tenantA);
+    tenantScope: tenantA,
+    allowMultipleActive: false);
 
 var active = await manager.GetActiveVersionsAsync(
     resourceId: "product-1",
     channel: "Published",
-    tenantScope: tenantA);
+    tenantScope: tenantA,
+    cancellationToken: CancellationToken.None);
 ```
 
 An activation in `tenant-a` does not affect `tenant-b`, even when resource IDs and channel names match.

--- a/specs/015-tenant-scoping/quickstart.md
+++ b/specs/015-tenant-scoping/quickstart.md
@@ -1,0 +1,153 @@
+# Quickstart: Tenant Scoping
+
+This quickstart shows the tenant-scoped SDK behavior.
+
+## Default Single-Tenant Behavior
+
+Existing callers do not need to provide tenant scope:
+
+```csharp
+builder.Services.AddAsterCore();
+
+var definition = new ResourceDefinitionBuilder()
+    .WithDefinitionId("Product")
+    .Build();
+
+await definitionStore.RegisterDefinitionAsync(definition);
+
+var product = await manager.CreateAsync("Product", new CreateResourceRequest
+{
+    ResourceId = "product-1",
+});
+```
+
+These operations use the documented default single-tenant scope.
+
+## Explicit Tenant Scope
+
+Hosts that need tenant isolation pass a tenant scope explicitly:
+
+```csharp
+var tenantA = TenantScope.FromTenantId("tenant-a");
+var tenantB = TenantScope.FromTenantId("tenant-b");
+
+await definitionStore.RegisterDefinitionAsync(productDefinition, tenantA);
+await definitionStore.RegisterDefinitionAsync(productDefinition, tenantB);
+
+var productA = await manager.CreateAsync("Product", new CreateResourceRequest
+{
+    TenantScope = tenantA,
+    ResourceId = "product-1",
+});
+
+var productB = await manager.CreateAsync("Product", new CreateResourceRequest
+{
+    TenantScope = tenantB,
+    ResourceId = "product-1",
+});
+```
+
+The same definition and resource IDs can exist in both tenants.
+
+## Tenant-Scoped Query
+
+Queries select one effective tenant:
+
+```csharp
+var results = await queryService.QueryAsync(new ResourceQuery
+{
+    TenantScope = tenantA,
+    DefinitionId = "Product",
+    Scope = ResourceVersionScope.Latest,
+});
+```
+
+Results include only resources from `tenant-a`.
+
+## Tenant-Scoped Activation
+
+Activation state is isolated by tenant:
+
+```csharp
+await manager.ActivateAsync(
+    resourceId: "product-1",
+    version: 1,
+    channel: "Published",
+    tenantScope: tenantA);
+
+var active = await manager.GetActiveVersionsAsync(
+    resourceId: "product-1",
+    channel: "Published",
+    tenantScope: tenantA);
+```
+
+An activation in `tenant-a` does not affect `tenant-b`, even when resource IDs and channel names match.
+
+## Tenant-Scoped Portability
+
+Exports record the source tenant:
+
+```csharp
+var export = await portability.ExportAsync(new PortableSnapshotExportRequest
+{
+    TenantScope = tenantA,
+    ScopeMode = PortableExportScopeMode.SelectedResources,
+    ResourceIds = ["product-1"],
+    ResourceVersionScope = PortableResourceVersionScope.AllVersions,
+});
+
+var snapshot = export.Snapshot!;
+Console.WriteLine(snapshot.SourceTenantScope.TenantId); // tenant-a
+```
+
+Imports target one explicit tenant:
+
+```csharp
+var preview = await portability.PreviewImportAsync(
+    snapshot,
+    new PortableImportOptions
+    {
+        TargetTenantScope = tenantB,
+    });
+```
+
+Preview and import diagnostics report both source and target tenant metadata.
+
+## Lifecycle Hooks
+
+Hook contexts expose the same effective tenant used by the operation:
+
+```csharp
+public sealed class TenantAuditHook : ResourceLifecycleHook
+{
+    public override ValueTask<LifecycleHookOutcome> OnBeforeSaveAsync(
+        ResourceSaveLifecycleContext context,
+        CancellationToken cancellationToken = default)
+    {
+        var tenant = context.TenantScope;
+        return ValueTask.FromResult(LifecycleHookOutcome.Continue());
+    }
+}
+```
+
+Hooks do not discover tenant state through ambient context.
+
+## Failure Cases
+
+Tenant scope fails closed before data is read or written:
+
+```csharp
+var invalid = TenantScope.FromTenantId(" ");
+```
+
+Expected failure codes include:
+
+- `tenant-scope-invalid`
+- `tenant-scope-mismatch`
+- `tenant-scope-required`
+- `invalid-tenant-scope`
+- `source-tenant-scope-mismatch`
+
+## Exclusions
+
+This slice does not add shared definitions, tenant hierarchy, cross-tenant queries, authorization, policies, migrations, runtime scanning, provider registries, public SQL, or public `IQueryable<Resource>`.

--- a/specs/015-tenant-scoping/quickstart.md
+++ b/specs/015-tenant-scoping/quickstart.md
@@ -134,13 +134,13 @@ Hooks do not discover tenant state through ambient context.
 
 ## Failure Cases
 
-Tenant scope fails closed before data is read or written:
+Tenant scope construction rejects blank IDs immediately:
 
 ```csharp
 var invalid = TenantScope.FromTenantId(" ");
 ```
 
-Expected failure codes include:
+This throws `ArgumentException`. Operation-boundary validation still fails closed with stable codes when a malformed scope instance is supplied on a request, query, snapshot, or import option. Expected failure codes include:
 
 - `tenant-scope-invalid`
 - `tenant-scope-mismatch`

--- a/specs/015-tenant-scoping/research.md
+++ b/specs/015-tenant-scoping/research.md
@@ -1,0 +1,103 @@
+# Research: Tenant Scoping
+
+## Decision: Explicit Request-Level Tenant Scope
+
+**Decision**: Tenant-aware operations use explicit operation input to select tenant scope. If no tenant scope is supplied, the operation uses the documented default single-tenant scope.
+
+**Rationale**: Explicit operation input is visible in code reviews, tests, diagnostics, and documentation. It avoids hidden ambient state becoming the isolation boundary and keeps existing no-tenant callers compatible.
+
+**Alternatives considered**:
+
+- Ambient host context: rejected because it hides tenant selection and makes background jobs/tests harder to reason about.
+- Hybrid ambient fallback: rejected for this slice because it introduces precedence rules before there is a demonstrated need.
+
+## Decision: Default Single-Tenant Scope Is Always Valid
+
+**Decision**: Omitted tenant scope always maps to the default single-tenant scope, even after explicit tenant-scoped data exists.
+
+**Rationale**: This keeps the feature additive for existing SDK consumers. Compatibility should not depend on whether another part of the process has started using tenants.
+
+**Alternatives considered**:
+
+- Fail omitted scope after tenant-specific data exists: rejected because behavior would depend on mutable store state.
+- Require tenant scope for all writes: rejected because it breaks the current quickstart and existing tests without adding isolation value for default-scope hosts.
+
+## Decision: Opaque Exact-Match Tenant Identifiers
+
+**Decision**: Tenant identifiers are opaque exact-match values. The SDK rejects null, empty, or whitespace tenant identifiers but does not case-fold, slugify, trim into a different identity, or normalize valid identifiers.
+
+**Rationale**: Hosts often already own tenant identity rules. Exact matching avoids hidden normalization collisions and keeps the SDK provider-agnostic.
+
+**Alternatives considered**:
+
+- Case-insensitive tenant IDs: rejected because it assumes host identity semantics.
+- Restricted slug tenant IDs: rejected because it creates unnecessary host coupling.
+
+## Decision: Definition And Resource Identities Are Tenant-Scoped
+
+**Decision**: Definition and resource identifiers are unique only within their effective tenant scope. The same IDs may exist independently in different tenants.
+
+**Rationale**: This is the clearest isolation model and enables environment import/export workflows where identical IDs can exist in different tenant boundaries.
+
+**Alternatives considered**:
+
+- Globally unique resource IDs with tenant-scoped definitions: rejected because it creates inconsistent identity rules.
+- Globally unique all IDs with tenant filtering: rejected because it prevents true tenant independence and complicates import conflict behavior.
+
+## Decision: Single-Source Snapshot, Single-Target Import
+
+**Decision**: Portable snapshots record one source tenant identity. Import preview and write import target one explicit tenant and report source/target tenant metadata.
+
+**Rationale**: This preserves auditability and tenant isolation without introducing multi-tenant remapping or recipe execution.
+
+**Alternatives considered**:
+
+- Tenant-neutral snapshots: rejected because source tenant identity is useful diagnostic metadata.
+- Multi-tenant snapshots with remapping: rejected as a future recipe/admin feature with larger acceptance criteria.
+
+## Decision: Central Tenant Scope Validation
+
+**Decision**: Add a small central tenant scope validation/resolution path used by resource manager, query, schema upgrade, portability, and provider-facing requests.
+
+**Rationale**: The validation rules are intentionally small but cross-cutting. Centralizing null/empty/default resolution prevents each service/provider from inventing slightly different rules.
+
+**Alternatives considered**:
+
+- Inline validation everywhere: rejected because it risks inconsistent failure behavior.
+- Tenant registry service: rejected because the slice does not create, discover, or authorize tenants.
+
+## Decision: Additive API Shape
+
+**Decision**: Request DTOs that already exist gain optional tenant scope properties. Method-style APIs without request DTOs gain additive tenant-aware overloads while existing methods continue to target the default single-tenant scope.
+
+**Rationale**: This keeps the public API explicit without forcing a broad request-object refactor across established method-shaped contracts. Existing callers remain source-compatible, and tenant-aware callers can choose the scoped overloads or request fields.
+
+**Alternatives considered**:
+
+- Add tenant scope only through request DTOs: rejected because several current APIs have no request object and converting them would be a larger public API redesign.
+- Add ambient tenant context: rejected because it hides tenant selection.
+- Replace existing methods with tenant-required methods: rejected because it breaks default single-tenant compatibility.
+
+## Decision: SQLite Default-Scope Compatibility Bootstrap
+
+**Decision**: SQLite JSON initialization may perform minimal idempotent compatibility work for existing pre-tenant databases by adding tenant metadata and treating existing rows as default-scope data. This is not a general migration framework.
+
+**Rationale**: The feature must preserve existing single-tenant hosts. Without a compatibility path, old SQLite files would either fail or leak into an undefined tenant boundary. Keeping this work in provider initialization preserves operational simplicity while avoiding a new migration policy.
+
+**Alternatives considered**:
+
+- Fresh databases only: rejected because it weakens the compatibility requirement for existing SQLite users.
+- Full migration framework: rejected as a separate operational hardening topic.
+- Runtime query fallback without persisted tenant metadata: rejected because it complicates every query and write path instead of making the storage boundary explicit.
+
+## Decision: Provider-Specific Filtering Without New Infrastructure
+
+**Decision**: In-memory and SQLite JSON providers add explicit tenant filtering/partitioning using the existing provider packages and test stack. The slice does not introduce migrations, a provider registry, a planner, or a provisioning framework.
+
+**Rationale**: Tenant filtering is a storage/provider responsibility once core defines the scope. The existing provider boundaries are sufficient for this slice.
+
+**Alternatives considered**:
+
+- New provider registry/framework: rejected because one active provider remains the model.
+- Migration/provisioning framework: rejected because migration policy is a separate operational hardening topic.
+- Encode tenant behavior through query predicates only: rejected because definitions, activation, schema upgrades, and direct resource lookups also need tenant boundaries.

--- a/specs/015-tenant-scoping/spec.md
+++ b/specs/015-tenant-scoping/spec.md
@@ -1,0 +1,130 @@
+# Feature Specification: Tenant Scoping
+
+**Feature Branch**: `015-tenant-scoping`  
+**Created**: 2026-05-24  
+**Status**: Draft  
+**Input**: User description: "Add tenant-aware boundaries as the first Phase 5 slice. Hosts should be able to keep resource definitions, resources, activation state, queries, schema upgrades, portability snapshots, and lifecycle hooks isolated by an explicit tenant scope. The slice should stay small: explicit tenant context and scoped operations, clear default single-tenant behavior for existing apps, fail-closed behavior when a tenant-scoped operation is ambiguous, and no shared-definition inheritance, cross-tenant queries, policy engine, authorization system, migrations, runtime scanning, provider registry, public SQL, or IQueryable<Resource>."
+
+## Clarifications
+
+### Session 2026-05-24
+
+- Q: How should tenant scope be selected for tenant-aware SDK operations? -> A: Each tenant-aware operation carries an explicit tenant scope; omitted scope means the documented default single-tenant scope.
+- Q: How should tenant identifiers be compared and validated? -> A: Tenant identifiers are opaque exact-match values; the SDK rejects null, empty, or whitespace identifiers but does not case-fold or normalize.
+- Q: How should tenant scope behave in portable snapshots and imports? -> A: Snapshots record source tenant identity; import writes only to one explicit target tenant and reports source/target tenant metadata.
+- Q: What should omitted tenant scope mean after tenants are introduced? -> A: Omitted tenant scope always means the default single-tenant scope, even after tenant-specific data exists.
+- Q: Should definition and resource identities be tenant-scoped or globally unique? -> A: Definition and resource identities are tenant-scoped; the same IDs may exist independently in different tenants.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Isolate Definitions And Resources By Tenant (Priority: P1)
+
+As a host author, I need definitions and resources created for one tenant to be invisible to other tenants, so separate tenants can safely use the same resource types and names without accidental collisions.
+
+**Why this priority**: Tenant isolation is the foundation for every later multi-tenant capability. Without it, policies, recipes, and operational hardening would sit on ambiguous data boundaries.
+
+**Independent Test**: Create two tenants with the same resource type and resource names, then verify each tenant can create, update, read, and activate its own resources without seeing the other tenant's data.
+
+**Acceptance Scenarios**:
+
+1. **Given** two tenants define the same resource type, **When** each tenant creates resources for that type, **Then** each tenant sees only its own definitions and resources.
+2. **Given** a resource exists in one tenant, **When** another tenant attempts to read, update, activate, or deactivate it, **Then** the operation fails as not found or out of scope without exposing the other tenant's data.
+3. **Given** two tenants use the same definition or resource identifiers, **When** each tenant reads or mutates by identifier, **Then** each operation resolves only the data inside its effective tenant scope.
+4. **Given** an existing single-tenant host does not provide a tenant scope, **When** it uses current definition and resource workflows, **Then** behavior remains equivalent to the current default environment regardless of whether other tenant-scoped data exists.
+
+---
+
+### User Story 2 - Query Within An Explicit Tenant Boundary (Priority: P2)
+
+As a host author, I need queries to run against one effective tenant scope, so list views, lookup flows, and provider-backed searches cannot leak data across tenants.
+
+**Why this priority**: Query leakage is the highest-risk read-path failure mode in a multi-tenant SDK.
+
+**Independent Test**: Store matching resources in multiple tenants, run metadata, activation, and facet queries for one tenant, and verify results contain only resources from that tenant.
+
+**Acceptance Scenarios**:
+
+1. **Given** multiple tenants contain resources matching the same query, **When** the host queries within one tenant, **Then** only matching resources from that tenant are returned.
+2. **Given** active versions exist in the same activation channel across tenants, **When** the host queries active resources in one tenant, **Then** activation state from other tenants has no effect on the result.
+3. **Given** an operation requires a tenant and no effective tenant can be determined, **When** the host attempts the operation, **Then** the SDK fails closed with a stable diagnostic or exception.
+
+---
+
+### User Story 3 - Keep Integration Workflows Tenant-Scoped (Priority: P3)
+
+As a host author, I need schema upgrades, portability, and lifecycle hooks to carry the effective tenant scope, so integration code can apply tenant-specific validation and avoid cross-tenant side effects.
+
+**Why this priority**: These workflows span multiple records and are commonly used by host-level integrations. They must inherit the same isolation rules before higher-level recipes or policies are added.
+
+**Independent Test**: Run schema upgrade, export, import preview, write import, and lifecycle hook flows for one tenant while another tenant contains similar data, then verify only the selected tenant participates.
+
+**Acceptance Scenarios**:
+
+1. **Given** a resource uses an older definition version in one tenant, **When** that tenant upgrades the resource schema, **Then** the upgrade resolves definition lineage only within that tenant.
+2. **Given** a tenant exports resources, **When** the snapshot is created, **Then** it contains only the selected tenant's definitions, resources, versions, activation entries, and source tenant identity.
+3. **Given** lifecycle hooks are registered, **When** a tenant-scoped operation runs, **Then** hook contexts identify the effective tenant and hooks cannot infer hidden cross-tenant state from the SDK workflow.
+
+### Edge Cases
+
+- A tenant identifier is empty, whitespace, or not in canonical form.
+- A host mixes default single-tenant operations with explicit tenant-scoped operations in the same process; omitted tenant scope still targets only the default single-tenant scope.
+- Two tenants use the same resource type, definition identifier, activation channel, and facet values.
+- A query, schema upgrade, export, or import request omits tenant scope after tenant-scoped data exists.
+- A portability import snapshot targets a tenant that already contains conflicting definitions or resources.
+- Lifecycle hooks reject an operation for one tenant while another tenant has a similar operation in progress.
+
+### Constitution Alignment *(mandatory)*
+
+- **Simplicity**: The simplest acceptable behavior is one explicit effective tenant scope per operation plus a documented default single-tenant scope for existing hosts. Shared definition inheritance, tenant hierarchies, cross-tenant queries, policy engines, authorization, migrations, runtime scanning, provider registries, public SQL, and public `IQueryable<Resource>` are out of scope.
+- **Explicitness**: Tenant scope must be visible through operation inputs, context, diagnostics, and documentation. The SDK must not discover tenants implicitly through naming conventions, ambient host context, ambient runtime scanning, or hidden provider state.
+- **Dependencies**: None.
+- **Operational Impact**: Existing local development and single-tenant usage remain unchanged. Multi-tenant hosts opt in through explicit scope selection and receive fail-closed diagnostics for ambiguous scoped operations.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The SDK MUST define an explicit tenant scope concept with a stable tenant identity and a documented default single-tenant scope.
+- **FR-001a**: Tenant-aware SDK operations MUST select tenant scope from explicit operation input; when no tenant scope is supplied, the operation MUST use the documented default single-tenant scope.
+- **FR-001b**: Omitted tenant scope MUST always target the documented default single-tenant scope, including after explicit tenant-specific data exists.
+- **FR-002**: Definition registration, lookup, and uniqueness checks MUST operate within the effective tenant scope.
+- **FR-003**: Resource create, update, read, activation, and deactivation operations MUST operate within the effective tenant scope.
+- **FR-003a**: Definition identities and resource identities MUST be unique only within their effective tenant scope; the same identifiers MAY exist independently in different tenants.
+- **FR-004**: Query operations MUST evaluate against one effective tenant scope and MUST NOT return resources from any other tenant.
+- **FR-005**: Schema status and schema upgrade workflows MUST resolve definition lineage within the effective tenant scope.
+- **FR-006**: Portability export, import preview, and write import workflows MUST be tenant-scoped and MUST NOT read or write data from another tenant unless a future feature explicitly introduces cross-tenant behavior.
+- **FR-006a**: Portable snapshots MUST record the source tenant identity. Import preview and write import MUST write only to one explicit target tenant and MUST report source and target tenant metadata.
+- **FR-006b**: Portable snapshots MUST NOT contain multiple source tenants, and imports MUST NOT remap multiple source tenants to multiple target tenants in this feature.
+- **FR-007**: Lifecycle hook contexts for tenant-scoped operations MUST expose the effective tenant scope.
+- **FR-008**: Existing single-tenant hosts MUST continue to work without requiring new tenant input when they use the documented default single-tenant scope.
+- **FR-009**: Tenant-scoped operations MUST fail closed with stable diagnostics or exceptions when the effective tenant scope is missing, ambiguous, invalid, or mismatched with the target data.
+- **FR-010**: Tenant identifiers MUST be validated consistently before data is read or written.
+- **FR-010a**: Tenant identifiers MUST be treated as opaque exact-match values. The SDK MUST reject null, empty, or whitespace tenant identifiers and MUST NOT case-fold, trim into a different identity, slugify, or otherwise normalize valid tenant identifiers.
+- **FR-011**: Documentation MUST explain default single-tenant behavior, explicit tenant usage, fail-closed troubleshooting, query isolation, portability isolation, and lifecycle hook tenant context.
+- **FR-012**: The feature MUST NOT introduce shared-definition inheritance, tenant hierarchy, cross-tenant queries, authorization or permission checks, policy engines, retention rules, migrations, runtime scanning, provider registries, public SQL, or public `IQueryable<Resource>`.
+
+### Key Entities
+
+- **Tenant Scope**: The effective boundary for definitions, resources, activation state, queries, schema upgrades, portability operations, and lifecycle hooks. It includes a stable tenant identity and may represent the default single-tenant environment. Tenant identities are opaque exact-match values.
+- **Tenant-Scoped Definition**: A resource definition whose identity, uniqueness, lookup, and version lineage are evaluated within a tenant scope.
+- **Tenant-Scoped Resource**: A resource and its versions whose identity, lifecycle operations, and activation records are evaluated within a tenant scope.
+- **Tenant-Scoped Operation**: Any SDK workflow that reads, writes, queries, upgrades, exports, imports, or invokes hooks using one effective tenant scope.
+- **Tenant-Scoped Snapshot**: A portable snapshot containing data from exactly one source tenant plus metadata that identifies that source tenant. Import workflows write it to exactly one explicit target tenant.
+- **Tenant Scope Failure**: A stable failure condition reported when a requested operation has no valid tenant boundary or targets data outside the effective tenant scope.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: A host can create the same definition and resource identifiers in two tenants and complete create, update, activate, read, and query workflows for each tenant with zero cross-tenant results.
+- **SC-002**: Existing single-tenant quickstart flows and regression tests continue to pass without tenant-specific changes.
+- **SC-003**: All missing, invalid, ambiguous, and mismatched tenant-scope cases produce stable failures that can be asserted by automated tests.
+- **SC-004**: Tenant-scoped export/import workflows preserve tenant isolation for definitions, resources, versions, activation state, source tenant metadata, and target tenant metadata across round trips.
+- **SC-005**: Lifecycle hook tests can assert the effective tenant scope for save, activation, deactivation, schema upgrade, export, preview import, and write import operations.
+
+## Assumptions
+
+- The first slice uses a default single-tenant scope to preserve existing host behavior.
+- Tenant authorization and user permissions are host responsibilities and are not part of this feature.
+- Shared definitions, tenant inheritance, and cross-tenant administrative queries require separate specifications.
+- Provider storage changes, if needed, are limited to preserving the tenant boundary for current in-memory and SQLite JSON behavior; migration policy is out of scope for this slice.

--- a/specs/015-tenant-scoping/tasks.md
+++ b/specs/015-tenant-scoping/tasks.md
@@ -1,0 +1,239 @@
+# Tasks: Tenant Scoping
+
+**Input**: Design documents from `/specs/015-tenant-scoping/`  
+**Prerequisites**: [plan.md](plan.md), [spec.md](spec.md), [research.md](research.md), [data-model.md](data-model.md), [contracts/tenant-scoping.md](contracts/tenant-scoping.md), [quickstart.md](quickstart.md)
+
+**Tests**: Included because the feature specification defines independent tests for every user story and this slice changes isolation semantics.
+
+**Organization**: Tasks are grouped by user story so tenant definition/resource isolation can ship as the MVP before tenant-aware query and integration workflows.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel because it touches different files and has no dependency on another incomplete task.
+- **[Story]**: Maps the task to a user story from [spec.md](spec.md).
+- Every task includes an exact file path.
+
+## Phase 1: Setup
+
+**Purpose**: Prepare shared test and source locations for the tenant-scoping slice.
+
+- [X] T001 Create tenant test folder and shared fixture placeholder in `test/Aster.Tests/Tenancy/TenantScopeTestFixtures.cs`
+- [X] T002 Create tenant model folder for SDK tenancy types in `src/core/Aster.Core/Models/Tenancy/`
+- [X] T003 Confirm no new package references are required in `src/core/Aster.Core/Aster.Core.csproj`
+- [X] T004 Confirm no new package references are required in `src/persistence/Aster.Persistence.SqliteJson/Aster.Persistence.SqliteJson.csproj`
+
+---
+
+## Phase 2: Foundational
+
+**Purpose**: Define tenant scope primitives and request/context surfaces that block every user story.
+
+**Critical**: No user story implementation should begin until tenant scope resolution and public request shape are in place.
+
+- [X] T005 [P] Add tenant scope value-object tests in `test/Aster.Tests/Tenancy/TenantScopeTests.cs`
+- [X] T006 [P] Add tenant scope failure tests in `test/Aster.Tests/Tenancy/TenantScopeFailureTests.cs`
+- [X] T007 Implement `TenantScope` with default-scope resolution and opaque exact-match validation in `src/core/Aster.Core/Models/Tenancy/TenantScope.cs`
+- [X] T008 Implement stable tenant-scope failure exception or diagnostic model in `src/core/Aster.Core/Exceptions/AsterExceptions.cs`
+- [X] T009 Add central tenant scope resolver/validator in `src/core/Aster.Core/Services/TenantScopeResolver.cs`
+- [X] T010 Add tenant scope properties to existing create/update request DTOs in `src/core/Aster.Core/Abstractions/Requests.cs`
+- [X] T011 Add tenant scope to version read requests in `src/core/Aster.Core/Abstractions/IResourceVersionReader.cs`
+- [X] T012 Add tenant scope to query model in `src/core/Aster.Core/Models/Querying/ResourceQuery.cs`
+- [X] T013 Add tenant scope metadata to lifecycle context base record in `src/core/Aster.Core/Models/Lifecycle/LifecycleHookContexts.cs`
+- [X] T014 Add tenant scope metadata to portability snapshot, export request, and import options in `src/core/Aster.Core/Models/Portability/PortableSnapshot.cs`
+- [X] T015 Add tenant scope metadata to portability result models in `src/core/Aster.Core/Models/Portability/PortableResults.cs`
+- [X] T016 Run focused foundational tenant tests with `dotnet test Aster.sln --no-restore --filter "FullyQualifiedName~TenantScope"` using `Aster.sln`
+
+**Checkpoint**: Tenant scope primitives compile, validate, and can be carried by shared SDK requests/contexts.
+
+---
+
+## Phase 3: User Story 1 - Isolate Definitions And Resources By Tenant (Priority: P1) MVP
+
+**Goal**: Definitions, resources, versions, and activation state are isolated by tenant while omitted scope remains default single-tenant behavior.
+
+**Independent Test**: Create two tenants with identical definition/resource IDs and verify create, update, read, activate, deactivate, and default-scope compatibility never cross tenant boundaries.
+
+### Tests for User Story 1
+
+- [X] T017 [P] [US1] Add tenant-scoped definition store tests in `test/Aster.Tests/Tenancy/TenantDefinitionStoreTests.cs`
+- [X] T018 [P] [US1] Add tenant-scoped resource lifecycle tests in `test/Aster.Tests/Tenancy/TenantResourceManagerTests.cs`
+- [X] T019 [P] [US1] Add tenant-scoped activation tests in `test/Aster.Tests/Tenancy/TenantActivationTests.cs`
+- [X] T020 [P] [US1] Add default single-tenant compatibility tests in `test/Aster.Tests/Tenancy/TenantDefaultScopeCompatibilityTests.cs`
+- [X] T021 [P] [US1] Add SQLite JSON tenant isolation and pre-tenant default-scope compatibility tests in `test/Aster.Tests/SqliteJson/SqliteJsonTenantScopeTests.cs`
+
+### Implementation for User Story 1
+
+- [X] T022 [US1] Add additive tenant-aware overloads while preserving default-scope methods in `src/core/Aster.Core/Abstractions/IResourceDefinitionStore.cs`
+- [X] T023 [US1] Implement tenant-partitioned definition storage in `src/core/Aster.Core/InMemory/InMemoryResourceDefinitionStore.cs`
+- [X] T024 [US1] Add additive tenant-aware overloads for method-style resource manager APIs while using request tenant fields for create/update in `src/core/Aster.Core/Abstractions/IResourceManager.cs`
+- [X] T025 [US1] Implement tenant scope flow for create/update/read/activation in `src/core/Aster.Core/Services/DefaultResourceManager.cs`
+- [X] T026 [US1] Implement tenant-partitioned resource versions and activation state in `src/core/Aster.Core/InMemory/InMemoryResourceStore.cs`
+- [X] T027 [US1] Add tenant-aware SQLite table shape and idempotent default-scope compatibility bootstrap for existing databases in `src/persistence/Aster.Persistence.SqliteJson/SqliteJsonSchema.cs`
+- [X] T028 [US1] Implement tenant-scoped definition/resource/activation reads and writes in `src/persistence/Aster.Persistence.SqliteJson/SqliteJsonResourceStore.cs`
+- [X] T029 [US1] Preserve default-scope behavior in web sample setup in `src/apps/Aster.Web/SeedDataInitializer.cs`
+- [X] T030 [US1] Run User Story 1 focused tests with `dotnet test Aster.sln --no-restore --filter "FullyQualifiedName~TenantDefinitionStore|FullyQualifiedName~TenantResourceManager|FullyQualifiedName~TenantActivation|FullyQualifiedName~TenantDefaultScopeCompatibility|FullyQualifiedName~SqliteJsonTenantScope"` using `Aster.sln`
+
+**Checkpoint**: User Story 1 is independently functional as the MVP.
+
+---
+
+## Phase 4: User Story 2 - Query Within An Explicit Tenant Boundary (Priority: P2)
+
+**Goal**: In-memory and SQLite JSON queries resolve one effective tenant and never return resources from another tenant.
+
+**Independent Test**: Store matching resources in multiple tenants, run metadata, activation, and facet queries for one tenant, and verify only that tenant's results are returned.
+
+### Tests for User Story 2
+
+- [X] T031 [P] [US2] Add tenant-aware query validation tests in `test/Aster.Tests/Querying/TenantQueryValidatorTests.cs`
+- [X] T032 [P] [US2] Add in-memory tenant query isolation tests in `test/Aster.Tests/Tenancy/TenantQueryServiceTests.cs`
+- [X] T033 [P] [US2] Add SQLite JSON tenant query isolation tests in `test/Aster.Tests/SqliteJson/SqliteJsonTenantQueryServiceTests.cs`
+- [X] T034 [P] [US2] Add active-channel tenant query isolation tests in `test/Aster.Tests/Tenancy/TenantActiveQueryTests.cs`
+
+### Implementation for User Story 2
+
+- [X] T035 [US2] Validate query tenant scope before provider capability traversal in `src/core/Aster.Core/Services/ResourceQueryValidator.cs`
+- [X] T036 [US2] Apply tenant scope before query predicates in `src/core/Aster.Core/InMemory/InMemoryQueryService.cs`
+- [X] T037 [US2] Pass tenant scope through candidate version reads in `src/core/Aster.Core/InMemory/InMemoryResourceStore.cs`
+- [X] T038 [US2] Add tenant predicates to SQLite query builder inputs in `src/persistence/Aster.Persistence.SqliteJson/SqliteJsonQueryService.cs`
+- [X] T039 [US2] Add tenant filter SQL support in `src/persistence/Aster.Persistence.SqliteJson/Querying/SqliteQueryBuilder.cs`
+- [X] T040 [US2] Add tenant filter translation support in `src/persistence/Aster.Persistence.SqliteJson/Querying/SqliteWhereTranslator.cs`
+- [X] T041 [US2] Run User Story 2 focused tests with `dotnet test Aster.sln --no-restore --filter "FullyQualifiedName~TenantQuery|FullyQualifiedName~SqliteJsonTenantQuery"` using `Aster.sln`
+
+**Checkpoint**: User Stories 1 and 2 are independently functional.
+
+---
+
+## Phase 5: User Story 3 - Keep Integration Workflows Tenant-Scoped (Priority: P3)
+
+**Goal**: Schema upgrades, portability, and lifecycle hooks carry tenant scope and preserve single-source/single-target tenant behavior.
+
+**Independent Test**: Run schema upgrade, export, import preview, write import, and lifecycle hook flows for one tenant while another tenant contains similar data, then verify only the selected tenant participates.
+
+### Tests for User Story 3
+
+- [X] T042 [P] [US3] Add tenant-scoped schema upgrade tests in `test/Aster.Tests/SchemaVersions/TenantSchemaVersionServiceTests.cs`
+- [X] T043 [P] [US3] Add tenant-scoped portability export tests in `test/Aster.Tests/Portability/TenantPortabilityExportTests.cs`
+- [X] T044 [P] [US3] Add tenant-scoped portability preview/import tests in `test/Aster.Tests/Portability/TenantPortabilityImportTests.cs`
+- [X] T045 [P] [US3] Add tenant lifecycle hook context tests in `test/Aster.Tests/Lifecycle/TenantLifecycleHookTests.cs`
+- [X] T046 [P] [US3] Add SQLite JSON tenant portability tests in `test/Aster.Tests/SqliteJson/SqliteJsonTenantPortabilityStoreTests.cs`
+
+### Implementation for User Story 3
+
+- [X] T047 [US3] Resolve definition lineage within tenant scope in `src/core/Aster.Core/Services/ResourceSchemaVersionService.cs`
+- [X] T048 [US3] Add source tenant and target tenant diagnostics constants in `src/core/Aster.Core/Models/Portability/PortableDiagnostic.cs`
+- [X] T049 [US3] Enforce single-source snapshot validation in `src/core/Aster.Core/Services/ResourcePortabilityService.cs`
+- [X] T050 [US3] Enforce explicit target tenant import preview/write behavior in `src/core/Aster.Core/Services/ResourcePortabilityService.cs`
+- [X] T051 [US3] Add tenant-scoped export/import store behavior in `src/core/Aster.Core/InMemory/InMemoryPortabilityStore.cs`
+- [X] T052 [US3] Add tenant-scoped SQLite export/import store behavior in `src/persistence/Aster.Persistence.SqliteJson/SqliteJsonResourceStore.cs`
+- [X] T053 [US3] Populate tenant scope in lifecycle hook context snapshots in `src/core/Aster.Core/Services/ResourceLifecycleHookContextSnapshots.cs`
+- [X] T054 [US3] Ensure lifecycle dispatcher preserves tenant-scoped context values in `src/core/Aster.Core/Services/ResourceLifecycleHookDispatcher.cs`
+- [X] T055 [US3] Run User Story 3 focused tests with `dotnet test Aster.sln --no-restore --filter "FullyQualifiedName~TenantSchema|FullyQualifiedName~TenantPortability|FullyQualifiedName~TenantLifecycle|FullyQualifiedName~SqliteJsonTenantPortability"` using `Aster.sln`
+
+**Checkpoint**: All tenant-scoping user stories are independently functional.
+
+---
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+**Purpose**: Documentation, compatibility, cleanup, and full verification.
+
+- [X] T056 [P] Update core tenant-scoping guidance in `src/core/Aster.Core/README.md`
+- [X] T057 [P] Update SQLite JSON provider tenant notes in `src/persistence/Aster.Persistence.SqliteJson/README.md`
+- [X] T058 [P] Update public roadmap/status docs for tenant scoping in `README.md`
+- [X] T059 [P] Validate tenant quickstart snippets against implemented APIs in `specs/015-tenant-scoping/quickstart.md`
+- [X] T060 Re-run Constitution Check and remove unnecessary tenant abstractions in `specs/015-tenant-scoping/plan.md`
+- [X] T061 Run all tests with `dotnet test Aster.sln --no-restore` using `Aster.sln`
+- [X] T062 Run full build with `dotnet build Aster.sln /m:1 --no-restore` using `Aster.sln`
+- [X] T063 Run whitespace validation with `git diff --check` using `/Users/sipke/Projects/ValenceWorks/aster`
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies.
+- **Foundational (Phase 2)**: Depends on Setup and blocks all user stories.
+- **User Story 1 (Phase 3)**: Depends on Foundational and is the MVP.
+- **User Story 2 (Phase 4)**: Depends on Foundational and benefits from User Story 1 store partitioning.
+- **User Story 3 (Phase 5)**: Depends on Foundational and benefits from User Story 1 scoped lifecycle/storage behavior.
+- **Polish (Phase 6)**: Depends on all desired user stories.
+
+### User Story Dependencies
+
+- **US1 Isolate Definitions And Resources By Tenant**: Start after Foundational; validates core write/read isolation.
+- **US2 Query Within An Explicit Tenant Boundary**: Start after Foundational; practically follows US1 because query candidates come from tenant-scoped stores.
+- **US3 Keep Integration Workflows Tenant-Scoped**: Start after Foundational; practically follows US1 because schema upgrades, portability, and hooks rely on scoped lifecycle/storage data.
+
+### Within Each User Story
+
+- Write story tests first and verify they fail.
+- Implement core models/contracts before service/provider behavior.
+- Implement in-memory behavior before SQLite provider behavior when both are required.
+- Run focused story tests at the checkpoint before moving to the next story.
+
+### Parallel Opportunities
+
+- Setup tasks T001-T004 can be split by file.
+- Foundational tests T005-T006 can be written in parallel.
+- User Story 1 tests T017-T021 can be written in parallel.
+- User Story 2 tests T031-T034 can be written in parallel.
+- User Story 3 tests T042-T046 can be written in parallel.
+- Documentation tasks T056-T059 can be completed in parallel after implementation stabilizes.
+
+---
+
+## Parallel Example: User Story 1
+
+```text
+Task: "Add tenant-scoped definition store tests in test/Aster.Tests/Tenancy/TenantDefinitionStoreTests.cs"
+Task: "Add tenant-scoped resource lifecycle tests in test/Aster.Tests/Tenancy/TenantResourceManagerTests.cs"
+Task: "Add tenant-scoped activation tests in test/Aster.Tests/Tenancy/TenantActivationTests.cs"
+Task: "Add default single-tenant compatibility tests in test/Aster.Tests/Tenancy/TenantDefaultScopeCompatibilityTests.cs"
+Task: "Add SQLite JSON tenant definition/resource isolation tests in test/Aster.Tests/SqliteJson/SqliteJsonTenantScopeTests.cs"
+```
+
+## Parallel Example: User Story 2
+
+```text
+Task: "Add tenant-aware query validation tests in test/Aster.Tests/Querying/TenantQueryValidatorTests.cs"
+Task: "Add in-memory tenant query isolation tests in test/Aster.Tests/Tenancy/TenantQueryServiceTests.cs"
+Task: "Add SQLite JSON tenant query isolation tests in test/Aster.Tests/SqliteJson/SqliteJsonTenantQueryServiceTests.cs"
+Task: "Add active-channel tenant query isolation tests in test/Aster.Tests/Tenancy/TenantActiveQueryTests.cs"
+```
+
+## Parallel Example: User Story 3
+
+```text
+Task: "Add tenant-scoped schema upgrade tests in test/Aster.Tests/SchemaVersions/TenantSchemaVersionServiceTests.cs"
+Task: "Add tenant-scoped portability export tests in test/Aster.Tests/Portability/TenantPortabilityExportTests.cs"
+Task: "Add tenant-scoped portability preview/import tests in test/Aster.Tests/Portability/TenantPortabilityImportTests.cs"
+Task: "Add tenant lifecycle hook context tests in test/Aster.Tests/Lifecycle/TenantLifecycleHookTests.cs"
+Task: "Add SQLite JSON tenant portability tests in test/Aster.Tests/SqliteJson/SqliteJsonTenantPortabilityStoreTests.cs"
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First
+
+1. Complete Phase 1 setup.
+2. Complete Phase 2 foundational tenant scope model/request/context work.
+3. Complete Phase 3 User Story 1.
+4. Stop and validate tenant definition/resource/activation isolation independently.
+
+### Incremental Delivery
+
+1. Deliver US1 to establish scoped definitions, resources, versions, and activation state.
+2. Add US2 to prove queries cannot leak across tenants.
+3. Add US3 to carry tenant scope through schema upgrades, portability, and lifecycle hooks.
+4. Finish with docs, quickstart validation, full tests, full build, and whitespace validation.
+
+### Quality Bar
+
+- Preserve default single-tenant compatibility throughout.
+- Keep tenant behavior explicit in request/context models.
+- Do not add ambient tenant context, tenant registry, authorization, policy engine, migration framework, public SQL, or public `IQueryable<Resource>`.
+- Prefer direct scoped keys and provider filters over broad framework abstractions.

--- a/src/core/Aster.Core/Abstractions/IResourceDefinitionStore.cs
+++ b/src/core/Aster.Core/Abstractions/IResourceDefinitionStore.cs
@@ -1,4 +1,5 @@
 using Aster.Core.Models.Definitions;
+using Aster.Core.Models.Tenancy;
 
 namespace Aster.Core.Abstractions;
 
@@ -16,12 +17,29 @@ public interface IResourceDefinitionStore
     ValueTask<ResourceDefinition?> GetDefinitionAsync(string definitionId, CancellationToken cancellationToken = default);
 
     /// <summary>
+    /// Returns the latest version of the definition in the specified tenant, or <see langword="null"/> if not registered.
+    /// </summary>
+    /// <param name="definitionId">The logical definition identifier.</param>
+    /// <param name="tenantScope">Tenant scope for lookup.</param>
+    /// <param name="cancellationToken">Token to cancel the operation.</param>
+    ValueTask<ResourceDefinition?> GetDefinitionAsync(string definitionId, TenantScope tenantScope, CancellationToken cancellationToken = default);
+
+    /// <summary>
     /// Returns a specific (<c>DefinitionId</c>, <c>Version</c>) snapshot, or <see langword="null"/> if not found.
     /// </summary>
     /// <param name="definitionId">The logical definition identifier.</param>
     /// <param name="version">The specific version number to retrieve.</param>
     /// <param name="cancellationToken">Token to cancel the operation.</param>
     ValueTask<ResourceDefinition?> GetDefinitionVersionAsync(string definitionId, int version, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Returns a specific tenant-scoped definition snapshot, or <see langword="null"/> if not found.
+    /// </summary>
+    /// <param name="definitionId">The logical definition identifier.</param>
+    /// <param name="version">The specific version number to retrieve.</param>
+    /// <param name="tenantScope">Tenant scope for lookup.</param>
+    /// <param name="cancellationToken">Token to cancel the operation.</param>
+    ValueTask<ResourceDefinition?> GetDefinitionVersionAsync(string definitionId, int version, TenantScope tenantScope, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Always appends a new immutable version. Auto-increments <see cref="ResourceDefinition.Version"/>.
@@ -32,8 +50,23 @@ public interface IResourceDefinitionStore
     ValueTask RegisterDefinitionAsync(ResourceDefinition definition, CancellationToken cancellationToken = default);
 
     /// <summary>
+    /// Always appends a new immutable definition version inside the specified tenant.
+    /// </summary>
+    /// <param name="definition">The definition to register.</param>
+    /// <param name="tenantScope">Tenant scope for registration.</param>
+    /// <param name="cancellationToken">Token to cancel the operation.</param>
+    ValueTask RegisterDefinitionAsync(ResourceDefinition definition, TenantScope tenantScope, CancellationToken cancellationToken = default);
+
+    /// <summary>
     /// Returns the latest version of each distinct definition ID.
     /// </summary>
     /// <param name="cancellationToken">Token to cancel the operation.</param>
     ValueTask<IEnumerable<ResourceDefinition>> ListDefinitionsAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Returns the latest version of each distinct definition ID in the specified tenant.
+    /// </summary>
+    /// <param name="tenantScope">Tenant scope for listing.</param>
+    /// <param name="cancellationToken">Token to cancel the operation.</param>
+    ValueTask<IEnumerable<ResourceDefinition>> ListDefinitionsAsync(TenantScope tenantScope, CancellationToken cancellationToken = default);
 }

--- a/src/core/Aster.Core/Abstractions/IResourceDefinitionStore.cs
+++ b/src/core/Aster.Core/Abstractions/IResourceDefinitionStore.cs
@@ -22,7 +22,7 @@ public interface IResourceDefinitionStore
     /// <param name="definitionId">The logical definition identifier.</param>
     /// <param name="tenantScope">Tenant scope for lookup.</param>
     /// <param name="cancellationToken">Token to cancel the operation.</param>
-    ValueTask<ResourceDefinition?> GetDefinitionAsync(string definitionId, TenantScope tenantScope, CancellationToken cancellationToken = default);
+    ValueTask<ResourceDefinition?> GetDefinitionAsync(string definitionId, TenantScope tenantScope, CancellationToken cancellationToken);
 
     /// <summary>
     /// Returns a specific (<c>DefinitionId</c>, <c>Version</c>) snapshot, or <see langword="null"/> if not found.
@@ -39,7 +39,7 @@ public interface IResourceDefinitionStore
     /// <param name="version">The specific version number to retrieve.</param>
     /// <param name="tenantScope">Tenant scope for lookup.</param>
     /// <param name="cancellationToken">Token to cancel the operation.</param>
-    ValueTask<ResourceDefinition?> GetDefinitionVersionAsync(string definitionId, int version, TenantScope tenantScope, CancellationToken cancellationToken = default);
+    ValueTask<ResourceDefinition?> GetDefinitionVersionAsync(string definitionId, int version, TenantScope tenantScope, CancellationToken cancellationToken);
 
     /// <summary>
     /// Always appends a new immutable version. Auto-increments <see cref="ResourceDefinition.Version"/>.
@@ -55,7 +55,7 @@ public interface IResourceDefinitionStore
     /// <param name="definition">The definition to register.</param>
     /// <param name="tenantScope">Tenant scope for registration.</param>
     /// <param name="cancellationToken">Token to cancel the operation.</param>
-    ValueTask RegisterDefinitionAsync(ResourceDefinition definition, TenantScope tenantScope, CancellationToken cancellationToken = default);
+    ValueTask RegisterDefinitionAsync(ResourceDefinition definition, TenantScope tenantScope, CancellationToken cancellationToken);
 
     /// <summary>
     /// Returns the latest version of each distinct definition ID.
@@ -68,5 +68,5 @@ public interface IResourceDefinitionStore
     /// </summary>
     /// <param name="tenantScope">Tenant scope for listing.</param>
     /// <param name="cancellationToken">Token to cancel the operation.</param>
-    ValueTask<IEnumerable<ResourceDefinition>> ListDefinitionsAsync(TenantScope tenantScope, CancellationToken cancellationToken = default);
+    ValueTask<IEnumerable<ResourceDefinition>> ListDefinitionsAsync(TenantScope tenantScope, CancellationToken cancellationToken);
 }

--- a/src/core/Aster.Core/Abstractions/IResourceManager.cs
+++ b/src/core/Aster.Core/Abstractions/IResourceManager.cs
@@ -56,7 +56,7 @@ public interface IResourceManager
     /// <param name="version">The version number to retrieve.</param>
     /// <param name="tenantScope">Tenant scope for lookup.</param>
     /// <param name="cancellationToken">Token to cancel the operation.</param>
-    ValueTask<Resource?> GetVersionAsync(string resourceId, int version, TenantScope tenantScope, CancellationToken cancellationToken = default);
+    ValueTask<Resource?> GetVersionAsync(string resourceId, int version, TenantScope tenantScope, CancellationToken cancellationToken);
 
     /// <summary>
     /// Returns all versions of the specified resource.
@@ -71,7 +71,7 @@ public interface IResourceManager
     /// <param name="resourceId">Logical resource identifier.</param>
     /// <param name="tenantScope">Tenant scope for lookup.</param>
     /// <param name="cancellationToken">Token to cancel the operation.</param>
-    ValueTask<IEnumerable<Resource>> GetVersionsAsync(string resourceId, TenantScope tenantScope, CancellationToken cancellationToken = default);
+    ValueTask<IEnumerable<Resource>> GetVersionsAsync(string resourceId, TenantScope tenantScope, CancellationToken cancellationToken);
 
     /// <summary>
     /// Returns the latest version of the specified resource, or <see langword="null"/> if it does not exist.
@@ -86,7 +86,7 @@ public interface IResourceManager
     /// <param name="resourceId">Logical resource identifier.</param>
     /// <param name="tenantScope">Tenant scope for lookup.</param>
     /// <param name="cancellationToken">Token to cancel the operation.</param>
-    ValueTask<Resource?> GetLatestVersionAsync(string resourceId, TenantScope tenantScope, CancellationToken cancellationToken = default);
+    ValueTask<Resource?> GetLatestVersionAsync(string resourceId, TenantScope tenantScope, CancellationToken cancellationToken);
 
     /// <summary>
     /// Activates the given version in the specified channel.
@@ -114,7 +114,7 @@ public interface IResourceManager
     /// <param name="tenantScope">Tenant scope for activation.</param>
     /// <param name="allowMultipleActive">Whether to permit multiple active versions in the channel.</param>
     /// <param name="cancellationToken">Token to cancel the operation.</param>
-    ValueTask ActivateAsync(string resourceId, int version, string channel, TenantScope tenantScope, bool allowMultipleActive = false, CancellationToken cancellationToken = default);
+    ValueTask ActivateAsync(string resourceId, int version, string channel, TenantScope tenantScope, bool allowMultipleActive, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Deactivates the given version in the specified channel.
@@ -133,7 +133,7 @@ public interface IResourceManager
     /// <param name="channel">The channel name.</param>
     /// <param name="tenantScope">Tenant scope for deactivation.</param>
     /// <param name="cancellationToken">Token to cancel the operation.</param>
-    ValueTask DeactivateAsync(string resourceId, int version, string channel, TenantScope tenantScope, CancellationToken cancellationToken = default);
+    ValueTask DeactivateAsync(string resourceId, int version, string channel, TenantScope tenantScope, CancellationToken cancellationToken);
 
     /// <summary>
     /// Returns all active resource versions in the specified channel.
@@ -150,5 +150,5 @@ public interface IResourceManager
     /// <param name="channel">The channel name.</param>
     /// <param name="tenantScope">Tenant scope for lookup.</param>
     /// <param name="cancellationToken">Token to cancel the operation.</param>
-    ValueTask<IEnumerable<Resource>> GetActiveVersionsAsync(string resourceId, string channel, TenantScope tenantScope, CancellationToken cancellationToken = default);
+    ValueTask<IEnumerable<Resource>> GetActiveVersionsAsync(string resourceId, string channel, TenantScope tenantScope, CancellationToken cancellationToken);
 }

--- a/src/core/Aster.Core/Abstractions/IResourceManager.cs
+++ b/src/core/Aster.Core/Abstractions/IResourceManager.cs
@@ -1,5 +1,6 @@
 using Aster.Core.Exceptions;
 using Aster.Core.Models.Instances;
+using Aster.Core.Models.Tenancy;
 
 namespace Aster.Core.Abstractions;
 
@@ -49,6 +50,15 @@ public interface IResourceManager
     ValueTask<Resource?> GetVersionAsync(string resourceId, int version, CancellationToken cancellationToken = default);
 
     /// <summary>
+    /// Returns a specific version of a tenant-scoped resource, or <see langword="null"/> if not found.
+    /// </summary>
+    /// <param name="resourceId">Logical resource identifier.</param>
+    /// <param name="version">The version number to retrieve.</param>
+    /// <param name="tenantScope">Tenant scope for lookup.</param>
+    /// <param name="cancellationToken">Token to cancel the operation.</param>
+    ValueTask<Resource?> GetVersionAsync(string resourceId, int version, TenantScope tenantScope, CancellationToken cancellationToken = default);
+
+    /// <summary>
     /// Returns all versions of the specified resource.
     /// </summary>
     /// <param name="resourceId">Logical resource identifier.</param>
@@ -56,11 +66,27 @@ public interface IResourceManager
     ValueTask<IEnumerable<Resource>> GetVersionsAsync(string resourceId, CancellationToken cancellationToken = default);
 
     /// <summary>
+    /// Returns all versions of the tenant-scoped resource.
+    /// </summary>
+    /// <param name="resourceId">Logical resource identifier.</param>
+    /// <param name="tenantScope">Tenant scope for lookup.</param>
+    /// <param name="cancellationToken">Token to cancel the operation.</param>
+    ValueTask<IEnumerable<Resource>> GetVersionsAsync(string resourceId, TenantScope tenantScope, CancellationToken cancellationToken = default);
+
+    /// <summary>
     /// Returns the latest version of the specified resource, or <see langword="null"/> if it does not exist.
     /// </summary>
     /// <param name="resourceId">Logical resource identifier.</param>
     /// <param name="cancellationToken">Token to cancel the operation.</param>
     ValueTask<Resource?> GetLatestVersionAsync(string resourceId, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Returns the latest version of the tenant-scoped resource, or <see langword="null"/> if it does not exist.
+    /// </summary>
+    /// <param name="resourceId">Logical resource identifier.</param>
+    /// <param name="tenantScope">Tenant scope for lookup.</param>
+    /// <param name="cancellationToken">Token to cancel the operation.</param>
+    ValueTask<Resource?> GetLatestVersionAsync(string resourceId, TenantScope tenantScope, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Activates the given version in the specified channel.
@@ -80,6 +106,17 @@ public interface IResourceManager
     ValueTask ActivateAsync(string resourceId, int version, string channel, bool allowMultipleActive = false, CancellationToken cancellationToken = default);
 
     /// <summary>
+    /// Activates the given tenant-scoped resource version in the specified channel.
+    /// </summary>
+    /// <param name="resourceId">Logical resource identifier.</param>
+    /// <param name="version">The version number to activate.</param>
+    /// <param name="channel">The channel name.</param>
+    /// <param name="tenantScope">Tenant scope for activation.</param>
+    /// <param name="allowMultipleActive">Whether to permit multiple active versions in the channel.</param>
+    /// <param name="cancellationToken">Token to cancel the operation.</param>
+    ValueTask ActivateAsync(string resourceId, int version, string channel, TenantScope tenantScope, bool allowMultipleActive = false, CancellationToken cancellationToken = default);
+
+    /// <summary>
     /// Deactivates the given version in the specified channel.
     /// </summary>
     /// <param name="resourceId">Logical resource identifier.</param>
@@ -89,10 +126,29 @@ public interface IResourceManager
     ValueTask DeactivateAsync(string resourceId, int version, string channel, CancellationToken cancellationToken = default);
 
     /// <summary>
+    /// Deactivates the tenant-scoped resource version in the specified channel.
+    /// </summary>
+    /// <param name="resourceId">Logical resource identifier.</param>
+    /// <param name="version">The version number to deactivate.</param>
+    /// <param name="channel">The channel name.</param>
+    /// <param name="tenantScope">Tenant scope for deactivation.</param>
+    /// <param name="cancellationToken">Token to cancel the operation.</param>
+    ValueTask DeactivateAsync(string resourceId, int version, string channel, TenantScope tenantScope, CancellationToken cancellationToken = default);
+
+    /// <summary>
     /// Returns all active resource versions in the specified channel.
     /// </summary>
     /// <param name="resourceId">Logical resource identifier.</param>
     /// <param name="channel">The channel name.</param>
     /// <param name="cancellationToken">Token to cancel the operation.</param>
     ValueTask<IEnumerable<Resource>> GetActiveVersionsAsync(string resourceId, string channel, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Returns all active tenant-scoped resource versions in the specified channel.
+    /// </summary>
+    /// <param name="resourceId">Logical resource identifier.</param>
+    /// <param name="channel">The channel name.</param>
+    /// <param name="tenantScope">Tenant scope for lookup.</param>
+    /// <param name="cancellationToken">Token to cancel the operation.</param>
+    ValueTask<IEnumerable<Resource>> GetActiveVersionsAsync(string resourceId, string channel, TenantScope tenantScope, CancellationToken cancellationToken = default);
 }

--- a/src/core/Aster.Core/Abstractions/IResourceManager.cs
+++ b/src/core/Aster.Core/Abstractions/IResourceManager.cs
@@ -114,7 +114,7 @@ public interface IResourceManager
     /// <param name="tenantScope">Tenant scope for activation.</param>
     /// <param name="allowMultipleActive">Whether to permit multiple active versions in the channel.</param>
     /// <param name="cancellationToken">Token to cancel the operation.</param>
-    ValueTask ActivateAsync(string resourceId, int version, string channel, TenantScope tenantScope, bool allowMultipleActive, CancellationToken cancellationToken = default);
+    ValueTask ActivateAsync(string resourceId, int version, string channel, TenantScope tenantScope, bool allowMultipleActive, CancellationToken cancellationToken);
 
     /// <summary>
     /// Deactivates the given version in the specified channel.

--- a/src/core/Aster.Core/Abstractions/IResourceVersionReader.cs
+++ b/src/core/Aster.Core/Abstractions/IResourceVersionReader.cs
@@ -1,5 +1,6 @@
 using Aster.Core.Models.Instances;
 using Aster.Core.Models.Querying;
+using Aster.Core.Models.Tenancy;
 
 namespace Aster.Core.Abstractions;
 
@@ -25,6 +26,11 @@ public interface IResourceVersionReader
 /// </summary>
 public sealed record ResourceVersionReadRequest
 {
+    /// <summary>
+    /// Tenant scope for the read. When omitted, the default single-tenant scope is used.
+    /// </summary>
+    public TenantScope? TenantScope { get; init; }
+
     /// <summary>
     /// Which resource versions to include. Defaults to latest versions only.
     /// </summary>

--- a/src/core/Aster.Core/Abstractions/Requests.cs
+++ b/src/core/Aster.Core/Abstractions/Requests.cs
@@ -1,3 +1,5 @@
+using Aster.Core.Models.Tenancy;
+
 namespace Aster.Core.Abstractions;
 
 /// <summary>
@@ -5,6 +7,11 @@ namespace Aster.Core.Abstractions;
 /// </summary>
 public sealed class CreateResourceRequest
 {
+    /// <summary>
+    /// Tenant scope for this create operation. When omitted, the default single-tenant scope is used.
+    /// </summary>
+    public TenantScope? TenantScope { get; set; }
+
     /// <summary>
     /// Optional caller-supplied logical resource ID (<c>ResourceId</c>).
     /// When <see langword="null"/> or empty, the engine delegates to <see cref="IIdentityGenerator"/>.
@@ -27,6 +34,11 @@ public sealed class CreateResourceRequest
 /// </summary>
 public sealed class UpdateResourceRequest
 {
+    /// <summary>
+    /// Tenant scope for this update operation. When omitted, the default single-tenant scope is used.
+    /// </summary>
+    public TenantScope? TenantScope { get; set; }
+
     /// <summary>
     /// Optimistic lock token. Must match the current latest <c>Resource.Version</c>.
     /// </summary>

--- a/src/core/Aster.Core/Exceptions/AsterExceptions.cs
+++ b/src/core/Aster.Core/Exceptions/AsterExceptions.cs
@@ -3,6 +3,65 @@ using Aster.Core.Models.Querying;
 namespace Aster.Core.Exceptions;
 
 /// <summary>
+/// Thrown when tenant scope is invalid or mismatched with a tenant-scoped operation.
+/// </summary>
+public sealed class TenantScopeException : Exception
+{
+    /// <summary>
+    /// Stable code for invalid tenant scope.
+    /// </summary>
+    public const string InvalidCode = "tenant-scope-invalid";
+
+    /// <summary>
+    /// Stable code for required tenant scope.
+    /// </summary>
+    public const string RequiredCode = "tenant-scope-required";
+
+    /// <summary>
+    /// Stable code for tenant scope mismatch.
+    /// </summary>
+    public const string MismatchCode = "tenant-scope-mismatch";
+
+    /// <summary>
+    /// Gets the stable tenant-scope failure code.
+    /// </summary>
+    public string Code { get; }
+
+    /// <summary>
+    /// Gets the tenant identifier associated with the failure, when available.
+    /// </summary>
+    public string? TenantId { get; }
+
+    /// <inheritdoc />
+    public TenantScopeException()
+        : this(InvalidCode, "The tenant scope is invalid.") { }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="TenantScopeException"/> class.
+    /// </summary>
+    /// <param name="code">Stable tenant-scope failure code.</param>
+    /// <param name="message">Human-readable explanation.</param>
+    /// <param name="tenantId">Optional tenant identifier.</param>
+    public TenantScopeException(string code, string message, string? tenantId = null)
+        : base(message)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(code);
+        ArgumentException.ThrowIfNullOrWhiteSpace(message);
+
+        Code = code;
+        TenantId = tenantId;
+    }
+
+    /// <inheritdoc />
+    public TenantScopeException(string message, Exception innerException)
+        : base(message, innerException)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(message);
+        Code = InvalidCode;
+    }
+}
+
+/// <summary>
 /// Thrown when a specific resource version cannot be found.
 /// </summary>
 public sealed class VersionNotFoundException : Exception

--- a/src/core/Aster.Core/InMemory/InMemoryPortabilityStore.cs
+++ b/src/core/Aster.Core/InMemory/InMemoryPortabilityStore.cs
@@ -2,6 +2,8 @@ using Aster.Core.Abstractions;
 using Aster.Core.Models.Definitions;
 using Aster.Core.Models.Instances;
 using Aster.Core.Models.Portability;
+using Aster.Core.Models.Tenancy;
+using Aster.Core.Services;
 
 namespace Aster.Core.InMemory;
 
@@ -33,10 +35,11 @@ public sealed class InMemoryPortabilityStore : IResourcePortabilityStore
         CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(request);
+        var tenant = TenantScopeResolver.Resolve(request.ExportRequest.TenantScope);
 
-        var resources = SelectResources(request.ExportRequest, cancellationToken);
-        var definitions = SelectDefinitions(request.ExportRequest, resources, cancellationToken);
-        var (activationStates, skippedActivationEntries) = SelectActivationStates(resources, cancellationToken);
+        var resources = SelectResources(request.ExportRequest, tenant, cancellationToken);
+        var definitions = SelectDefinitions(request.ExportRequest, tenant, resources, cancellationToken);
+        var (activationStates, skippedActivationEntries) = SelectActivationStates(tenant, resources, cancellationToken);
 
         return ValueTask.FromResult(new PortableStoreSnapshot
         {
@@ -53,13 +56,14 @@ public sealed class InMemoryPortabilityStore : IResourcePortabilityStore
         CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(snapshot);
+        var tenant = TenantScopeResolver.Resolve(snapshot.SourceTenantScope);
 
         var definitions = new List<ResourceDefinition>();
         foreach (var definition in snapshot.Definitions)
         {
             cancellationToken.ThrowIfCancellationRequested();
 
-            var existing = definitionStore.GetDefinitionVersion(definition.DefinitionId, definition.Version);
+            var existing = definitionStore.GetDefinitionVersion(definition.DefinitionId, definition.Version, tenant);
             if (existing is not null)
                 definitions.Add(existing);
         }
@@ -69,7 +73,7 @@ public sealed class InMemoryPortabilityStore : IResourcePortabilityStore
         {
             cancellationToken.ThrowIfCancellationRequested();
 
-            var versions = resourceStore.TryGetVersions(resource.ResourceId);
+            var versions = resourceStore.TryGetVersions(resource.ResourceId, tenant);
             if (versions is null)
                 continue;
 
@@ -86,7 +90,7 @@ public sealed class InMemoryPortabilityStore : IResourcePortabilityStore
         {
             cancellationToken.ThrowIfCancellationRequested();
 
-            if (resourceStore.ActivationStates.TryGetValue(state.ResourceId, out var states)
+            if (resourceStore.ActivationStates.TryGetValue((tenant.TenantId, state.ResourceId), out var states)
                 && states.TryGetValue(state.Channel, out var existing))
             {
                 activationStates.Add(existing);
@@ -108,6 +112,7 @@ public sealed class InMemoryPortabilityStore : IResourcePortabilityStore
     {
         ArgumentNullException.ThrowIfNull(plannedSnapshot);
         cancellationToken.ThrowIfCancellationRequested();
+        var tenant = TenantScopeResolver.Resolve(plannedSnapshot.SourceTenantScope);
 
         var appliedDefinitions = new List<ResourceDefinition>();
         var appliedResources = new List<Resource>();
@@ -120,8 +125,9 @@ public sealed class InMemoryPortabilityStore : IResourcePortabilityStore
                 .ThenBy(static definition => definition.Version))
             {
                 cancellationToken.ThrowIfCancellationRequested();
-                definitionStore.ImportDefinitionVersion(definition);
-                appliedDefinitions.Add(definition);
+                var scopedDefinition = definition with { TenantScope = tenant };
+                definitionStore.ImportDefinitionVersion(scopedDefinition);
+                appliedDefinitions.Add(scopedDefinition);
             }
 
             foreach (var resource in plannedSnapshot.Resources
@@ -129,8 +135,9 @@ public sealed class InMemoryPortabilityStore : IResourcePortabilityStore
                 .ThenBy(static resource => resource.Version))
             {
                 cancellationToken.ThrowIfCancellationRequested();
-                resourceStore.ImportVersion(resource);
-                appliedResources.Add(resource);
+                var scopedResource = resource with { TenantScope = tenant };
+                resourceStore.ImportVersion(scopedResource);
+                appliedResources.Add(scopedResource);
             }
 
             foreach (var state in plannedSnapshot.ActivationStates
@@ -138,9 +145,10 @@ public sealed class InMemoryPortabilityStore : IResourcePortabilityStore
                 .ThenBy(static state => state.Channel, StringComparer.Ordinal))
             {
                 cancellationToken.ThrowIfCancellationRequested();
-                var previous = resourceStore.GetActivationState(state.ResourceId, state.Channel);
-                await resourceStore.UpdateActivationAsync(state.ResourceId, state.Channel, state, cancellationToken);
-                appliedActivationStates.Add((state, previous));
+                var scopedState = state with { TenantScope = tenant };
+                var previous = resourceStore.GetActivationState(scopedState.ResourceId, scopedState.Channel, tenant);
+                await resourceStore.UpdateActivationAsync(scopedState.ResourceId, scopedState.Channel, scopedState, cancellationToken);
+                appliedActivationStates.Add((scopedState, previous));
             }
         }
         catch
@@ -156,7 +164,7 @@ public sealed class InMemoryPortabilityStore : IResourcePortabilityStore
         IReadOnlyList<(ActivationState State, ActivationState? PreviousState)> appliedActivationStates)
     {
         foreach (var (state, previousState) in appliedActivationStates.Reverse())
-            resourceStore.RestoreActivationState(state.ResourceId, state.Channel, previousState);
+            resourceStore.RestoreActivationState(state.ResourceId, state.Channel, state.TenantScope, previousState);
 
         foreach (var resource in appliedResources.Reverse())
             resourceStore.RemoveImportedVersion(resource);
@@ -167,6 +175,7 @@ public sealed class InMemoryPortabilityStore : IResourcePortabilityStore
 
     private List<ResourceDefinition> SelectDefinitions(
         PortableSnapshotExportRequest request,
+        TenantScope tenant,
         IReadOnlyCollection<Resource> resources,
         CancellationToken cancellationToken)
     {
@@ -178,7 +187,7 @@ public sealed class InMemoryPortabilityStore : IResourcePortabilityStore
             {
                 cancellationToken.ThrowIfCancellationRequested();
 
-                foreach (var definition in definitionStore.GetDefinitionVersions(definitionId))
+                foreach (var definition in definitionStore.GetDefinitionVersions(definitionId, tenant))
                     definitionVersions[(definition.DefinitionId, definition.Version)] = definition;
             }
         }
@@ -190,7 +199,7 @@ public sealed class InMemoryPortabilityStore : IResourcePortabilityStore
             if (resource.DefinitionVersion is null)
                 continue;
 
-            var definition = definitionStore.GetDefinitionVersion(resource.DefinitionId, resource.DefinitionVersion.Value);
+            var definition = definitionStore.GetDefinitionVersion(resource.DefinitionId, resource.DefinitionVersion.Value, tenant);
             if (definition is not null)
                 definitionVersions[(definition.DefinitionId, definition.Version)] = definition;
         }
@@ -203,6 +212,7 @@ public sealed class InMemoryPortabilityStore : IResourcePortabilityStore
 
     private List<Resource> SelectResources(
         PortableSnapshotExportRequest request,
+        TenantScope tenant,
         CancellationToken cancellationToken)
     {
         var resourceIds = request.ScopeMode switch
@@ -212,7 +222,7 @@ public sealed class InMemoryPortabilityStore : IResourcePortabilityStore
                 ? request.SpecificResourceVersions.Select(static reference => reference.ResourceId).ToHashSet(StringComparer.Ordinal)
                 : request.ResourceIds,
             PortableExportScopeMode.DefinitionWithResources => request.DefinitionIds
-                .SelectMany(resourceStore.GetResourceIdsForDefinition)
+                .SelectMany(definitionId => resourceStore.GetResourceIdsForDefinition(definitionId, tenant))
                 .ToHashSet(StringComparer.Ordinal),
             _ => [],
         };
@@ -224,7 +234,7 @@ public sealed class InMemoryPortabilityStore : IResourcePortabilityStore
         {
             cancellationToken.ThrowIfCancellationRequested();
 
-            var versions = resourceStore.TryGetVersions(resourceId);
+            var versions = resourceStore.TryGetVersions(resourceId, tenant);
             if (versions is null)
                 continue;
 
@@ -242,6 +252,7 @@ public sealed class InMemoryPortabilityStore : IResourcePortabilityStore
     }
 
     private (List<ActivationState> ActivationStates, List<SkippedActivationEntry> SkippedActivationEntries) SelectActivationStates(
+        TenantScope tenant,
         IReadOnlyCollection<Resource> resources,
         CancellationToken cancellationToken)
     {
@@ -255,9 +266,11 @@ public sealed class InMemoryPortabilityStore : IResourcePortabilityStore
         var activationStates = new List<ActivationState>();
         var skippedEntries = new List<SkippedActivationEntry>();
 
-        foreach (var (resourceId, resourceActivationStates) in resourceStore.ActivationStates.OrderBy(static item => item.Key, StringComparer.Ordinal))
+        foreach (var ((tenantId, resourceId), resourceActivationStates) in resourceStore.ActivationStates.OrderBy(static item => item.Key.ResourceId, StringComparer.Ordinal))
         {
             cancellationToken.ThrowIfCancellationRequested();
+            if (!string.Equals(tenantId, tenant.TenantId, StringComparison.Ordinal))
+                continue;
 
             if (!includedVersions.TryGetValue(resourceId, out var includedResourceVersions))
                 continue;

--- a/src/core/Aster.Core/InMemory/InMemoryQueryService.cs
+++ b/src/core/Aster.Core/InMemory/InMemoryQueryService.cs
@@ -55,6 +55,7 @@ public sealed partial class InMemoryQueryService : IResourceQueryService, IResou
 
         var candidates = await versionReader.ReadVersionsAsync(new ResourceVersionReadRequest
         {
+            TenantScope = query.TenantScope,
             Scope = query.Scope,
             ActivationChannel = query.ActivationChannel,
         }, cancellationToken);

--- a/src/core/Aster.Core/InMemory/InMemoryResourceDefinitionStore.cs
+++ b/src/core/Aster.Core/InMemory/InMemoryResourceDefinitionStore.cs
@@ -31,7 +31,7 @@ public sealed partial class InMemoryResourceDefinitionStore : IResourceDefinitio
         GetDefinitionAsync(definitionId, TenantScope.Default, cancellationToken);
 
     /// <inheritdoc />
-    public ValueTask<ResourceDefinition?> GetDefinitionAsync(string definitionId, TenantScope tenantScope, CancellationToken cancellationToken = default)
+    public ValueTask<ResourceDefinition?> GetDefinitionAsync(string definitionId, TenantScope tenantScope, CancellationToken cancellationToken)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(definitionId);
         var tenant = TenantScopeResolver.Resolve(tenantScope);
@@ -56,7 +56,7 @@ public sealed partial class InMemoryResourceDefinitionStore : IResourceDefinitio
         string definitionId,
         int version,
         TenantScope tenantScope,
-        CancellationToken cancellationToken = default)
+        CancellationToken cancellationToken)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(definitionId);
         var tenant = TenantScopeResolver.Resolve(tenantScope);
@@ -81,7 +81,7 @@ public sealed partial class InMemoryResourceDefinitionStore : IResourceDefinitio
     public ValueTask RegisterDefinitionAsync(
         ResourceDefinition definition,
         TenantScope tenantScope,
-        CancellationToken cancellationToken = default)
+        CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(definition);
         var tenant = TenantScopeResolver.Resolve(tenantScope);
@@ -104,7 +104,7 @@ public sealed partial class InMemoryResourceDefinitionStore : IResourceDefinitio
         ListDefinitionsAsync(TenantScope.Default, cancellationToken);
 
     /// <inheritdoc />
-    public ValueTask<IEnumerable<ResourceDefinition>> ListDefinitionsAsync(TenantScope tenantScope, CancellationToken cancellationToken = default)
+    public ValueTask<IEnumerable<ResourceDefinition>> ListDefinitionsAsync(TenantScope tenantScope, CancellationToken cancellationToken)
     {
         var tenant = TenantScopeResolver.Resolve(tenantScope);
         var latest = new List<ResourceDefinition>();

--- a/src/core/Aster.Core/InMemory/InMemoryResourceDefinitionStore.cs
+++ b/src/core/Aster.Core/InMemory/InMemoryResourceDefinitionStore.cs
@@ -1,6 +1,8 @@
 using System.Collections.Concurrent;
 using Aster.Core.Abstractions;
 using Aster.Core.Models.Definitions;
+using Aster.Core.Models.Tenancy;
+using Aster.Core.Services;
 using Microsoft.Extensions.Logging;
 
 namespace Aster.Core.InMemory;
@@ -11,7 +13,7 @@ namespace Aster.Core.InMemory;
 /// </summary>
 public sealed partial class InMemoryResourceDefinitionStore : IResourceDefinitionStore
 {
-    private readonly ConcurrentDictionary<string, List<ResourceDefinition>> definitions = new(StringComparer.Ordinal);
+    private readonly ConcurrentDictionary<(string TenantId, string DefinitionId), List<ResourceDefinition>> definitions = [];
     private readonly ILogger<InMemoryResourceDefinitionStore> logger;
 
     /// <summary>
@@ -25,11 +27,16 @@ public sealed partial class InMemoryResourceDefinitionStore : IResourceDefinitio
     }
 
     /// <inheritdoc />
-    public ValueTask<ResourceDefinition?> GetDefinitionAsync(string definitionId, CancellationToken cancellationToken = default)
+    public ValueTask<ResourceDefinition?> GetDefinitionAsync(string definitionId, CancellationToken cancellationToken = default) =>
+        GetDefinitionAsync(definitionId, TenantScope.Default, cancellationToken);
+
+    /// <inheritdoc />
+    public ValueTask<ResourceDefinition?> GetDefinitionAsync(string definitionId, TenantScope tenantScope, CancellationToken cancellationToken = default)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(definitionId);
+        var tenant = TenantScopeResolver.Resolve(tenantScope);
 
-        if (definitions.TryGetValue(definitionId, out var versions))
+        if (definitions.TryGetValue((tenant.TenantId, definitionId), out var versions))
         {
             lock (versions)
             {
@@ -41,11 +48,20 @@ public sealed partial class InMemoryResourceDefinitionStore : IResourceDefinitio
     }
 
     /// <inheritdoc />
-    public ValueTask<ResourceDefinition?> GetDefinitionVersionAsync(string definitionId, int version, CancellationToken cancellationToken = default)
+    public ValueTask<ResourceDefinition?> GetDefinitionVersionAsync(string definitionId, int version, CancellationToken cancellationToken = default) =>
+        GetDefinitionVersionAsync(definitionId, version, TenantScope.Default, cancellationToken);
+
+    /// <inheritdoc />
+    public ValueTask<ResourceDefinition?> GetDefinitionVersionAsync(
+        string definitionId,
+        int version,
+        TenantScope tenantScope,
+        CancellationToken cancellationToken = default)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(definitionId);
+        var tenant = TenantScopeResolver.Resolve(tenantScope);
 
-        if (definitions.TryGetValue(definitionId, out var versions))
+        if (definitions.TryGetValue((tenant.TenantId, definitionId), out var versions))
         {
             lock (versions)
             {
@@ -58,16 +74,24 @@ public sealed partial class InMemoryResourceDefinitionStore : IResourceDefinitio
     }
 
     /// <inheritdoc />
-    public ValueTask RegisterDefinitionAsync(ResourceDefinition definition, CancellationToken cancellationToken = default)
+    public ValueTask RegisterDefinitionAsync(ResourceDefinition definition, CancellationToken cancellationToken = default) =>
+        RegisterDefinitionAsync(definition, definition.TenantScope, cancellationToken);
+
+    /// <inheritdoc />
+    public ValueTask RegisterDefinitionAsync(
+        ResourceDefinition definition,
+        TenantScope tenantScope,
+        CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(definition);
+        var tenant = TenantScopeResolver.Resolve(tenantScope);
 
-        var versions = definitions.GetOrAdd(definition.DefinitionId, _ => []);
+        var versions = definitions.GetOrAdd((tenant.TenantId, definition.DefinitionId), _ => []);
 
         lock (versions)
         {
             int nextVersion = versions.Count > 0 ? versions[^1].Version + 1 : 1;
-            var versionedDefinition = definition with { Version = nextVersion };
+            var versionedDefinition = definition with { TenantScope = tenant, Version = nextVersion };
             versions.Add(versionedDefinition);
             LogDefinitionRegistered(definition.DefinitionId, nextVersion);
         }
@@ -76,12 +100,20 @@ public sealed partial class InMemoryResourceDefinitionStore : IResourceDefinitio
     }
 
     /// <inheritdoc />
-    public ValueTask<IEnumerable<ResourceDefinition>> ListDefinitionsAsync(CancellationToken cancellationToken = default)
+    public ValueTask<IEnumerable<ResourceDefinition>> ListDefinitionsAsync(CancellationToken cancellationToken = default) =>
+        ListDefinitionsAsync(TenantScope.Default, cancellationToken);
+
+    /// <inheritdoc />
+    public ValueTask<IEnumerable<ResourceDefinition>> ListDefinitionsAsync(TenantScope tenantScope, CancellationToken cancellationToken = default)
     {
+        var tenant = TenantScopeResolver.Resolve(tenantScope);
         var latest = new List<ResourceDefinition>();
 
-        foreach (var versions in definitions.Values)
+        foreach (var ((tenantId, _), versions) in definitions)
         {
+            if (!string.Equals(tenantId, tenant.TenantId, StringComparison.Ordinal))
+                continue;
+
             lock (versions)
             {
                 if (versions.Count > 0)
@@ -95,11 +127,18 @@ public sealed partial class InMemoryResourceDefinitionStore : IResourceDefinitio
     /// <summary>
     /// Returns all versions for a definition.
     /// </summary>
-    internal IReadOnlyList<ResourceDefinition> GetDefinitionVersions(string definitionId)
+    internal IReadOnlyList<ResourceDefinition> GetDefinitionVersions(string definitionId) =>
+        GetDefinitionVersions(definitionId, TenantScope.Default);
+
+    /// <summary>
+    /// Returns all versions for a definition in a tenant.
+    /// </summary>
+    internal IReadOnlyList<ResourceDefinition> GetDefinitionVersions(string definitionId, TenantScope tenantScope)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(definitionId);
+        var tenant = TenantScopeResolver.Resolve(tenantScope);
 
-        if (!definitions.TryGetValue(definitionId, out var versions))
+        if (!definitions.TryGetValue((tenant.TenantId, definitionId), out var versions))
             return [];
 
         lock (versions)
@@ -109,11 +148,18 @@ public sealed partial class InMemoryResourceDefinitionStore : IResourceDefinitio
     /// <summary>
     /// Returns a specific definition version.
     /// </summary>
-    internal ResourceDefinition? GetDefinitionVersion(string definitionId, int version)
+    internal ResourceDefinition? GetDefinitionVersion(string definitionId, int version) =>
+        GetDefinitionVersion(definitionId, version, TenantScope.Default);
+
+    /// <summary>
+    /// Returns a specific definition version in a tenant.
+    /// </summary>
+    internal ResourceDefinition? GetDefinitionVersion(string definitionId, int version, TenantScope tenantScope)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(definitionId);
+        var tenant = TenantScopeResolver.Resolve(tenantScope);
 
-        if (!definitions.TryGetValue(definitionId, out var versions))
+        if (!definitions.TryGetValue((tenant.TenantId, definitionId), out var versions))
             return null;
 
         lock (versions)
@@ -126,8 +172,9 @@ public sealed partial class InMemoryResourceDefinitionStore : IResourceDefinitio
     internal void ImportDefinitionVersion(ResourceDefinition definition)
     {
         ArgumentNullException.ThrowIfNull(definition);
+        var tenant = TenantScopeResolver.Resolve(definition.TenantScope);
 
-        var versions = definitions.GetOrAdd(definition.DefinitionId, _ => []);
+        var versions = definitions.GetOrAdd((tenant.TenantId, definition.DefinitionId), _ => []);
         lock (versions)
         {
             var insertIndex = versions.FindIndex(existing => existing.Version >= definition.Version);
@@ -147,8 +194,9 @@ public sealed partial class InMemoryResourceDefinitionStore : IResourceDefinitio
     internal void RemoveImportedDefinitionVersion(ResourceDefinition definition)
     {
         ArgumentNullException.ThrowIfNull(definition);
+        var tenant = TenantScopeResolver.Resolve(definition.TenantScope);
 
-        if (!definitions.TryGetValue(definition.DefinitionId, out var versions))
+        if (!definitions.TryGetValue((tenant.TenantId, definition.DefinitionId), out var versions))
             return;
 
         lock (versions)

--- a/src/core/Aster.Core/InMemory/InMemoryResourceDefinitionStore.cs
+++ b/src/core/Aster.Core/InMemory/InMemoryResourceDefinitionStore.cs
@@ -75,7 +75,7 @@ public sealed partial class InMemoryResourceDefinitionStore : IResourceDefinitio
 
     /// <inheritdoc />
     public ValueTask RegisterDefinitionAsync(ResourceDefinition definition, CancellationToken cancellationToken = default) =>
-        RegisterDefinitionAsync(definition, definition.TenantScope, cancellationToken);
+        RegisterDefinitionAsync(definition, TenantScope.Default, cancellationToken);
 
     /// <inheritdoc />
     public ValueTask RegisterDefinitionAsync(

--- a/src/core/Aster.Core/InMemory/InMemoryResourceManager.cs
+++ b/src/core/Aster.Core/InMemory/InMemoryResourceManager.cs
@@ -1,6 +1,8 @@
 using Aster.Core.Abstractions;
 using Aster.Core.Exceptions;
 using Aster.Core.Models.Instances;
+using Aster.Core.Models.Tenancy;
+using Aster.Core.Services;
 using Microsoft.Extensions.Logging;
 
 namespace Aster.Core.InMemory;
@@ -52,6 +54,7 @@ public sealed partial class InMemoryResourceManager : IResourceManager, IResourc
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(definitionId);
         ArgumentNullException.ThrowIfNull(request);
+        var tenant = TenantScopeResolver.Resolve(request.TenantScope);
 
         // Resolve ResourceId
         var resourceId = string.IsNullOrWhiteSpace(request.ResourceId)
@@ -60,20 +63,23 @@ public sealed partial class InMemoryResourceManager : IResourceManager, IResourc
 
         // Atomic duplicate ID check — TryAdd is atomic so only one creator can win
         var versionList = new List<Resource>();
-        if (!store.Versions.TryAdd(resourceId, versionList))
+        if (!store.Versions.TryAdd((tenant.TenantId, resourceId), versionList))
             throw new DuplicateResourceIdException(resourceId);
 
         // Singleton enforcement
-        var definition = await definitionStore.GetDefinitionAsync(definitionId, cancellationToken);
+        var definition = tenant.IsDefault
+            ? await definitionStore.GetDefinitionAsync(definitionId, cancellationToken)
+            : await definitionStore.GetDefinitionAsync(definitionId, tenant, cancellationToken);
         if (definition?.IsSingleton == true)
         {
-            var existingIds = store.GetResourceIdsForDefinition(definitionId);
+            var existingIds = store.GetResourceIdsForDefinition(definitionId, tenant);
             if (existingIds.Any())
                 throw new SingletonViolationException(definitionId);
         }
 
         var resource = new Resource
         {
+            TenantScope = tenant,
             ResourceId = resourceId,
             Id = identityGenerator.NewId(),
             DefinitionId = definitionId,
@@ -94,8 +100,9 @@ public sealed partial class InMemoryResourceManager : IResourceManager, IResourc
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(resourceId);
         ArgumentNullException.ThrowIfNull(request);
+        var tenant = TenantScopeResolver.Resolve(request.TenantScope);
 
-        var versions = store.TryGetVersions(resourceId)
+        var versions = store.TryGetVersions(resourceId, tenant)
             ?? throw new VersionNotFoundException(resourceId, request.BaseVersion);
 
         Resource latest;
@@ -131,11 +138,20 @@ public sealed partial class InMemoryResourceManager : IResourceManager, IResourc
     // ──────────────────────────────────────────────────────────────────────────
 
     /// <inheritdoc />
-    public ValueTask<Resource?> GetVersionAsync(string resourceId, int version, CancellationToken cancellationToken = default)
+    public ValueTask<Resource?> GetVersionAsync(string resourceId, int version, CancellationToken cancellationToken = default) =>
+        GetVersionAsync(resourceId, version, TenantScope.Default, cancellationToken);
+
+    /// <inheritdoc />
+    public ValueTask<Resource?> GetVersionAsync(
+        string resourceId,
+        int version,
+        TenantScope tenantScope,
+        CancellationToken cancellationToken = default)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(resourceId);
+        var tenant = TenantScopeResolver.Resolve(tenantScope);
 
-        var versions = store.TryGetVersions(resourceId);
+        var versions = store.TryGetVersions(resourceId, tenant);
         if (versions is null)
             return ValueTask.FromResult<Resource?>(null);
 
@@ -147,11 +163,19 @@ public sealed partial class InMemoryResourceManager : IResourceManager, IResourc
     }
 
     /// <inheritdoc />
-    public ValueTask<IEnumerable<Resource>> GetVersionsAsync(string resourceId, CancellationToken cancellationToken = default)
+    public ValueTask<IEnumerable<Resource>> GetVersionsAsync(string resourceId, CancellationToken cancellationToken = default) =>
+        GetVersionsAsync(resourceId, TenantScope.Default, cancellationToken);
+
+    /// <inheritdoc />
+    public ValueTask<IEnumerable<Resource>> GetVersionsAsync(
+        string resourceId,
+        TenantScope tenantScope,
+        CancellationToken cancellationToken = default)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(resourceId);
+        var tenant = TenantScopeResolver.Resolve(tenantScope);
 
-        var versions = store.TryGetVersions(resourceId);
+        var versions = store.TryGetVersions(resourceId, tenant);
         if (versions is null)
             return ValueTask.FromResult<IEnumerable<Resource>>([]);
 
@@ -162,11 +186,19 @@ public sealed partial class InMemoryResourceManager : IResourceManager, IResourc
     }
 
     /// <inheritdoc />
-    public ValueTask<Resource?> GetLatestVersionAsync(string resourceId, CancellationToken cancellationToken = default)
+    public ValueTask<Resource?> GetLatestVersionAsync(string resourceId, CancellationToken cancellationToken = default) =>
+        GetLatestVersionAsync(resourceId, TenantScope.Default, cancellationToken);
+
+    /// <inheritdoc />
+    public ValueTask<Resource?> GetLatestVersionAsync(
+        string resourceId,
+        TenantScope tenantScope,
+        CancellationToken cancellationToken = default)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(resourceId);
+        var tenant = TenantScopeResolver.Resolve(tenantScope);
 
-        var versions = store.TryGetVersions(resourceId);
+        var versions = store.TryGetVersions(resourceId, tenant);
         if (versions is null)
             return ValueTask.FromResult<Resource?>(null);
 
@@ -186,12 +218,23 @@ public sealed partial class InMemoryResourceManager : IResourceManager, IResourc
         int version,
         string channel,
         bool allowMultipleActive = false,
+        CancellationToken cancellationToken = default) =>
+        await ActivateAsync(resourceId, version, channel, TenantScope.Default, allowMultipleActive, cancellationToken);
+
+    /// <inheritdoc />
+    public async ValueTask ActivateAsync(
+        string resourceId,
+        int version,
+        string channel,
+        TenantScope tenantScope,
+        bool allowMultipleActive = false,
         CancellationToken cancellationToken = default)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(resourceId);
         ArgumentException.ThrowIfNullOrWhiteSpace(channel);
+        var tenant = TenantScopeResolver.Resolve(tenantScope);
 
-        var versions = store.TryGetVersions(resourceId);
+        var versions = store.TryGetVersions(resourceId, tenant);
         if (versions is null)
             throw new VersionNotFoundException(resourceId, version);
 
@@ -209,7 +252,7 @@ public sealed partial class InMemoryResourceManager : IResourceManager, IResourc
         if (version != latest.Version)
             throw new ConcurrencyException(resourceId, version, latest.Version);
 
-        var channelActivations = store.GetOrAddActivations(resourceId);
+        var channelActivations = store.GetOrAddActivations(resourceId, tenant);
         var newActiveVersions = new HashSet<int>();
 
         lock (channelActivations)
@@ -226,6 +269,7 @@ public sealed partial class InMemoryResourceManager : IResourceManager, IResourc
 
         var state = new ActivationState
         {
+            TenantScope = tenant,
             ResourceId = resourceId,
             Channel = channel,
             ActiveVersions = [.. newActiveVersions],
@@ -241,12 +285,22 @@ public sealed partial class InMemoryResourceManager : IResourceManager, IResourc
         string resourceId,
         int version,
         string channel,
+        CancellationToken cancellationToken = default) =>
+        await DeactivateAsync(resourceId, version, channel, TenantScope.Default, cancellationToken);
+
+    /// <inheritdoc />
+    public async ValueTask DeactivateAsync(
+        string resourceId,
+        int version,
+        string channel,
+        TenantScope tenantScope,
         CancellationToken cancellationToken = default)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(resourceId);
         ArgumentException.ThrowIfNullOrWhiteSpace(channel);
+        var tenant = TenantScopeResolver.Resolve(tenantScope);
 
-        var channelActivations = store.GetOrAddActivations(resourceId);
+        var channelActivations = store.GetOrAddActivations(resourceId, tenant);
 
         lock (channelActivations)
         {
@@ -260,6 +314,7 @@ public sealed partial class InMemoryResourceManager : IResourceManager, IResourc
         var remaining = channelActivations.TryGetValue(channel, out var current) ? current : new HashSet<int>();
         var state = new ActivationState
         {
+            TenantScope = tenant,
             ResourceId = resourceId,
             Channel = channel,
             ActiveVersions = [.. remaining],
@@ -274,16 +329,25 @@ public sealed partial class InMemoryResourceManager : IResourceManager, IResourc
     public ValueTask<IEnumerable<Resource>> GetActiveVersionsAsync(
         string resourceId,
         string channel,
+        CancellationToken cancellationToken = default) =>
+        GetActiveVersionsAsync(resourceId, channel, TenantScope.Default, cancellationToken);
+
+    /// <inheritdoc />
+    public ValueTask<IEnumerable<Resource>> GetActiveVersionsAsync(
+        string resourceId,
+        string channel,
+        TenantScope tenantScope,
         CancellationToken cancellationToken = default)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(resourceId);
         ArgumentException.ThrowIfNullOrWhiteSpace(channel);
+        var tenant = TenantScopeResolver.Resolve(tenantScope);
 
-        var versions = store.TryGetVersions(resourceId);
+        var versions = store.TryGetVersions(resourceId, tenant);
         if (versions is null)
             return ValueTask.FromResult<IEnumerable<Resource>>([]);
 
-        if (!store.Activations.TryGetValue(resourceId, out var channelActivations))
+        if (!store.Activations.TryGetValue((tenant.TenantId, resourceId), out var channelActivations))
             return ValueTask.FromResult<IEnumerable<Resource>>([]);
 
         HashSet<int> activeVersionNumbers;
@@ -311,16 +375,18 @@ public sealed partial class InMemoryResourceManager : IResourceManager, IResourc
     public ValueTask<Resource> SaveVersionAsync(Resource resource, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(resource);
+        var tenant = TenantScopeResolver.Resolve(resource.TenantScope);
+        var scopedResource = resource with { TenantScope = tenant };
 
-        var versions = store.Versions.GetOrAdd(resource.ResourceId, _ => []);
+        var versions = store.Versions.GetOrAdd((tenant.TenantId, scopedResource.ResourceId), _ => []);
         lock (versions)
         {
-            versions.Add(resource);
+            versions.Add(scopedResource);
         }
 
-        LogResourceSaved(resource.ResourceId, resource.Version, resource.Id);
+        LogResourceSaved(scopedResource.ResourceId, scopedResource.Version, scopedResource.Id);
 
-        return ValueTask.FromResult(resource);
+        return ValueTask.FromResult(scopedResource);
     }
 
     /// <inheritdoc />

--- a/src/core/Aster.Core/InMemory/InMemoryResourceManager.cs
+++ b/src/core/Aster.Core/InMemory/InMemoryResourceManager.cs
@@ -170,7 +170,7 @@ public sealed partial class InMemoryResourceManager : IResourceManager, IResourc
     public ValueTask<IEnumerable<Resource>> GetVersionsAsync(
         string resourceId,
         TenantScope tenantScope,
-        CancellationToken cancellationToken = default)
+        CancellationToken cancellationToken)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(resourceId);
         var tenant = TenantScopeResolver.Resolve(tenantScope);
@@ -193,7 +193,7 @@ public sealed partial class InMemoryResourceManager : IResourceManager, IResourc
     public ValueTask<Resource?> GetLatestVersionAsync(
         string resourceId,
         TenantScope tenantScope,
-        CancellationToken cancellationToken = default)
+        CancellationToken cancellationToken)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(resourceId);
         var tenant = TenantScopeResolver.Resolve(tenantScope);
@@ -337,7 +337,7 @@ public sealed partial class InMemoryResourceManager : IResourceManager, IResourc
         string resourceId,
         string channel,
         TenantScope tenantScope,
-        CancellationToken cancellationToken = default)
+        CancellationToken cancellationToken)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(resourceId);
         ArgumentException.ThrowIfNullOrWhiteSpace(channel);

--- a/src/core/Aster.Core/InMemory/InMemoryResourceManager.cs
+++ b/src/core/Aster.Core/InMemory/InMemoryResourceManager.cs
@@ -61,21 +61,19 @@ public sealed partial class InMemoryResourceManager : IResourceManager, IResourc
             ? identityGenerator.NewId()
             : request.ResourceId;
 
-        // Atomic duplicate ID check — TryAdd is atomic so only one creator can win
-        var versionList = new List<Resource>();
-        if (!store.Versions.TryAdd((tenant.TenantId, resourceId), versionList))
-            throw new DuplicateResourceIdException(resourceId);
-
         // Singleton enforcement
-        var definition = tenant.IsDefault
-            ? await definitionStore.GetDefinitionAsync(definitionId, cancellationToken)
-            : await definitionStore.GetDefinitionAsync(definitionId, tenant, cancellationToken);
+        var definition = await definitionStore.GetDefinitionAsync(definitionId, tenant, cancellationToken);
         if (definition?.IsSingleton == true)
         {
             var existingIds = store.GetResourceIdsForDefinition(definitionId, tenant);
             if (existingIds.Any())
                 throw new SingletonViolationException(definitionId);
         }
+
+        // Atomic duplicate ID check - TryAdd is atomic so only one creator can win.
+        var versionList = new List<Resource>();
+        if (!store.Versions.TryAdd((tenant.TenantId, resourceId), versionList))
+            throw new DuplicateResourceIdException(resourceId);
 
         var resource = new Resource
         {

--- a/src/core/Aster.Core/InMemory/InMemoryResourceManager.cs
+++ b/src/core/Aster.Core/InMemory/InMemoryResourceManager.cs
@@ -146,7 +146,7 @@ public sealed partial class InMemoryResourceManager : IResourceManager, IResourc
         string resourceId,
         int version,
         TenantScope tenantScope,
-        CancellationToken cancellationToken = default)
+        CancellationToken cancellationToken)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(resourceId);
         var tenant = TenantScopeResolver.Resolve(tenantScope);
@@ -227,8 +227,8 @@ public sealed partial class InMemoryResourceManager : IResourceManager, IResourc
         int version,
         string channel,
         TenantScope tenantScope,
-        bool allowMultipleActive = false,
-        CancellationToken cancellationToken = default)
+        bool allowMultipleActive,
+        CancellationToken cancellationToken)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(resourceId);
         ArgumentException.ThrowIfNullOrWhiteSpace(channel);
@@ -294,7 +294,7 @@ public sealed partial class InMemoryResourceManager : IResourceManager, IResourc
         int version,
         string channel,
         TenantScope tenantScope,
-        CancellationToken cancellationToken = default)
+        CancellationToken cancellationToken)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(resourceId);
         ArgumentException.ThrowIfNullOrWhiteSpace(channel);

--- a/src/core/Aster.Core/InMemory/InMemoryResourceStore.cs
+++ b/src/core/Aster.Core/InMemory/InMemoryResourceStore.cs
@@ -204,7 +204,12 @@ public sealed class InMemoryResourceStore : IResourceVersionReader, IResourceVer
         ArgumentNullException.ThrowIfNull(state);
         cancellationToken.ThrowIfCancellationRequested();
         var tenant = TenantScopeResolver.Resolve(state.TenantScope);
-        var scopedState = state with { TenantScope = tenant };
+        var scopedState = state with
+        {
+            TenantScope = tenant,
+            ResourceId = resourceId,
+            Channel = channel,
+        };
 
         var channelActivations = GetOrAddActivations(resourceId, tenant);
         lock (channelActivations)

--- a/src/core/Aster.Core/InMemory/InMemoryResourceStore.cs
+++ b/src/core/Aster.Core/InMemory/InMemoryResourceStore.cs
@@ -14,20 +14,20 @@ namespace Aster.Core.InMemory;
 public sealed class InMemoryResourceStore : IResourceVersionReader, IResourceVersionWriter
 {
     /// <summary>
-    /// Resource version history keyed by <c>ResourceId</c>.
+    /// Resource version history keyed by tenant ID and <c>ResourceId</c>.
     /// Each list is ordered from V1 to the latest; access must be synchronised via <c>lock</c>.
     /// </summary>
     internal readonly ConcurrentDictionary<(string TenantId, string ResourceId), List<Resource>> Versions = [];
 
     /// <summary>
-    /// Activation state keyed by <c>ResourceId</c> → channel name → set of active version numbers.
+    /// Activation state keyed by tenant ID and <c>ResourceId</c> → channel name → set of active version numbers.
     /// The inner <see cref="ConcurrentDictionary{TKey,TValue}"/> is used as a lock target for
     /// atomic read-modify-write on the contained <see cref="HashSet{T}"/>.
     /// </summary>
     internal readonly ConcurrentDictionary<(string TenantId, string ResourceId), ConcurrentDictionary<string, HashSet<int>>> Activations = [];
 
     /// <summary>
-    /// Last persisted activation state keyed by <c>ResourceId</c> → channel name.
+    /// Last persisted activation state keyed by tenant ID and <c>ResourceId</c> → channel name.
     /// </summary>
     internal readonly ConcurrentDictionary<(string TenantId, string ResourceId), ConcurrentDictionary<string, ActivationState>> ActivationStates = [];
 

--- a/src/core/Aster.Core/InMemory/InMemoryResourceStore.cs
+++ b/src/core/Aster.Core/InMemory/InMemoryResourceStore.cs
@@ -2,6 +2,8 @@ using System.Collections.Concurrent;
 using Aster.Core.Abstractions;
 using Aster.Core.Models.Instances;
 using Aster.Core.Models.Querying;
+using Aster.Core.Models.Tenancy;
+using Aster.Core.Services;
 
 namespace Aster.Core.InMemory;
 
@@ -15,35 +17,50 @@ public sealed class InMemoryResourceStore : IResourceVersionReader, IResourceVer
     /// Resource version history keyed by <c>ResourceId</c>.
     /// Each list is ordered from V1 to the latest; access must be synchronised via <c>lock</c>.
     /// </summary>
-    internal readonly ConcurrentDictionary<string, List<Resource>> Versions =
-        new(StringComparer.Ordinal);
+    internal readonly ConcurrentDictionary<(string TenantId, string ResourceId), List<Resource>> Versions = [];
 
     /// <summary>
     /// Activation state keyed by <c>ResourceId</c> → channel name → set of active version numbers.
     /// The inner <see cref="ConcurrentDictionary{TKey,TValue}"/> is used as a lock target for
     /// atomic read-modify-write on the contained <see cref="HashSet{T}"/>.
     /// </summary>
-    internal readonly ConcurrentDictionary<string, ConcurrentDictionary<string, HashSet<int>>> Activations =
-        new(StringComparer.Ordinal);
+    internal readonly ConcurrentDictionary<(string TenantId, string ResourceId), ConcurrentDictionary<string, HashSet<int>>> Activations = [];
 
     /// <summary>
     /// Last persisted activation state keyed by <c>ResourceId</c> → channel name.
     /// </summary>
-    internal readonly ConcurrentDictionary<string, ConcurrentDictionary<string, ActivationState>> ActivationStates =
-        new(StringComparer.Ordinal);
+    internal readonly ConcurrentDictionary<(string TenantId, string ResourceId), ConcurrentDictionary<string, ActivationState>> ActivationStates = [];
 
     /// <summary>
     /// Returns the ordered version list for a resource, or <see langword="null"/> if it does not exist.
     /// The caller must <c>lock</c> the returned list when reading or mutating.
     /// </summary>
     internal List<Resource>? TryGetVersions(string resourceId) =>
-        Versions.TryGetValue(resourceId, out var list) ? list : null;
+        TryGetVersions(resourceId, TenantScope.Default);
+
+    /// <summary>
+    /// Returns the ordered version list for a tenant-scoped resource, or <see langword="null"/> if it does not exist.
+    /// </summary>
+    internal List<Resource>? TryGetVersions(string resourceId, TenantScope tenantScope)
+    {
+        var tenant = TenantScopeResolver.Resolve(tenantScope);
+        return Versions.TryGetValue((tenant.TenantId, resourceId), out var list) ? list : null;
+    }
 
     /// <summary>
     /// Returns the activation channel map for a resource, creating it if absent.
     /// </summary>
     internal ConcurrentDictionary<string, HashSet<int>> GetOrAddActivations(string resourceId) =>
-        Activations.GetOrAdd(resourceId, _ => new ConcurrentDictionary<string, HashSet<int>>(StringComparer.Ordinal));
+        GetOrAddActivations(resourceId, TenantScope.Default);
+
+    /// <summary>
+    /// Returns the activation channel map for a tenant-scoped resource, creating it if absent.
+    /// </summary>
+    internal ConcurrentDictionary<string, HashSet<int>> GetOrAddActivations(string resourceId, TenantScope tenantScope)
+    {
+        var tenant = TenantScopeResolver.Resolve(tenantScope);
+        return Activations.GetOrAdd((tenant.TenantId, resourceId), _ => new ConcurrentDictionary<string, HashSet<int>>(StringComparer.Ordinal));
+    }
 
     /// <summary>
     /// Imports an exact resource version while preserving version ordering.
@@ -51,8 +68,9 @@ public sealed class InMemoryResourceStore : IResourceVersionReader, IResourceVer
     internal void ImportVersion(Resource resource)
     {
         ArgumentNullException.ThrowIfNull(resource);
+        var tenant = TenantScopeResolver.Resolve(resource.TenantScope);
 
-        var versions = Versions.GetOrAdd(resource.ResourceId, _ => []);
+        var versions = Versions.GetOrAdd((tenant.TenantId, resource.ResourceId), _ => []);
         lock (versions)
         {
             var insertIndex = versions.FindIndex(existing => existing.Version >= resource.Version);
@@ -72,8 +90,9 @@ public sealed class InMemoryResourceStore : IResourceVersionReader, IResourceVer
     internal void RemoveImportedVersion(Resource resource)
     {
         ArgumentNullException.ThrowIfNull(resource);
+        var tenant = TenantScopeResolver.Resolve(resource.TenantScope);
 
-        if (!Versions.TryGetValue(resource.ResourceId, out var versions))
+        if (!Versions.TryGetValue((tenant.TenantId, resource.ResourceId), out var versions))
             return;
 
         lock (versions)
@@ -86,20 +105,39 @@ public sealed class InMemoryResourceStore : IResourceVersionReader, IResourceVer
     /// Returns the persisted activation state for a resource/channel pair.
     /// </summary>
     internal ActivationState? GetActivationState(string resourceId, string channel) =>
-        ActivationStates.TryGetValue(resourceId, out var states)
+        GetActivationState(resourceId, channel, TenantScope.Default);
+
+    /// <summary>
+    /// Returns the persisted activation state for a tenant-scoped resource/channel pair.
+    /// </summary>
+    internal ActivationState? GetActivationState(string resourceId, string channel, TenantScope tenantScope)
+    {
+        var tenant = TenantScopeResolver.Resolve(tenantScope);
+        return ActivationStates.TryGetValue((tenant.TenantId, resourceId), out var states)
         && states.TryGetValue(channel, out var state)
             ? state
             : null;
+    }
 
     /// <summary>
     /// Restores a persisted activation state, or removes it when <paramref name="state"/> is <see langword="null"/>.
     /// </summary>
     internal void RestoreActivationState(string resourceId, string channel, ActivationState? state)
     {
+        var tenantScope = state?.TenantScope ?? TenantScope.Default;
+        RestoreActivationState(resourceId, channel, tenantScope, state);
+    }
+
+    /// <summary>
+    /// Restores a tenant-scoped persisted activation state, or removes it when <paramref name="state"/> is <see langword="null"/>.
+    /// </summary>
+    internal void RestoreActivationState(string resourceId, string channel, TenantScope tenantScope, ActivationState? state)
+    {
         ArgumentException.ThrowIfNullOrWhiteSpace(resourceId);
         ArgumentException.ThrowIfNullOrWhiteSpace(channel);
+        var tenant = TenantScopeResolver.Resolve(tenantScope);
 
-        var channelActivations = GetOrAddActivations(resourceId);
+        var channelActivations = GetOrAddActivations(resourceId, tenant);
         lock (channelActivations)
         {
             if (state is null)
@@ -109,7 +147,7 @@ public sealed class InMemoryResourceStore : IResourceVersionReader, IResourceVer
         }
 
         var states = ActivationStates.GetOrAdd(
-            resourceId,
+            (tenant.TenantId, resourceId),
             _ => new ConcurrentDictionary<string, ActivationState>(StringComparer.Ordinal));
 
         if (state is null)
@@ -124,13 +162,14 @@ public sealed class InMemoryResourceStore : IResourceVersionReader, IResourceVer
         CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(request);
+        var tenant = TenantScopeResolver.Resolve(request.TenantScope);
 
         var resources = request.Scope switch
         {
-            ResourceVersionScope.Latest => ReadLatestVersions(cancellationToken),
-            ResourceVersionScope.AllVersions => ReadAllVersions(cancellationToken),
-            ResourceVersionScope.Active => ReadActiveVersions(request.ActivationChannel, cancellationToken),
-            ResourceVersionScope.Draft => ReadDraftVersions(cancellationToken),
+            ResourceVersionScope.Latest => ReadLatestVersions(tenant, cancellationToken),
+            ResourceVersionScope.AllVersions => ReadAllVersions(tenant, cancellationToken),
+            ResourceVersionScope.Active => ReadActiveVersions(tenant, request.ActivationChannel, cancellationToken),
+            ResourceVersionScope.Draft => ReadDraftVersions(tenant, cancellationToken),
             _ => throw new ArgumentOutOfRangeException(nameof(request), request.Scope, "Unknown resource version scope.")
         };
 
@@ -141,14 +180,16 @@ public sealed class InMemoryResourceStore : IResourceVersionReader, IResourceVer
     public ValueTask<Resource> SaveVersionAsync(Resource resource, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(resource);
+        var tenant = TenantScopeResolver.Resolve(resource.TenantScope);
+        var scopedResource = resource with { TenantScope = tenant };
 
-        var versions = Versions.GetOrAdd(resource.ResourceId, _ => []);
+        var versions = Versions.GetOrAdd((tenant.TenantId, scopedResource.ResourceId), _ => []);
         lock (versions)
         {
-            versions.Add(resource);
+            versions.Add(scopedResource);
         }
 
-        return ValueTask.FromResult(resource);
+        return ValueTask.FromResult(scopedResource);
     }
 
     /// <inheritdoc />
@@ -162,26 +203,38 @@ public sealed class InMemoryResourceStore : IResourceVersionReader, IResourceVer
         ArgumentException.ThrowIfNullOrWhiteSpace(channel);
         ArgumentNullException.ThrowIfNull(state);
         cancellationToken.ThrowIfCancellationRequested();
+        var tenant = TenantScopeResolver.Resolve(state.TenantScope);
+        var scopedState = state with { TenantScope = tenant };
 
-        var channelActivations = GetOrAddActivations(resourceId);
+        var channelActivations = GetOrAddActivations(resourceId, tenant);
         lock (channelActivations)
-            channelActivations[channel] = state.ActiveVersions.ToHashSet();
+            channelActivations[channel] = scopedState.ActiveVersions.ToHashSet();
 
         var states = ActivationStates.GetOrAdd(
-            resourceId,
+            (tenant.TenantId, resourceId),
             _ => new ConcurrentDictionary<string, ActivationState>(StringComparer.Ordinal));
-        states[channel] = state;
+        states[channel] = scopedState;
 
-        return ValueTask.FromResult(state);
+        return ValueTask.FromResult(scopedState);
     }
 
     /// <summary>
     /// Returns all resource IDs that belong to the specified definition.
     /// </summary>
-    internal IEnumerable<string> GetResourceIdsForDefinition(string definitionId)
+    internal IEnumerable<string> GetResourceIdsForDefinition(string definitionId) =>
+        GetResourceIdsForDefinition(definitionId, TenantScope.Default);
+
+    /// <summary>
+    /// Returns all resource IDs that belong to the specified definition in a tenant.
+    /// </summary>
+    internal IEnumerable<string> GetResourceIdsForDefinition(string definitionId, TenantScope tenantScope)
     {
-        foreach (var (resourceId, list) in Versions)
+        var tenant = TenantScopeResolver.Resolve(tenantScope);
+        foreach (var ((tenantId, resourceId), list) in Versions)
         {
+            if (!string.Equals(tenantId, tenant.TenantId, StringComparison.Ordinal))
+                continue;
+
             lock (list)
             {
                 if (list.Count > 0 && string.Equals(list[0].DefinitionId, definitionId, StringComparison.Ordinal))
@@ -190,11 +243,13 @@ public sealed class InMemoryResourceStore : IResourceVersionReader, IResourceVer
         }
     }
 
-    private IEnumerable<Resource> ReadLatestVersions(CancellationToken cancellationToken)
+    private IEnumerable<Resource> ReadLatestVersions(TenantScope tenant, CancellationToken cancellationToken)
     {
-        foreach (var versionList in Versions.Values)
+        foreach (var ((tenantId, _), versionList) in Versions)
         {
             cancellationToken.ThrowIfCancellationRequested();
+            if (!string.Equals(tenantId, tenant.TenantId, StringComparison.Ordinal))
+                continue;
 
             lock (versionList)
             {
@@ -204,11 +259,13 @@ public sealed class InMemoryResourceStore : IResourceVersionReader, IResourceVer
         }
     }
 
-    private IEnumerable<Resource> ReadAllVersions(CancellationToken cancellationToken)
+    private IEnumerable<Resource> ReadAllVersions(TenantScope tenant, CancellationToken cancellationToken)
     {
-        foreach (var versionList in Versions.Values)
+        foreach (var ((tenantId, _), versionList) in Versions)
         {
             cancellationToken.ThrowIfCancellationRequested();
+            if (!string.Equals(tenantId, tenant.TenantId, StringComparison.Ordinal))
+                continue;
 
             List<Resource> snapshot;
             lock (versionList)
@@ -219,15 +276,17 @@ public sealed class InMemoryResourceStore : IResourceVersionReader, IResourceVer
         }
     }
 
-    private IEnumerable<Resource> ReadActiveVersions(string? channel, CancellationToken cancellationToken)
+    private IEnumerable<Resource> ReadActiveVersions(TenantScope tenant, string? channel, CancellationToken cancellationToken)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(channel);
 
-        foreach (var (resourceId, versionList) in Versions)
+        foreach (var ((tenantId, resourceId), versionList) in Versions)
         {
             cancellationToken.ThrowIfCancellationRequested();
+            if (!string.Equals(tenantId, tenant.TenantId, StringComparison.Ordinal))
+                continue;
 
-            if (!Activations.TryGetValue(resourceId, out var channelActivations))
+            if (!Activations.TryGetValue((tenant.TenantId, resourceId), out var channelActivations))
                 continue;
 
             HashSet<int> activeVersionNumbers;
@@ -250,13 +309,15 @@ public sealed class InMemoryResourceStore : IResourceVersionReader, IResourceVer
         }
     }
 
-    private IEnumerable<Resource> ReadDraftVersions(CancellationToken cancellationToken)
+    private IEnumerable<Resource> ReadDraftVersions(TenantScope tenant, CancellationToken cancellationToken)
     {
         var activeVersionsByResource = new Dictionary<string, HashSet<int>>(StringComparer.Ordinal);
 
-        foreach (var (resourceId, channelActivations) in Activations)
+        foreach (var ((tenantId, resourceId), channelActivations) in Activations)
         {
             cancellationToken.ThrowIfCancellationRequested();
+            if (!string.Equals(tenantId, tenant.TenantId, StringComparison.Ordinal))
+                continue;
 
             lock (channelActivations)
             {
@@ -266,9 +327,11 @@ public sealed class InMemoryResourceStore : IResourceVersionReader, IResourceVer
             }
         }
 
-        foreach (var (resourceId, versionList) in Versions)
+        foreach (var ((tenantId, resourceId), versionList) in Versions)
         {
             cancellationToken.ThrowIfCancellationRequested();
+            if (!string.Equals(tenantId, tenant.TenantId, StringComparison.Ordinal))
+                continue;
 
             activeVersionsByResource.TryGetValue(resourceId, out var activeVersionNumbers);
 

--- a/src/core/Aster.Core/Models/Definitions/ResourceDefinition.cs
+++ b/src/core/Aster.Core/Models/Definitions/ResourceDefinition.cs
@@ -1,3 +1,5 @@
+using Aster.Core.Models.Tenancy;
+
 namespace Aster.Core.Models.Definitions;
 
 /// <summary>
@@ -10,6 +12,11 @@ namespace Aster.Core.Models.Definitions;
 /// </remarks>
 public sealed record ResourceDefinition
 {
+    /// <summary>
+    /// Tenant scope that owns this definition version.
+    /// </summary>
+    public TenantScope TenantScope { get; init; } = TenantScope.Default;
+
     /// <summary>
     /// Logical persistent identifier (e.g., "Product"). Shared across all definition versions.
     /// </summary>

--- a/src/core/Aster.Core/Models/Instances/ActivationState.cs
+++ b/src/core/Aster.Core/Models/Instances/ActivationState.cs
@@ -1,3 +1,5 @@
+using Aster.Core.Models.Tenancy;
+
 namespace Aster.Core.Models.Instances;
 
 /// <summary>
@@ -5,6 +7,11 @@ namespace Aster.Core.Models.Instances;
 /// </summary>
 public sealed record ActivationState
 {
+    /// <summary>
+    /// Tenant scope that owns this activation state.
+    /// </summary>
+    public TenantScope TenantScope { get; init; } = TenantScope.Default;
+
     /// <summary>
     /// FK to <c>Resource.ResourceId</c> (logical identifier).
     /// </summary>

--- a/src/core/Aster.Core/Models/Instances/Resource.cs
+++ b/src/core/Aster.Core/Models/Instances/Resource.cs
@@ -1,3 +1,5 @@
+using Aster.Core.Models.Tenancy;
+
 namespace Aster.Core.Models.Instances;
 
 /// <summary>
@@ -12,6 +14,11 @@ namespace Aster.Core.Models.Instances;
 /// </remarks>
 public sealed record Resource
 {
+    /// <summary>
+    /// Tenant scope that owns this resource version.
+    /// </summary>
+    public TenantScope TenantScope { get; init; } = TenantScope.Default;
+
     /// <summary>
     /// Logical persistent identifier. Shared across all versions. Assigned at V1 by
     /// <see cref="Aster.Core.Abstractions.IIdentityGenerator"/> or supplied by the caller.

--- a/src/core/Aster.Core/Models/Instances/ResourceSchemaUpgrade.cs
+++ b/src/core/Aster.Core/Models/Instances/ResourceSchemaUpgrade.cs
@@ -1,3 +1,5 @@
+using Aster.Core.Models.Tenancy;
+
 namespace Aster.Core.Models.Instances;
 
 /// <summary>
@@ -5,6 +7,11 @@ namespace Aster.Core.Models.Instances;
 /// </summary>
 public sealed class ResourceSchemaUpgradeRequest
 {
+    /// <summary>
+    /// Tenant scope for the schema upgrade. When omitted, the default single-tenant scope is used.
+    /// </summary>
+    public TenantScope? TenantScope { get; set; }
+
     /// <summary>
     /// Optimistic concurrency token. Must match the current latest resource version.
     /// </summary>

--- a/src/core/Aster.Core/Models/Lifecycle/LifecycleHookContexts.cs
+++ b/src/core/Aster.Core/Models/Lifecycle/LifecycleHookContexts.cs
@@ -1,5 +1,6 @@
 using Aster.Core.Models.Instances;
 using Aster.Core.Models.Portability;
+using Aster.Core.Models.Tenancy;
 
 namespace Aster.Core.Models.Lifecycle;
 
@@ -8,6 +9,11 @@ namespace Aster.Core.Models.Lifecycle;
 /// </summary>
 public abstract record ResourceLifecycleContext
 {
+    /// <summary>
+    /// Tenant scope used by the underlying operation.
+    /// </summary>
+    public TenantScope TenantScope { get; init; } = TenantScope.Default;
+
     /// <summary>
     /// Per-operation identifier shared by before and after hooks.
     /// </summary>

--- a/src/core/Aster.Core/Models/Portability/PortableDiagnostic.cs
+++ b/src/core/Aster.Core/Models/Portability/PortableDiagnostic.cs
@@ -123,6 +123,16 @@ public static class PortableDiagnosticCodes
     public const string LifecycleHookRejected = "lifecycle-hook-rejected";
 
     /// <summary>
+    /// Tenant scope was malformed or unusable.
+    /// </summary>
+    public const string InvalidTenantScope = "invalid-tenant-scope";
+
+    /// <summary>
+    /// Snapshot contains entries from a tenant other than the declared source tenant.
+    /// </summary>
+    public const string SourceTenantScopeMismatch = "source-tenant-scope-mismatch";
+
+    /// <summary>
     /// Lifecycle hook failed while observing or gating an operation.
     /// </summary>
     public const string LifecycleHookFailed = "lifecycle-hook-failed";

--- a/src/core/Aster.Core/Models/Portability/PortableImportModels.cs
+++ b/src/core/Aster.Core/Models/Portability/PortableImportModels.cs
@@ -1,3 +1,5 @@
+using Aster.Core.Models.Tenancy;
+
 namespace Aster.Core.Models.Portability;
 
 /// <summary>
@@ -5,6 +7,11 @@ namespace Aster.Core.Models.Portability;
 /// </summary>
 public sealed class PortableImportOptions
 {
+    /// <summary>
+    /// Target tenant scope for preview/import. When omitted, the default single-tenant scope is used.
+    /// </summary>
+    public TenantScope? TargetTenantScope { get; set; }
+
     /// <summary>
     /// Collision handling mode.
     /// </summary>

--- a/src/core/Aster.Core/Models/Portability/PortableResults.cs
+++ b/src/core/Aster.Core/Models/Portability/PortableResults.cs
@@ -1,3 +1,5 @@
+using Aster.Core.Models.Tenancy;
+
 namespace Aster.Core.Models.Portability;
 
 /// <summary>
@@ -5,6 +7,11 @@ namespace Aster.Core.Models.Portability;
 /// </summary>
 public sealed record PortableSnapshotExportResult
 {
+    /// <summary>
+    /// Source tenant scope used for export.
+    /// </summary>
+    public TenantScope SourceTenantScope { get; init; } = TenantScope.Default;
+
     /// <summary>
     /// Exported snapshot, or <see langword="null"/> when export failed validation.
     /// </summary>
@@ -43,6 +50,16 @@ public sealed record PortableSnapshotValidationResult
 public sealed record PortableImportPreview
 {
     /// <summary>
+    /// Source tenant scope recorded in the snapshot.
+    /// </summary>
+    public TenantScope SourceTenantScope { get; init; } = TenantScope.Default;
+
+    /// <summary>
+    /// Target tenant scope for the planned import.
+    /// </summary>
+    public TenantScope TargetTenantScope { get; init; } = TenantScope.Default;
+
+    /// <summary>
     /// Whether the snapshot can be imported.
     /// </summary>
     public required bool CanImport { get; init; }
@@ -68,6 +85,16 @@ public sealed record PortableImportPreview
 /// </summary>
 public sealed record PortableImportResult
 {
+    /// <summary>
+    /// Source tenant scope recorded in the snapshot.
+    /// </summary>
+    public TenantScope SourceTenantScope { get; init; } = TenantScope.Default;
+
+    /// <summary>
+    /// Target tenant scope for the import.
+    /// </summary>
+    public TenantScope TargetTenantScope { get; init; } = TenantScope.Default;
+
     /// <summary>
     /// Import status.
     /// </summary>

--- a/src/core/Aster.Core/Models/Portability/PortableSnapshot.cs
+++ b/src/core/Aster.Core/Models/Portability/PortableSnapshot.cs
@@ -1,5 +1,6 @@
 using Aster.Core.Models.Definitions;
 using Aster.Core.Models.Instances;
+using Aster.Core.Models.Tenancy;
 
 namespace Aster.Core.Models.Portability;
 
@@ -17,6 +18,11 @@ public sealed record PortableSnapshot
     /// Snapshot format version.
     /// </summary>
     public required int FormatVersion { get; init; }
+
+    /// <summary>
+    /// Source tenant scope represented by the snapshot.
+    /// </summary>
+    public TenantScope SourceTenantScope { get; init; } = TenantScope.Default;
 
     /// <summary>
     /// Definition versions included in the snapshot.
@@ -39,6 +45,11 @@ public sealed record PortableSnapshot
 /// </summary>
 public sealed class PortableSnapshotExportRequest
 {
+    /// <summary>
+    /// Tenant scope to export. When omitted, the default single-tenant scope is used.
+    /// </summary>
+    public TenantScope? TenantScope { get; set; }
+
     /// <summary>
     /// Requested export scope.
     /// </summary>

--- a/src/core/Aster.Core/Models/Querying/ResourceQuery.cs
+++ b/src/core/Aster.Core/Models/Querying/ResourceQuery.cs
@@ -1,3 +1,5 @@
+using Aster.Core.Models.Tenancy;
+
 namespace Aster.Core.Models.Querying;
 
 /// <summary>
@@ -5,6 +7,11 @@ namespace Aster.Core.Models.Querying;
 /// </summary>
 public sealed record ResourceQuery
 {
+    /// <summary>
+    /// Tenant scope for the query. When omitted, the default single-tenant scope is used.
+    /// </summary>
+    public TenantScope? TenantScope { get; init; }
+
     /// <summary>
     /// Which resource versions to query. Defaults to latest versions only.
     /// </summary>

--- a/src/core/Aster.Core/Models/Tenancy/TenantScope.cs
+++ b/src/core/Aster.Core/Models/Tenancy/TenantScope.cs
@@ -1,0 +1,45 @@
+namespace Aster.Core.Models.Tenancy;
+
+/// <summary>
+/// Tenant boundary for tenant-aware SDK operations.
+/// </summary>
+public sealed record TenantScope
+{
+    /// <summary>
+    /// Stable tenant identifier used by existing single-tenant callers.
+    /// </summary>
+    public const string DefaultTenantId = "default";
+
+    /// <summary>
+    /// The default single-tenant scope.
+    /// </summary>
+    public static TenantScope Default { get; } = new() { TenantId = DefaultTenantId };
+
+    /// <summary>
+    /// Opaque exact-match tenant identifier.
+    /// </summary>
+    public required string TenantId { get; init; }
+
+    /// <summary>
+    /// Whether this scope represents the default single-tenant environment.
+    /// </summary>
+    public bool IsDefault => string.Equals(TenantId, DefaultTenantId, StringComparison.Ordinal);
+
+    /// <summary>
+    /// Creates an explicit tenant scope.
+    /// </summary>
+    /// <param name="tenantId">Opaque exact-match tenant identifier.</param>
+    /// <returns>A tenant scope for <paramref name="tenantId"/>.</returns>
+    public static TenantScope FromTenantId(string tenantId)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(tenantId);
+        return new TenantScope { TenantId = tenantId };
+    }
+
+    /// <summary>
+    /// Resolves an optional scope to an effective scope.
+    /// </summary>
+    /// <param name="scope">Optional tenant scope.</param>
+    /// <returns><paramref name="scope"/> when supplied; otherwise <see cref="Default"/>.</returns>
+    public static TenantScope Resolve(TenantScope? scope) => scope ?? Default;
+}

--- a/src/core/Aster.Core/README.md
+++ b/src/core/Aster.Core/README.md
@@ -241,7 +241,7 @@ var results = await queryService.QueryAsync(new ResourceQuery
 });
 ```
 
-Tenant IDs are opaque exact-match values. Blank tenant IDs fail closed through `TenantScopeException` or query/portability diagnostics. Aster does not add tenant registries, ambient tenant context, authorization policy, cross-tenant query, or tenant hierarchy in this slice.
+Tenant IDs are opaque exact-match values. `TenantScope.FromTenantId(...)` rejects blank IDs with `ArgumentException` during construction. Operation-boundary resolution, such as malformed scope instances supplied on requests, fails closed through `TenantScopeException` or query/portability diagnostics. Aster does not add tenant registries, ambient tenant context, authorization policy, cross-tenant query, or tenant hierarchy in this slice.
 
 ---
 

--- a/src/core/Aster.Core/README.md
+++ b/src/core/Aster.Core/README.md
@@ -226,7 +226,7 @@ Tenant-aware hosts pass `TenantScope` explicitly on request DTOs or method overl
 ```csharp
 var tenant = TenantScope.FromTenantId("tenant-a");
 
-await definitionStore.RegisterDefinitionAsync(definition, tenant);
+await definitionStore.RegisterDefinitionAsync(definition, tenant, CancellationToken.None);
 
 var resource = await manager.CreateAsync("Product", new CreateResourceRequest
 {

--- a/src/core/Aster.Core/README.md
+++ b/src/core/Aster.Core/README.md
@@ -221,6 +221,28 @@ if (status.Status == ResourceSchemaStatus.OlderThanLatest)
 
 Invalid upgrade targets throw `ResourceSchemaUpgradeException` with a stable `Code` such as `missing-definition`, `missing-definition-version`, `target-definition-version-too-new`, or `target-definition-version-before-source`. Stale base versions keep using `ConcurrencyException`.
 
+Tenant-aware hosts pass `TenantScope` explicitly on request DTOs or method overloads. Omitted tenant scope resolves to the default single-tenant scope.
+
+```csharp
+var tenant = TenantScope.FromTenantId("tenant-a");
+
+await definitionStore.RegisterDefinitionAsync(definition, tenant);
+
+var resource = await manager.CreateAsync("Product", new CreateResourceRequest
+{
+    TenantScope = tenant,
+    ResourceId = "product-1",
+});
+
+var results = await queryService.QueryAsync(new ResourceQuery
+{
+    TenantScope = tenant,
+    DefinitionId = "Product",
+});
+```
+
+Tenant IDs are opaque exact-match values. Blank tenant IDs fail closed through `TenantScopeException` or query/portability diagnostics. Aster does not add tenant registries, ambient tenant context, authorization policy, cross-tenant query, or tenant hierarchy in this slice.
+
 ---
 
 ### 8. Export, preview, and import portable snapshots

--- a/src/core/Aster.Core/Services/DefaultResourceManager.cs
+++ b/src/core/Aster.Core/Services/DefaultResourceManager.cs
@@ -89,9 +89,7 @@ public sealed partial class DefaultResourceManager : IResourceManager
         if (existingVersions.Any(r => string.Equals(r.ResourceId, resourceId, StringComparison.Ordinal)))
             throw new DuplicateResourceIdException(resourceId);
 
-        var definition = tenant.IsDefault
-            ? await definitionStore.GetDefinitionAsync(definitionId, cancellationToken)
-            : await definitionStore.GetDefinitionAsync(definitionId, tenant, cancellationToken);
+        var definition = await definitionStore.GetDefinitionAsync(definitionId, tenant, cancellationToken);
         if (definition?.IsSingleton == true
             && existingVersions.Any(r => string.Equals(r.DefinitionId, definitionId, StringComparison.Ordinal)))
             throw new SingletonViolationException(definitionId);

--- a/src/core/Aster.Core/Services/DefaultResourceManager.cs
+++ b/src/core/Aster.Core/Services/DefaultResourceManager.cs
@@ -263,7 +263,7 @@ public sealed partial class DefaultResourceManager : IResourceManager
     public async ValueTask<IEnumerable<Resource>> GetVersionsAsync(
         string resourceId,
         TenantScope tenantScope,
-        CancellationToken cancellationToken = default)
+        CancellationToken cancellationToken)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(resourceId);
         var tenant = TenantScopeResolver.Resolve(tenantScope);
@@ -280,7 +280,7 @@ public sealed partial class DefaultResourceManager : IResourceManager
     public async ValueTask<Resource?> GetLatestVersionAsync(
         string resourceId,
         TenantScope tenantScope,
-        CancellationToken cancellationToken = default)
+        CancellationToken cancellationToken)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(resourceId);
         var tenant = TenantScopeResolver.Resolve(tenantScope);
@@ -449,7 +449,7 @@ public sealed partial class DefaultResourceManager : IResourceManager
         string resourceId,
         string channel,
         TenantScope tenantScope,
-        CancellationToken cancellationToken = default)
+        CancellationToken cancellationToken)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(resourceId);
         ArgumentException.ThrowIfNullOrWhiteSpace(channel);

--- a/src/core/Aster.Core/Services/DefaultResourceManager.cs
+++ b/src/core/Aster.Core/Services/DefaultResourceManager.cs
@@ -3,6 +3,7 @@ using Aster.Core.Exceptions;
 using Aster.Core.Models.Instances;
 using Aster.Core.Models.Lifecycle;
 using Aster.Core.Models.Querying;
+using Aster.Core.Models.Tenancy;
 using Microsoft.Extensions.Logging;
 
 namespace Aster.Core.Services;
@@ -73,6 +74,7 @@ public sealed partial class DefaultResourceManager : IResourceManager
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(definitionId);
         ArgumentNullException.ThrowIfNull(request);
+        var tenant = TenantScopeResolver.Resolve(request.TenantScope);
 
         var resourceId = string.IsNullOrWhiteSpace(request.ResourceId)
             ? identityGenerator.NewId()
@@ -81,18 +83,22 @@ public sealed partial class DefaultResourceManager : IResourceManager
         var existingVersions = (await versionReader.ReadVersionsAsync(new ResourceVersionReadRequest
         {
             Scope = ResourceVersionScope.AllVersions,
+            TenantScope = tenant,
         }, cancellationToken)).ToList();
 
         if (existingVersions.Any(r => string.Equals(r.ResourceId, resourceId, StringComparison.Ordinal)))
             throw new DuplicateResourceIdException(resourceId);
 
-        var definition = await definitionStore.GetDefinitionAsync(definitionId, cancellationToken);
+        var definition = tenant.IsDefault
+            ? await definitionStore.GetDefinitionAsync(definitionId, cancellationToken)
+            : await definitionStore.GetDefinitionAsync(definitionId, tenant, cancellationToken);
         if (definition?.IsSingleton == true
             && existingVersions.Any(r => string.Equals(r.DefinitionId, definitionId, StringComparison.Ordinal)))
             throw new SingletonViolationException(definitionId);
 
         var resource = new Resource
         {
+            TenantScope = tenant,
             ResourceId = resourceId,
             Id = identityGenerator.NewId(),
             DefinitionId = definitionId,
@@ -108,6 +114,7 @@ public sealed partial class DefaultResourceManager : IResourceManager
             OperationId = operationId,
             LifecyclePoint = LifecyclePoint.BeforeSave,
             CancellationToken = cancellationToken,
+            TenantScope = tenant,
             SaveKind = ResourceSaveKind.Create,
             DefinitionId = definitionId,
             ResourceId = resourceId,
@@ -119,6 +126,7 @@ public sealed partial class DefaultResourceManager : IResourceManager
             OperationId = operationId,
             LifecyclePoint = LifecyclePoint.AfterSave,
             CancellationToken = cancellationToken,
+            TenantScope = tenant,
             SaveKind = ResourceSaveKind.Create,
             DefinitionId = definitionId,
             ResourceId = resourceId,
@@ -154,8 +162,9 @@ public sealed partial class DefaultResourceManager : IResourceManager
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(resourceId);
         ArgumentNullException.ThrowIfNull(request);
+        var tenant = TenantScopeResolver.Resolve(request.TenantScope);
 
-        var versions = (await GetResourceVersionsAsync(resourceId, cancellationToken)).ToList();
+        var versions = (await GetResourceVersionsAsync(resourceId, tenant, cancellationToken)).ToList();
         var latest = versions.LastOrDefault()
             ?? throw new VersionNotFoundException(resourceId, request.BaseVersion);
 
@@ -180,6 +189,7 @@ public sealed partial class DefaultResourceManager : IResourceManager
             OperationId = operationId,
             LifecyclePoint = LifecyclePoint.BeforeSave,
             CancellationToken = cancellationToken,
+            TenantScope = tenant,
             SaveKind = ResourceSaveKind.Update,
             DefinitionId = updated.DefinitionId,
             ResourceId = resourceId,
@@ -192,6 +202,7 @@ public sealed partial class DefaultResourceManager : IResourceManager
             OperationId = operationId,
             LifecyclePoint = LifecyclePoint.AfterSave,
             CancellationToken = cancellationToken,
+            TenantScope = tenant,
             SaveKind = ResourceSaveKind.Update,
             DefinitionId = updated.DefinitionId,
             ResourceId = updated.ResourceId,
@@ -225,31 +236,56 @@ public sealed partial class DefaultResourceManager : IResourceManager
     public async ValueTask<Resource?> GetVersionAsync(
         string resourceId,
         int version,
+        CancellationToken cancellationToken = default) =>
+        await GetVersionAsync(resourceId, version, TenantScope.Default, cancellationToken);
+
+    /// <inheritdoc />
+    public async ValueTask<Resource?> GetVersionAsync(
+        string resourceId,
+        int version,
+        TenantScope tenantScope,
         CancellationToken cancellationToken = default)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(resourceId);
+        var tenant = TenantScopeResolver.Resolve(tenantScope);
 
-        return (await GetResourceVersionsAsync(resourceId, cancellationToken))
+        return (await GetResourceVersionsAsync(resourceId, tenant, cancellationToken))
             .FirstOrDefault(r => r.Version == version);
     }
 
     /// <inheritdoc />
     public async ValueTask<IEnumerable<Resource>> GetVersionsAsync(
         string resourceId,
+        CancellationToken cancellationToken = default) =>
+        await GetVersionsAsync(resourceId, TenantScope.Default, cancellationToken);
+
+    /// <inheritdoc />
+    public async ValueTask<IEnumerable<Resource>> GetVersionsAsync(
+        string resourceId,
+        TenantScope tenantScope,
         CancellationToken cancellationToken = default)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(resourceId);
-        return await GetResourceVersionsAsync(resourceId, cancellationToken);
+        var tenant = TenantScopeResolver.Resolve(tenantScope);
+        return await GetResourceVersionsAsync(resourceId, tenant, cancellationToken);
     }
 
     /// <inheritdoc />
     public async ValueTask<Resource?> GetLatestVersionAsync(
         string resourceId,
+        CancellationToken cancellationToken = default) =>
+        await GetLatestVersionAsync(resourceId, TenantScope.Default, cancellationToken);
+
+    /// <inheritdoc />
+    public async ValueTask<Resource?> GetLatestVersionAsync(
+        string resourceId,
+        TenantScope tenantScope,
         CancellationToken cancellationToken = default)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(resourceId);
+        var tenant = TenantScopeResolver.Resolve(tenantScope);
 
-        return (await GetResourceVersionsAsync(resourceId, cancellationToken))
+        return (await GetResourceVersionsAsync(resourceId, tenant, cancellationToken))
             .LastOrDefault();
     }
 
@@ -259,12 +295,23 @@ public sealed partial class DefaultResourceManager : IResourceManager
         int version,
         string channel,
         bool allowMultipleActive = false,
+        CancellationToken cancellationToken = default) =>
+        await ActivateAsync(resourceId, version, channel, TenantScope.Default, allowMultipleActive, cancellationToken);
+
+    /// <inheritdoc />
+    public async ValueTask ActivateAsync(
+        string resourceId,
+        int version,
+        string channel,
+        TenantScope tenantScope,
+        bool allowMultipleActive = false,
         CancellationToken cancellationToken = default)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(resourceId);
         ArgumentException.ThrowIfNullOrWhiteSpace(channel);
+        var tenant = TenantScopeResolver.Resolve(tenantScope);
 
-        var versions = (await GetResourceVersionsAsync(resourceId, cancellationToken)).ToList();
+        var versions = (await GetResourceVersionsAsync(resourceId, tenant, cancellationToken)).ToList();
         if (versions.All(r => r.Version != version))
             throw new VersionNotFoundException(resourceId, version);
 
@@ -273,7 +320,7 @@ public sealed partial class DefaultResourceManager : IResourceManager
             throw new ConcurrencyException(resourceId, version, latest.Version);
 
         var activeVersions = allowMultipleActive
-            ? (await GetActiveVersionsAsync(resourceId, channel, cancellationToken))
+            ? (await GetActiveVersionsAsync(resourceId, channel, tenant, cancellationToken))
                 .Select(r => r.Version)
                 .ToHashSet()
             : [];
@@ -287,6 +334,7 @@ public sealed partial class DefaultResourceManager : IResourceManager
             OperationId = operationId,
             LifecyclePoint = LifecyclePoint.BeforeActivate,
             CancellationToken = cancellationToken,
+            TenantScope = tenant,
             ResourceId = resourceId,
             Version = version,
             Channel = channel,
@@ -299,6 +347,7 @@ public sealed partial class DefaultResourceManager : IResourceManager
             OperationId = operationId,
             LifecyclePoint = LifecyclePoint.AfterActivate,
             CancellationToken = cancellationToken,
+            TenantScope = tenant,
             ResourceId = resourceId,
             Version = version,
             Channel = channel,
@@ -308,7 +357,7 @@ public sealed partial class DefaultResourceManager : IResourceManager
 
         try
         {
-            await WriteActivationStateAsync(resourceId, channel, resultingActiveVersions, cancellationToken);
+            await WriteActivationStateAsync(resourceId, channel, tenant, resultingActiveVersions, cancellationToken);
         }
         catch (Exception exception) when (exception is not OperationCanceledException)
         {
@@ -326,12 +375,22 @@ public sealed partial class DefaultResourceManager : IResourceManager
         string resourceId,
         int version,
         string channel,
+        CancellationToken cancellationToken = default) =>
+        await DeactivateAsync(resourceId, version, channel, TenantScope.Default, cancellationToken);
+
+    /// <inheritdoc />
+    public async ValueTask DeactivateAsync(
+        string resourceId,
+        int version,
+        string channel,
+        TenantScope tenantScope,
         CancellationToken cancellationToken = default)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(resourceId);
         ArgumentException.ThrowIfNullOrWhiteSpace(channel);
+        var tenant = TenantScopeResolver.Resolve(tenantScope);
 
-        var activeVersions = (await GetActiveVersionsAsync(resourceId, channel, cancellationToken))
+        var activeVersions = (await GetActiveVersionsAsync(resourceId, channel, tenant, cancellationToken))
             .Select(r => r.Version)
             .ToHashSet();
 
@@ -344,6 +403,7 @@ public sealed partial class DefaultResourceManager : IResourceManager
             OperationId = operationId,
             LifecyclePoint = LifecyclePoint.BeforeDeactivate,
             CancellationToken = cancellationToken,
+            TenantScope = tenant,
             ResourceId = resourceId,
             Version = version,
             Channel = channel,
@@ -355,6 +415,7 @@ public sealed partial class DefaultResourceManager : IResourceManager
             OperationId = operationId,
             LifecyclePoint = LifecyclePoint.AfterDeactivate,
             CancellationToken = cancellationToken,
+            TenantScope = tenant,
             ResourceId = resourceId,
             Version = version,
             Channel = channel,
@@ -363,7 +424,7 @@ public sealed partial class DefaultResourceManager : IResourceManager
 
         try
         {
-            await WriteActivationStateAsync(resourceId, channel, resultingActiveVersions, cancellationToken);
+            await WriteActivationStateAsync(resourceId, channel, tenant, resultingActiveVersions, cancellationToken);
         }
         catch (Exception exception) when (exception is not OperationCanceledException)
         {
@@ -380,15 +441,25 @@ public sealed partial class DefaultResourceManager : IResourceManager
     public async ValueTask<IEnumerable<Resource>> GetActiveVersionsAsync(
         string resourceId,
         string channel,
+        CancellationToken cancellationToken = default) =>
+        await GetActiveVersionsAsync(resourceId, channel, TenantScope.Default, cancellationToken);
+
+    /// <inheritdoc />
+    public async ValueTask<IEnumerable<Resource>> GetActiveVersionsAsync(
+        string resourceId,
+        string channel,
+        TenantScope tenantScope,
         CancellationToken cancellationToken = default)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(resourceId);
         ArgumentException.ThrowIfNullOrWhiteSpace(channel);
+        var tenant = TenantScopeResolver.Resolve(tenantScope);
 
         var active = await versionReader.ReadVersionsAsync(new ResourceVersionReadRequest
         {
             Scope = ResourceVersionScope.Active,
             ActivationChannel = channel,
+            TenantScope = tenant,
         }, cancellationToken);
 
         return active
@@ -399,11 +470,14 @@ public sealed partial class DefaultResourceManager : IResourceManager
 
     private async Task<IEnumerable<Resource>> GetResourceVersionsAsync(
         string resourceId,
+        TenantScope tenantScope,
         CancellationToken cancellationToken)
     {
+        var tenant = TenantScopeResolver.Resolve(tenantScope);
         var versions = await versionReader.ReadVersionsAsync(new ResourceVersionReadRequest
         {
             Scope = ResourceVersionScope.AllVersions,
+            TenantScope = tenant,
         }, cancellationToken);
 
         return versions
@@ -415,11 +489,14 @@ public sealed partial class DefaultResourceManager : IResourceManager
     private async Task WriteActivationStateAsync(
         string resourceId,
         string channel,
+        TenantScope tenantScope,
         IReadOnlyCollection<int> activeVersions,
         CancellationToken cancellationToken)
     {
+        var tenant = TenantScopeResolver.Resolve(tenantScope);
         var state = new ActivationState
         {
+            TenantScope = tenant,
             ResourceId = resourceId,
             Channel = channel,
             ActiveVersions = activeVersions.Order().ToList(),

--- a/src/core/Aster.Core/Services/DefaultResourceManager.cs
+++ b/src/core/Aster.Core/Services/DefaultResourceManager.cs
@@ -244,7 +244,7 @@ public sealed partial class DefaultResourceManager : IResourceManager
         string resourceId,
         int version,
         TenantScope tenantScope,
-        CancellationToken cancellationToken = default)
+        CancellationToken cancellationToken)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(resourceId);
         var tenant = TenantScopeResolver.Resolve(tenantScope);
@@ -304,8 +304,8 @@ public sealed partial class DefaultResourceManager : IResourceManager
         int version,
         string channel,
         TenantScope tenantScope,
-        bool allowMultipleActive = false,
-        CancellationToken cancellationToken = default)
+        bool allowMultipleActive,
+        CancellationToken cancellationToken)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(resourceId);
         ArgumentException.ThrowIfNullOrWhiteSpace(channel);
@@ -384,7 +384,7 @@ public sealed partial class DefaultResourceManager : IResourceManager
         int version,
         string channel,
         TenantScope tenantScope,
-        CancellationToken cancellationToken = default)
+        CancellationToken cancellationToken)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(resourceId);
         ArgumentException.ThrowIfNullOrWhiteSpace(channel);

--- a/src/core/Aster.Core/Services/ResourceLifecycleHookContextSnapshots.cs
+++ b/src/core/Aster.Core/Services/ResourceLifecycleHookContextSnapshots.cs
@@ -79,6 +79,7 @@ internal static class ResourceLifecycleHookContextSnapshots
     public static PortableSnapshotExportRequest Snapshot(PortableSnapshotExportRequest request) =>
         new()
         {
+            TenantScope = request.TenantScope,
             ScopeMode = request.ScopeMode,
             DefinitionIds = new HashSet<string>(request.DefinitionIds ?? [], StringComparer.Ordinal),
             ResourceIds = new HashSet<string>(request.ResourceIds ?? [], StringComparer.Ordinal),
@@ -89,6 +90,7 @@ internal static class ResourceLifecycleHookContextSnapshots
     public static PortableImportOptions Snapshot(PortableImportOptions options) =>
         new()
         {
+            TargetTenantScope = options.TargetTenantScope,
             CollisionMode = options.CollisionMode,
         };
 

--- a/src/core/Aster.Core/Services/ResourcePortabilityService.cs
+++ b/src/core/Aster.Core/Services/ResourcePortabilityService.cs
@@ -6,6 +6,7 @@ using Aster.Core.Models.Definitions;
 using Aster.Core.Models.Instances;
 using Aster.Core.Models.Lifecycle;
 using Aster.Core.Models.Portability;
+using Aster.Core.Models.Tenancy;
 
 namespace Aster.Core.Services;
 
@@ -49,14 +50,20 @@ public sealed class ResourcePortabilityService : IResourcePortabilityService
         ArgumentNullException.ThrowIfNull(request);
 
         var diagnostics = ValidateExportRequest(request);
+        var sourceTenant = ResolveTenantForDiagnostics(request.TenantScope, "tenantScope", diagnostics);
         if (diagnostics.Any(static d => d.Severity == PortableDiagnosticSeverity.Error))
-            return new PortableSnapshotExportResult { Diagnostics = diagnostics };
+            return new PortableSnapshotExportResult
+            {
+                SourceTenantScope = sourceTenant,
+                Diagnostics = diagnostics,
+            };
 
         var operationId = Guid.NewGuid();
         try
         {
             await lifecycleHooks.InvokeBeforeExportAsync(new ResourceExportLifecycleContext
             {
+                TenantScope = sourceTenant,
                 OperationId = operationId,
                 LifecyclePoint = LifecyclePoint.BeforeExport,
                 CancellationToken = cancellationToken,
@@ -89,13 +96,15 @@ public sealed class ResourcePortabilityService : IResourcePortabilityService
             snapshot = new PortableSnapshot
             {
                 FormatVersion = PortableSnapshot.CurrentFormatVersion,
-                Definitions = storeSnapshot.Definitions,
-                Resources = storeSnapshot.Resources,
-                ActivationStates = storeSnapshot.ActivationStates,
+                SourceTenantScope = sourceTenant,
+                Definitions = storeSnapshot.Definitions.Select(definition => definition with { TenantScope = sourceTenant }).ToList(),
+                Resources = storeSnapshot.Resources.Select(resource => resource with { TenantScope = sourceTenant }).ToList(),
+                ActivationStates = storeSnapshot.ActivationStates.Select(state => state with { TenantScope = sourceTenant }).ToList(),
             };
 
             result = new PortableSnapshotExportResult
             {
+                SourceTenantScope = sourceTenant,
                 Snapshot = snapshot,
                 Diagnostics = diagnostics.Concat(skippedActivationDiagnostics).ToList(),
                 SkippedActivationEntries = storeSnapshot.SkippedActivationEntries,
@@ -122,6 +131,7 @@ public sealed class ResourcePortabilityService : IResourcePortabilityService
         {
             await lifecycleHooks.InvokeAfterExportAsync(new ResourceExportLifecycleContext
             {
+                TenantScope = sourceTenant,
                 OperationId = operationId,
                 LifecyclePoint = LifecyclePoint.AfterExport,
                 CancellationToken = cancellationToken,
@@ -162,12 +172,15 @@ public sealed class ResourcePortabilityService : IResourcePortabilityService
     {
         ArgumentNullException.ThrowIfNull(snapshot);
         options ??= new PortableImportOptions();
+        var sourceTenant = ResolveTenantOrDefault(snapshot.SourceTenantScope);
+        var targetTenant = ResolveTenantOrDefault(options.TargetTenantScope);
 
         var operationId = Guid.NewGuid();
         try
         {
             await lifecycleHooks.InvokeBeforePreviewImportAsync(new ResourceImportLifecycleContext
             {
+                TenantScope = targetTenant,
                 OperationId = operationId,
                 LifecyclePoint = LifecyclePoint.BeforePreviewImport,
                 CancellationToken = cancellationToken,
@@ -177,7 +190,7 @@ public sealed class ResourcePortabilityService : IResourcePortabilityService
         }
         catch (LifecycleHookException exception)
         {
-            return FailedPreview(ToPortableDiagnostic(exception));
+            return FailedPreview(ToPortableDiagnostic(exception), sourceTenant, targetTenant);
         }
 
         PortableImportPreview preview;
@@ -186,6 +199,8 @@ public sealed class ResourcePortabilityService : IResourcePortabilityService
             var plan = await BuildImportPlanAsync(snapshot, options, cancellationToken);
             preview = new PortableImportPreview
             {
+                SourceTenantScope = sourceTenant,
+                TargetTenantScope = targetTenant,
                 CanImport = plan.Diagnostics.All(static diagnostic => diagnostic.Severity != PortableDiagnosticSeverity.Error),
                 Counts = plan.PlannedCounts,
                 IdentityMap = plan.IdentityMap,
@@ -194,13 +209,14 @@ public sealed class ResourcePortabilityService : IResourcePortabilityService
         }
         catch (Exception exception) when (exception is not OperationCanceledException)
         {
-            preview = FailedPreview(ToImportPlanningFailedDiagnostic(exception));
+            preview = FailedPreview(ToImportPlanningFailedDiagnostic(exception), sourceTenant, targetTenant);
         }
 
         try
         {
             await lifecycleHooks.InvokeAfterPreviewImportAsync(new ResourceImportLifecycleContext
             {
+                TenantScope = targetTenant,
                 OperationId = operationId,
                 LifecyclePoint = LifecyclePoint.AfterPreviewImport,
                 CancellationToken = cancellationToken,
@@ -229,12 +245,15 @@ public sealed class ResourcePortabilityService : IResourcePortabilityService
     {
         ArgumentNullException.ThrowIfNull(snapshot);
         options ??= new PortableImportOptions();
+        var sourceTenant = ResolveTenantOrDefault(snapshot.SourceTenantScope);
+        var targetTenant = ResolveTenantOrDefault(options.TargetTenantScope);
 
         var operationId = Guid.NewGuid();
         try
         {
             await lifecycleHooks.InvokeBeforeImportAsync(new ResourceImportLifecycleContext
             {
+                TenantScope = targetTenant,
                 OperationId = operationId,
                 LifecyclePoint = LifecyclePoint.BeforeImport,
                 CancellationToken = cancellationToken,
@@ -244,7 +263,7 @@ public sealed class ResourcePortabilityService : IResourcePortabilityService
         }
         catch (LifecycleHookException exception)
         {
-            return FailedImport(ToPortableDiagnostic(exception));
+            return FailedImport(ToPortableDiagnostic(exception), sourceTenant, targetTenant);
         }
 
         PortableImportResult result;
@@ -255,7 +274,7 @@ public sealed class ResourcePortabilityService : IResourcePortabilityService
         }
         catch (Exception exception) when (exception is not OperationCanceledException)
         {
-            result = FailedImport(ToImportPlanningFailedDiagnostic(exception));
+            result = FailedImport(ToImportPlanningFailedDiagnostic(exception), sourceTenant, targetTenant);
             return await InvokeAfterImportAsync(operationId, snapshot, options, result, cancellationToken);
         }
 
@@ -263,6 +282,8 @@ public sealed class ResourcePortabilityService : IResourcePortabilityService
         {
             result = new PortableImportResult
             {
+                SourceTenantScope = sourceTenant,
+                TargetTenantScope = targetTenant,
                 Status = PortableImportStatus.Failed,
                 Counts = new PortableActualImportCounts(),
                 IdentityMap = plan.IdentityMap,
@@ -276,6 +297,8 @@ public sealed class ResourcePortabilityService : IResourcePortabilityService
                 await portabilityStore.ApplyImportAsync(plan.PlannedSnapshot, cancellationToken);
                 result = new PortableImportResult
                 {
+                    SourceTenantScope = sourceTenant,
+                    TargetTenantScope = targetTenant,
                     Status = PortableImportStatus.Imported,
                     Counts = plan.ActualCounts,
                     IdentityMap = plan.IdentityMap,
@@ -286,6 +309,8 @@ public sealed class ResourcePortabilityService : IResourcePortabilityService
             {
                 result = new PortableImportResult
                 {
+                    SourceTenantScope = sourceTenant,
+                    TargetTenantScope = targetTenant,
                     Status = PortableImportStatus.Failed,
                     Counts = new PortableActualImportCounts(),
                     IdentityMap = plan.IdentityMap,
@@ -306,6 +331,8 @@ public sealed class ResourcePortabilityService : IResourcePortabilityService
         {
             result = new PortableImportResult
             {
+                SourceTenantScope = sourceTenant,
+                TargetTenantScope = targetTenant,
                 Status = PortableImportStatus.NoOp,
                 Counts = plan.ActualCounts,
                 IdentityMap = plan.IdentityMap,
@@ -327,6 +354,7 @@ public sealed class ResourcePortabilityService : IResourcePortabilityService
         {
             await lifecycleHooks.InvokeAfterImportAsync(new ResourceImportLifecycleContext
             {
+                TenantScope = result.TargetTenantScope,
                 OperationId = operationId,
                 LifecyclePoint = LifecyclePoint.AfterImport,
                 CancellationToken = cancellationToken,
@@ -343,17 +371,27 @@ public sealed class ResourcePortabilityService : IResourcePortabilityService
         return result;
     }
 
-    private static PortableImportPreview FailedPreview(PortableDiagnostic diagnostic) =>
+    private static PortableImportPreview FailedPreview(
+        PortableDiagnostic diagnostic,
+        TenantScope? sourceTenant = null,
+        TenantScope? targetTenant = null) =>
         new()
         {
+            SourceTenantScope = sourceTenant ?? TenantScope.Default,
+            TargetTenantScope = targetTenant ?? TenantScope.Default,
             CanImport = false,
             Counts = new PortablePlannedImportCounts(),
             Diagnostics = [diagnostic],
         };
 
-    private static PortableImportResult FailedImport(PortableDiagnostic diagnostic) =>
+    private static PortableImportResult FailedImport(
+        PortableDiagnostic diagnostic,
+        TenantScope? sourceTenant = null,
+        TenantScope? targetTenant = null) =>
         new()
         {
+            SourceTenantScope = sourceTenant ?? TenantScope.Default,
+            TargetTenantScope = targetTenant ?? TenantScope.Default,
             Status = PortableImportStatus.Failed,
             Counts = new PortableActualImportCounts(),
             Diagnostics = [diagnostic],
@@ -396,10 +434,13 @@ public sealed class ResourcePortabilityService : IResourcePortabilityService
 
         var diagnostics = ValidateSnapshot(snapshot);
         diagnostics.AddRange(ValidateImportOptions(options));
+        _ = ResolveTenantForDiagnostics(snapshot.SourceTenantScope, "sourceTenantScope", diagnostics);
+        var targetTenant = ResolveTenantForDiagnostics(options.TargetTenantScope, "targetTenantScope", diagnostics);
         if (diagnostics.Any(static diagnostic => diagnostic.Severity == PortableDiagnosticSeverity.Error))
             return ImportPlan.Failed(diagnostics);
 
-        var targetState = await portabilityStore.ReadTargetStateAsync(snapshot, cancellationToken);
+        var targetSnapshot = ScopeSnapshot(snapshot, targetTenant);
+        var targetState = await portabilityStore.ReadTargetStateAsync(targetSnapshot, cancellationToken);
         var identityMap = new List<PortableIdentityMapping>();
         var strictFailureIdentityMap = new List<PortableIdentityMapping>();
         var existingDefinitions = targetState.Definitions.ToDictionary(static definition => (definition.DefinitionId, definition.Version));
@@ -645,9 +686,10 @@ public sealed class ResourcePortabilityService : IResourcePortabilityService
         var plannedSnapshot = new PortableSnapshot
         {
             FormatVersion = PortableSnapshot.CurrentFormatVersion,
-            Definitions = plannedDefinitions,
-            Resources = plannedResources,
-            ActivationStates = plannedActivationStates,
+            SourceTenantScope = targetTenant,
+            Definitions = plannedDefinitions.Select(definition => definition with { TenantScope = targetTenant }).ToList(),
+            Resources = plannedResources.Select(resource => resource with { TenantScope = targetTenant }).ToList(),
+            ActivationStates = plannedActivationStates.Select(state => state with { TenantScope = targetTenant }).ToList(),
         };
         var plannedCounts = new PortablePlannedImportCounts
         {
@@ -769,6 +811,7 @@ public sealed class ResourcePortabilityService : IResourcePortabilityService
     private static List<PortableDiagnostic> ValidateSnapshot(PortableSnapshot snapshot)
     {
         var diagnostics = new List<PortableDiagnostic>();
+        var sourceTenant = ResolveTenantForDiagnostics(snapshot.SourceTenantScope, "sourceTenantScope", diagnostics);
         var validDefinitions = new List<ResourceDefinition>();
         var validResources = new List<Resource>();
         var validActivationStates = new List<ActivationState>();
@@ -841,7 +884,10 @@ public sealed class ResourcePortabilityService : IResourcePortabilityService
             }
 
             if (!isMalformed)
+            {
                 validDefinitions.Add(definition);
+                ValidateEntityTenant(definition.TenantScope, sourceTenant, $"definitions/{i}/tenantScope", diagnostics);
+            }
         }
 
         for (var i = 0; i < resources.Count; i++)
@@ -891,7 +937,10 @@ public sealed class ResourcePortabilityService : IResourcePortabilityService
             }
 
             if (!isMalformed)
+            {
                 validResources.Add(resource);
+                ValidateEntityTenant(resource.TenantScope, sourceTenant, $"resources/{i}/tenantScope", diagnostics);
+            }
         }
 
         for (var i = 0; i < activationStates.Count; i++)
@@ -928,7 +977,10 @@ public sealed class ResourcePortabilityService : IResourcePortabilityService
             }
 
             if (!isMalformed)
+            {
                 validActivationStates.Add(activationState);
+                ValidateEntityTenant(activationState.TenantScope, sourceTenant, $"activationStates/{i}/tenantScope", diagnostics);
+            }
         }
 
         diagnostics.AddRange(ValidateSnapshotIdentityUniqueness(validDefinitions, validResources, validActivationStates));
@@ -1108,6 +1160,72 @@ public sealed class ResourcePortabilityService : IResourcePortabilityService
             Severity = PortableDiagnosticSeverity.Error,
             Path = path,
             Message = message,
+        };
+
+    private static TenantScope ResolveTenant(TenantScope? tenantScope) =>
+        TenantScopeResolver.Resolve(tenantScope);
+
+    private static TenantScope ResolveTenantOrDefault(TenantScope? tenantScope)
+    {
+        try
+        {
+            return TenantScopeResolver.Resolve(tenantScope);
+        }
+        catch (TenantScopeException)
+        {
+            return TenantScope.Default;
+        }
+    }
+
+    private static TenantScope ResolveTenantForDiagnostics(
+        TenantScope? tenantScope,
+        string path,
+        ICollection<PortableDiagnostic> diagnostics)
+    {
+        try
+        {
+            return TenantScopeResolver.Resolve(tenantScope);
+        }
+        catch (TenantScopeException exception)
+        {
+            diagnostics.Add(new PortableDiagnostic
+            {
+                Code = PortableDiagnosticCodes.InvalidTenantScope,
+                Severity = PortableDiagnosticSeverity.Error,
+                Path = path,
+                Message = exception.Message,
+            });
+
+            return TenantScope.Default;
+        }
+    }
+
+    private static void ValidateEntityTenant(
+        TenantScope? entityTenantScope,
+        TenantScope sourceTenant,
+        string path,
+        ICollection<PortableDiagnostic> diagnostics)
+    {
+        var entityTenant = ResolveTenantForDiagnostics(entityTenantScope, path, diagnostics);
+        if (!string.Equals(entityTenant.TenantId, sourceTenant.TenantId, StringComparison.Ordinal))
+        {
+            diagnostics.Add(new PortableDiagnostic
+            {
+                Code = PortableDiagnosticCodes.SourceTenantScopeMismatch,
+                Severity = PortableDiagnosticSeverity.Error,
+                Path = path,
+                Message = $"Snapshot entry tenant '{entityTenant.TenantId}' does not match source tenant '{sourceTenant.TenantId}'.",
+            });
+        }
+    }
+
+    private static PortableSnapshot ScopeSnapshot(PortableSnapshot snapshot, TenantScope tenantScope) =>
+        snapshot with
+        {
+            SourceTenantScope = tenantScope,
+            Definitions = snapshot.Definitions.Select(definition => definition with { TenantScope = tenantScope }).ToList(),
+            Resources = snapshot.Resources.Select(resource => resource with { TenantScope = tenantScope }).ToList(),
+            ActivationStates = snapshot.ActivationStates.Select(state => state with { TenantScope = tenantScope }).ToList(),
         };
 
     private static bool ContentEquals<T>(T left, T right) =>

--- a/src/core/Aster.Core/Services/ResourcePortabilityService.cs
+++ b/src/core/Aster.Core/Services/ResourcePortabilityService.cs
@@ -1167,9 +1167,6 @@ public sealed class ResourcePortabilityService : IResourcePortabilityService
             Message = message,
         };
 
-    private static TenantScope ResolveTenant(TenantScope? tenantScope) =>
-        TenantScopeResolver.Resolve(tenantScope);
-
     private static TenantScope ResolveTenantOrDefault(TenantScope? tenantScope)
     {
         try

--- a/src/core/Aster.Core/Services/ResourcePortabilityService.cs
+++ b/src/core/Aster.Core/Services/ResourcePortabilityService.cs
@@ -439,7 +439,6 @@ public sealed class ResourcePortabilityService : IResourcePortabilityService
 
         var diagnostics = ValidateSnapshot(snapshot);
         diagnostics.AddRange(ValidateImportOptions(options));
-        _ = ResolveTenantForDiagnostics(snapshot.SourceTenantScope, "sourceTenantScope", diagnostics);
         var targetTenant = ResolveTenantForDiagnostics(options.TargetTenantScope, "targetTenantScope", diagnostics);
         if (diagnostics.Any(static diagnostic => diagnostic.Severity == PortableDiagnosticSeverity.Error))
             return ImportPlan.Failed(diagnostics);

--- a/src/core/Aster.Core/Services/ResourcePortabilityService.cs
+++ b/src/core/Aster.Core/Services/ResourcePortabilityService.cs
@@ -1208,6 +1208,11 @@ public sealed class ResourcePortabilityService : IResourcePortabilityService
         ICollection<PortableDiagnostic> diagnostics)
     {
         var entityTenant = ResolveTenantForDiagnostics(entityTenantScope, path, diagnostics);
+        if (diagnostics.Any(d =>
+            string.Equals(d.Path, path, StringComparison.Ordinal)
+            && d.Code == PortableDiagnosticCodes.InvalidTenantScope))
+            return;
+
         if (!string.Equals(entityTenant.TenantId, sourceTenant.TenantId, StringComparison.Ordinal))
         {
             diagnostics.Add(new PortableDiagnostic

--- a/src/core/Aster.Core/Services/ResourcePortabilityService.cs
+++ b/src/core/Aster.Core/Services/ResourcePortabilityService.cs
@@ -72,7 +72,11 @@ public sealed class ResourcePortabilityService : IResourcePortabilityService
         }
         catch (LifecycleHookException exception)
         {
-            return new PortableSnapshotExportResult { Diagnostics = [ToPortableDiagnostic(exception)] };
+            return new PortableSnapshotExportResult
+            {
+                SourceTenantScope = sourceTenant,
+                Diagnostics = [ToPortableDiagnostic(exception)],
+            };
         }
 
         PortableSnapshot? snapshot = null;
@@ -114,6 +118,7 @@ public sealed class ResourcePortabilityService : IResourcePortabilityService
         {
             result = new PortableSnapshotExportResult
             {
+                SourceTenantScope = sourceTenant,
                 Diagnostics =
                 [
                     .. diagnostics,

--- a/src/core/Aster.Core/Services/ResourceQueryValidator.cs
+++ b/src/core/Aster.Core/Services/ResourceQueryValidator.cs
@@ -1,6 +1,7 @@
 using System.Globalization;
 using System.Collections;
 using Aster.Core.Abstractions;
+using Aster.Core.Exceptions;
 using Aster.Core.Models.Querying;
 
 namespace Aster.Core.Services;
@@ -69,6 +70,7 @@ public sealed class ResourceQueryValidator : IResourceQueryValidator
         }
 
         var failures = new List<QueryValidationFailure>();
+        ValidateTenantScope(query, failures);
         ValidateScope(query, failures);
         ValidatePaging(query, failures);
 
@@ -80,6 +82,22 @@ public sealed class ResourceQueryValidator : IResourceQueryValidator
         return failures.Count == 0
             ? QueryValidationResult.Success
             : new(failures);
+    }
+
+    private static void ValidateTenantScope(ResourceQuery query, List<QueryValidationFailure> failures)
+    {
+        try
+        {
+            TenantScopeResolver.Resolve(query.TenantScope);
+        }
+        catch (TenantScopeException exception)
+        {
+            failures.Add(Failure(
+                exception.Code,
+                exception.Message,
+                "TenantScope",
+                "tenant scope"));
+        }
     }
 
     private void ValidateScope(ResourceQuery query, List<QueryValidationFailure> failures)

--- a/src/core/Aster.Core/Services/ResourceSchemaVersionService.cs
+++ b/src/core/Aster.Core/Services/ResourceSchemaVersionService.cs
@@ -4,6 +4,7 @@ using Aster.Core.Exceptions;
 using Aster.Core.Models.Definitions;
 using Aster.Core.Models.Instances;
 using Aster.Core.Models.Lifecycle;
+using Aster.Core.Models.Tenancy;
 
 namespace Aster.Core.Services;
 
@@ -73,8 +74,9 @@ public sealed class ResourceSchemaVersionService : IResourceSchemaVersionService
         CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(resource);
+        var tenant = TenantScopeResolver.Resolve(resource.TenantScope);
 
-        var latestDefinition = await definitionStore.GetDefinitionAsync(resource.DefinitionId, cancellationToken);
+        var latestDefinition = await definitionStore.GetDefinitionAsync(resource.DefinitionId, tenant, cancellationToken);
         if (latestDefinition is null)
             return Status(resource, ResourceSchemaStatus.MissingDefinition, latestDefinitionVersion: null,
                 $"Definition '{resource.DefinitionId}' was not found.");
@@ -86,6 +88,7 @@ public sealed class ResourceSchemaVersionService : IResourceSchemaVersionService
         var recordedDefinition = await definitionStore.GetDefinitionVersionAsync(
             resource.DefinitionId,
             resource.DefinitionVersion.Value,
+            tenant,
             cancellationToken);
         if (recordedDefinition is null)
             return Status(resource, ResourceSchemaStatus.MissingDefinitionVersion, latestDefinition.Version,
@@ -111,14 +114,15 @@ public sealed class ResourceSchemaVersionService : IResourceSchemaVersionService
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(resourceId);
         ArgumentNullException.ThrowIfNull(request);
+        var tenant = TenantScopeResolver.Resolve(request.TenantScope);
 
-        var latestResource = await resourceManager.GetLatestVersionAsync(resourceId, cancellationToken)
+        var latestResource = await resourceManager.GetLatestVersionAsync(resourceId, tenant, cancellationToken)
             ?? throw new VersionNotFoundException(resourceId, request.BaseVersion);
 
         if (latestResource.Version != request.BaseVersion)
             throw new ConcurrencyException(resourceId, request.BaseVersion, latestResource.Version);
 
-        var latestDefinition = await definitionStore.GetDefinitionAsync(latestResource.DefinitionId, cancellationToken)
+        var latestDefinition = await definitionStore.GetDefinitionAsync(latestResource.DefinitionId, tenant, cancellationToken)
             ?? throw UpgradeFailure(
                 "missing-definition",
                 $"Definition '{latestResource.DefinitionId}' was not found.",
@@ -136,6 +140,7 @@ public sealed class ResourceSchemaVersionService : IResourceSchemaVersionService
         var targetDefinition = await definitionStore.GetDefinitionVersionAsync(
             latestResource.DefinitionId,
             targetVersion,
+            tenant,
             cancellationToken);
         if (targetDefinition is null)
             throw UpgradeFailure(
@@ -204,6 +209,7 @@ public sealed class ResourceSchemaVersionService : IResourceSchemaVersionService
             OperationId = operationId,
             LifecyclePoint = LifecyclePoint.BeforeSave,
             CancellationToken = cancellationToken,
+            TenantScope = latestResource.TenantScope,
             SaveKind = ResourceSaveKind.SchemaUpgrade,
             DefinitionId = upgraded.DefinitionId,
             ResourceId = upgraded.ResourceId,
@@ -216,6 +222,7 @@ public sealed class ResourceSchemaVersionService : IResourceSchemaVersionService
             OperationId = operationId,
             LifecyclePoint = LifecyclePoint.AfterSave,
             CancellationToken = cancellationToken,
+            TenantScope = latestResource.TenantScope,
             SaveKind = ResourceSaveKind.SchemaUpgrade,
             DefinitionId = upgraded.DefinitionId,
             ResourceId = upgraded.ResourceId,

--- a/src/core/Aster.Core/Services/TenantScopeResolver.cs
+++ b/src/core/Aster.Core/Services/TenantScopeResolver.cs
@@ -1,0 +1,36 @@
+using Aster.Core.Exceptions;
+using Aster.Core.Models.Tenancy;
+
+namespace Aster.Core.Services;
+
+/// <summary>
+/// Resolves and validates tenant scopes at operation boundaries.
+/// </summary>
+public static class TenantScopeResolver
+{
+    /// <summary>
+    /// Resolves an optional tenant scope to an effective tenant scope.
+    /// </summary>
+    /// <param name="scope">Optional tenant scope.</param>
+    /// <returns>The effective tenant scope.</returns>
+    /// <exception cref="TenantScopeException">Thrown when the supplied scope is invalid.</exception>
+    public static TenantScope Resolve(TenantScope? scope)
+    {
+        var effective = TenantScope.Resolve(scope);
+        if (string.IsNullOrWhiteSpace(effective.TenantId))
+        {
+            throw new TenantScopeException(
+                TenantScopeException.InvalidCode,
+                "Tenant scope must include a non-empty tenant identifier.");
+        }
+
+        return effective;
+    }
+
+    /// <summary>
+    /// Resolves an optional tenant scope to its effective tenant identifier.
+    /// </summary>
+    /// <param name="scope">Optional tenant scope.</param>
+    /// <returns>The effective tenant identifier.</returns>
+    public static string ResolveTenantId(TenantScope? scope) => Resolve(scope).TenantId;
+}

--- a/src/persistence/Aster.Persistence.SqliteJson/Querying/SqliteQueryBuilder.cs
+++ b/src/persistence/Aster.Persistence.SqliteJson/Querying/SqliteQueryBuilder.cs
@@ -1,6 +1,7 @@
 using System.Text;
 using Aster.Core.Exceptions;
 using Aster.Core.Models.Querying;
+using Aster.Core.Services;
 
 namespace Aster.Persistence.SqliteJson.Querying;
 
@@ -30,11 +31,13 @@ internal sealed class SqliteQueryBuilder(ResourceQuery query)
     public string Build()
     {
         var (baseSql, scopePredicates) = BuildScopeSql();
+        var tenantId = Parameters.Add(TenantScopeResolver.Resolve(query.TenantScope).TenantId);
         var sql = new StringBuilder();
         sql.Append("SELECT ");
         sql.AppendJoin(", ", ["rv.payload", .. projections]);
         sql.AppendLine();
         sql.Append(baseSql);
+        predicates.Add($"rv.tenant_id = {tenantId}");
         predicates.AddRange(scopePredicates);
 
         if (!string.IsNullOrWhiteSpace(query.DefinitionId))
@@ -87,11 +90,12 @@ internal sealed class SqliteQueryBuilder(ResourceQuery query)
         ResourceVersionScope.Latest => ("""
             FROM resource_versions rv
             INNER JOIN (
-                SELECT resource_id, MAX(version) AS version
+                SELECT tenant_id, resource_id, MAX(version) AS version
                 FROM resource_versions
-                GROUP BY resource_id
+                GROUP BY tenant_id, resource_id
             ) latest
-                ON latest.resource_id = rv.resource_id
+                ON latest.tenant_id = rv.tenant_id
+                AND latest.resource_id = rv.resource_id
                 AND latest.version = rv.version
             """, []),
         ResourceVersionScope.AllVersions => ("""
@@ -105,7 +109,8 @@ internal sealed class SqliteQueryBuilder(ResourceQuery query)
                     SELECT 1
                     FROM activation_states active_state
                     JOIN json_each(json_extract(active_state.payload, '$.activeVersions')) active_version
-                    WHERE active_state.resource_id = rv.resource_id
+                    WHERE active_state.tenant_id = rv.tenant_id
+                      AND active_state.resource_id = rv.resource_id
                       AND CAST(active_version.value AS INTEGER) = rv.version
                 )
                 """]),
@@ -122,7 +127,8 @@ internal sealed class SqliteQueryBuilder(ResourceQuery query)
         return ($$"""
             FROM resource_versions rv
             INNER JOIN activation_states active_state
-                ON active_state.resource_id = rv.resource_id
+                ON active_state.tenant_id = rv.tenant_id
+                AND active_state.resource_id = rv.resource_id
                 AND active_state.channel = {{channel}}
             """, ["""
                 EXISTS (

--- a/src/persistence/Aster.Persistence.SqliteJson/Querying/SqliteQueryBuilder.cs
+++ b/src/persistence/Aster.Persistence.SqliteJson/Querying/SqliteQueryBuilder.cs
@@ -30,8 +30,8 @@ internal sealed class SqliteQueryBuilder(ResourceQuery query)
 
     public string Build()
     {
-        var (baseSql, scopePredicates) = BuildScopeSql();
         var tenantId = Parameters.Add(TenantScopeResolver.Resolve(query.TenantScope).TenantId);
+        var (baseSql, scopePredicates) = BuildScopeSql(tenantId);
         var sql = new StringBuilder();
         sql.Append("SELECT ");
         sql.AppendJoin(", ", ["rv.payload", .. projections]);
@@ -85,13 +85,14 @@ internal sealed class SqliteQueryBuilder(ResourceQuery query)
             ? ["rv.resource_id ASC", "rv.version ASC"]
             : [.. orderings, "rv.resource_id ASC", "rv.version ASC"];
 
-    private (string Sql, IReadOnlyList<string> ScopePredicates) BuildScopeSql() => query.Scope switch
+    private (string Sql, IReadOnlyList<string> ScopePredicates) BuildScopeSql(string tenantId) => query.Scope switch
     {
-        ResourceVersionScope.Latest => ("""
+        ResourceVersionScope.Latest => ($$"""
             FROM resource_versions rv
             INNER JOIN (
                 SELECT tenant_id, resource_id, MAX(version) AS version
                 FROM resource_versions
+                WHERE tenant_id = {{tenantId}}
                 GROUP BY tenant_id, resource_id
             ) latest
                 ON latest.tenant_id = rv.tenant_id

--- a/src/persistence/Aster.Persistence.SqliteJson/README.md
+++ b/src/persistence/Aster.Persistence.SqliteJson/README.md
@@ -16,6 +16,7 @@ This package currently provides:
 It persists resource definitions, resource version snapshots, and activation state using SQLite tables with JSON payload columns.
 Query execution is provider-backed: `ResourceQuery` ASTs are translated to parameterized SQLite SQL and JSON1 expressions instead of materializing the full store in memory.
 Portability support is provider-backed too: the SQLite JSON resource store implements exact snapshot reads, target-state comparison reads, and atomic import apply for `IResourcePortabilityService`.
+All provider tables include `tenant_id`; fresh databases use tenant-aware primary keys, and provider initialization adds a default-scope `tenant_id` column to pre-tenant tables so existing rows remain visible to omitted-scope callers.
 
 ```csharp
 services.AddAsterSqliteJson(options =>
@@ -33,6 +34,7 @@ var portability = serviceProvider.GetRequiredService<IResourcePortabilityService
 
 var export = await portability.ExportAsync(new PortableSnapshotExportRequest
 {
+    TenantScope = TenantScope.FromTenantId("tenant-a"),
     ScopeMode = PortableExportScopeMode.SelectedResources,
     ResourceIds = ["product-1"],
     ResourceVersionScope = PortableResourceVersionScope.AllVersions,
@@ -41,7 +43,12 @@ var export = await portability.ExportAsync(new PortableSnapshotExportRequest
 if (export.Snapshot is null)
     return; // export failed; inspect export.Diagnostics
 
-var preview = await portability.PreviewImportAsync(export.Snapshot);
+var preview = await portability.PreviewImportAsync(
+    export.Snapshot,
+    new PortableImportOptions
+    {
+        TargetTenantScope = TenantScope.FromTenantId("tenant-b"),
+    });
 ```
 
 SQLite import apply is all-or-nothing for a planned snapshot. Strict imports fail before writing on divergent identity collisions; explicit `RemapDivergent` mode writes deterministic remapped identifiers and keeps definition lineage, resource versions, and activation entries consistent. No SQLite schema migration or physical indexing is introduced by portability primitives.
@@ -66,3 +73,5 @@ Date-like facet ranges match JSON string scalar values in the ISO-8601-style sha
 Unsupported query shapes throw `UnsupportedQueryFeatureException` with stable `Code`, `Feature`, optional `Path`, and an actionable message. Metadata range filters, unknown metadata fields, empty ranges, negative paging values, mixed range bound shapes, and invalid date-like range bounds are intentionally rejected.
 
 The provider also declares this support through `SqliteJsonQueryCapabilitiesProvider` with provider key `sqlite-json`, so callers can inspect capabilities or use `IResourceQueryValidator` before execution. Execution runs shared validation first and remains authoritative if validation is skipped.
+
+Tenant scope is applied as a provider-owned predicate before user query predicates. Latest, active, and draft scopes all include tenant-aware joins so matching resource IDs or activation channels in another tenant cannot affect results.

--- a/src/persistence/Aster.Persistence.SqliteJson/SqliteJsonResourceStore.cs
+++ b/src/persistence/Aster.Persistence.SqliteJson/SqliteJsonResourceStore.cs
@@ -50,7 +50,7 @@ public sealed class SqliteJsonResourceStore :
     public async ValueTask<ResourceDefinition?> GetDefinitionAsync(
         string definitionId,
         TenantScope tenantScope,
-        CancellationToken cancellationToken = default)
+        CancellationToken cancellationToken)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(definitionId);
         var tenant = TenantScopeResolver.Resolve(tenantScope);
@@ -83,7 +83,7 @@ public sealed class SqliteJsonResourceStore :
         string definitionId,
         int version,
         TenantScope tenantScope,
-        CancellationToken cancellationToken = default)
+        CancellationToken cancellationToken)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(definitionId);
         var tenant = TenantScopeResolver.Resolve(tenantScope);
@@ -113,7 +113,7 @@ public sealed class SqliteJsonResourceStore :
     public async ValueTask RegisterDefinitionAsync(
         ResourceDefinition definition,
         TenantScope tenantScope,
-        CancellationToken cancellationToken = default)
+        CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(definition);
         var tenant = TenantScopeResolver.Resolve(tenantScope);
@@ -148,7 +148,7 @@ public sealed class SqliteJsonResourceStore :
     /// <inheritdoc />
     public async ValueTask<IEnumerable<ResourceDefinition>> ListDefinitionsAsync(
         TenantScope tenantScope,
-        CancellationToken cancellationToken = default)
+        CancellationToken cancellationToken)
     {
         var tenant = TenantScopeResolver.Resolve(tenantScope);
         await using var connection = await OpenConnectionAsync(cancellationToken);

--- a/src/persistence/Aster.Persistence.SqliteJson/SqliteJsonResourceStore.cs
+++ b/src/persistence/Aster.Persistence.SqliteJson/SqliteJsonResourceStore.cs
@@ -236,7 +236,12 @@ public sealed class SqliteJsonResourceStore :
         ArgumentException.ThrowIfNullOrWhiteSpace(channel);
         ArgumentNullException.ThrowIfNull(state);
         var tenant = TenantScopeResolver.Resolve(state.TenantScope);
-        var scopedState = state with { TenantScope = tenant };
+        var scopedState = state with
+        {
+            TenantScope = tenant,
+            ResourceId = resourceId,
+            Channel = channel,
+        };
 
         await using var connection = await OpenConnectionAsync(cancellationToken);
         await using var command = connection.CreateCommand();

--- a/src/persistence/Aster.Persistence.SqliteJson/SqliteJsonResourceStore.cs
+++ b/src/persistence/Aster.Persistence.SqliteJson/SqliteJsonResourceStore.cs
@@ -107,7 +107,7 @@ public sealed class SqliteJsonResourceStore :
     public async ValueTask RegisterDefinitionAsync(
         ResourceDefinition definition,
         CancellationToken cancellationToken = default) =>
-        await RegisterDefinitionAsync(definition, definition.TenantScope, cancellationToken);
+        await RegisterDefinitionAsync(definition, TenantScope.Default, cancellationToken);
 
     /// <inheritdoc />
     public async ValueTask RegisterDefinitionAsync(

--- a/src/persistence/Aster.Persistence.SqliteJson/SqliteJsonResourceStore.cs
+++ b/src/persistence/Aster.Persistence.SqliteJson/SqliteJsonResourceStore.cs
@@ -4,6 +4,8 @@ using Aster.Core.Models.Definitions;
 using Aster.Core.Models.Instances;
 using Aster.Core.Models.Portability;
 using Aster.Core.Models.Querying;
+using Aster.Core.Models.Tenancy;
+using Aster.Core.Services;
 using Microsoft.Data.Sqlite;
 
 namespace Aster.Persistence.SqliteJson;
@@ -41,19 +43,28 @@ public sealed class SqliteJsonResourceStore :
     /// <inheritdoc />
     public async ValueTask<ResourceDefinition?> GetDefinitionAsync(
         string definitionId,
+        CancellationToken cancellationToken = default) =>
+        await GetDefinitionAsync(definitionId, TenantScope.Default, cancellationToken);
+
+    /// <inheritdoc />
+    public async ValueTask<ResourceDefinition?> GetDefinitionAsync(
+        string definitionId,
+        TenantScope tenantScope,
         CancellationToken cancellationToken = default)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(definitionId);
+        var tenant = TenantScopeResolver.Resolve(tenantScope);
 
         await using var connection = await OpenConnectionAsync(cancellationToken);
         await using var command = connection.CreateCommand();
         command.CommandText = """
             SELECT payload
             FROM resource_definitions
-            WHERE definition_id = $definitionId
+            WHERE tenant_id = $tenantId AND definition_id = $definitionId
             ORDER BY version DESC
             LIMIT 1;
             """;
+        command.Parameters.AddWithValue("$tenantId", tenant.TenantId);
         command.Parameters.AddWithValue("$definitionId", definitionId);
 
         var payload = await command.ExecuteScalarAsync(cancellationToken) as string;
@@ -64,17 +75,27 @@ public sealed class SqliteJsonResourceStore :
     public async ValueTask<ResourceDefinition?> GetDefinitionVersionAsync(
         string definitionId,
         int version,
+        CancellationToken cancellationToken = default) =>
+        await GetDefinitionVersionAsync(definitionId, version, TenantScope.Default, cancellationToken);
+
+    /// <inheritdoc />
+    public async ValueTask<ResourceDefinition?> GetDefinitionVersionAsync(
+        string definitionId,
+        int version,
+        TenantScope tenantScope,
         CancellationToken cancellationToken = default)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(definitionId);
+        var tenant = TenantScopeResolver.Resolve(tenantScope);
 
         await using var connection = await OpenConnectionAsync(cancellationToken);
         await using var command = connection.CreateCommand();
         command.CommandText = """
             SELECT payload
             FROM resource_definitions
-            WHERE definition_id = $definitionId AND version = $version;
+            WHERE tenant_id = $tenantId AND definition_id = $definitionId AND version = $version;
             """;
+        command.Parameters.AddWithValue("$tenantId", tenant.TenantId);
         command.Parameters.AddWithValue("$definitionId", definitionId);
         command.Parameters.AddWithValue("$version", version);
 
@@ -85,22 +106,31 @@ public sealed class SqliteJsonResourceStore :
     /// <inheritdoc />
     public async ValueTask RegisterDefinitionAsync(
         ResourceDefinition definition,
+        CancellationToken cancellationToken = default) =>
+        await RegisterDefinitionAsync(definition, definition.TenantScope, cancellationToken);
+
+    /// <inheritdoc />
+    public async ValueTask RegisterDefinitionAsync(
+        ResourceDefinition definition,
+        TenantScope tenantScope,
         CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(definition);
+        var tenant = TenantScopeResolver.Resolve(tenantScope);
 
         await using var connection = await OpenConnectionAsync(cancellationToken);
         await using var transaction = (SqliteTransaction)await connection.BeginTransactionAsync(cancellationToken);
 
-        var nextVersion = await GetNextDefinitionVersionAsync(connection, definition.DefinitionId, cancellationToken);
-        var versionedDefinition = definition with { Version = nextVersion };
+        var nextVersion = await GetNextDefinitionVersionAsync(connection, definition.DefinitionId, tenant, cancellationToken);
+        var versionedDefinition = definition with { TenantScope = tenant, Version = nextVersion };
 
         await using var command = connection.CreateCommand();
         command.Transaction = (SqliteTransaction)transaction;
         command.CommandText = """
-            INSERT INTO resource_definitions (definition_id, version, id, payload)
-            VALUES ($definitionId, $version, $id, $payload);
+            INSERT INTO resource_definitions (tenant_id, definition_id, version, id, payload)
+            VALUES ($tenantId, $definitionId, $version, $id, $payload);
             """;
+        command.Parameters.AddWithValue("$tenantId", tenant.TenantId);
         command.Parameters.AddWithValue("$definitionId", versionedDefinition.DefinitionId);
         command.Parameters.AddWithValue("$version", versionedDefinition.Version);
         command.Parameters.AddWithValue("$id", versionedDefinition.Id);
@@ -112,22 +142,33 @@ public sealed class SqliteJsonResourceStore :
 
     /// <inheritdoc />
     public async ValueTask<IEnumerable<ResourceDefinition>> ListDefinitionsAsync(
+        CancellationToken cancellationToken = default) =>
+        await ListDefinitionsAsync(TenantScope.Default, cancellationToken);
+
+    /// <inheritdoc />
+    public async ValueTask<IEnumerable<ResourceDefinition>> ListDefinitionsAsync(
+        TenantScope tenantScope,
         CancellationToken cancellationToken = default)
     {
+        var tenant = TenantScopeResolver.Resolve(tenantScope);
         await using var connection = await OpenConnectionAsync(cancellationToken);
         await using var command = connection.CreateCommand();
         command.CommandText = """
             SELECT rd.payload
             FROM resource_definitions rd
             INNER JOIN (
-                SELECT definition_id, MAX(version) AS version
+                SELECT tenant_id, definition_id, MAX(version) AS version
                 FROM resource_definitions
-                GROUP BY definition_id
+                WHERE tenant_id = $tenantId
+                GROUP BY tenant_id, definition_id
             ) latest
-                ON latest.definition_id = rd.definition_id
+                ON latest.tenant_id = rd.tenant_id
+                AND latest.definition_id = rd.definition_id
                 AND latest.version = rd.version
+            WHERE rd.tenant_id = $tenantId
             ORDER BY rd.definition_id;
             """;
+        command.Parameters.AddWithValue("$tenantId", tenant.TenantId);
 
         return await ReadPayloadsAsync<ResourceDefinition>(command, cancellationToken);
     }
@@ -138,11 +179,14 @@ public sealed class SqliteJsonResourceStore :
         CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(resource);
+        var tenant = TenantScopeResolver.Resolve(resource.TenantScope);
+        var scopedResource = resource with { TenantScope = tenant };
 
         await using var connection = await OpenConnectionAsync(cancellationToken);
         await using var command = connection.CreateCommand();
         command.CommandText = """
             INSERT INTO resource_versions (
+                tenant_id,
                 resource_id,
                 version,
                 id,
@@ -154,6 +198,7 @@ public sealed class SqliteJsonResourceStore :
                 payload
             )
             VALUES (
+                $tenantId,
                 $resourceId,
                 $version,
                 $id,
@@ -165,18 +210,19 @@ public sealed class SqliteJsonResourceStore :
                 $payload
             );
             """;
-        command.Parameters.AddWithValue("$resourceId", resource.ResourceId);
-        command.Parameters.AddWithValue("$version", resource.Version);
-        command.Parameters.AddWithValue("$id", resource.Id);
-        command.Parameters.AddWithValue("$definitionId", resource.DefinitionId);
-        command.Parameters.AddWithValue("$definitionVersion", (object?)resource.DefinitionVersion ?? DBNull.Value);
-        command.Parameters.AddWithValue("$created", resource.Created.ToUniversalTime().ToString("O"));
-        command.Parameters.AddWithValue("$owner", (object?)resource.Owner ?? DBNull.Value);
-        command.Parameters.AddWithValue("$hash", (object?)resource.Hash ?? DBNull.Value);
-        command.Parameters.AddWithValue("$payload", Serialize(resource));
+        command.Parameters.AddWithValue("$tenantId", tenant.TenantId);
+        command.Parameters.AddWithValue("$resourceId", scopedResource.ResourceId);
+        command.Parameters.AddWithValue("$version", scopedResource.Version);
+        command.Parameters.AddWithValue("$id", scopedResource.Id);
+        command.Parameters.AddWithValue("$definitionId", scopedResource.DefinitionId);
+        command.Parameters.AddWithValue("$definitionVersion", (object?)scopedResource.DefinitionVersion ?? DBNull.Value);
+        command.Parameters.AddWithValue("$created", scopedResource.Created.ToUniversalTime().ToString("O"));
+        command.Parameters.AddWithValue("$owner", (object?)scopedResource.Owner ?? DBNull.Value);
+        command.Parameters.AddWithValue("$hash", (object?)scopedResource.Hash ?? DBNull.Value);
+        command.Parameters.AddWithValue("$payload", Serialize(scopedResource));
 
         await command.ExecuteNonQueryAsync(cancellationToken);
-        return resource;
+        return scopedResource;
     }
 
     /// <inheritdoc />
@@ -189,21 +235,24 @@ public sealed class SqliteJsonResourceStore :
         ArgumentException.ThrowIfNullOrWhiteSpace(resourceId);
         ArgumentException.ThrowIfNullOrWhiteSpace(channel);
         ArgumentNullException.ThrowIfNull(state);
+        var tenant = TenantScopeResolver.Resolve(state.TenantScope);
+        var scopedState = state with { TenantScope = tenant };
 
         await using var connection = await OpenConnectionAsync(cancellationToken);
         await using var command = connection.CreateCommand();
         command.CommandText = """
-            INSERT INTO activation_states (resource_id, channel, payload)
-            VALUES ($resourceId, $channel, $payload)
-            ON CONFLICT(resource_id, channel)
+            INSERT INTO activation_states (tenant_id, resource_id, channel, payload)
+            VALUES ($tenantId, $resourceId, $channel, $payload)
+            ON CONFLICT(tenant_id, resource_id, channel)
             DO UPDATE SET payload = excluded.payload;
             """;
+        command.Parameters.AddWithValue("$tenantId", tenant.TenantId);
         command.Parameters.AddWithValue("$resourceId", resourceId);
         command.Parameters.AddWithValue("$channel", channel);
-        command.Parameters.AddWithValue("$payload", Serialize(state));
+        command.Parameters.AddWithValue("$payload", Serialize(scopedState));
 
         await command.ExecuteNonQueryAsync(cancellationToken);
-        return state;
+        return scopedState;
     }
 
     /// <inheritdoc />
@@ -212,13 +261,14 @@ public sealed class SqliteJsonResourceStore :
         CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(request);
+        var tenant = TenantScopeResolver.Resolve(request.TenantScope);
 
         return request.Scope switch
         {
-            ResourceVersionScope.Latest => await ReadLatestVersionsAsync(cancellationToken),
-            ResourceVersionScope.AllVersions => await ReadAllVersionsAsync(cancellationToken),
-            ResourceVersionScope.Active => await ReadActiveVersionsAsync(request.ActivationChannel, cancellationToken),
-            ResourceVersionScope.Draft => await ReadDraftVersionsAsync(cancellationToken),
+            ResourceVersionScope.Latest => await ReadLatestVersionsAsync(tenant, cancellationToken),
+            ResourceVersionScope.AllVersions => await ReadAllVersionsAsync(tenant, cancellationToken),
+            ResourceVersionScope.Active => await ReadActiveVersionsAsync(tenant, request.ActivationChannel, cancellationToken),
+            ResourceVersionScope.Draft => await ReadDraftVersionsAsync(tenant, cancellationToken),
             _ => throw new ArgumentOutOfRangeException(nameof(request), request.Scope, "Unknown resource version scope.")
         };
     }
@@ -238,11 +288,13 @@ public sealed class SqliteJsonResourceStore :
             };
         }
 
+        var tenant = TenantScopeResolver.Resolve(request.ExportRequest.TenantScope);
         var resources = SelectResourceVersions(
             request.ExportRequest,
-            await ReadScopedResourceVersionsAsync(request.ExportRequest, cancellationToken));
+            await ReadScopedResourceVersionsAsync(request.ExportRequest, tenant, cancellationToken));
         var definitions = await SelectDefinitionsAsync(request.ExportRequest, resources, cancellationToken);
         var activationStates = await ReadScopedActivationStatesAsync(
+            tenant,
             resources.Select(static resource => resource.ResourceId).ToHashSet(StringComparer.Ordinal),
             cancellationToken);
         var (includedActivationStates, skippedActivationEntries) = SelectActivationStates(resources, activationStates);
@@ -263,7 +315,8 @@ public sealed class SqliteJsonResourceStore :
     {
         ArgumentNullException.ThrowIfNull(snapshot);
 
-        var definitions = await ReadTargetDefinitionVersionsAsync(snapshot, cancellationToken);
+        var tenant = TenantScopeResolver.Resolve(snapshot.SourceTenantScope);
+        var definitions = await ReadTargetDefinitionVersionsAsync(snapshot, tenant, cancellationToken);
         var resources = await ReadSpecificResourceVersionsAsync(
             snapshot.Resources
                 .Select(static resource => new ResourceVersionReference
@@ -272,8 +325,9 @@ public sealed class SqliteJsonResourceStore :
                     Version = resource.Version,
                 })
                 .ToHashSet(),
+            tenant,
             cancellationToken);
-        var activationStates = await ReadSpecificActivationStatesAsync(snapshot.ActivationStates, cancellationToken);
+        var activationStates = await ReadSpecificActivationStatesAsync(snapshot.ActivationStates, tenant, cancellationToken);
 
         return new PortableTargetState
         {
@@ -289,6 +343,7 @@ public sealed class SqliteJsonResourceStore :
         CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(plannedSnapshot);
+        var tenant = TenantScopeResolver.Resolve(plannedSnapshot.SourceTenantScope);
 
         await using var connection = await OpenConnectionAsync(cancellationToken);
         await using var transaction = (SqliteTransaction)await connection.BeginTransactionAsync(cancellationToken);
@@ -296,13 +351,13 @@ public sealed class SqliteJsonResourceStore :
         try
         {
             foreach (var definition in plannedSnapshot.Definitions)
-                await InsertDefinitionAsync(connection, transaction, definition, cancellationToken);
+                await InsertDefinitionAsync(connection, transaction, definition with { TenantScope = tenant }, cancellationToken);
 
             foreach (var resource in plannedSnapshot.Resources)
-                await InsertResourceAsync(connection, transaction, resource, cancellationToken);
+                await InsertResourceAsync(connection, transaction, resource with { TenantScope = tenant }, cancellationToken);
 
             foreach (var state in plannedSnapshot.ActivationStates)
-                await InsertActivationStateAsync(connection, transaction, state, cancellationToken);
+                await InsertActivationStateAsync(connection, transaction, state with { TenantScope = tenant }, cancellationToken);
 
             await transaction.CommitAsync(cancellationToken);
         }
@@ -313,7 +368,9 @@ public sealed class SqliteJsonResourceStore :
         }
     }
 
-    private async Task<IEnumerable<Resource>> ReadLatestVersionsAsync(CancellationToken cancellationToken)
+    private async Task<IEnumerable<Resource>> ReadLatestVersionsAsync(
+        TenantScope tenant,
+        CancellationToken cancellationToken)
     {
         await using var connection = await OpenConnectionAsync(cancellationToken);
         await using var command = connection.CreateCommand();
@@ -321,27 +378,35 @@ public sealed class SqliteJsonResourceStore :
             SELECT rv.payload
             FROM resource_versions rv
             INNER JOIN (
-                SELECT resource_id, MAX(version) AS version
+                SELECT tenant_id, resource_id, MAX(version) AS version
                 FROM resource_versions
-                GROUP BY resource_id
+                WHERE tenant_id = $tenantId
+                GROUP BY tenant_id, resource_id
             ) latest
-                ON latest.resource_id = rv.resource_id
+                ON latest.tenant_id = rv.tenant_id
+                AND latest.resource_id = rv.resource_id
                 AND latest.version = rv.version
+            WHERE rv.tenant_id = $tenantId
             ORDER BY rv.resource_id;
             """;
+        command.Parameters.AddWithValue("$tenantId", tenant.TenantId);
 
         return await ReadPayloadsAsync<Resource>(command, cancellationToken);
     }
 
-    private async Task<IEnumerable<Resource>> ReadAllVersionsAsync(CancellationToken cancellationToken)
+    private async Task<IEnumerable<Resource>> ReadAllVersionsAsync(
+        TenantScope tenant,
+        CancellationToken cancellationToken)
     {
         await using var connection = await OpenConnectionAsync(cancellationToken);
         await using var command = connection.CreateCommand();
         command.CommandText = """
             SELECT payload
             FROM resource_versions
+            WHERE tenant_id = $tenantId
             ORDER BY resource_id, version;
             """;
+        command.Parameters.AddWithValue("$tenantId", tenant.TenantId);
 
         return await ReadPayloadsAsync<Resource>(command, cancellationToken);
     }
@@ -351,7 +416,8 @@ public sealed class SqliteJsonResourceStore :
         IReadOnlyCollection<Resource> resources,
         CancellationToken cancellationToken)
     {
-        var scopedDefinitions = await ReadScopedDefinitionVersionsAsync(request, resources, cancellationToken);
+        var tenant = TenantScopeResolver.Resolve(request.TenantScope);
+        var scopedDefinitions = await ReadScopedDefinitionVersionsAsync(request, resources, tenant, cancellationToken);
         var scopedDefinitionsByVersion = scopedDefinitions.ToDictionary(
             static definition => (definition.DefinitionId, definition.Version));
         var definitions = new Dictionary<(string DefinitionId, int Version), ResourceDefinition>();
@@ -380,6 +446,7 @@ public sealed class SqliteJsonResourceStore :
     private async Task<List<ResourceDefinition>> ReadScopedDefinitionVersionsAsync(
         PortableSnapshotExportRequest request,
         IReadOnlyCollection<Resource> resources,
+        TenantScope tenant,
         CancellationToken cancellationToken)
     {
         var fullDefinitionIds = request.ScopeMode is PortableExportScopeMode.DefinitionsOnly or PortableExportScopeMode.DefinitionWithResources
@@ -396,6 +463,7 @@ public sealed class SqliteJsonResourceStore :
         var definitions = await ReadPayloadsByTextIdsAsync<ResourceDefinition>(
             tableName: "resource_definitions",
             columnName: "definition_id",
+            tenant: tenant,
             ids: definitionIds,
             orderBy: "definition_id, version",
             cancellationToken);
@@ -411,6 +479,7 @@ public sealed class SqliteJsonResourceStore :
 
     private async Task<List<ResourceDefinition>> ReadTargetDefinitionVersionsAsync(
         PortableSnapshot snapshot,
+        TenantScope tenant,
         CancellationToken cancellationToken)
     {
         var definitionVersions = snapshot.Definitions
@@ -435,9 +504,10 @@ public sealed class SqliteJsonResourceStore :
             command.CommandText = $"""
                 SELECT payload
                 FROM resource_definitions
-                WHERE {string.Join(" OR ", predicates)}
+                WHERE tenant_id = $tenantId AND ({string.Join(" OR ", predicates)})
                 ORDER BY definition_id, version;
                 """;
+            command.Parameters.AddWithValue("$tenantId", tenant.TenantId);
 
             results.AddRange(await ReadPayloadsAsync<ResourceDefinition>(command, cancellationToken));
         }
@@ -450,6 +520,7 @@ public sealed class SqliteJsonResourceStore :
 
     private async Task<List<ActivationState>> ReadSpecificActivationStatesAsync(
         IReadOnlyCollection<ActivationState> activationStates,
+        TenantScope tenant,
         CancellationToken cancellationToken)
     {
         if (activationStates.Count == 0)
@@ -469,9 +540,10 @@ public sealed class SqliteJsonResourceStore :
             command.CommandText = $"""
                 SELECT payload
                 FROM activation_states
-                WHERE {string.Join(" OR ", predicates)}
+                WHERE tenant_id = $tenantId AND ({string.Join(" OR ", predicates)})
                 ORDER BY resource_id, channel;
                 """;
+            command.Parameters.AddWithValue("$tenantId", tenant.TenantId);
 
             results.AddRange(await ReadPayloadsAsync<ActivationState>(command, cancellationToken));
         }
@@ -483,23 +555,26 @@ public sealed class SqliteJsonResourceStore :
     }
 
     private async Task<List<ActivationState>> ReadScopedActivationStatesAsync(
+        TenantScope tenant,
         IReadOnlyCollection<string> resourceIds,
         CancellationToken cancellationToken) =>
         await ReadPayloadsByTextIdsAsync<ActivationState>(
             tableName: "activation_states",
             columnName: "resource_id",
+            tenant: tenant,
             ids: resourceIds,
             orderBy: "resource_id, channel",
             cancellationToken);
 
     private async Task<List<Resource>> ReadScopedResourceVersionsAsync(
         PortableSnapshotExportRequest request,
+        TenantScope tenant,
         CancellationToken cancellationToken)
     {
         if (request.ScopeMode == PortableExportScopeMode.SelectedResources
             && request.ResourceVersionScope == PortableResourceVersionScope.SpecificVersions)
         {
-            return await ReadSpecificResourceVersionsAsync(request.SpecificResourceVersions, cancellationToken);
+            return await ReadSpecificResourceVersionsAsync(request.SpecificResourceVersions, tenant, cancellationToken);
         }
 
         var (columnName, ids) = request.ScopeMode switch
@@ -516,8 +591,9 @@ public sealed class SqliteJsonResourceStore :
 
         var resources = await ReadPayloadsByTextIdsAsync<Resource>(
             tableName: "resource_versions",
-            columnName,
-            ids,
+            columnName: columnName,
+            tenant: tenant,
+            ids: ids,
             orderBy: "resource_id, version",
             cancellationToken);
 
@@ -529,6 +605,7 @@ public sealed class SqliteJsonResourceStore :
 
     private async Task<List<Resource>> ReadSpecificResourceVersionsAsync(
         IReadOnlyCollection<ResourceVersionReference> references,
+        TenantScope tenant,
         CancellationToken cancellationToken)
     {
         if (references.Count == 0)
@@ -546,9 +623,10 @@ public sealed class SqliteJsonResourceStore :
             command.CommandText = $"""
                 SELECT payload
                 FROM resource_versions
-                WHERE {string.Join(" OR ", predicates)}
+                WHERE tenant_id = $tenantId AND ({string.Join(" OR ", predicates)})
                 ORDER BY resource_id, version;
                 """;
+            command.Parameters.AddWithValue("$tenantId", tenant.TenantId);
 
             results.AddRange(await ReadPayloadsAsync<Resource>(command, cancellationToken));
         }
@@ -726,6 +804,7 @@ public sealed class SqliteJsonResourceStore :
     private async Task<List<T>> ReadPayloadsByTextIdsAsync<T>(
         string tableName,
         string columnName,
+        TenantScope tenant,
         IReadOnlyCollection<string> ids,
         string orderBy,
         CancellationToken cancellationToken)
@@ -742,9 +821,10 @@ public sealed class SqliteJsonResourceStore :
             command.CommandText = $"""
                 SELECT payload
                 FROM {tableName}
-                WHERE {columnName} IN ({string.Join(", ", parameterNames)})
+                WHERE tenant_id = $tenantId AND {columnName} IN ({string.Join(", ", parameterNames)})
                 ORDER BY {orderBy};
                 """;
+            command.Parameters.AddWithValue("$tenantId", tenant.TenantId);
 
             results.AddRange(await ReadPayloadsAsync<T>(command, cancellationToken));
         }
@@ -753,13 +833,14 @@ public sealed class SqliteJsonResourceStore :
     }
 
     private async Task<IEnumerable<Resource>> ReadActiveVersionsAsync(
+        TenantScope tenant,
         string? channel,
         CancellationToken cancellationToken)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(channel);
 
-        var resources = (await ReadAllVersionsAsync(cancellationToken)).ToList();
-        var active = await ReadActivationStatesAsync(channel, cancellationToken);
+        var resources = (await ReadAllVersionsAsync(tenant, cancellationToken)).ToList();
+        var active = await ReadActivationStatesAsync(tenant, channel, cancellationToken);
 
         return resources
             .Where(resource =>
@@ -768,10 +849,12 @@ public sealed class SqliteJsonResourceStore :
             .ToList();
     }
 
-    private async Task<IEnumerable<Resource>> ReadDraftVersionsAsync(CancellationToken cancellationToken)
+    private async Task<IEnumerable<Resource>> ReadDraftVersionsAsync(
+        TenantScope tenant,
+        CancellationToken cancellationToken)
     {
-        var resources = (await ReadAllVersionsAsync(cancellationToken)).ToList();
-        var active = await ReadActivationStatesAsync(channel: null, cancellationToken);
+        var resources = (await ReadAllVersionsAsync(tenant, cancellationToken)).ToList();
+        var active = await ReadActivationStatesAsync(tenant, channel: null, cancellationToken);
 
         return resources
             .Where(resource =>
@@ -781,15 +864,17 @@ public sealed class SqliteJsonResourceStore :
     }
 
     private async Task<Dictionary<string, HashSet<int>>> ReadActivationStatesAsync(
+        TenantScope tenant,
         string? channel,
         CancellationToken cancellationToken)
     {
         await using var connection = await OpenConnectionAsync(cancellationToken);
         await using var command = connection.CreateCommand();
         command.CommandText = channel is null
-            ? "SELECT payload FROM activation_states;"
-            : "SELECT payload FROM activation_states WHERE channel = $channel;";
+            ? "SELECT payload FROM activation_states WHERE tenant_id = $tenantId;"
+            : "SELECT payload FROM activation_states WHERE tenant_id = $tenantId AND channel = $channel;";
 
+        command.Parameters.AddWithValue("$tenantId", tenant.TenantId);
         if (channel is not null)
             command.Parameters.AddWithValue("$channel", channel);
 
@@ -820,9 +905,10 @@ public sealed class SqliteJsonResourceStore :
         await using var command = connection.CreateCommand();
         command.Transaction = transaction;
         command.CommandText = """
-            INSERT INTO resource_definitions (definition_id, version, id, payload)
-            VALUES ($definitionId, $version, $id, $payload);
+            INSERT INTO resource_definitions (tenant_id, definition_id, version, id, payload)
+            VALUES ($tenantId, $definitionId, $version, $id, $payload);
             """;
+        command.Parameters.AddWithValue("$tenantId", TenantScopeResolver.Resolve(definition.TenantScope).TenantId);
         command.Parameters.AddWithValue("$definitionId", definition.DefinitionId);
         command.Parameters.AddWithValue("$version", definition.Version);
         command.Parameters.AddWithValue("$id", definition.Id);
@@ -841,6 +927,7 @@ public sealed class SqliteJsonResourceStore :
         command.Transaction = transaction;
         command.CommandText = """
             INSERT INTO resource_versions (
+                tenant_id,
                 resource_id,
                 version,
                 id,
@@ -852,6 +939,7 @@ public sealed class SqliteJsonResourceStore :
                 payload
             )
             VALUES (
+                $tenantId,
                 $resourceId,
                 $version,
                 $id,
@@ -863,6 +951,7 @@ public sealed class SqliteJsonResourceStore :
                 $payload
             );
             """;
+        command.Parameters.AddWithValue("$tenantId", TenantScopeResolver.Resolve(resource.TenantScope).TenantId);
         command.Parameters.AddWithValue("$resourceId", resource.ResourceId);
         command.Parameters.AddWithValue("$version", resource.Version);
         command.Parameters.AddWithValue("$id", resource.Id);
@@ -885,9 +974,10 @@ public sealed class SqliteJsonResourceStore :
         await using var command = connection.CreateCommand();
         command.Transaction = transaction;
         command.CommandText = """
-            INSERT INTO activation_states (resource_id, channel, payload)
-            VALUES ($resourceId, $channel, $payload);
+            INSERT INTO activation_states (tenant_id, resource_id, channel, payload)
+            VALUES ($tenantId, $resourceId, $channel, $payload);
             """;
+        command.Parameters.AddWithValue("$tenantId", TenantScopeResolver.Resolve(state.TenantScope).TenantId);
         command.Parameters.AddWithValue("$resourceId", state.ResourceId);
         command.Parameters.AddWithValue("$channel", state.Channel);
         command.Parameters.AddWithValue("$payload", Serialize(state));
@@ -905,14 +995,16 @@ public sealed class SqliteJsonResourceStore :
     private static async Task<int> GetNextDefinitionVersionAsync(
         SqliteConnection connection,
         string definitionId,
+        TenantScope tenant,
         CancellationToken cancellationToken)
     {
         await using var command = connection.CreateCommand();
         command.CommandText = """
             SELECT COALESCE(MAX(version), 0) + 1
             FROM resource_definitions
-            WHERE definition_id = $definitionId;
+            WHERE tenant_id = $tenantId AND definition_id = $definitionId;
             """;
+        command.Parameters.AddWithValue("$tenantId", tenant.TenantId);
         command.Parameters.AddWithValue("$definitionId", definitionId);
 
         var result = await command.ExecuteScalarAsync(cancellationToken);

--- a/src/persistence/Aster.Persistence.SqliteJson/SqliteJsonSchema.cs
+++ b/src/persistence/Aster.Persistence.SqliteJson/SqliteJsonSchema.cs
@@ -4,6 +4,43 @@ namespace Aster.Persistence.SqliteJson;
 
 internal static class SqliteJsonSchema
 {
+    private const string CreateResourceDefinitionsSql = """
+        CREATE TABLE IF NOT EXISTS resource_definitions (
+            tenant_id TEXT NOT NULL DEFAULT 'default',
+            definition_id TEXT NOT NULL,
+            version INTEGER NOT NULL,
+            id TEXT NOT NULL,
+            payload TEXT NOT NULL,
+            PRIMARY KEY (tenant_id, definition_id, version)
+        );
+        """;
+
+    private const string CreateResourceVersionsSql = """
+        CREATE TABLE IF NOT EXISTS resource_versions (
+            tenant_id TEXT NOT NULL DEFAULT 'default',
+            resource_id TEXT NOT NULL,
+            version INTEGER NOT NULL,
+            id TEXT NOT NULL,
+            definition_id TEXT NOT NULL,
+            definition_version INTEGER NULL,
+            created TEXT NOT NULL,
+            owner TEXT NULL,
+            hash TEXT NULL,
+            payload TEXT NOT NULL,
+            PRIMARY KEY (tenant_id, resource_id, version)
+        );
+        """;
+
+    private const string CreateActivationStatesSql = """
+        CREATE TABLE IF NOT EXISTS activation_states (
+            tenant_id TEXT NOT NULL DEFAULT 'default',
+            resource_id TEXT NOT NULL,
+            channel TEXT NOT NULL,
+            payload TEXT NOT NULL,
+            PRIMARY KEY (tenant_id, resource_id, channel)
+        );
+        """;
+
     public static void Initialize(string connectionString)
     {
         using var connection = new SqliteConnection(connectionString);
@@ -12,67 +49,114 @@ internal static class SqliteJsonSchema
         using var command = connection.CreateCommand();
         command.CommandText = """
             PRAGMA journal_mode = WAL;
-
-            CREATE TABLE IF NOT EXISTS resource_definitions (
-                tenant_id TEXT NOT NULL DEFAULT 'default',
-                definition_id TEXT NOT NULL,
-                version INTEGER NOT NULL,
-                id TEXT NOT NULL,
-                payload TEXT NOT NULL,
-                PRIMARY KEY (tenant_id, definition_id, version)
-            );
-
-            CREATE TABLE IF NOT EXISTS resource_versions (
-                tenant_id TEXT NOT NULL DEFAULT 'default',
-                resource_id TEXT NOT NULL,
-                version INTEGER NOT NULL,
-                id TEXT NOT NULL,
-                definition_id TEXT NOT NULL,
-                definition_version INTEGER NULL,
-                created TEXT NOT NULL,
-                owner TEXT NULL,
-                hash TEXT NULL,
-                payload TEXT NOT NULL,
-                PRIMARY KEY (tenant_id, resource_id, version)
-            );
-
-            CREATE TABLE IF NOT EXISTS activation_states (
-                tenant_id TEXT NOT NULL DEFAULT 'default',
-                resource_id TEXT NOT NULL,
-                channel TEXT NOT NULL,
-                payload TEXT NOT NULL,
-                PRIMARY KEY (tenant_id, resource_id, channel)
-            );
             """;
 
         command.ExecuteNonQuery();
 
-        AddTenantColumnIfMissing(connection, "resource_definitions");
-        AddTenantColumnIfMissing(connection, "resource_versions");
-        AddTenantColumnIfMissing(connection, "activation_states");
+        using var transaction = connection.BeginTransaction();
+        EnsureTenantAwareTable(
+            connection,
+            transaction,
+            "resource_definitions",
+            CreateResourceDefinitionsSql,
+            ["tenant_id", "definition_id", "version", "id", "payload"],
+            ["tenant_id", "definition_id", "version"]);
+        EnsureTenantAwareTable(
+            connection,
+            transaction,
+            "resource_versions",
+            CreateResourceVersionsSql,
+            ["tenant_id", "resource_id", "version", "id", "definition_id", "definition_version", "created", "owner", "hash", "payload"],
+            ["tenant_id", "resource_id", "version"]);
+        EnsureTenantAwareTable(
+            connection,
+            transaction,
+            "activation_states",
+            CreateActivationStatesSql,
+            ["tenant_id", "resource_id", "channel", "payload"],
+            ["tenant_id", "resource_id", "channel"]);
 
         using var index = connection.CreateCommand();
+        index.Transaction = transaction;
         index.CommandText = """
             CREATE INDEX IF NOT EXISTS ix_resource_versions_definition_id
                 ON resource_versions (tenant_id, definition_id);
             """;
         index.ExecuteNonQuery();
+
+        transaction.Commit();
     }
 
-    private static void AddTenantColumnIfMissing(SqliteConnection connection, string tableName)
+    private static void EnsureTenantAwareTable(
+        SqliteConnection connection,
+        SqliteTransaction transaction,
+        string tableName,
+        string createSql,
+        IReadOnlyList<string> columns,
+        IReadOnlyList<string> expectedPrimaryKey)
+    {
+        ExecuteNonQuery(connection, transaction, createSql);
+
+        var tableColumns = ReadColumns(connection, transaction, tableName);
+        var actualPrimaryKey = tableColumns
+            .Where(static column => column.PrimaryKeyOrdinal > 0)
+            .OrderBy(static column => column.PrimaryKeyOrdinal)
+            .Select(static column => column.Name)
+            .ToArray();
+
+        if (actualPrimaryKey.SequenceEqual(expectedPrimaryKey, StringComparer.OrdinalIgnoreCase))
+            return;
+
+        var legacyTableName = $"{tableName}__legacy_tenant_bootstrap";
+        ExecuteNonQuery(connection, transaction, $"DROP TABLE IF EXISTS {legacyTableName};");
+        ExecuteNonQuery(connection, transaction, $"ALTER TABLE {tableName} RENAME TO {legacyTableName};");
+        ExecuteNonQuery(connection, transaction, createSql);
+
+        var legacyColumns = ReadColumns(connection, transaction, legacyTableName)
+            .Select(static column => column.Name)
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+        var selectExpressions = columns
+            .Select(column => legacyColumns.Contains(column) ? column : "'default'")
+            .ToArray();
+
+        ExecuteNonQuery(
+            connection,
+            transaction,
+            $"""
+            INSERT INTO {tableName} ({string.Join(", ", columns)})
+            SELECT {string.Join(", ", selectExpressions)}
+            FROM {legacyTableName};
+            """);
+        ExecuteNonQuery(connection, transaction, $"DROP TABLE {legacyTableName};");
+    }
+
+    private static List<ColumnInfo> ReadColumns(
+        SqliteConnection connection,
+        SqliteTransaction transaction,
+        string tableName)
     {
         using var tableInfo = connection.CreateCommand();
+        tableInfo.Transaction = transaction;
         tableInfo.CommandText = $"PRAGMA table_info({tableName});";
 
         using var reader = tableInfo.ExecuteReader();
+        var columns = new List<ColumnInfo>();
         while (reader.Read())
-        {
-            if (string.Equals(reader.GetString(1), "tenant_id", StringComparison.OrdinalIgnoreCase))
-                return;
-        }
+            columns.Add(new ColumnInfo(reader.GetString(1), reader.GetInt32(5)));
 
-        using var alter = connection.CreateCommand();
-        alter.CommandText = $"ALTER TABLE {tableName} ADD COLUMN tenant_id TEXT NOT NULL DEFAULT 'default';";
-        alter.ExecuteNonQuery();
+        return columns;
     }
+
+    private static void ExecuteNonQuery(
+        SqliteConnection connection,
+        SqliteTransaction transaction,
+        string commandText)
+    {
+        using var command = connection.CreateCommand();
+        command.Transaction = transaction;
+        command.CommandText = commandText;
+        command.ExecuteNonQuery();
+    }
+
+    private sealed record ColumnInfo(string Name, int PrimaryKeyOrdinal);
 }

--- a/src/persistence/Aster.Persistence.SqliteJson/SqliteJsonSchema.cs
+++ b/src/persistence/Aster.Persistence.SqliteJson/SqliteJsonSchema.cs
@@ -14,14 +14,16 @@ internal static class SqliteJsonSchema
             PRAGMA journal_mode = WAL;
 
             CREATE TABLE IF NOT EXISTS resource_definitions (
+                tenant_id TEXT NOT NULL DEFAULT 'default',
                 definition_id TEXT NOT NULL,
                 version INTEGER NOT NULL,
                 id TEXT NOT NULL,
                 payload TEXT NOT NULL,
-                PRIMARY KEY (definition_id, version)
+                PRIMARY KEY (tenant_id, definition_id, version)
             );
 
             CREATE TABLE IF NOT EXISTS resource_versions (
+                tenant_id TEXT NOT NULL DEFAULT 'default',
                 resource_id TEXT NOT NULL,
                 version INTEGER NOT NULL,
                 id TEXT NOT NULL,
@@ -31,20 +33,46 @@ internal static class SqliteJsonSchema
                 owner TEXT NULL,
                 hash TEXT NULL,
                 payload TEXT NOT NULL,
-                PRIMARY KEY (resource_id, version)
+                PRIMARY KEY (tenant_id, resource_id, version)
             );
 
-            CREATE INDEX IF NOT EXISTS ix_resource_versions_definition_id
-                ON resource_versions (definition_id);
-
             CREATE TABLE IF NOT EXISTS activation_states (
+                tenant_id TEXT NOT NULL DEFAULT 'default',
                 resource_id TEXT NOT NULL,
                 channel TEXT NOT NULL,
                 payload TEXT NOT NULL,
-                PRIMARY KEY (resource_id, channel)
+                PRIMARY KEY (tenant_id, resource_id, channel)
             );
             """;
 
         command.ExecuteNonQuery();
+
+        AddTenantColumnIfMissing(connection, "resource_definitions");
+        AddTenantColumnIfMissing(connection, "resource_versions");
+        AddTenantColumnIfMissing(connection, "activation_states");
+
+        using var index = connection.CreateCommand();
+        index.CommandText = """
+            CREATE INDEX IF NOT EXISTS ix_resource_versions_definition_id
+                ON resource_versions (tenant_id, definition_id);
+            """;
+        index.ExecuteNonQuery();
+    }
+
+    private static void AddTenantColumnIfMissing(SqliteConnection connection, string tableName)
+    {
+        using var tableInfo = connection.CreateCommand();
+        tableInfo.CommandText = $"PRAGMA table_info({tableName});";
+
+        using var reader = tableInfo.ExecuteReader();
+        while (reader.Read())
+        {
+            if (string.Equals(reader.GetString(1), "tenant_id", StringComparison.OrdinalIgnoreCase))
+                return;
+        }
+
+        using var alter = connection.CreateCommand();
+        alter.CommandText = $"ALTER TABLE {tableName} ADD COLUMN tenant_id TEXT NOT NULL DEFAULT 'default';";
+        alter.ExecuteNonQuery();
     }
 }

--- a/src/persistence/Aster.Persistence.SqliteJson/SqliteJsonSchema.cs
+++ b/src/persistence/Aster.Persistence.SqliteJson/SqliteJsonSchema.cs
@@ -1,12 +1,15 @@
+using Aster.Core.Models.Tenancy;
 using Microsoft.Data.Sqlite;
 
 namespace Aster.Persistence.SqliteJson;
 
 internal static class SqliteJsonSchema
 {
-    private const string CreateResourceDefinitionsSql = """
+    private const string DefaultTenantSqlLiteral = $"'{TenantScope.DefaultTenantId}'";
+
+    private static readonly string CreateResourceDefinitionsSql = $$"""
         CREATE TABLE IF NOT EXISTS resource_definitions (
-            tenant_id TEXT NOT NULL DEFAULT 'default',
+            tenant_id TEXT NOT NULL DEFAULT {{DefaultTenantSqlLiteral}},
             definition_id TEXT NOT NULL,
             version INTEGER NOT NULL,
             id TEXT NOT NULL,
@@ -15,9 +18,9 @@ internal static class SqliteJsonSchema
         );
         """;
 
-    private const string CreateResourceVersionsSql = """
+    private static readonly string CreateResourceVersionsSql = $$"""
         CREATE TABLE IF NOT EXISTS resource_versions (
-            tenant_id TEXT NOT NULL DEFAULT 'default',
+            tenant_id TEXT NOT NULL DEFAULT {{DefaultTenantSqlLiteral}},
             resource_id TEXT NOT NULL,
             version INTEGER NOT NULL,
             id TEXT NOT NULL,
@@ -31,9 +34,9 @@ internal static class SqliteJsonSchema
         );
         """;
 
-    private const string CreateActivationStatesSql = """
+    private static readonly string CreateActivationStatesSql = $$"""
         CREATE TABLE IF NOT EXISTS activation_states (
-            tenant_id TEXT NOT NULL DEFAULT 'default',
+            tenant_id TEXT NOT NULL DEFAULT {{DefaultTenantSqlLiteral}},
             resource_id TEXT NOT NULL,
             channel TEXT NOT NULL,
             payload TEXT NOT NULL,
@@ -116,7 +119,7 @@ internal static class SqliteJsonSchema
             .Select(static column => column.Name)
             .ToHashSet(StringComparer.OrdinalIgnoreCase);
         var selectExpressions = columns
-            .Select(column => legacyColumns.Contains(column) ? column : "'default'")
+            .Select(column => legacyColumns.Contains(column) ? column : DefaultTenantSqlLiteral)
             .ToArray();
 
         ExecuteNonQuery(

--- a/test/Aster.Tests/InMemory/InMemoryResourceManagerTests.cs
+++ b/test/Aster.Tests/InMemory/InMemoryResourceManagerTests.cs
@@ -2,6 +2,7 @@ using Aster.Core.Abstractions;
 using Aster.Core.Definitions;
 using Aster.Core.Exceptions;
 using Aster.Core.InMemory;
+using Aster.Core.Models.Tenancy;
 using Microsoft.Extensions.Logging.Abstractions;
 using NSubstitute;
 
@@ -84,7 +85,7 @@ public sealed class InMemoryResourceManagerTests
         definition = definition with { Version = 1 };
 
         var defStore = Substitute.For<IResourceDefinitionStore>();
-        defStore.GetDefinitionAsync("Config").Returns(definition);
+        defStore.GetDefinitionAsync("Config", Arg.Any<TenantScope>(), Arg.Any<CancellationToken>()).Returns(definition);
 
         var (manager, _) = CreateManager(defStore);
 
@@ -94,6 +95,29 @@ public sealed class InMemoryResourceManagerTests
         // Act & Assert — second instance must throw
         await Assert.ThrowsAsync<SingletonViolationException>(() =>
             manager.CreateAsync("Config", new CreateResourceRequest()).AsTask());
+    }
+
+    [Fact]
+    public async Task CreateAsync_SingletonViolation_DoesNotReserveFailedResourceId()
+    {
+        // Arrange
+        var definition = new ResourceDefinitionBuilder()
+            .WithDefinitionId("Config")
+            .WithSingleton()
+            .Build() with { Version = 1 };
+
+        var defStore = Substitute.For<IResourceDefinitionStore>();
+        defStore.GetDefinitionAsync("Config", Arg.Any<TenantScope>(), Arg.Any<CancellationToken>()).Returns(definition);
+
+        var (manager, _) = CreateManager(defStore);
+        await manager.CreateAsync("Config", new CreateResourceRequest { ResourceId = "config-1" });
+
+        await Assert.ThrowsAsync<SingletonViolationException>(() =>
+            manager.CreateAsync("Config", new CreateResourceRequest { ResourceId = "config-2" }).AsTask());
+
+        // Act & Assert
+        await Assert.ThrowsAsync<SingletonViolationException>(() =>
+            manager.CreateAsync("Config", new CreateResourceRequest { ResourceId = "config-2" }).AsTask());
     }
 
     // ──────────────────────────────────────────────────────────────────────────

--- a/test/Aster.Tests/Lifecycle/TenantLifecycleHookTests.cs
+++ b/test/Aster.Tests/Lifecycle/TenantLifecycleHookTests.cs
@@ -1,0 +1,50 @@
+using Aster.Core.Abstractions;
+using Aster.Core.Extensions;
+using Aster.Core.Models.Lifecycle;
+using Aster.Tests.Tenancy;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Aster.Tests.Lifecycle;
+
+public sealed class TenantLifecycleHookTests : IAsyncDisposable
+{
+    private readonly ServiceProvider provider;
+    private readonly TenantLifecycleRecorder recorder;
+
+    public TenantLifecycleHookTests()
+    {
+        provider = new ServiceCollection()
+            .AddAsterCore()
+            .AddSingleton<TenantLifecycleRecorder>()
+            .AddResourceLifecycleHook<TenantRecordingHook>()
+            .BuildServiceProvider();
+        recorder = provider.GetRequiredService<TenantLifecycleRecorder>();
+    }
+
+    public async ValueTask DisposeAsync() => await provider.DisposeAsync();
+
+    [Fact]
+    public async Task LifecycleHookContexts_CarryOperationTenantScope()
+    {
+        await TenantScopeTestFixtures.RegisterProductDefinitionAsync(provider, TenantScopeTestFixtures.TenantA);
+        await TenantScopeTestFixtures.CreateProductAsync(provider, "tenant-product", "Tenant A", TenantScopeTestFixtures.TenantA);
+
+        Assert.Contains(recorder.TenantIds, id => id == TenantScopeTestFixtures.TenantA.TenantId);
+    }
+
+    private sealed class TenantLifecycleRecorder
+    {
+        public List<string> TenantIds { get; } = [];
+    }
+
+    private sealed class TenantRecordingHook(TenantLifecycleRecorder recorder) : ResourceLifecycleHook
+    {
+        public override ValueTask<LifecycleHookOutcome> OnBeforeSaveAsync(
+            ResourceSaveLifecycleContext context,
+            CancellationToken cancellationToken = default)
+        {
+            recorder.TenantIds.Add(context.TenantScope.TenantId);
+            return ValueTask.FromResult(LifecycleHookOutcome.Continue());
+        }
+    }
+}

--- a/test/Aster.Tests/Portability/PortabilityValidationTests.cs
+++ b/test/Aster.Tests/Portability/PortabilityValidationTests.cs
@@ -123,4 +123,34 @@ public sealed class PortabilityValidationTests
         Assert.Equal(PortableDiagnosticCodes.InvalidTenantScope, diagnostic.Code);
         Assert.Equal("sourceTenantScope", diagnostic.Path);
     }
+
+    [Fact]
+    public async Task ValidateAsync_InvalidEntityTenantScope_DoesNotAddMismatchDiagnostic()
+    {
+        await using var provider = new ServiceCollection()
+            .AddAsterCore()
+            .BuildServiceProvider();
+        var portability = provider.GetRequiredService<IResourcePortabilityService>();
+
+        var result = await portability.ValidateAsync(new PortableSnapshot
+        {
+            FormatVersion = PortableSnapshot.CurrentFormatVersion,
+            SourceTenantScope = TenantScope.FromTenantId("tenant-a"),
+            Definitions =
+            [
+                new ResourceDefinition
+                {
+                    TenantScope = new TenantScope { TenantId = " " },
+                    DefinitionId = "Product",
+                    Id = "product-definition-v1",
+                    Version = 1,
+                },
+            ],
+        });
+
+        Assert.False(result.IsValid);
+        var diagnostic = Assert.Single(result.Diagnostics);
+        Assert.Equal(PortableDiagnosticCodes.InvalidTenantScope, diagnostic.Code);
+        Assert.Equal("definitions/0/tenantScope", diagnostic.Path);
+    }
 }

--- a/test/Aster.Tests/Portability/PortabilityValidationTests.cs
+++ b/test/Aster.Tests/Portability/PortabilityValidationTests.cs
@@ -3,6 +3,7 @@ using Aster.Core.Extensions;
 using Aster.Core.Models.Definitions;
 using Aster.Core.Models.Instances;
 using Aster.Core.Models.Portability;
+using Aster.Core.Models.Tenancy;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Aster.Tests.Portability;
@@ -101,5 +102,25 @@ public sealed class PortabilityValidationTests
         var diagnostic = Assert.Single(result.Diagnostics);
         Assert.Equal(PortableDiagnosticCodes.MalformedSnapshot, diagnostic.Code);
         Assert.Equal("resources/0/resourceId", diagnostic.Path);
+    }
+
+    [Fact]
+    public async Task PreviewImportAsync_InvalidSourceTenantScope_ReturnsSingleSourceTenantDiagnostic()
+    {
+        await using var provider = new ServiceCollection()
+            .AddAsterCore()
+            .BuildServiceProvider();
+        var portability = provider.GetRequiredService<IResourcePortabilityService>();
+
+        var result = await portability.PreviewImportAsync(new PortableSnapshot
+        {
+            FormatVersion = PortableSnapshot.CurrentFormatVersion,
+            SourceTenantScope = new TenantScope { TenantId = " " },
+        });
+
+        Assert.False(result.CanImport);
+        var diagnostic = Assert.Single(result.Diagnostics);
+        Assert.Equal(PortableDiagnosticCodes.InvalidTenantScope, diagnostic.Code);
+        Assert.Equal("sourceTenantScope", diagnostic.Path);
     }
 }

--- a/test/Aster.Tests/Portability/TenantPortabilityExportTests.cs
+++ b/test/Aster.Tests/Portability/TenantPortabilityExportTests.cs
@@ -32,4 +32,38 @@ public sealed class TenantPortabilityExportTests : IDisposable
         Assert.Equal(TenantScopeTestFixtures.TenantA, result.Snapshot.SourceTenantScope);
         Assert.All(result.Snapshot.Resources, resource => Assert.Equal(TenantScopeTestFixtures.TenantA, resource.TenantScope));
     }
+
+    [Fact]
+    public async Task ExportAsync_ReadFailureRetainsSourceTenantScope()
+    {
+        var portability = new Aster.Core.Services.ResourcePortabilityService(new ThrowingReadPortabilityStore());
+
+        var result = await portability.ExportAsync(new PortableSnapshotExportRequest
+        {
+            TenantScope = TenantScopeTestFixtures.TenantA,
+            ScopeMode = PortableExportScopeMode.SelectedResources,
+            ResourceIds = ["product-1"],
+        });
+
+        Assert.Equal(TenantScopeTestFixtures.TenantA, result.SourceTenantScope);
+        Assert.Contains(result.Diagnostics, static diagnostic => diagnostic.Code == PortableDiagnosticCodes.ExportReadFailed);
+    }
+
+    private sealed class ThrowingReadPortabilityStore : IResourcePortabilityStore
+    {
+        public ValueTask<PortableStoreSnapshot> ReadSnapshotAsync(
+            PortableStoreReadRequest request,
+            CancellationToken cancellationToken = default) =>
+            throw new InvalidOperationException("read failed");
+
+        public ValueTask<PortableTargetState> ReadTargetStateAsync(
+            PortableSnapshot snapshot,
+            CancellationToken cancellationToken = default) =>
+            ValueTask.FromResult(new PortableTargetState());
+
+        public ValueTask ApplyImportAsync(
+            PortableSnapshot plannedSnapshot,
+            CancellationToken cancellationToken = default) =>
+            ValueTask.CompletedTask;
+    }
 }

--- a/test/Aster.Tests/Portability/TenantPortabilityExportTests.cs
+++ b/test/Aster.Tests/Portability/TenantPortabilityExportTests.cs
@@ -1,0 +1,35 @@
+using Aster.Core.Abstractions;
+using Aster.Core.Models.Portability;
+using Aster.Tests.Tenancy;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Aster.Tests.Portability;
+
+public sealed class TenantPortabilityExportTests : IDisposable
+{
+    private readonly ServiceProvider provider = TenantScopeTestFixtures.CreateCoreProvider();
+
+    public void Dispose() => provider.Dispose();
+
+    [Fact]
+    public async Task ExportAsync_ExportsOnlyRequestedTenant()
+    {
+        await TenantScopeTestFixtures.RegisterProductDefinitionAsync(provider, TenantScopeTestFixtures.TenantA);
+        await TenantScopeTestFixtures.RegisterProductDefinitionAsync(provider, TenantScopeTestFixtures.TenantB);
+        await TenantScopeTestFixtures.CreateProductAsync(provider, "shared-product", "Tenant A", TenantScopeTestFixtures.TenantA);
+        await TenantScopeTestFixtures.CreateProductAsync(provider, "shared-product", "Tenant B", TenantScopeTestFixtures.TenantB);
+
+        var portability = provider.GetRequiredService<IResourcePortabilityService>();
+        var result = await portability.ExportAsync(new PortableSnapshotExportRequest
+        {
+            TenantScope = TenantScopeTestFixtures.TenantA,
+            ScopeMode = PortableExportScopeMode.SelectedResources,
+            ResourceIds = ["shared-product"],
+        });
+
+        Assert.NotNull(result.Snapshot);
+        Assert.Equal(TenantScopeTestFixtures.TenantA, result.SourceTenantScope);
+        Assert.Equal(TenantScopeTestFixtures.TenantA, result.Snapshot.SourceTenantScope);
+        Assert.All(result.Snapshot.Resources, resource => Assert.Equal(TenantScopeTestFixtures.TenantA, resource.TenantScope));
+    }
+}

--- a/test/Aster.Tests/Portability/TenantPortabilityImportTests.cs
+++ b/test/Aster.Tests/Portability/TenantPortabilityImportTests.cs
@@ -1,0 +1,59 @@
+using Aster.Core.Abstractions;
+using Aster.Core.Definitions;
+using Aster.Core.Models.Portability;
+using Aster.Tests.Tenancy;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Aster.Tests.Portability;
+
+public sealed class TenantPortabilityImportTests : IDisposable
+{
+    private readonly ServiceProvider provider = TenantScopeTestFixtures.CreateCoreProvider();
+
+    public void Dispose() => provider.Dispose();
+
+    [Fact]
+    public async Task ImportAsync_WritesSnapshotIntoExplicitTargetTenant()
+    {
+        var portability = provider.GetRequiredService<IResourcePortabilityService>();
+        var reader = provider.GetRequiredService<IResourceVersionReader>();
+        var snapshot = CreateSnapshot();
+
+        var result = await portability.ImportAsync(snapshot, new PortableImportOptions
+        {
+            TargetTenantScope = TenantScopeTestFixtures.TenantB,
+        });
+
+        var targetResources = (await reader.ReadVersionsAsync(new ResourceVersionReadRequest
+        {
+            TenantScope = TenantScopeTestFixtures.TenantB,
+        })).ToList();
+        var sourceResources = (await reader.ReadVersionsAsync(new ResourceVersionReadRequest
+        {
+            TenantScope = TenantScopeTestFixtures.TenantA,
+        })).ToList();
+
+        Assert.Equal(PortableImportStatus.Imported, result.Status);
+        Assert.Equal(TenantScopeTestFixtures.TenantA, result.SourceTenantScope);
+        Assert.Equal(TenantScopeTestFixtures.TenantB, result.TargetTenantScope);
+        Assert.Single(targetResources);
+        Assert.Empty(sourceResources);
+    }
+
+    private static PortableSnapshot CreateSnapshot() =>
+        new()
+        {
+            FormatVersion = PortableSnapshot.CurrentFormatVersion,
+            SourceTenantScope = TenantScopeTestFixtures.TenantA,
+            Definitions =
+            [
+                new ResourceDefinitionBuilder()
+                    .WithDefinitionId("Product")
+                    .Build() with { Version = 1, TenantScope = TenantScopeTestFixtures.TenantA },
+            ],
+            Resources =
+            [
+                TenantScopeTestFixtures.CreateResource("imported-product", "Imported", TenantScopeTestFixtures.TenantA),
+            ],
+        };
+}

--- a/test/Aster.Tests/Querying/TenantQueryValidatorTests.cs
+++ b/test/Aster.Tests/Querying/TenantQueryValidatorTests.cs
@@ -1,0 +1,24 @@
+using Aster.Core.InMemory;
+using Aster.Core.Models.Querying;
+using Aster.Core.Models.Tenancy;
+using Aster.Core.Services;
+
+namespace Aster.Tests.Querying;
+
+public sealed class TenantQueryValidatorTests
+{
+    private readonly ResourceQueryValidator validator = new([new InMemoryQueryCapabilitiesProvider()]);
+
+    [Fact]
+    public void Validate_BlankTenantScope_ReturnsTenantScopeFailureBeforeProviderTraversal()
+    {
+        var result = validator.Validate(new ResourceQuery
+        {
+            TenantScope = new TenantScope { TenantId = " " },
+        });
+
+        var failure = Assert.Single(result.Failures);
+        Assert.Equal("tenant-scope-invalid", failure.Code);
+        Assert.Equal("TenantScope", failure.Path);
+    }
+}

--- a/test/Aster.Tests/SchemaVersions/TenantSchemaVersionServiceTests.cs
+++ b/test/Aster.Tests/SchemaVersions/TenantSchemaVersionServiceTests.cs
@@ -1,0 +1,48 @@
+using Aster.Core.Abstractions;
+using Aster.Core.Definitions;
+using Aster.Core.Extensions;
+using Aster.Core.Models.Instances;
+using Aster.Tests.Tenancy;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Aster.Tests.SchemaVersions;
+
+public sealed class TenantSchemaVersionServiceTests : IDisposable
+{
+    private readonly ServiceProvider provider = TenantScopeTestFixtures.CreateCoreProvider();
+
+    public void Dispose() => provider.Dispose();
+
+    [Fact]
+    public async Task UpgradeAsync_ResolvesDefinitionLineageWithinTenant()
+    {
+        var definitions = provider.GetRequiredService<IResourceDefinitionStore>();
+        var manager = provider.GetRequiredService<IResourceManager>();
+        var schemaVersions = provider.GetRequiredService<IResourceSchemaVersionService>();
+
+        await RegisterDefinitionAsync(definitions, TenantScopeTestFixtures.TenantA);
+        var tenantAResource = await TenantScopeTestFixtures.CreateProductAsync(provider, "shared-product", "Tenant A", TenantScopeTestFixtures.TenantA);
+        await RegisterDefinitionAsync(definitions, TenantScopeTestFixtures.TenantA);
+        await RegisterDefinitionAsync(definitions, TenantScopeTestFixtures.TenantB);
+        await TenantScopeTestFixtures.CreateProductAsync(provider, "shared-product", "Tenant B", TenantScopeTestFixtures.TenantB);
+
+        var result = await schemaVersions.UpgradeAsync("shared-product", new ResourceSchemaUpgradeRequest
+        {
+            TenantScope = TenantScopeTestFixtures.TenantA,
+            BaseVersion = tenantAResource.Version,
+        });
+
+        var tenantBLatest = await manager.GetLatestVersionAsync("shared-product", TenantScopeTestFixtures.TenantB);
+        Assert.Equal(ResourceSchemaUpgradeStatus.Upgraded, result.Status);
+        Assert.Equal(2, result.Resource!.DefinitionVersion);
+        Assert.Equal(TenantScopeTestFixtures.TenantA, result.Resource.TenantScope);
+        Assert.Equal(1, tenantBLatest!.DefinitionVersion);
+    }
+
+    private static async Task RegisterDefinitionAsync(IResourceDefinitionStore store, Aster.Core.Models.Tenancy.TenantScope tenantScope)
+    {
+        await store.RegisterDefinitionAsync(new ResourceDefinitionBuilder()
+            .WithDefinitionId("Product")
+            .Build(), tenantScope);
+    }
+}

--- a/test/Aster.Tests/SchemaVersions/TenantSchemaVersionServiceTests.cs
+++ b/test/Aster.Tests/SchemaVersions/TenantSchemaVersionServiceTests.cs
@@ -32,7 +32,7 @@ public sealed class TenantSchemaVersionServiceTests : IDisposable
             BaseVersion = tenantAResource.Version,
         });
 
-        var tenantBLatest = await manager.GetLatestVersionAsync("shared-product", TenantScopeTestFixtures.TenantB);
+        var tenantBLatest = await manager.GetLatestVersionAsync("shared-product", TenantScopeTestFixtures.TenantB, CancellationToken.None);
         Assert.Equal(ResourceSchemaUpgradeStatus.Upgraded, result.Status);
         Assert.Equal(2, result.Resource!.DefinitionVersion);
         Assert.Equal(TenantScopeTestFixtures.TenantA, result.Resource.TenantScope);
@@ -43,6 +43,6 @@ public sealed class TenantSchemaVersionServiceTests : IDisposable
     {
         await store.RegisterDefinitionAsync(new ResourceDefinitionBuilder()
             .WithDefinitionId("Product")
-            .Build(), tenantScope);
+            .Build(), tenantScope, CancellationToken.None);
     }
 }

--- a/test/Aster.Tests/SqliteJson/SqliteJsonTenantPortabilityStoreTests.cs
+++ b/test/Aster.Tests/SqliteJson/SqliteJsonTenantPortabilityStoreTests.cs
@@ -1,0 +1,47 @@
+using Aster.Core.Abstractions;
+using Aster.Core.Models.Portability;
+using Aster.Tests.Tenancy;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Aster.Tests.SqliteJson;
+
+public sealed class SqliteJsonTenantPortabilityStoreTests : IDisposable
+{
+    private readonly string databasePath =
+        Path.Combine(Path.GetTempPath(), $"aster-tenant-portability-{Guid.NewGuid():N}.db");
+
+    public void Dispose()
+    {
+        TryDelete(databasePath);
+        TryDelete($"{databasePath}-shm");
+        TryDelete($"{databasePath}-wal");
+    }
+
+    [Fact]
+    public async Task ExportAsync_UsesTenantScopedSqliteStoreReads()
+    {
+        await using var provider = TenantScopeTestFixtures.CreateSqliteProvider(databasePath);
+        await TenantScopeTestFixtures.RegisterProductDefinitionAsync(provider, TenantScopeTestFixtures.TenantA);
+        await TenantScopeTestFixtures.RegisterProductDefinitionAsync(provider, TenantScopeTestFixtures.TenantB);
+        await TenantScopeTestFixtures.CreateProductAsync(provider, "shared-product", "Tenant A", TenantScopeTestFixtures.TenantA);
+        await TenantScopeTestFixtures.CreateProductAsync(provider, "shared-product", "Tenant B", TenantScopeTestFixtures.TenantB);
+
+        var portability = provider.GetRequiredService<IResourcePortabilityService>();
+        var result = await portability.ExportAsync(new PortableSnapshotExportRequest
+        {
+            TenantScope = TenantScopeTestFixtures.TenantB,
+            ScopeMode = PortableExportScopeMode.SelectedResources,
+            ResourceIds = ["shared-product"],
+        });
+
+        Assert.NotNull(result.Snapshot);
+        var resource = Assert.Single(result.Snapshot.Resources);
+        Assert.Equal(TenantScopeTestFixtures.TenantB, resource.TenantScope);
+    }
+
+    private static void TryDelete(string path)
+    {
+        if (File.Exists(path))
+            File.Delete(path);
+    }
+}

--- a/test/Aster.Tests/SqliteJson/SqliteJsonTenantPortabilityStoreTests.cs
+++ b/test/Aster.Tests/SqliteJson/SqliteJsonTenantPortabilityStoreTests.cs
@@ -41,7 +41,11 @@ public sealed class SqliteJsonTenantPortabilityStoreTests : IDisposable
 
     private static void TryDelete(string path)
     {
-        if (File.Exists(path))
+        try
+        {
             File.Delete(path);
+        }
+        catch (IOException) { }
+        catch (UnauthorizedAccessException) { }
     }
 }

--- a/test/Aster.Tests/SqliteJson/SqliteJsonTenantQueryServiceTests.cs
+++ b/test/Aster.Tests/SqliteJson/SqliteJsonTenantQueryServiceTests.cs
@@ -1,0 +1,65 @@
+using Aster.Core.Abstractions;
+using Aster.Core.Models.Instances;
+using Aster.Core.Models.Querying;
+using Aster.Tests.Tenancy;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Aster.Tests.SqliteJson;
+
+public sealed class SqliteJsonTenantQueryServiceTests : IDisposable
+{
+    private readonly string databasePath =
+        Path.Combine(Path.GetTempPath(), $"aster-tenant-query-{Guid.NewGuid():N}.db");
+
+    public void Dispose()
+    {
+        TryDelete(databasePath);
+        TryDelete($"{databasePath}-shm");
+        TryDelete($"{databasePath}-wal");
+    }
+
+    [Fact]
+    public async Task QueryAsync_FiltersLatestActiveAndDraftByTenant()
+    {
+        await using var provider = TenantScopeTestFixtures.CreateSqliteProvider(databasePath);
+        var writer = provider.GetRequiredService<IResourceVersionWriter>();
+        var query = provider.GetRequiredService<IResourceQueryService>();
+
+        await writer.SaveVersionAsync(TenantScopeTestFixtures.CreateResource("shared-product", "Tenant A", TenantScopeTestFixtures.TenantA));
+        await writer.SaveVersionAsync(TenantScopeTestFixtures.CreateResource("shared-product", "Tenant B v1", TenantScopeTestFixtures.TenantB));
+        await writer.SaveVersionAsync(TenantScopeTestFixtures.CreateResource("shared-product", "Tenant B v2", TenantScopeTestFixtures.TenantB, version: 2));
+        await writer.UpdateActivationAsync("shared-product", "Published", new ActivationState
+        {
+            TenantScope = TenantScopeTestFixtures.TenantB,
+            ResourceId = "shared-product",
+            Channel = "Published",
+            ActiveVersions = [2],
+            LastUpdated = DateTime.UtcNow,
+        });
+
+        var latest = (await query.QueryAsync(TenantScopeTestFixtures.ProductQuery(TenantScopeTestFixtures.TenantB))).ToList();
+        var active = (await query.QueryAsync(new ResourceQuery
+        {
+            TenantScope = TenantScopeTestFixtures.TenantB,
+            DefinitionId = "Product",
+            Scope = ResourceVersionScope.Active,
+            ActivationChannel = "Published",
+        })).ToList();
+        var draft = (await query.QueryAsync(new ResourceQuery
+        {
+            TenantScope = TenantScopeTestFixtures.TenantB,
+            DefinitionId = "Product",
+            Scope = ResourceVersionScope.Draft,
+        })).ToList();
+
+        Assert.Equal(2, latest.Single().Version);
+        Assert.Equal(2, active.Single().Version);
+        Assert.Equal(1, draft.Single().Version);
+    }
+
+    private static void TryDelete(string path)
+    {
+        if (File.Exists(path))
+            File.Delete(path);
+    }
+}

--- a/test/Aster.Tests/SqliteJson/SqliteJsonTenantQueryServiceTests.cs
+++ b/test/Aster.Tests/SqliteJson/SqliteJsonTenantQueryServiceTests.cs
@@ -59,7 +59,11 @@ public sealed class SqliteJsonTenantQueryServiceTests : IDisposable
 
     private static void TryDelete(string path)
     {
-        if (File.Exists(path))
+        try
+        {
             File.Delete(path);
+        }
+        catch (IOException) { }
+        catch (UnauthorizedAccessException) { }
     }
 }

--- a/test/Aster.Tests/SqliteJson/SqliteJsonTenantScopeTests.cs
+++ b/test/Aster.Tests/SqliteJson/SqliteJsonTenantScopeTests.cs
@@ -63,6 +63,35 @@ public sealed class SqliteJsonTenantScopeTests : IDisposable
     }
 
     [Fact]
+    public async Task UpdateActivationAsync_NormalizesPersistedPayloadIdentityToMethodArguments()
+    {
+        await using var provider = TenantScopeTestFixtures.CreateSqliteProvider(databasePath);
+        var writer = provider.GetRequiredService<IResourceVersionWriter>();
+        var reader = provider.GetRequiredService<IResourceVersionReader>();
+        await writer.SaveVersionAsync(TenantScopeTestFixtures.CreateResource("product-1", "Tenant A", TenantScopeTestFixtures.TenantA));
+
+        var state = await writer.UpdateActivationAsync("product-1", "Published", new ActivationState
+        {
+            TenantScope = TenantScopeTestFixtures.TenantA,
+            ResourceId = "wrong-product",
+            Channel = "Wrong",
+            ActiveVersions = [1],
+            LastUpdated = DateTime.UtcNow,
+        });
+
+        var active = (await reader.ReadVersionsAsync(new ResourceVersionReadRequest
+        {
+            TenantScope = TenantScopeTestFixtures.TenantA,
+            Scope = ResourceVersionScope.Active,
+            ActivationChannel = "Published",
+        })).ToList();
+
+        Assert.Equal("product-1", state.ResourceId);
+        Assert.Equal("Published", state.Channel);
+        Assert.Equal("product-1", active.Single().ResourceId);
+    }
+
+    [Fact]
     public async Task ExistingPreTenantTables_ReadBackAsDefaultTenant()
     {
         var resource = TenantScopeTestFixtures.CreateResource("legacy-product", "Legacy");

--- a/test/Aster.Tests/SqliteJson/SqliteJsonTenantScopeTests.cs
+++ b/test/Aster.Tests/SqliteJson/SqliteJsonTenantScopeTests.cs
@@ -1,0 +1,130 @@
+using System.Text.Json;
+using Aster.Core.Abstractions;
+using Aster.Core.Definitions;
+using Aster.Core.Models.Querying;
+using Aster.Tests.Tenancy;
+using Microsoft.Data.Sqlite;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Aster.Tests.SqliteJson;
+
+public sealed class SqliteJsonTenantScopeTests : IDisposable
+{
+    private readonly string databasePath =
+        Path.Combine(Path.GetTempPath(), $"aster-tenant-scope-{Guid.NewGuid():N}.db");
+
+    public void Dispose()
+    {
+        TryDelete(databasePath);
+        TryDelete($"{databasePath}-shm");
+        TryDelete($"{databasePath}-wal");
+    }
+
+    [Fact]
+    public async Task Store_AllowsSameDefinitionAndResourceIdsAcrossTenants()
+    {
+        await using var provider = TenantScopeTestFixtures.CreateSqliteProvider(databasePath);
+        var definitions = provider.GetRequiredService<IResourceDefinitionStore>();
+        var writer = provider.GetRequiredService<IResourceVersionWriter>();
+        var reader = provider.GetRequiredService<IResourceVersionReader>();
+
+        await definitions.RegisterDefinitionAsync(CreateDefinition(), TenantScopeTestFixtures.TenantA);
+        await definitions.RegisterDefinitionAsync(CreateDefinition(), TenantScopeTestFixtures.TenantB);
+        await writer.SaveVersionAsync(TenantScopeTestFixtures.CreateResource("shared-product", "Tenant A", TenantScopeTestFixtures.TenantA));
+        await writer.SaveVersionAsync(TenantScopeTestFixtures.CreateResource("shared-product", "Tenant B", TenantScopeTestFixtures.TenantB));
+
+        var tenantAResources = (await reader.ReadVersionsAsync(new ResourceVersionReadRequest
+        {
+            TenantScope = TenantScopeTestFixtures.TenantA,
+        })).ToList();
+        var tenantBResources = (await reader.ReadVersionsAsync(new ResourceVersionReadRequest
+        {
+            TenantScope = TenantScopeTestFixtures.TenantB,
+        })).ToList();
+
+        Assert.Equal(1, (await definitions.GetDefinitionAsync("Product", TenantScopeTestFixtures.TenantA))!.Version);
+        Assert.Equal(1, (await definitions.GetDefinitionAsync("Product", TenantScopeTestFixtures.TenantB))!.Version);
+        Assert.Equal(TenantScopeTestFixtures.TenantA, tenantAResources.Single().TenantScope);
+        Assert.Equal(TenantScopeTestFixtures.TenantB, tenantBResources.Single().TenantScope);
+    }
+
+    [Fact]
+    public async Task ExistingPreTenantTables_ReadBackAsDefaultTenant()
+    {
+        var resource = TenantScopeTestFixtures.CreateResource("legacy-product", "Legacy");
+        await CreateLegacyResourceVersionAsync(resource);
+
+        await using var provider = TenantScopeTestFixtures.CreateSqliteProvider(databasePath);
+        var reader = provider.GetRequiredService<IResourceVersionReader>();
+
+        var results = (await reader.ReadVersionsAsync(new ResourceVersionReadRequest())).ToList();
+
+        var result = Assert.Single(results);
+        Assert.Equal("legacy-product", result.ResourceId);
+        Assert.Equal("default", result.TenantScope.TenantId);
+    }
+
+    private async Task CreateLegacyResourceVersionAsync(Aster.Core.Models.Instances.Resource resource)
+    {
+        await using var connection = new SqliteConnection($"Data Source={databasePath}");
+        await connection.OpenAsync();
+        await using var command = connection.CreateCommand();
+        command.CommandText = """
+            CREATE TABLE resource_versions (
+                resource_id TEXT NOT NULL,
+                version INTEGER NOT NULL,
+                id TEXT NOT NULL,
+                definition_id TEXT NOT NULL,
+                definition_version INTEGER NULL,
+                created TEXT NOT NULL,
+                owner TEXT NULL,
+                hash TEXT NULL,
+                payload TEXT NOT NULL,
+                PRIMARY KEY (resource_id, version)
+            );
+
+            INSERT INTO resource_versions (
+                resource_id,
+                version,
+                id,
+                definition_id,
+                definition_version,
+                created,
+                owner,
+                hash,
+                payload
+            )
+            VALUES (
+                $resourceId,
+                $version,
+                $id,
+                $definitionId,
+                $definitionVersion,
+                $created,
+                $owner,
+                $hash,
+                $payload
+            );
+            """;
+        command.Parameters.AddWithValue("$resourceId", resource.ResourceId);
+        command.Parameters.AddWithValue("$version", resource.Version);
+        command.Parameters.AddWithValue("$id", resource.Id);
+        command.Parameters.AddWithValue("$definitionId", resource.DefinitionId);
+        command.Parameters.AddWithValue("$definitionVersion", resource.DefinitionVersion);
+        command.Parameters.AddWithValue("$created", resource.Created.ToUniversalTime().ToString("O"));
+        command.Parameters.AddWithValue("$owner", DBNull.Value);
+        command.Parameters.AddWithValue("$hash", DBNull.Value);
+        command.Parameters.AddWithValue("$payload", JsonSerializer.Serialize(resource, new JsonSerializerOptions(JsonSerializerDefaults.Web)));
+
+        await command.ExecuteNonQueryAsync();
+    }
+
+    private static Aster.Core.Models.Definitions.ResourceDefinition CreateDefinition() =>
+        new ResourceDefinitionBuilder().WithDefinitionId("Product").Build();
+
+    private static void TryDelete(string path)
+    {
+        if (File.Exists(path))
+            File.Delete(path);
+    }
+}

--- a/test/Aster.Tests/SqliteJson/SqliteJsonTenantScopeTests.cs
+++ b/test/Aster.Tests/SqliteJson/SqliteJsonTenantScopeTests.cs
@@ -29,8 +29,8 @@ public sealed class SqliteJsonTenantScopeTests : IDisposable
         var writer = provider.GetRequiredService<IResourceVersionWriter>();
         var reader = provider.GetRequiredService<IResourceVersionReader>();
 
-        await definitions.RegisterDefinitionAsync(CreateDefinition(), TenantScopeTestFixtures.TenantA);
-        await definitions.RegisterDefinitionAsync(CreateDefinition(), TenantScopeTestFixtures.TenantB);
+        await definitions.RegisterDefinitionAsync(CreateDefinition(), TenantScopeTestFixtures.TenantA, CancellationToken.None);
+        await definitions.RegisterDefinitionAsync(CreateDefinition(), TenantScopeTestFixtures.TenantB, CancellationToken.None);
         await writer.SaveVersionAsync(TenantScopeTestFixtures.CreateResource("shared-product", "Tenant A", TenantScopeTestFixtures.TenantA));
         await writer.SaveVersionAsync(TenantScopeTestFixtures.CreateResource("shared-product", "Tenant B", TenantScopeTestFixtures.TenantB));
 
@@ -43,8 +43,8 @@ public sealed class SqliteJsonTenantScopeTests : IDisposable
             TenantScope = TenantScopeTestFixtures.TenantB,
         })).ToList();
 
-        Assert.Equal(1, (await definitions.GetDefinitionAsync("Product", TenantScopeTestFixtures.TenantA))!.Version);
-        Assert.Equal(1, (await definitions.GetDefinitionAsync("Product", TenantScopeTestFixtures.TenantB))!.Version);
+        Assert.Equal(1, (await definitions.GetDefinitionAsync("Product", TenantScopeTestFixtures.TenantA, CancellationToken.None))!.Version);
+        Assert.Equal(1, (await definitions.GetDefinitionAsync("Product", TenantScopeTestFixtures.TenantB, CancellationToken.None))!.Version);
         Assert.Equal(TenantScopeTestFixtures.TenantA, tenantAResources.Single().TenantScope);
         Assert.Equal(TenantScopeTestFixtures.TenantB, tenantBResources.Single().TenantScope);
     }
@@ -59,7 +59,7 @@ public sealed class SqliteJsonTenantScopeTests : IDisposable
         await definitions.RegisterDefinitionAsync(definition);
 
         Assert.NotNull(await definitions.GetDefinitionAsync("Product"));
-        Assert.Null(await definitions.GetDefinitionAsync("Product", TenantScopeTestFixtures.TenantA));
+        Assert.Null(await definitions.GetDefinitionAsync("Product", TenantScopeTestFixtures.TenantA, CancellationToken.None));
     }
 
     [Fact]

--- a/test/Aster.Tests/SqliteJson/SqliteJsonTenantScopeTests.cs
+++ b/test/Aster.Tests/SqliteJson/SqliteJsonTenantScopeTests.cs
@@ -50,6 +50,19 @@ public sealed class SqliteJsonTenantScopeTests : IDisposable
     }
 
     [Fact]
+    public async Task RegisterDefinitionAsync_WithoutTenantScope_AlwaysUsesDefaultTenant()
+    {
+        await using var provider = TenantScopeTestFixtures.CreateSqliteProvider(databasePath);
+        var definitions = provider.GetRequiredService<IResourceDefinitionStore>();
+        var definition = CreateDefinition() with { TenantScope = TenantScopeTestFixtures.TenantA };
+
+        await definitions.RegisterDefinitionAsync(definition);
+
+        Assert.NotNull(await definitions.GetDefinitionAsync("Product"));
+        Assert.Null(await definitions.GetDefinitionAsync("Product", TenantScopeTestFixtures.TenantA));
+    }
+
+    [Fact]
     public async Task ExistingPreTenantTables_ReadBackAsDefaultTenant()
     {
         var resource = TenantScopeTestFixtures.CreateResource("legacy-product", "Legacy");

--- a/test/Aster.Tests/SqliteJson/SqliteJsonTenantScopeTests.cs
+++ b/test/Aster.Tests/SqliteJson/SqliteJsonTenantScopeTests.cs
@@ -243,7 +243,11 @@ public sealed class SqliteJsonTenantScopeTests : IDisposable
 
     private static void TryDelete(string path)
     {
-        if (File.Exists(path))
+        try
+        {
             File.Delete(path);
+        }
+        catch (IOException) { }
+        catch (UnauthorizedAccessException) { }
     }
 }

--- a/test/Aster.Tests/SqliteJson/SqliteJsonTenantScopeTests.cs
+++ b/test/Aster.Tests/SqliteJson/SqliteJsonTenantScopeTests.cs
@@ -1,6 +1,7 @@
 using System.Text.Json;
 using Aster.Core.Abstractions;
 using Aster.Core.Definitions;
+using Aster.Core.Models.Instances;
 using Aster.Core.Models.Querying;
 using Aster.Tests.Tenancy;
 using Microsoft.Data.Sqlite;
@@ -64,25 +65,57 @@ public sealed class SqliteJsonTenantScopeTests : IDisposable
         Assert.Equal("default", result.TenantScope.TenantId);
     }
 
+    [Fact]
+    public async Task ExistingPreTenantTables_AreRebuiltForTenantAwareCollisionsAndUpserts()
+    {
+        await CreateLegacyTablesAsync();
+
+        await using var provider = TenantScopeTestFixtures.CreateSqliteProvider(databasePath);
+        var writer = provider.GetRequiredService<IResourceVersionWriter>();
+        var reader = provider.GetRequiredService<IResourceVersionReader>();
+
+        await writer.SaveVersionAsync(TenantScopeTestFixtures.CreateResource("shared-product", "Tenant A", TenantScopeTestFixtures.TenantA));
+        await writer.SaveVersionAsync(TenantScopeTestFixtures.CreateResource("shared-product", "Tenant B", TenantScopeTestFixtures.TenantB));
+        await writer.UpdateActivationAsync("shared-product", "Published", new ActivationState
+        {
+            TenantScope = TenantScopeTestFixtures.TenantA,
+            ResourceId = "shared-product",
+            Channel = "Published",
+            ActiveVersions = [1],
+            LastUpdated = DateTime.UtcNow,
+        });
+        await writer.UpdateActivationAsync("shared-product", "Published", new ActivationState
+        {
+            TenantScope = TenantScopeTestFixtures.TenantB,
+            ResourceId = "shared-product",
+            Channel = "Published",
+            ActiveVersions = [1],
+            LastUpdated = DateTime.UtcNow,
+        });
+
+        var tenantAActive = (await reader.ReadVersionsAsync(new ResourceVersionReadRequest
+        {
+            TenantScope = TenantScopeTestFixtures.TenantA,
+            Scope = ResourceVersionScope.Active,
+            ActivationChannel = "Published",
+        })).ToList();
+        var tenantBActive = (await reader.ReadVersionsAsync(new ResourceVersionReadRequest
+        {
+            TenantScope = TenantScopeTestFixtures.TenantB,
+            Scope = ResourceVersionScope.Active,
+            ActivationChannel = "Published",
+        })).ToList();
+
+        Assert.Single(tenantAActive);
+        Assert.Single(tenantBActive);
+    }
+
     private async Task CreateLegacyResourceVersionAsync(Aster.Core.Models.Instances.Resource resource)
     {
-        await using var connection = new SqliteConnection($"Data Source={databasePath}");
-        await connection.OpenAsync();
+        await CreateLegacyTablesAsync();
+        await using var connection = await OpenConnectionAsync();
         await using var command = connection.CreateCommand();
         command.CommandText = """
-            CREATE TABLE resource_versions (
-                resource_id TEXT NOT NULL,
-                version INTEGER NOT NULL,
-                id TEXT NOT NULL,
-                definition_id TEXT NOT NULL,
-                definition_version INTEGER NULL,
-                created TEXT NOT NULL,
-                owner TEXT NULL,
-                hash TEXT NULL,
-                payload TEXT NOT NULL,
-                PRIMARY KEY (resource_id, version)
-            );
-
             INSERT INTO resource_versions (
                 resource_id,
                 version,
@@ -117,6 +150,50 @@ public sealed class SqliteJsonTenantScopeTests : IDisposable
         command.Parameters.AddWithValue("$payload", JsonSerializer.Serialize(resource, new JsonSerializerOptions(JsonSerializerDefaults.Web)));
 
         await command.ExecuteNonQueryAsync();
+    }
+
+    private async Task CreateLegacyTablesAsync()
+    {
+        await using var connection = await OpenConnectionAsync();
+        await using var command = connection.CreateCommand();
+        command.CommandText = """
+            CREATE TABLE IF NOT EXISTS resource_definitions (
+                definition_id TEXT NOT NULL,
+                version INTEGER NOT NULL,
+                id TEXT NOT NULL,
+                payload TEXT NOT NULL,
+                PRIMARY KEY (definition_id, version)
+            );
+
+            CREATE TABLE IF NOT EXISTS resource_versions (
+                resource_id TEXT NOT NULL,
+                version INTEGER NOT NULL,
+                id TEXT NOT NULL,
+                definition_id TEXT NOT NULL,
+                definition_version INTEGER NULL,
+                created TEXT NOT NULL,
+                owner TEXT NULL,
+                hash TEXT NULL,
+                payload TEXT NOT NULL,
+                PRIMARY KEY (resource_id, version)
+            );
+
+            CREATE TABLE IF NOT EXISTS activation_states (
+                resource_id TEXT NOT NULL,
+                channel TEXT NOT NULL,
+                payload TEXT NOT NULL,
+                PRIMARY KEY (resource_id, channel)
+            );
+            """;
+
+        await command.ExecuteNonQueryAsync();
+    }
+
+    private async Task<SqliteConnection> OpenConnectionAsync()
+    {
+        var connection = new SqliteConnection($"Data Source={databasePath}");
+        await connection.OpenAsync();
+        return connection;
     }
 
     private static Aster.Core.Models.Definitions.ResourceDefinition CreateDefinition() =>

--- a/test/Aster.Tests/Tenancy/TenantActivationTests.cs
+++ b/test/Aster.Tests/Tenancy/TenantActivationTests.cs
@@ -1,4 +1,5 @@
 using Aster.Core.Abstractions;
+using Aster.Core.Models.Instances;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Aster.Tests.Tenancy;
@@ -32,5 +33,24 @@ public sealed class TenantActivationTests : IDisposable
 
         Assert.Equal(2, tenantAActive.Single().Version);
         Assert.Equal(1, tenantBActive.Single().Version);
+    }
+
+    [Fact]
+    public async Task UpdateActivationAsync_NormalizesPayloadIdentityToMethodArguments()
+    {
+        var writer = provider.GetRequiredService<IResourceVersionWriter>();
+
+        var state = await writer.UpdateActivationAsync("product-1", "Published", new ActivationState
+        {
+            TenantScope = TenantScopeTestFixtures.TenantA,
+            ResourceId = "wrong-product",
+            Channel = "Wrong",
+            ActiveVersions = [1],
+            LastUpdated = DateTime.UtcNow,
+        });
+
+        Assert.Equal(TenantScopeTestFixtures.TenantA, state.TenantScope);
+        Assert.Equal("product-1", state.ResourceId);
+        Assert.Equal("Published", state.Channel);
     }
 }

--- a/test/Aster.Tests/Tenancy/TenantActivationTests.cs
+++ b/test/Aster.Tests/Tenancy/TenantActivationTests.cs
@@ -1,0 +1,36 @@
+using Aster.Core.Abstractions;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Aster.Tests.Tenancy;
+
+public sealed class TenantActivationTests : IDisposable
+{
+    private readonly ServiceProvider provider = TenantScopeTestFixtures.CreateCoreProvider();
+    private readonly IResourceManager manager;
+
+    public TenantActivationTests()
+    {
+        manager = provider.GetRequiredService<IResourceManager>();
+    }
+
+    public void Dispose() => provider.Dispose();
+
+    [Fact]
+    public async Task ActivationState_IsScopedByTenant()
+    {
+        await TenantScopeTestFixtures.RegisterProductDefinitionAsync(provider, TenantScopeTestFixtures.TenantA);
+        await TenantScopeTestFixtures.RegisterProductDefinitionAsync(provider, TenantScopeTestFixtures.TenantB);
+        await TenantScopeTestFixtures.CreateProductAsync(provider, "shared-product", "Tenant A", TenantScopeTestFixtures.TenantA);
+        await TenantScopeTestFixtures.CreateProductAsync(provider, "shared-product", "Tenant B", TenantScopeTestFixtures.TenantB);
+        await manager.UpdateAsync("shared-product", new UpdateResourceRequest { TenantScope = TenantScopeTestFixtures.TenantA, BaseVersion = 1 });
+
+        await manager.ActivateAsync("shared-product", 2, "Published", TenantScopeTestFixtures.TenantA);
+        await manager.ActivateAsync("shared-product", 1, "Published", TenantScopeTestFixtures.TenantB);
+
+        var tenantAActive = (await manager.GetActiveVersionsAsync("shared-product", "Published", TenantScopeTestFixtures.TenantA)).ToList();
+        var tenantBActive = (await manager.GetActiveVersionsAsync("shared-product", "Published", TenantScopeTestFixtures.TenantB)).ToList();
+
+        Assert.Equal(2, tenantAActive.Single().Version);
+        Assert.Equal(1, tenantBActive.Single().Version);
+    }
+}

--- a/test/Aster.Tests/Tenancy/TenantActivationTests.cs
+++ b/test/Aster.Tests/Tenancy/TenantActivationTests.cs
@@ -25,8 +25,8 @@ public sealed class TenantActivationTests : IDisposable
         await TenantScopeTestFixtures.CreateProductAsync(provider, "shared-product", "Tenant B", TenantScopeTestFixtures.TenantB);
         await manager.UpdateAsync("shared-product", new UpdateResourceRequest { TenantScope = TenantScopeTestFixtures.TenantA, BaseVersion = 1 });
 
-        await manager.ActivateAsync("shared-product", 2, "Published", TenantScopeTestFixtures.TenantA, allowMultipleActive: false);
-        await manager.ActivateAsync("shared-product", 1, "Published", TenantScopeTestFixtures.TenantB, allowMultipleActive: false);
+        await manager.ActivateAsync("shared-product", 2, "Published", TenantScopeTestFixtures.TenantA, allowMultipleActive: false, CancellationToken.None);
+        await manager.ActivateAsync("shared-product", 1, "Published", TenantScopeTestFixtures.TenantB, allowMultipleActive: false, CancellationToken.None);
 
         var tenantAActive = (await manager.GetActiveVersionsAsync("shared-product", "Published", TenantScopeTestFixtures.TenantA, CancellationToken.None)).ToList();
         var tenantBActive = (await manager.GetActiveVersionsAsync("shared-product", "Published", TenantScopeTestFixtures.TenantB, CancellationToken.None)).ToList();

--- a/test/Aster.Tests/Tenancy/TenantActivationTests.cs
+++ b/test/Aster.Tests/Tenancy/TenantActivationTests.cs
@@ -24,11 +24,11 @@ public sealed class TenantActivationTests : IDisposable
         await TenantScopeTestFixtures.CreateProductAsync(provider, "shared-product", "Tenant B", TenantScopeTestFixtures.TenantB);
         await manager.UpdateAsync("shared-product", new UpdateResourceRequest { TenantScope = TenantScopeTestFixtures.TenantA, BaseVersion = 1 });
 
-        await manager.ActivateAsync("shared-product", 2, "Published", TenantScopeTestFixtures.TenantA);
-        await manager.ActivateAsync("shared-product", 1, "Published", TenantScopeTestFixtures.TenantB);
+        await manager.ActivateAsync("shared-product", 2, "Published", TenantScopeTestFixtures.TenantA, allowMultipleActive: false);
+        await manager.ActivateAsync("shared-product", 1, "Published", TenantScopeTestFixtures.TenantB, allowMultipleActive: false);
 
-        var tenantAActive = (await manager.GetActiveVersionsAsync("shared-product", "Published", TenantScopeTestFixtures.TenantA)).ToList();
-        var tenantBActive = (await manager.GetActiveVersionsAsync("shared-product", "Published", TenantScopeTestFixtures.TenantB)).ToList();
+        var tenantAActive = (await manager.GetActiveVersionsAsync("shared-product", "Published", TenantScopeTestFixtures.TenantA, CancellationToken.None)).ToList();
+        var tenantBActive = (await manager.GetActiveVersionsAsync("shared-product", "Published", TenantScopeTestFixtures.TenantB, CancellationToken.None)).ToList();
 
         Assert.Equal(2, tenantAActive.Single().Version);
         Assert.Equal(1, tenantBActive.Single().Version);

--- a/test/Aster.Tests/Tenancy/TenantActiveQueryTests.cs
+++ b/test/Aster.Tests/Tenancy/TenantActiveQueryTests.cs
@@ -26,8 +26,8 @@ public sealed class TenantActiveQueryTests : IDisposable
         await TenantScopeTestFixtures.CreateProductAsync(provider, "shared-product", "Tenant A", TenantScopeTestFixtures.TenantA);
         await TenantScopeTestFixtures.CreateProductAsync(provider, "shared-product", "Tenant B", TenantScopeTestFixtures.TenantB);
         await manager.UpdateAsync("shared-product", new UpdateResourceRequest { TenantScope = TenantScopeTestFixtures.TenantB, BaseVersion = 1 });
-        await manager.ActivateAsync("shared-product", 1, "Published", TenantScopeTestFixtures.TenantA, allowMultipleActive: false);
-        await manager.ActivateAsync("shared-product", 2, "Published", TenantScopeTestFixtures.TenantB, allowMultipleActive: false);
+        await manager.ActivateAsync("shared-product", 1, "Published", TenantScopeTestFixtures.TenantA, allowMultipleActive: false, CancellationToken.None);
+        await manager.ActivateAsync("shared-product", 2, "Published", TenantScopeTestFixtures.TenantB, allowMultipleActive: false, CancellationToken.None);
 
         var results = (await query.QueryAsync(new ResourceQuery
         {

--- a/test/Aster.Tests/Tenancy/TenantActiveQueryTests.cs
+++ b/test/Aster.Tests/Tenancy/TenantActiveQueryTests.cs
@@ -26,8 +26,8 @@ public sealed class TenantActiveQueryTests : IDisposable
         await TenantScopeTestFixtures.CreateProductAsync(provider, "shared-product", "Tenant A", TenantScopeTestFixtures.TenantA);
         await TenantScopeTestFixtures.CreateProductAsync(provider, "shared-product", "Tenant B", TenantScopeTestFixtures.TenantB);
         await manager.UpdateAsync("shared-product", new UpdateResourceRequest { TenantScope = TenantScopeTestFixtures.TenantB, BaseVersion = 1 });
-        await manager.ActivateAsync("shared-product", 1, "Published", TenantScopeTestFixtures.TenantA);
-        await manager.ActivateAsync("shared-product", 2, "Published", TenantScopeTestFixtures.TenantB);
+        await manager.ActivateAsync("shared-product", 1, "Published", TenantScopeTestFixtures.TenantA, allowMultipleActive: false);
+        await manager.ActivateAsync("shared-product", 2, "Published", TenantScopeTestFixtures.TenantB, allowMultipleActive: false);
 
         var results = (await query.QueryAsync(new ResourceQuery
         {

--- a/test/Aster.Tests/Tenancy/TenantActiveQueryTests.cs
+++ b/test/Aster.Tests/Tenancy/TenantActiveQueryTests.cs
@@ -1,0 +1,44 @@
+using Aster.Core.Abstractions;
+using Aster.Core.Models.Querying;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Aster.Tests.Tenancy;
+
+public sealed class TenantActiveQueryTests : IDisposable
+{
+    private readonly ServiceProvider provider = TenantScopeTestFixtures.CreateCoreProvider();
+    private readonly IResourceManager manager;
+    private readonly IResourceQueryService query;
+
+    public TenantActiveQueryTests()
+    {
+        manager = provider.GetRequiredService<IResourceManager>();
+        query = provider.GetRequiredService<IResourceQueryService>();
+    }
+
+    public void Dispose() => provider.Dispose();
+
+    [Fact]
+    public async Task ActiveQuery_UsesTenantScopedActivationState()
+    {
+        await TenantScopeTestFixtures.RegisterProductDefinitionAsync(provider, TenantScopeTestFixtures.TenantA);
+        await TenantScopeTestFixtures.RegisterProductDefinitionAsync(provider, TenantScopeTestFixtures.TenantB);
+        await TenantScopeTestFixtures.CreateProductAsync(provider, "shared-product", "Tenant A", TenantScopeTestFixtures.TenantA);
+        await TenantScopeTestFixtures.CreateProductAsync(provider, "shared-product", "Tenant B", TenantScopeTestFixtures.TenantB);
+        await manager.UpdateAsync("shared-product", new UpdateResourceRequest { TenantScope = TenantScopeTestFixtures.TenantB, BaseVersion = 1 });
+        await manager.ActivateAsync("shared-product", 1, "Published", TenantScopeTestFixtures.TenantA);
+        await manager.ActivateAsync("shared-product", 2, "Published", TenantScopeTestFixtures.TenantB);
+
+        var results = (await query.QueryAsync(new ResourceQuery
+        {
+            TenantScope = TenantScopeTestFixtures.TenantB,
+            Scope = ResourceVersionScope.Active,
+            ActivationChannel = "Published",
+            DefinitionId = "Product",
+        })).ToList();
+
+        var result = Assert.Single(results);
+        Assert.Equal(2, result.Version);
+        Assert.Equal(TenantScopeTestFixtures.TenantB, result.TenantScope);
+    }
+}

--- a/test/Aster.Tests/Tenancy/TenantApiOverloadCompatibilityTests.cs
+++ b/test/Aster.Tests/Tenancy/TenantApiOverloadCompatibilityTests.cs
@@ -1,5 +1,7 @@
 using Aster.Core.Abstractions;
 using Aster.Core.Definitions;
+using Aster.Core.InMemory;
+using Aster.Core.Services;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Aster.Tests.Tenancy;
@@ -36,5 +38,23 @@ public sealed class TenantApiOverloadCompatibilityTests : IDisposable
         Assert.NotNull(await definitions.GetDefinitionAsync("Product", default));
         Assert.Equal(1, latest!.Version);
         Assert.Equal(1, active.Single().Version);
+    }
+
+    [Fact]
+    public async Task ConcreteResourceManagers_AcceptDefaultLiteralWithoutTenantAmbiguity()
+    {
+        await TenantScopeTestFixtures.RegisterProductDefinitionAsync(provider);
+        await TenantScopeTestFixtures.CreateProductAsync(provider, "product-1", "Default");
+        await manager.ActivateAsync("product-1", 1, "Published");
+
+        var defaultManager = provider.GetRequiredService<DefaultResourceManager>();
+        var inMemoryManager = provider.GetRequiredService<InMemoryResourceManager>();
+
+        Assert.Single(await defaultManager.GetVersionsAsync("product-1", default));
+        Assert.Single(await inMemoryManager.GetVersionsAsync("product-1", default));
+        Assert.NotNull(await defaultManager.GetLatestVersionAsync("product-1", default));
+        Assert.NotNull(await inMemoryManager.GetLatestVersionAsync("product-1", default));
+        Assert.Single(await defaultManager.GetActiveVersionsAsync("product-1", "Published", default));
+        Assert.Single(await inMemoryManager.GetActiveVersionsAsync("product-1", "Published", default));
     }
 }

--- a/test/Aster.Tests/Tenancy/TenantApiOverloadCompatibilityTests.cs
+++ b/test/Aster.Tests/Tenancy/TenantApiOverloadCompatibilityTests.cs
@@ -1,0 +1,40 @@
+using Aster.Core.Abstractions;
+using Aster.Core.Definitions;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Aster.Tests.Tenancy;
+
+public sealed class TenantApiOverloadCompatibilityTests : IDisposable
+{
+    private readonly ServiceProvider provider = TenantScopeTestFixtures.CreateCoreProvider();
+    private readonly IResourceDefinitionStore definitions;
+    private readonly IResourceManager manager;
+
+    public TenantApiOverloadCompatibilityTests()
+    {
+        definitions = provider.GetRequiredService<IResourceDefinitionStore>();
+        manager = provider.GetRequiredService<IResourceManager>();
+    }
+
+    public void Dispose() => provider.Dispose();
+
+    [Fact]
+    public async Task LegacyOverloads_AcceptDefaultLiteralWithoutTenantAmbiguity()
+    {
+        await definitions.RegisterDefinitionAsync(
+            new ResourceDefinitionBuilder()
+                .WithDefinitionId("Product")
+                .Build(),
+            default);
+
+        await TenantScopeTestFixtures.CreateProductAsync(provider, "product-1", "Default");
+        await manager.ActivateAsync("product-1", 1, "Published", default);
+
+        var latest = await manager.GetLatestVersionAsync("product-1", default);
+        var active = (await manager.GetActiveVersionsAsync("product-1", "Published", default)).ToList();
+
+        Assert.NotNull(await definitions.GetDefinitionAsync("Product", default));
+        Assert.Equal(1, latest!.Version);
+        Assert.Equal(1, active.Single().Version);
+    }
+}

--- a/test/Aster.Tests/Tenancy/TenantDefaultScopeCompatibilityTests.cs
+++ b/test/Aster.Tests/Tenancy/TenantDefaultScopeCompatibilityTests.cs
@@ -1,0 +1,34 @@
+using Aster.Core.Abstractions;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Aster.Tests.Tenancy;
+
+public sealed class TenantDefaultScopeCompatibilityTests : IDisposable
+{
+    private readonly ServiceProvider provider = TenantScopeTestFixtures.CreateCoreProvider();
+    private readonly IResourceManager manager;
+
+    public TenantDefaultScopeCompatibilityTests()
+    {
+        manager = provider.GetRequiredService<IResourceManager>();
+    }
+
+    public void Dispose() => provider.Dispose();
+
+    [Fact]
+    public async Task OmittedTenantScope_ContinuesToUseDefaultTenant()
+    {
+        await TenantScopeTestFixtures.RegisterProductDefinitionAsync(provider);
+        await TenantScopeTestFixtures.RegisterProductDefinitionAsync(provider, TenantScopeTestFixtures.TenantA);
+        await TenantScopeTestFixtures.CreateProductAsync(provider, "shared-product", "Default");
+        await TenantScopeTestFixtures.CreateProductAsync(provider, "shared-product", "Tenant A", TenantScopeTestFixtures.TenantA);
+
+        await manager.UpdateAsync("shared-product", new UpdateResourceRequest { BaseVersion = 1 });
+
+        var defaultLatest = await manager.GetLatestVersionAsync("shared-product");
+        var tenantALatest = await manager.GetLatestVersionAsync("shared-product", TenantScopeTestFixtures.TenantA);
+
+        Assert.Equal(2, defaultLatest!.Version);
+        Assert.Equal(1, tenantALatest!.Version);
+    }
+}

--- a/test/Aster.Tests/Tenancy/TenantDefaultScopeCompatibilityTests.cs
+++ b/test/Aster.Tests/Tenancy/TenantDefaultScopeCompatibilityTests.cs
@@ -26,7 +26,7 @@ public sealed class TenantDefaultScopeCompatibilityTests : IDisposable
         await manager.UpdateAsync("shared-product", new UpdateResourceRequest { BaseVersion = 1 });
 
         var defaultLatest = await manager.GetLatestVersionAsync("shared-product");
-        var tenantALatest = await manager.GetLatestVersionAsync("shared-product", TenantScopeTestFixtures.TenantA);
+        var tenantALatest = await manager.GetLatestVersionAsync("shared-product", TenantScopeTestFixtures.TenantA, CancellationToken.None);
 
         Assert.Equal(2, defaultLatest!.Version);
         Assert.Equal(1, tenantALatest!.Version);

--- a/test/Aster.Tests/Tenancy/TenantDefinitionStoreTests.cs
+++ b/test/Aster.Tests/Tenancy/TenantDefinitionStoreTests.cs
@@ -1,0 +1,37 @@
+using Aster.Core.Abstractions;
+using Aster.Core.Definitions;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Aster.Tests.Tenancy;
+
+public sealed class TenantDefinitionStoreTests : IDisposable
+{
+    private readonly ServiceProvider provider = TenantScopeTestFixtures.CreateCoreProvider();
+    private readonly IResourceDefinitionStore store;
+
+    public TenantDefinitionStoreTests()
+    {
+        store = provider.GetRequiredService<IResourceDefinitionStore>();
+    }
+
+    public void Dispose() => provider.Dispose();
+
+    [Fact]
+    public async Task Definitions_AreVersionedIndependentlyPerTenant()
+    {
+        await store.RegisterDefinitionAsync(CreateDefinition(), TenantScopeTestFixtures.TenantA);
+        await store.RegisterDefinitionAsync(CreateDefinition(), TenantScopeTestFixtures.TenantA);
+        await store.RegisterDefinitionAsync(CreateDefinition(), TenantScopeTestFixtures.TenantB);
+
+        var tenantALatest = await store.GetDefinitionAsync("Product", TenantScopeTestFixtures.TenantA);
+        var tenantBLatest = await store.GetDefinitionAsync("Product", TenantScopeTestFixtures.TenantB);
+        var tenantBDefinitions = (await store.ListDefinitionsAsync(TenantScopeTestFixtures.TenantB)).ToList();
+
+        Assert.Equal(2, tenantALatest!.Version);
+        Assert.Equal(1, tenantBLatest!.Version);
+        Assert.Single(tenantBDefinitions);
+    }
+
+    private static Aster.Core.Models.Definitions.ResourceDefinition CreateDefinition() =>
+        new ResourceDefinitionBuilder().WithDefinitionId("Product").Build();
+}

--- a/test/Aster.Tests/Tenancy/TenantDefinitionStoreTests.cs
+++ b/test/Aster.Tests/Tenancy/TenantDefinitionStoreTests.cs
@@ -19,13 +19,13 @@ public sealed class TenantDefinitionStoreTests : IDisposable
     [Fact]
     public async Task Definitions_AreVersionedIndependentlyPerTenant()
     {
-        await store.RegisterDefinitionAsync(CreateDefinition(), TenantScopeTestFixtures.TenantA);
-        await store.RegisterDefinitionAsync(CreateDefinition(), TenantScopeTestFixtures.TenantA);
-        await store.RegisterDefinitionAsync(CreateDefinition(), TenantScopeTestFixtures.TenantB);
+        await store.RegisterDefinitionAsync(CreateDefinition(), TenantScopeTestFixtures.TenantA, CancellationToken.None);
+        await store.RegisterDefinitionAsync(CreateDefinition(), TenantScopeTestFixtures.TenantA, CancellationToken.None);
+        await store.RegisterDefinitionAsync(CreateDefinition(), TenantScopeTestFixtures.TenantB, CancellationToken.None);
 
-        var tenantALatest = await store.GetDefinitionAsync("Product", TenantScopeTestFixtures.TenantA);
-        var tenantBLatest = await store.GetDefinitionAsync("Product", TenantScopeTestFixtures.TenantB);
-        var tenantBDefinitions = (await store.ListDefinitionsAsync(TenantScopeTestFixtures.TenantB)).ToList();
+        var tenantALatest = await store.GetDefinitionAsync("Product", TenantScopeTestFixtures.TenantA, CancellationToken.None);
+        var tenantBLatest = await store.GetDefinitionAsync("Product", TenantScopeTestFixtures.TenantB, CancellationToken.None);
+        var tenantBDefinitions = (await store.ListDefinitionsAsync(TenantScopeTestFixtures.TenantB, CancellationToken.None)).ToList();
 
         Assert.Equal(2, tenantALatest!.Version);
         Assert.Equal(1, tenantBLatest!.Version);
@@ -40,7 +40,7 @@ public sealed class TenantDefinitionStoreTests : IDisposable
         await store.RegisterDefinitionAsync(definition);
 
         Assert.NotNull(await store.GetDefinitionAsync("Product"));
-        Assert.Null(await store.GetDefinitionAsync("Product", TenantScopeTestFixtures.TenantA));
+        Assert.Null(await store.GetDefinitionAsync("Product", TenantScopeTestFixtures.TenantA, CancellationToken.None));
     }
 
     private static Aster.Core.Models.Definitions.ResourceDefinition CreateDefinition() =>

--- a/test/Aster.Tests/Tenancy/TenantDefinitionStoreTests.cs
+++ b/test/Aster.Tests/Tenancy/TenantDefinitionStoreTests.cs
@@ -32,6 +32,17 @@ public sealed class TenantDefinitionStoreTests : IDisposable
         Assert.Single(tenantBDefinitions);
     }
 
+    [Fact]
+    public async Task RegisterDefinitionAsync_WithoutTenantScope_AlwaysUsesDefaultTenant()
+    {
+        var definition = CreateDefinition() with { TenantScope = TenantScopeTestFixtures.TenantA };
+
+        await store.RegisterDefinitionAsync(definition);
+
+        Assert.NotNull(await store.GetDefinitionAsync("Product"));
+        Assert.Null(await store.GetDefinitionAsync("Product", TenantScopeTestFixtures.TenantA));
+    }
+
     private static Aster.Core.Models.Definitions.ResourceDefinition CreateDefinition() =>
         new ResourceDefinitionBuilder().WithDefinitionId("Product").Build();
 }

--- a/test/Aster.Tests/Tenancy/TenantQueryServiceTests.cs
+++ b/test/Aster.Tests/Tenancy/TenantQueryServiceTests.cs
@@ -1,0 +1,33 @@
+using Aster.Core.Abstractions;
+using Aster.Core.Models.Querying;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Aster.Tests.Tenancy;
+
+public sealed class TenantQueryServiceTests : IDisposable
+{
+    private readonly ServiceProvider provider = TenantScopeTestFixtures.CreateCoreProvider();
+    private readonly IResourceQueryService query;
+
+    public TenantQueryServiceTests()
+    {
+        query = provider.GetRequiredService<IResourceQueryService>();
+    }
+
+    public void Dispose() => provider.Dispose();
+
+    [Fact]
+    public async Task QueryAsync_ReturnsOnlyRequestedTenant()
+    {
+        await TenantScopeTestFixtures.RegisterProductDefinitionAsync(provider, TenantScopeTestFixtures.TenantA);
+        await TenantScopeTestFixtures.RegisterProductDefinitionAsync(provider, TenantScopeTestFixtures.TenantB);
+        await TenantScopeTestFixtures.CreateProductAsync(provider, "product-a", "Tenant A", TenantScopeTestFixtures.TenantA);
+        await TenantScopeTestFixtures.CreateProductAsync(provider, "product-b", "Tenant B", TenantScopeTestFixtures.TenantB);
+
+        var results = (await query.QueryAsync(TenantScopeTestFixtures.ProductQuery(TenantScopeTestFixtures.TenantA))).ToList();
+
+        var result = Assert.Single(results);
+        Assert.Equal("product-a", result.ResourceId);
+        Assert.Equal(TenantScopeTestFixtures.TenantA, result.TenantScope);
+    }
+}

--- a/test/Aster.Tests/Tenancy/TenantResourceManagerTests.cs
+++ b/test/Aster.Tests/Tenancy/TenantResourceManagerTests.cs
@@ -1,0 +1,39 @@
+using Aster.Core.Abstractions;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Aster.Tests.Tenancy;
+
+public sealed class TenantResourceManagerTests : IDisposable
+{
+    private readonly ServiceProvider provider = TenantScopeTestFixtures.CreateCoreProvider();
+    private readonly IResourceManager manager;
+
+    public TenantResourceManagerTests()
+    {
+        manager = provider.GetRequiredService<IResourceManager>();
+    }
+
+    public void Dispose() => provider.Dispose();
+
+    [Fact]
+    public async Task Resources_WithSameId_AreIsolatedByTenant()
+    {
+        await TenantScopeTestFixtures.RegisterProductDefinitionAsync(provider, TenantScopeTestFixtures.TenantA);
+        await TenantScopeTestFixtures.RegisterProductDefinitionAsync(provider, TenantScopeTestFixtures.TenantB);
+        await TenantScopeTestFixtures.CreateProductAsync(provider, "shared-product", "Tenant A", TenantScopeTestFixtures.TenantA);
+        await TenantScopeTestFixtures.CreateProductAsync(provider, "shared-product", "Tenant B", TenantScopeTestFixtures.TenantB);
+
+        await manager.UpdateAsync("shared-product", new UpdateResourceRequest
+        {
+            TenantScope = TenantScopeTestFixtures.TenantA,
+            BaseVersion = 1,
+            AspectUpdates = { ["Title"] = new TenantScopeTestFixtures.TitleAspect("Tenant A v2") },
+        });
+
+        var tenantALatest = await manager.GetLatestVersionAsync("shared-product", TenantScopeTestFixtures.TenantA);
+        var tenantBLatest = await manager.GetLatestVersionAsync("shared-product", TenantScopeTestFixtures.TenantB);
+
+        Assert.Equal(2, tenantALatest!.Version);
+        Assert.Equal(1, tenantBLatest!.Version);
+    }
+}

--- a/test/Aster.Tests/Tenancy/TenantResourceManagerTests.cs
+++ b/test/Aster.Tests/Tenancy/TenantResourceManagerTests.cs
@@ -30,8 +30,8 @@ public sealed class TenantResourceManagerTests : IDisposable
             AspectUpdates = { ["Title"] = new TenantScopeTestFixtures.TitleAspect("Tenant A v2") },
         });
 
-        var tenantALatest = await manager.GetLatestVersionAsync("shared-product", TenantScopeTestFixtures.TenantA);
-        var tenantBLatest = await manager.GetLatestVersionAsync("shared-product", TenantScopeTestFixtures.TenantB);
+        var tenantALatest = await manager.GetLatestVersionAsync("shared-product", TenantScopeTestFixtures.TenantA, CancellationToken.None);
+        var tenantBLatest = await manager.GetLatestVersionAsync("shared-product", TenantScopeTestFixtures.TenantB, CancellationToken.None);
 
         Assert.Equal(2, tenantALatest!.Version);
         Assert.Equal(1, tenantBLatest!.Version);

--- a/test/Aster.Tests/Tenancy/TenantScopeFailureTests.cs
+++ b/test/Aster.Tests/Tenancy/TenantScopeFailureTests.cs
@@ -1,0 +1,23 @@
+using Aster.Core.Exceptions;
+using Aster.Core.Models.Tenancy;
+using Aster.Core.Services;
+
+namespace Aster.Tests.Tenancy;
+
+public sealed class TenantScopeFailureTests
+{
+    [Fact]
+    public void FromTenantId_BlankTenantId_ThrowsArgumentException()
+    {
+        Assert.Throws<ArgumentException>(() => TenantScope.FromTenantId(" "));
+    }
+
+    [Fact]
+    public void Resolve_BlankTenantId_ThrowsStableTenantScopeException()
+    {
+        var exception = Assert.Throws<TenantScopeException>(() =>
+            TenantScopeResolver.Resolve(new TenantScope { TenantId = " " }));
+
+        Assert.Equal(TenantScopeException.InvalidCode, exception.Code);
+    }
+}

--- a/test/Aster.Tests/Tenancy/TenantScopeTestFixtures.cs
+++ b/test/Aster.Tests/Tenancy/TenantScopeTestFixtures.cs
@@ -1,0 +1,91 @@
+using Aster.Core.Abstractions;
+using Aster.Core.Definitions;
+using Aster.Core.Extensions;
+using Aster.Core.Models.Instances;
+using Aster.Core.Models.Querying;
+using Aster.Core.Models.Tenancy;
+using Aster.Persistence.SqliteJson;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Aster.Tests.Tenancy;
+
+public static class TenantScopeTestFixtures
+{
+    public static TenantScope TenantA { get; } = TenantScope.FromTenantId("tenant-a");
+
+    public static TenantScope TenantB { get; } = TenantScope.FromTenantId("tenant-b");
+
+    public static ServiceProvider CreateCoreProvider() =>
+        new ServiceCollection()
+            .AddAsterCore()
+            .BuildServiceProvider();
+
+    public static ServiceProvider CreateSqliteProvider(string databasePath) =>
+        new ServiceCollection()
+            .AddAsterCore()
+            .AddAsterSqliteJson(options => options.ConnectionString = $"Data Source={databasePath}")
+            .BuildServiceProvider();
+
+    public static async Task RegisterProductDefinitionAsync(
+        IServiceProvider provider,
+        TenantScope? tenantScope = null)
+    {
+        var store = provider.GetRequiredService<IResourceDefinitionStore>();
+        var definition = new ResourceDefinitionBuilder()
+            .WithDefinitionId("Product")
+            .Build();
+
+        if (tenantScope is null)
+            await store.RegisterDefinitionAsync(definition);
+        else
+            await store.RegisterDefinitionAsync(definition, tenantScope);
+    }
+
+    public static async Task<Resource> CreateProductAsync(
+        IServiceProvider provider,
+        string resourceId,
+        string title,
+        TenantScope? tenantScope = null)
+    {
+        var manager = provider.GetRequiredService<IResourceManager>();
+        return await manager.CreateAsync("Product", new CreateResourceRequest
+        {
+            ResourceId = resourceId,
+            TenantScope = tenantScope,
+            InitialAspects =
+            {
+                ["Title"] = new TitleAspect(title),
+            },
+        });
+    }
+
+    public static Resource CreateResource(
+        string resourceId,
+        string title,
+        TenantScope? tenantScope = null,
+        int version = 1) =>
+        new()
+        {
+            TenantScope = tenantScope ?? TenantScope.Default,
+            ResourceId = resourceId,
+            Id = $"{resourceId}-{version}",
+            DefinitionId = "Product",
+            DefinitionVersion = 1,
+            Version = version,
+            Created = DateTime.UtcNow.AddMinutes(version),
+            Aspects = new Dictionary<string, object>
+            {
+                ["Title"] = new TitleAspect(title),
+            },
+        };
+
+    public static ResourceQuery ProductQuery(TenantScope? tenantScope = null) =>
+        new()
+        {
+            TenantScope = tenantScope,
+            DefinitionId = "Product",
+            Sorts = [new SortExpression("ResourceId")],
+        };
+
+    public sealed record TitleAspect(string Title);
+}

--- a/test/Aster.Tests/Tenancy/TenantScopeTestFixtures.cs
+++ b/test/Aster.Tests/Tenancy/TenantScopeTestFixtures.cs
@@ -38,7 +38,7 @@ public static class TenantScopeTestFixtures
         if (tenantScope is null)
             await store.RegisterDefinitionAsync(definition);
         else
-            await store.RegisterDefinitionAsync(definition, tenantScope);
+            await store.RegisterDefinitionAsync(definition, tenantScope, CancellationToken.None);
     }
 
     public static async Task<Resource> CreateProductAsync(

--- a/test/Aster.Tests/Tenancy/TenantScopeTests.cs
+++ b/test/Aster.Tests/Tenancy/TenantScopeTests.cs
@@ -1,0 +1,26 @@
+using Aster.Core.Models.Tenancy;
+using Aster.Core.Services;
+
+namespace Aster.Tests.Tenancy;
+
+public sealed class TenantScopeTests
+{
+    [Fact]
+    public void Resolve_NullScope_ReturnsDefaultTenant()
+    {
+        var scope = TenantScopeResolver.Resolve(null);
+
+        Assert.Equal(TenantScope.DefaultTenantId, scope.TenantId);
+        Assert.True(scope.IsDefault);
+    }
+
+    [Fact]
+    public void FromTenantId_PreservesOpaqueExactTenantId()
+    {
+        var lower = TenantScope.FromTenantId("tenant-a");
+        var upper = TenantScope.FromTenantId("Tenant-A");
+
+        Assert.Equal("tenant-a", lower.TenantId);
+        Assert.NotEqual(lower, upper);
+    }
+}

--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -4,7 +4,7 @@ Welcome to the Aster documentation wiki.
 
 **Aster** is a .NET SDK for defining, versioning, and querying composable resources using a **Resource → Aspect → Facet** model. It provides a headless, backend-agnostic foundation for attaching reusable, cross-cutting capabilities to any resource type.
 
-> **Current Status:** Phase 4 in progress — Core SDK, in-memory engine, SQLite JSON persistence/querying, query capability discovery, preflight validation, typed query helpers, provider authoring/conformance support, explicit index projections, schema upgrades, and portability primitives are available.
+> **Current Status:** Phase 5 in progress — Core SDK, in-memory engine, SQLite JSON persistence/querying, query capability discovery, preflight validation, typed query helpers, provider authoring/conformance support, explicit index projections, schema upgrades, portability primitives, host lifecycle hooks, and explicit tenant scoping are available.
 
 ---
 

--- a/wiki/Roadmap.md
+++ b/wiki/Roadmap.md
@@ -2,7 +2,7 @@
 
 Aster is delivered in six phases. Each phase builds on the last, with clean extension points so earlier work is not thrown away.
 
-> **Current status:** Phase 5 starting — Core SDK, in-memory engine, SQLite JSON persistence/querying, query capability discovery, preflight validation, typed query authoring helpers, provider authoring/conformance support, SQLite facet sorting, portable operators, SQLite date-like ranges, explicit index projection contracts, explicit definition schema upgrade behavior, portability primitives, and host lifecycle hooks are available.
+> **Current status:** Phase 5 in progress — Core SDK, in-memory engine, SQLite JSON persistence/querying, query capability discovery, preflight validation, typed query authoring helpers, provider authoring/conformance support, SQLite facet sorting, portable operators, SQLite date-like ranges, explicit index projection contracts, explicit definition schema upgrade behavior, portability primitives, host lifecycle hooks, and explicit tenant scoping are available.
 >
 > For the current implementation trail and next Spec Kit slices, see [`docs/ExecutionRoadmap.md`](../docs/ExecutionRoadmap.md).
 
@@ -30,7 +30,8 @@ Aster is delivered in six phases. Each phase builds on the last, with clean exte
 | **012 Definition Schema Versions & Upgrade Flow** | Landed | Make long-lived resource schema versioning and upgrade behavior explicit. |
 | **013 Portability Primitives** | Landed | Add deterministic export/import primitives for definitions and resources. |
 | **014 Host Lifecycle Hooks** | Landed | Add explicit hooks around save, activation, deactivation, and import/export without hidden runtime scanning. |
-| **015 Tenant Scoping** | Next | Add explicit tenant boundaries for definitions, resources, activation, queries, portability, and lifecycle hooks. |
+| **015 Tenant Scoping** | Landed | Add explicit tenant boundaries for definitions, resources, activation, queries, portability, and lifecycle hooks. |
+| **016 Policy Foundations** | Next | Introduce explicit retention, archival, soft-delete, and pruning policy contracts without hidden background processing. |
 
 ---
 

--- a/wiki/Roadmap.md
+++ b/wiki/Roadmap.md
@@ -2,7 +2,7 @@
 
 Aster is delivered in six phases. Each phase builds on the last, with clean extension points so earlier work is not thrown away.
 
-> **Current status:** Phase 4 in progress — Core SDK, in-memory engine, SQLite JSON persistence/querying, query capability discovery, preflight validation, typed query authoring helpers, provider authoring/conformance support, SQLite facet sorting, portable operators, SQLite date-like ranges, explicit index projection contracts, explicit definition schema upgrade behavior, and portability primitives are available.
+> **Current status:** Phase 5 starting — Core SDK, in-memory engine, SQLite JSON persistence/querying, query capability discovery, preflight validation, typed query authoring helpers, provider authoring/conformance support, SQLite facet sorting, portable operators, SQLite date-like ranges, explicit index projection contracts, explicit definition schema upgrade behavior, portability primitives, and host lifecycle hooks are available.
 >
 > For the current implementation trail and next Spec Kit slices, see [`docs/ExecutionRoadmap.md`](../docs/ExecutionRoadmap.md).
 
@@ -15,8 +15,8 @@ Aster is delivered in six phases. Each phase builds on the last, with clean exte
 | **1** | Core SDK & In-Memory Engine | Complete |
 | **2A** | SQLite JSON Persistence & Querying | Complete |
 | **3** | Query Capabilities & Typed Querying | Complete |
-| **4** | Portability & Integration Hooks | In Progress |
-| **5** | Multi-tenancy, Policies, Advanced Versioning | Planned |
+| **4** | Portability & Integration Hooks | Core Complete |
+| **5** | Multi-tenancy, Policies, Advanced Versioning | In Progress |
 | **6** | Operational Hardening | Planned |
 
 ## Immediate Next Slices
@@ -29,7 +29,8 @@ Aster is delivered in six phases. Each phase builds on the last, with clean exte
 | **011 Explicit Indexing Model** | Landed | Introduce intentional index projection contracts without a hidden planner or runtime scanning. |
 | **012 Definition Schema Versions & Upgrade Flow** | Landed | Make long-lived resource schema versioning and upgrade behavior explicit. |
 | **013 Portability Primitives** | Landed | Add deterministic export/import primitives for definitions and resources. |
-| **014 Host Lifecycle Hooks** | Next | Add explicit hooks around save, activation, deactivation, and import/export without hidden runtime scanning. |
+| **014 Host Lifecycle Hooks** | Landed | Add explicit hooks around save, activation, deactivation, and import/export without hidden runtime scanning. |
+| **015 Tenant Scoping** | Next | Add explicit tenant boundaries for definitions, resources, activation, queries, portability, and lifecycle hooks. |
 
 ---
 


### PR DESCRIPTION
## Summary
- add explicit TenantScope model and default-scope resolution across core request/context models
- scope definitions, resources, activation state, queries, schema upgrades, portability, and lifecycle hooks by tenant
- add SQLite tenant columns, default-scope bootstrap for pre-tenant tables, docs, and tenant-focused tests

## Validation
- dotnet test Aster.sln --no-restore
- dotnet build Aster.sln /m:1 --no-restore
- git diff --check