### PR TITLE
Add policy foundations

### DIFF
--- a/.github/agents/copilot-instructions.md
+++ b/.github/agents/copilot-instructions.md
@@ -14,6 +14,8 @@ Auto-generated from all feature plans. Last updated: 2026-05-17
 - Existing SQLite JSON payload shape; no migration (007-sqlite-facet-sorting)
 - C# latest, .NET 8.0 / 9.0 / 10.0 multi-targeting + Existing core SDK and xUnit test stack; no new dependencies (008-typed-query-authoring)
 - N/A; no persistence or schema changes (008-typed-query-authoring)
+- C# latest, .NET 8.0 / 9.0 / 10.0 multi-targeting + Existing core SDK, in-memory store, SQLite JSON provider, resource manager/store abstractions, query capability/validation stack, portability service, lifecycle hook dispatcher, xUnit test stack; no new dependencies (016-policy-foundations)
+- Existing resource definitions gain policy declaration metadata; resource lifecycle markers are stored as additive state separate from immutable resource versions; portable snapshots include policy declarations and lifecycle markers; SQLite JSON adds policy/marker storage without a general migration framework (016-policy-foundations)
 
 - C# / .NET 9.0 (Standard 2.0/2.1 compatible ideally, but targeted for net9.0) + Microsoft.Extensions.DependencyInjection, Microsoft.Extensions.Logging (001-core-sdk-foundation)
 
@@ -33,9 +35,9 @@ tests/
 C# / .NET 9.0 (Standard 2.0/2.1 compatible ideally, but targeted for net9.0): Follow standard conventions
 
 ## Recent Changes
+- 016-policy-foundations: Added C# latest, .NET 8.0 / 9.0 / 10.0 multi-targeting + Existing core SDK, in-memory store, SQLite JSON provider, resource manager/store abstractions, query capability/validation stack, portability service, lifecycle hook dispatcher, xUnit test stack; no new dependencies
 - 008-typed-query-authoring: Added C# latest, .NET 8.0 / 9.0 / 10.0 multi-targeting + Existing core SDK and xUnit test stack; no new dependencies
 - 007-sqlite-facet-sorting: Added C# latest, .NET 8.0 / 9.0 / 10.0 multi-targeting + Existing SQLite JSON provider and test stack
-- 006-provider-conformance-tests: Added C# latest, .NET 8.0 / 9.0 / 10.0 multi-targeting for libraries; tests target net10.0 + Existing xUnit and Microsoft.Extensions.DependencyInjection test stack
 
 
 <!-- MANUAL ADDITIONS START -->

--- a/.github/agents/copilot-instructions.md
+++ b/.github/agents/copilot-instructions.md
@@ -1,6 +1,6 @@
 # main Development Guidelines
 
-Auto-generated from all feature plans. Last updated: 2026-05-17
+Auto-generated from all feature plans. Last updated: 2026-05-25
 
 ## Active Technologies
 - C# latest, .NET 8.0 / 9.0 / 10.0 multi-targeting + Existing `Microsoft.Extensions.DependencyInjection.Abstractions`, `Microsoft.Extensions.Logging.Abstractions`; SQLite provider keeps existing `Microsoft.Data.Sqlite` (003-query-capabilities-typed)

--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "featureDir": "specs/015-tenant-scoping"
+  "featureDir": "specs/016-policy-foundations"
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 <!-- SPECKIT START -->
 For additional context about technologies to be used, project structure,
-shell commands, and other important information, read `specs/015-tenant-scoping/plan.md`.
+shell commands, and other important information, read `specs/016-policy-foundations/plan.md`.
 <!-- SPECKIT END -->
 
 ## Active Technologies
@@ -16,8 +16,11 @@ shell commands, and other important information, read `specs/015-tenant-scoping/
 - Existing resource definitions, resource versions, activation state, and portable snapshots; no schema migration or persisted hook state (014-host-lifecycle-hooks)
 - C# latest, .NET 8.0 / 9.0 / 10.0 multi-targeting + Existing core SDK, in-memory store, SQLite JSON provider, resource manager/store abstractions, query capability/validation stack, portability service, lifecycle hook dispatcher, xUnit test stack; no new dependencies (015-tenant-scoping)
 - Existing resource definitions, resource versions, activation state, and portable snapshots extended with tenant scope metadata; no automatic migration policy or external storage service (015-tenant-scoping)
+- C# latest, .NET 8.0 / 9.0 / 10.0 multi-targeting + Existing core SDK, in-memory store, SQLite JSON provider, resource manager/store abstractions, query capability/validation stack, portability service, lifecycle hook dispatcher, xUnit test stack; no new dependencies (016-policy-foundations)
+- Existing resource definitions gain policy declaration metadata; resource lifecycle markers are stored as additive state separate from immutable resource versions; portable snapshots include policy declarations and lifecycle markers; SQLite JSON adds policy/marker storage without a general migration framework (016-policy-foundations)
 
 ## Recent Changes
+- 016-policy-foundations: Added explicit policy foundations planning for definition-attached policy declarations, deterministic previews, archive/soft-delete lifecycle markers, lifecycle-state queries, portability, and provider support; no automatic execution, pruning writes, scheduler, policy engine, provider registry, public SQL, or public IQueryable<Resource>
 - 015-tenant-scoping: Added explicit tenant boundary planning for definitions, resources, activation state, queries, schema upgrades, portability, and lifecycle hooks; no automatic migration policy or tenant registry
 - 014-host-lifecycle-hooks: Added explicit host lifecycle hook planning over save, activation, deactivation, export, preview import, and write import; no schema migration or persisted hook state
 - 013-portability-primitives: Added deterministic export/import portability planning over existing definitions, resources, and activation state; no schema migration planned

--- a/docs/ExecutionRoadmap.md
+++ b/docs/ExecutionRoadmap.md
@@ -1,14 +1,14 @@
 # Aster Execution Roadmap
 
-Last updated: 2026-05-24
+Last updated: 2026-05-25
 
 This roadmap tracks the implementation trail we have already cut through the repo and the next product slices that should stay small enough for Spec Kit-driven PRs. It is intentionally execution-oriented; the broader architecture narrative remains in `docs/Roadmap.md` and the wiki.
 
 ## Current Position
 
-Aster now has a working Core SDK, in-memory runtime, SQLite JSON persistence/querying, provider capability discovery, provider validation alignment, provider authoring ergonomics, a reusable provider conformance harness, SQLite facet sorting, portable operator expansion, SQLite date-like ranges, explicit provider-declared index projections, explicit definition schema upgrade behavior, deterministic portability primitives, explicit host lifecycle hooks, and explicit tenant scoping.
+Aster now has a working Core SDK, in-memory runtime, SQLite JSON persistence/querying, provider capability discovery, provider validation alignment, provider authoring ergonomics, a reusable provider conformance harness, SQLite facet sorting, portable operator expansion, SQLite date-like ranges, explicit provider-declared index projections, explicit definition schema upgrade behavior, deterministic portability primitives, explicit host lifecycle hooks, explicit tenant scoping, and policy foundations.
 
-The Phase 4 core workstream is complete enough to defer optional recipes. The active workstream is now **Phase 5: Multi-tenancy, Policies, Advanced Versioning**. Explicit tenant-aware boundaries have landed; policy foundations are the next small slice before cross-tenant behavior is introduced.
+The Phase 4 core workstream is complete enough to defer optional recipes. The active workstream is now **Phase 5: Multi-tenancy, Policies, Advanced Versioning**. Explicit tenant-aware boundaries and policy foundations have landed; the next slices should stay focused on either policy execution affordances or advanced tenant/versioning behavior, not both at once.
 
 ## Landed Slices
 
@@ -29,20 +29,21 @@ The Phase 4 core workstream is complete enough to defer optional recipes. The ac
 | `013-portability-primitives` | Landed | Deterministic export/import primitives for definitions, resources, resource versions, activation state, strict validation, previews, identity mapping, remapping, and provider-backed atomic writes. |
 | `014-host-lifecycle-hooks` | Landed | Explicit before/after hooks for save, activation, deactivation, schema upgrades, export, preview import, and write import with deterministic ordering and fail-closed diagnostics. |
 | `015-tenant-scoping` | Landed | Explicit tenant boundaries for definitions, resources, activation state, queries, schema upgrades, portability snapshots, and lifecycle hook contexts with default single-tenant compatibility. |
+| `016-policy-foundations` | Landed | Definition-attached policy declarations, validation diagnostics, deterministic non-mutating previews, explicit archive/soft-delete lifecycle markers, lifecycle-state querying, and portability preservation. |
 
 ## Near-Term Roadmap
 
-### 016 — Policy Foundations
+### 017 — Policy Application Orchestration
 
-**Goal:** Introduce explicit policy contracts for retention, archival, soft-delete, and version pruning while preserving append-only resource history by default.
+**Goal:** Add host-controlled affordances for applying previewed policy outcomes without introducing schedulers, hidden retention jobs, or destructive pruning writes.
 
 Candidate scope:
 
-- Policy metadata models and validation diagnostics.
-- Explicit policy evaluation entry points for hosts and providers.
-- Soft-delete/archive markers that remain queryable through declared scopes.
-- Version pruning previews before destructive writes.
-- Keep background schedulers, hidden retention jobs, authorization policy engines, runtime scanning, provider registries, public SQL, and `IQueryable<Resource>` out of scope.
+- Batch application request/response models for archive and soft-delete preview candidates.
+- Idempotent application over explicit lifecycle marker writes.
+- Structured partial-failure diagnostics for stale/missing resources.
+- Optional lifecycle-hook context coverage for policy-applied marker writes if the existing hook surfaces are insufficient.
+- Keep background schedulers, hidden retention jobs, authorization policy engines, destructive pruning writes, provider registries, public SQL, and `IQueryable<Resource>` out of scope.
 
 ## Later Roadmap
 
@@ -50,7 +51,7 @@ Candidate scope:
 |---|---|
 | Optional recipes | Separate `Aster.Recipes` package for hosts that want recipe execution over portability primitives. |
 | Multi-tenancy extensions | Shared definitions, tenant hierarchy, and cross-tenant administrative workflows after explicit tenant boundaries exist. |
-| Policies | Retention, archival, soft-delete, and pruning policies. |
+| Policies | Host-controlled policy application, restore workflows, and eventual pruning write semantics after separate specs. |
 | Operational hardening | Benchmarks, migration idempotency, concurrency hardening, and large-data test suites. |
 
 ## Guardrails

--- a/docs/Roadmap.md
+++ b/docs/Roadmap.md
@@ -771,12 +771,19 @@ Define the minimal contracts needed for portable export/import of definitions/re
 
 ## Epic 5.2 — Policies
 **Deliverables**
-- Retention/archival policies
-- Soft delete policy aspect
-- Version pruning strategies
+- Definition-attached policy declarations for retention, archival, soft-delete, and version-pruning intent
+- Stable policy validation diagnostics
+- Deterministic, non-mutating policy evaluation previews
+- Explicit archive and soft-delete lifecycle markers
+- Lifecycle-state query criteria
+- Portability preservation for policy declarations and lifecycle markers
+- Future specs: host-controlled policy application orchestration, restore workflows, and destructive pruning semantics
 
 **DoD**
-- Host can configure policies without custom code per resource type
+- Host can inspect and validate policy intent without hidden execution
+- Host can preview candidate outcomes before applying any write
+- Archive and soft-delete state remains explicit, tenant-scoped, queryable, and portable
+- Background schedulers, authorization policy engines, provider registries, public SQL, and public `IQueryable<Resource>` stay out of core policy foundations
 
 ---
 

--- a/specs/016-policy-foundations/checklists/requirements.md
+++ b/specs/016-policy-foundations/checklists/requirements.md
@@ -1,0 +1,34 @@
+# Specification Quality Checklist: Policy Foundations
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning  
+**Created**: 2026-05-25  
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [X] No implementation details (languages, frameworks, APIs)
+- [X] Focused on user value and business needs
+- [X] Written for non-technical stakeholders
+- [X] All mandatory sections completed
+
+## Requirement Completeness
+
+- [X] No [NEEDS CLARIFICATION] markers remain
+- [X] Requirements are testable and unambiguous
+- [X] Success criteria are measurable
+- [X] Success criteria are technology-agnostic (no implementation details)
+- [X] All acceptance scenarios are defined
+- [X] Edge cases are identified
+- [X] Scope is clearly bounded
+- [X] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [X] All functional requirements have clear acceptance criteria
+- [X] User scenarios cover primary flows
+- [X] Feature meets measurable outcomes defined in Success Criteria
+- [X] No implementation details leak into specification
+
+## Notes
+
+- Ready for `/speckit-clarify` or `/speckit-plan`.

--- a/specs/016-policy-foundations/contracts/policy-foundations.md
+++ b/specs/016-policy-foundations/contracts/policy-foundations.md
@@ -1,0 +1,166 @@
+# Contract: Policy Foundations
+
+This contract describes public SDK behavior for policy declarations, previews, lifecycle markers, and lifecycle-state querying. Names are provisional for planning, but behavior is normative.
+
+## Policy Declaration Behavior
+
+The SDK MUST support explicit policy declarations attached to resource definitions.
+
+Required behavior:
+
+- Policy declarations MUST be stored on resource definition versions.
+- Policy declarations MUST NOT attach directly to individual resources in this slice.
+- Registering a definition with policy declarations MUST append a normal immutable definition version.
+- Existing definitions without policy declarations MUST remain valid.
+- Policy declarations MUST be inspectable before validation or evaluation.
+- Policy declarations MUST NOT execute by themselves.
+
+Supported policy intent:
+
+- Retention intent.
+- Archive intent.
+- Soft-delete intent.
+- Version pruning intent.
+
+Supported criteria:
+
+- Age thresholds.
+- Retained-version counts.
+- Activation state.
+- Lifecycle marker state.
+- Resource definition identity.
+- Effective tenant boundary.
+
+Unsupported criteria:
+
+- Arbitrary resource facet predicates.
+- Expression trees.
+- SQL fragments.
+- Provider-specific query syntax.
+- Host code callbacks.
+
+## Policy Validation Behavior
+
+The SDK MUST expose validation behavior for policy declarations.
+
+Required behavior:
+
+- Validation MUST report stable diagnostics for missing, invalid, contradictory, or unsupported metadata.
+- Validation MUST NOT mutate resources, resource versions, activation state, lifecycle markers, definitions, or portable snapshots.
+- Validation MUST fail closed for unsupported criteria or outcomes.
+- Validation MUST distinguish unsupported policy kind, unsupported outcome, invalid target, unsupported criteria, conflicting declarations, and preview-only pruning enforcement.
+
+## Policy Preview Behavior
+
+The SDK MUST expose a host-requested policy preview workflow.
+
+Required behavior:
+
+- Preview requests MUST resolve one effective tenant.
+- Preview requests MUST be bounded by explicit host input such as tenant and optional definition/policy selection.
+- Age-based previews MUST require a host-supplied evaluation timestamp.
+- Preview services MUST NOT read an ambient system clock.
+- Preview results MUST include candidate outcomes, matching policy declaration identifiers, affected resource identifiers, affected version identifiers when applicable, and diagnostics.
+- Preview generation MUST NOT archive, soft-delete, prune, deactivate, delete, or otherwise mutate resource data.
+- Version pruning MUST remain preview-only in this slice.
+- Unsafe pruning previews that would remove all retained versions of a resource MUST produce diagnostics.
+
+Out of scope:
+
+- Automatic policy execution.
+- Background retention jobs.
+- Schedulers.
+- Destructive pruning writes.
+- Restore workflows.
+
+## Lifecycle Marker Behavior
+
+The SDK MUST represent archive and soft-delete outcomes as explicit lifecycle marker state.
+
+Required behavior:
+
+- Hosts MUST be able to explicitly apply archive and soft-delete markers to resources.
+- Marker writes MUST be host-requested and MUST NOT occur as a side effect of preview.
+- Marker writes MUST NOT physically delete resources or resource versions.
+- Marker writes MUST NOT deactivate active versions.
+- Marker writes MUST NOT rewrite historical resource data.
+- Each resource MUST have at most one effective lifecycle marker state.
+- Reapplying the same marker MUST be idempotent.
+- Applying archive to a soft-deleted resource, or soft-delete to an archived resource, MUST fail with a stable diagnostic and leave existing marker state unchanged.
+- Marker state MUST be scoped by effective tenant.
+
+Out of scope:
+
+- Marker restore.
+- Marker transition workflows.
+- Marker history/audit event stream beyond the effective marker state.
+
+## Query Behavior
+
+The portable query model MUST support explicit lifecycle-state criteria.
+
+Required behavior:
+
+- Hosts MUST be able to query resources by lifecycle marker state through explicit criteria.
+- Omitted lifecycle-state criteria MUST NOT hide archived or soft-deleted resources.
+- Lifecycle-state filtering MUST apply inside the effective tenant boundary.
+- Existing definition, version scope, activation, filter, sort, skip, and take behavior MUST remain deterministic.
+- Providers MUST fail closed if lifecycle-state filtering is requested but unsupported.
+
+Prohibited behavior:
+
+- Public raw SQL.
+- Public `IQueryable<Resource>`.
+- Hidden default exclusion of soft-deleted or archived resources.
+
+## Portability Behavior
+
+Portable workflows MUST preserve policy declarations and lifecycle markers when the selected scope includes them.
+
+Required behavior:
+
+- Exported definitions MUST include policy declarations stored on those definition versions.
+- Exported resources MUST include lifecycle marker state when the referenced resource is included in scope.
+- Import preview MUST report policy and marker conflicts with stable diagnostics.
+- Write import MUST preserve lifecycle marker state inside the target tenant without rewriting resource versions.
+- Snapshots MUST remain single-source-tenant and imports must target one tenant.
+
+## Provider Behavior
+
+In-memory and SQLite JSON providers MUST implement the storage and query behavior needed by this feature.
+
+Required behavior:
+
+- In-memory storage MUST persist policy declarations with definitions and lifecycle markers with resource state.
+- SQLite JSON storage MUST persist policy declarations with definitions and lifecycle markers in provider-owned storage.
+- SQLite initialization MAY add idempotent additive storage support for lifecycle markers, but MUST NOT introduce a general migration framework.
+- Providers MUST keep tenant filtering before policy preview and lifecycle query results can cross tenant boundaries.
+
+## Compatibility
+
+The feature MUST remain additive for existing hosts.
+
+Required behavior:
+
+- Existing `AddAsterCore()` and `AddAsterSqliteJson()` registration behavior MUST remain compatible.
+- Existing callers that do not declare policies MUST observe no automatic policy behavior.
+- Existing reads, writes, activation behavior, schema upgrades, portability, lifecycle hooks, and query behavior MUST continue to work without policy declarations.
+- Existing default single-tenant behavior MUST remain valid.
+
+## Out Of Scope
+
+This feature MUST NOT introduce:
+
+- background schedulers;
+- hidden retention jobs;
+- automatic policy execution;
+- authorization or permission policy engines;
+- cross-tenant policy evaluation;
+- runtime scanning;
+- provider registries;
+- arbitrary facet predicate policy criteria;
+- provider-specific policy languages;
+- public raw SQL;
+- public `IQueryable<Resource>`;
+- destructive pruning writes;
+- restore workflows.

--- a/specs/016-policy-foundations/data-model.md
+++ b/specs/016-policy-foundations/data-model.md
@@ -1,0 +1,242 @@
+# Data Model: Policy Foundations
+
+## Policy Declaration
+
+Represents declarative policy intent attached to a resource definition version.
+
+Fields:
+
+- `PolicyId`: Stable identifier unique within the definition version.
+- `Name`: Host-visible policy name.
+- `Kind`: Retention, archive, soft-delete, or version pruning.
+- `Target`: Resource or resource version target.
+- `Outcome`: Retain, archive, soft-delete, or prune-preview.
+- `Criteria`: Explicit policy criteria.
+- `Settings`: Kind-specific settings such as age threshold or retained-version count.
+
+Validation rules:
+
+- Policies attach to resource definitions only.
+- `PolicyId`, `Kind`, `Target`, `Outcome`, and criteria must be present.
+- The policy kind, target, and outcome must be compatible.
+- Criteria are limited to age thresholds, retained-version counts, activation state, lifecycle marker state, definition identity, and tenant boundary.
+- Arbitrary facet predicates, expression trees, SQL fragments, provider-specific query syntax, and callbacks are invalid.
+- Version pruning declarations are allowed, but pruning writes are not.
+
+Relationships:
+
+- Stored on `ResourceDefinition`.
+- Evaluated against resources of the declaring definition inside one effective tenant.
+- Preserved by portability when the containing definition is exported.
+
+## Policy Criteria
+
+Represents the explicit matching criteria supported by this slice.
+
+Fields:
+
+- `MinimumAge`: Optional age threshold relative to a host-supplied evaluation timestamp.
+- `MaximumRetainedVersions`: Optional count used by pruning previews.
+- `ActivationState`: Optional active/draft state criterion.
+- `LifecycleState`: Optional none, archived, or soft-deleted criterion.
+- `DefinitionId`: Effective definition identity, derived from the declaring definition.
+- `TenantScope`: Effective tenant boundary, supplied by the evaluation request.
+
+Validation rules:
+
+- Age-based evaluation requires an explicit `EvaluationTimestamp`.
+- Retained-version count must be greater than zero when supplied.
+- Lifecycle state must be one of the SDK-defined marker states.
+- Criteria must not select resources outside the effective tenant.
+
+Relationships:
+
+- Belongs to one policy declaration.
+- Produces zero or more policy candidate outcomes during preview.
+
+## Policy Evaluation Request
+
+Represents a host-requested policy preview.
+
+Fields:
+
+- `TenantScope`: Optional tenant scope; omitted means the default single-tenant scope.
+- `DefinitionIds`: Optional bounded definition set to evaluate.
+- `PolicyIds`: Optional bounded policy set to evaluate.
+- `EvaluationTimestamp`: Required timestamp for age-based criteria.
+
+Validation rules:
+
+- The request must resolve to exactly one effective tenant.
+- Age-based policy evaluation must fail closed when the timestamp is missing.
+- The request must not imply cross-tenant evaluation.
+- Policy evaluation must not mutate resources, versions, activation state, lifecycle markers, definitions, or snapshots.
+
+Relationships:
+
+- Reads policy declarations from definition storage.
+- Reads candidate resource versions and marker state from provider-backed stores.
+- Produces a policy evaluation preview.
+
+## Policy Evaluation Preview
+
+Represents deterministic preview output for a policy evaluation request.
+
+Fields:
+
+- `TenantScope`: Effective tenant evaluated.
+- `EvaluationTimestamp`: Timestamp used for age calculations.
+- `Candidates`: Candidate outcomes.
+- `Diagnostics`: Validation or preview diagnostics.
+
+Validation rules:
+
+- Preview generation must not write data.
+- Candidate outcomes must include the matching policy declaration and affected resource ID.
+- Version pruning candidates must include affected version IDs or version numbers.
+- Unsafe pruning previews that would remove all retained versions must produce diagnostics.
+
+Relationships:
+
+- Contains zero or more policy candidate outcomes.
+- Contains zero or more policy diagnostics.
+
+## Policy Candidate Outcome
+
+Represents one resource or version that matched a policy declaration during preview.
+
+Fields:
+
+- `PolicyId`: Matching declaration.
+- `PolicyKind`: Matching policy kind.
+- `Outcome`: Archive, soft-delete, retain, or prune-preview.
+- `ResourceId`: Affected resource.
+- `ResourceVersion`: Affected version when applicable.
+- `Reason`: Host-visible explanation.
+
+Validation rules:
+
+- Archive and soft-delete candidates are informational until the host explicitly applies marker writes.
+- Pruning candidates are preview-only and must not be applied by this slice.
+- Candidate resources and versions must belong to the effective tenant.
+
+## Lifecycle Marker State
+
+Represents the current lifecycle marker for one resource.
+
+Fields:
+
+- `TenantScope`: Effective tenant boundary.
+- `ResourceId`: Logical resource identifier.
+- `State`: None, archived, or soft-deleted.
+- `MarkedAt`: Timestamp supplied by the host operation.
+- `Reason`: Optional host-visible reason.
+
+Validation rules:
+
+- `(TenantScope, ResourceId)` has at most one effective marker state.
+- Applying the same non-none state is idempotent.
+- Applying archived to a soft-deleted resource, or soft-deleted to an archived resource, fails with a stable diagnostic.
+- Marker writes must not prune versions, physically delete resources, deactivate active versions, or rewrite resource history.
+- Restore and marker transition workflows are out of scope.
+
+Relationships:
+
+- References one logical resource inside one tenant.
+- Queried explicitly through lifecycle-state criteria.
+- Preserved by portability when the referenced resource is exported.
+
+## Lifecycle Marker Write Request
+
+Represents an explicit host operation to apply archive or soft-delete state.
+
+Fields:
+
+- `TenantScope`: Optional tenant scope; omitted means the default single-tenant scope.
+- `ResourceId`: Target logical resource.
+- `State`: Archived or soft-deleted.
+- `MarkedAt`: Host-supplied timestamp.
+- `Reason`: Optional host-visible reason.
+
+Validation rules:
+
+- Target resource must exist in the effective tenant.
+- State must be archived or soft-deleted.
+- Repeated same-state writes are idempotent.
+- Conflicting writes fail closed without changing existing marker state.
+
+## Resource Query Lifecycle Criterion
+
+Represents explicit lifecycle-state filtering in the portable resource query model.
+
+Fields:
+
+- `LifecycleState`: Optional none, archived, or soft-deleted criterion.
+
+Validation rules:
+
+- Omitted lifecycle-state criterion must not hide or exclude resources by marker state.
+- When supplied, filtering applies inside the effective tenant.
+- Providers must fail closed if they cannot support lifecycle-state filtering.
+
+Relationships:
+
+- Uses lifecycle marker state separate from immutable resource versions.
+- May combine with existing definition, version scope, activation, filter, sort, skip, and take behavior.
+
+## Policy Diagnostic
+
+Represents stable validation or preview failure output.
+
+Fields:
+
+- `Code`: Stable diagnostic code.
+- `Message`: Human-readable explanation.
+- `PolicyId`: Policy involved when available.
+- `ResourceId`: Resource involved when available.
+- `ResourceVersion`: Version involved when available.
+
+Candidate codes:
+
+- `policy-invalid`
+- `policy-kind-unsupported`
+- `policy-outcome-unsupported`
+- `policy-target-invalid`
+- `policy-criteria-unsupported`
+- `policy-conflict`
+- `policy-evaluation-timestamp-required`
+- `policy-pruning-unsafe`
+- `policy-pruning-preview-only`
+- `lifecycle-marker-conflict`
+- `lifecycle-marker-target-not-found`
+
+Validation rules:
+
+- Diagnostics must be stable enough for tests and hosts to distinguish failure categories.
+- Failures must not leak resources from outside the effective tenant.
+
+## State Transitions
+
+```text
+Register definition with policy declarations
+  -> Validate declaration shape
+  -> Append new immutable definition version
+
+Preview policies
+  -> Resolve effective tenant
+  -> Validate declarations and request timestamp
+  -> Read bounded resources and marker state
+  -> Return candidate outcomes and diagnostics without writes
+
+Apply archive or soft-delete marker
+  -> Resolve effective tenant
+  -> Verify target resource exists
+  -> If same marker exists: return current marker state
+  -> If different marker exists: return conflict diagnostic
+  -> Write additive marker state without changing resource versions or activation
+
+Query by lifecycle state
+  -> Resolve effective tenant
+  -> Read candidate resources
+  -> Apply explicit lifecycle-state criterion when supplied
+```

--- a/specs/016-policy-foundations/data-model.md
+++ b/specs/016-policy-foundations/data-model.md
@@ -206,9 +206,12 @@ Candidate codes:
 - `policy-conflict`
 - `policy-evaluation-timestamp-required`
 - `policy-pruning-unsafe`
-- `policy-pruning-preview-only`
 - `lifecycle-marker-conflict`
 - `lifecycle-marker-target-not-found`
+
+Reserved for future write-path enforcement:
+
+- `policy-pruning-preview-only`
 
 Validation rules:
 

--- a/specs/016-policy-foundations/plan.md
+++ b/specs/016-policy-foundations/plan.md
@@ -1,0 +1,139 @@
+# Implementation Plan: Policy Foundations
+
+**Branch**: `016-policy-foundations` | **Date**: 2026-05-25 | **Spec**: [spec.md](spec.md)  
+**Input**: Feature specification from `/specs/016-policy-foundations/spec.md`
+
+## Summary
+
+Add explicit policy foundations for retention, archive, soft-delete, and version pruning without automatic execution. The implementation adds policy declaration metadata to resource definitions, validation and deterministic preview services, explicit archive/soft-delete lifecycle marker operations, lifecycle-state query criteria, portability support for policy metadata and markers, and provider implementations for in-memory and SQLite JSON. Version pruning remains preview-only. The slice does not introduce background jobs, hidden retention behavior, authorization policies, runtime scanning, provider registries, public SQL, public `IQueryable<Resource>`, restore workflows, arbitrary facet predicates, or provider-specific policy languages.
+
+## Technical Context
+
+**Language/Version**: C# latest, .NET 8.0 / 9.0 / 10.0 multi-targeting  
+**Primary Dependencies**: Existing core SDK, in-memory store, SQLite JSON provider, resource manager/store abstractions, query capability/validation stack, portability service, lifecycle hook dispatcher, xUnit test stack; no new dependencies  
+**Storage**: Existing resource definitions gain policy declaration metadata; resource lifecycle markers are stored as additive state separate from immutable resource versions; portable snapshots include policy declarations and lifecycle markers; SQLite JSON adds policy/marker storage without a general migration framework  
+**Testing**: `dotnet test Aster.sln`, focused policy declaration/validation/preview/lifecycle marker/query/portability tests, SQLite JSON provider tests, existing single-tenant and tenant-scoped regression tests, `dotnet build Aster.sln /m:1`, `git diff --check`  
+**Target Platform**: .NET SDK/library consumers and local test environment  
+**Project Type**: SDK/library with provider packages and tests  
+**Performance Goals**: Existing no-policy operations remain behaviorally equivalent and continue to pass existing regression tests; lifecycle-marker lookups occur only when marker state is explicitly written, queried, exported, imported, or used by policy preview; policy preview uses bounded host-supplied scope and avoids scanning outside the effective tenant in provider-backed execution  
+**Constraints**: Policy declarations attach to resource definitions only; matching criteria are limited to age thresholds, retained-version counts, activation state, lifecycle marker state, definition identity, and tenant boundary; age-based previews require a host-supplied evaluation timestamp; archive/soft-delete marker writes are explicit host operations; same-marker writes are idempotent; conflicting marker writes fail closed; pruning writes and restore transitions are out of scope; no new dependencies, schedulers, hidden jobs, provider registry, runtime scanning, public SQL, or public `IQueryable<Resource>`  
+**Scale/Scope**: Current core SDK plus in-memory and SQLite JSON provider support for policy declarations, validation, previews, lifecycle markers, lifecycle-state queries, portability, documentation, and tests
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+- **SDK-first/headless**: PASS - Adds SDK/library contracts and provider behavior only; no UI, CMS, host framework, authorization, or scheduler coupling.
+- **Immutable versioning**: PASS - Resource versions remain append-only; lifecycle markers are additive state outside version snapshots.
+- **Channel activation**: PASS - Activation state remains separate from resource payloads and is only used as explicit policy/query criteria.
+- **Typed/queryable**: PASS - Querying remains through the portable query model; lifecycle-state criteria are explicit model fields, not public SQL or `IQueryable`.
+- **Provider agnostic**: PASS - Core defines policy semantics and provider abstractions; in-memory and SQLite translate them locally.
+- **Simplicity first**: PASS - The slice uses definition metadata, small services, and explicit store operations instead of a policy engine or registry.
+- **Modern C# idioms**: PASS - Records, nullable-safe request models, collection expressions, and async APIs match existing SDK style.
+- **Readability over cleverness**: PASS - Policy declaration, preview, marker write, and query behavior are direct and testable.
+- **Explicitness over magic**: PASS - No ambient clock, runtime scanning, automatic execution, or hidden filtering.
+- **Abstractions justified**: PASS - New policy and lifecycle marker contracts are needed because the behavior crosses core, providers, queries, and portability.
+- **Optimize for deletion**: PASS - Policy models and marker stores are localized and can be removed without changing resource version payloads.
+- **Composition over inheritance**: PASS - Uses composed records/services and avoids inheritance hierarchies.
+- **Intentional dependencies**: PASS - No new third-party dependencies.
+- **Operational simplicity**: PASS - Existing build/test workflows remain sufficient; no worker process, migration runner, or external service.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/016-policy-foundations/
++-- spec.md
++-- plan.md
++-- research.md
++-- data-model.md
++-- quickstart.md
++-- checklists/
+|   +-- requirements.md
++-- contracts/
+    +-- policy-foundations.md
+```
+
+### Source Code (repository root)
+
+```text
+src/
++-- core/Aster.Core/
+|   +-- Abstractions/
+|   |   +-- policy validation/evaluation/lifecycle marker contracts
+|   +-- Definitions/
+|   |   +-- builder support for definition-attached policy declarations
+|   +-- Models/Definitions/
+|   |   +-- ResourceDefinition policy declaration metadata
+|   +-- Models/Instances/
+|   |   +-- lifecycle marker state and lifecycle marker write results
+|   +-- Models/Policies/
+|   |   +-- policy declarations, criteria, preview results, diagnostics
+|   +-- Models/Portability/
+|   |   +-- portable lifecycle marker state
+|   +-- Models/Querying/
+|   |   +-- explicit lifecycle-state query criteria
+|   +-- InMemory/
+|   |   +-- in-memory policy preview and lifecycle marker storage behavior
+|   +-- Services/
+|       +-- policy validator, preview service, lifecycle marker service
+|
++-- persistence/Aster.Persistence.SqliteJson/
+|   +-- SQLite JSON policy declaration persistence and lifecycle marker storage/query support
+|
++-- apps/Aster.Web/
+    +-- no feature-specific host UI; compatibility updates only if needed
+
+test/
++-- Aster.Tests/
+    +-- Policies/
+    +-- InMemory/
+    +-- Querying/
+    +-- Portability/
+    +-- SqliteJson/
+    +-- Tenancy/
+```
+
+**Structure Decision**: Keep policy contracts in `Aster.Core` because declarations, validation, previews, lifecycle marker state, queries, portability, and tenant boundaries are SDK semantics. Provider packages implement storage and query translation behind existing provider boundaries. Do not add a policy engine package, registry, background runner, authorization layer, or new dependency.
+
+## Complexity Tracking
+
+No constitution violations.
+
+## Phase 0 Research Summary
+
+Research decisions are captured in [research.md](research.md). Key outcomes:
+
+- Attach policy declarations to resource definitions only.
+- Model lifecycle markers as provider-stored additive state, not resource version mutations.
+- Require explicit host-supplied evaluation timestamps for age-based previews.
+- Limit policy criteria to age/count/activation/lifecycle/definition/tenant criteria.
+- Keep pruning preview-only in this slice.
+- Extend the existing portable query model with lifecycle-state criteria instead of public SQL or `IQueryable`.
+- Preserve provider agnosticism through small core contracts and local in-memory/SQLite implementations.
+
+## Phase 1 Design Summary
+
+Design artifacts:
+
+- [data-model.md](data-model.md)
+- [contracts/policy-foundations.md](contracts/policy-foundations.md)
+- [quickstart.md](quickstart.md)
+
+## Post-Design Constitution Check
+
+- **SDK-first/headless**: PASS - Design exposes SDK contracts only and leaves scheduling, compliance decisions, and authorization to hosts.
+- **Immutable versioning**: PASS - Marker writes do not rewrite resources or resource versions.
+- **Channel activation**: PASS - Activation is a criterion, not a policy side effect.
+- **Typed/queryable**: PASS - Lifecycle-state filtering is an explicit query model addition; raw SQL and public `IQueryable` remain out of scope.
+- **Provider agnostic**: PASS - Core services depend on abstractions; SQLite details stay in the SQLite provider.
+- **Simplicity first**: PASS - The design implements current declaration/preview/marker needs without a general policy engine.
+- **Modern C# idioms**: PASS - Records and explicit async service contracts fit existing code.
+- **Readability over cleverness**: PASS - Direct request/result models replace hidden conventions and dynamic execution.
+- **Explicitness over magic**: PASS - Host-supplied timestamps, explicit marker operations, and explicit query criteria avoid ambient behavior.
+- **Abstractions justified**: PASS - Each new contract maps to a concrete cross-provider need: validate, preview, read/write marker state.
+- **Optimize for deletion**: PASS - Policy declarations and marker state are additive modules with minimal coupling to resource version storage.
+- **Composition over inheritance**: PASS - Data-oriented records and services compose with existing stores.
+- **Intentional dependencies**: PASS - No new dependencies.
+- **Operational simplicity**: PASS - No background worker, migration framework, external service, or deployment-time policy runner is introduced.

--- a/specs/016-policy-foundations/quickstart.md
+++ b/specs/016-policy-foundations/quickstart.md
@@ -195,9 +195,10 @@ Expected diagnostic codes include:
 - `policy-conflict`
 - `policy-evaluation-timestamp-required`
 - `policy-pruning-unsafe`
-- `policy-pruning-preview-only`
 - `lifecycle-marker-conflict`
 - `lifecycle-marker-target-not-found`
+
+`policy-pruning-preview-only` is reserved for a future write-path enforcement surface; this slice has no pruning write API.
 
 ## Exclusions
 

--- a/specs/016-policy-foundations/quickstart.md
+++ b/specs/016-policy-foundations/quickstart.md
@@ -1,0 +1,204 @@
+# Quickstart: Policy Foundations
+
+This quickstart shows the intended SDK behavior for explicit policy declarations, deterministic previews, lifecycle marker writes, and lifecycle-state queries.
+
+## Declare Policies On A Resource Definition
+
+Policy declarations are resource definition metadata. Registering the definition appends a normal immutable definition version.
+
+```csharp
+var definition = new ResourceDefinitionBuilder()
+    .WithDefinitionId("Product")
+    .WithPolicy(new ResourcePolicyDeclaration
+    {
+        PolicyId = "archive-old-products",
+        Name = "Archive old products",
+        Kind = ResourcePolicyKind.Archival,
+        Target = ResourcePolicyTarget.Resource,
+        Outcome = ResourcePolicyOutcome.Archive,
+        Criteria = new ResourcePolicyCriteria
+        {
+            MinimumAge = TimeSpan.FromDays(365),
+            LifecycleState = ResourceLifecycleMarkerState.None,
+        },
+    })
+    .WithPolicy(new ResourcePolicyDeclaration
+    {
+        PolicyId = "keep-last-three-versions",
+        Name = "Keep last three versions",
+        Kind = ResourcePolicyKind.VersionPruning,
+        Target = ResourcePolicyTarget.ResourceVersion,
+        Outcome = ResourcePolicyOutcome.PrunePreview,
+        Criteria = new ResourcePolicyCriteria
+        {
+            MaximumRetainedVersions = 3,
+        },
+    })
+    .Build();
+
+await definitionStore.RegisterDefinitionAsync(definition);
+```
+
+Policy declarations do not execute automatically.
+
+## Validate Policy Declarations
+
+Hosts can validate policy metadata before preview or execution decisions.
+
+```csharp
+var policyValidator = serviceProvider.GetRequiredService<IResourcePolicyValidator>();
+var result = policyValidator.Validate(definition);
+
+if (!result.IsValid)
+{
+    foreach (var diagnostic in result.Diagnostics)
+    {
+        Console.WriteLine($"{diagnostic.Code}: {diagnostic.Message}");
+    }
+}
+```
+
+Validation does not mutate resource data.
+
+## Preview Policy Outcomes
+
+Policy previews are deterministic. Age-based criteria require an explicit evaluation timestamp.
+
+```csharp
+var policyEvaluation = serviceProvider.GetRequiredService<IResourcePolicyEvaluationService>();
+var preview = await policyEvaluation.PreviewAsync(new ResourcePolicyEvaluationRequest
+{
+    DefinitionIds = ["Product"],
+    EvaluationTimestamp = new DateTimeOffset(2026, 05, 25, 12, 00, 00, TimeSpan.Zero),
+});
+
+foreach (var candidate in preview.Candidates)
+{
+    Console.WriteLine($"{candidate.Outcome}: {candidate.ResourceId} ({candidate.Reason})");
+}
+```
+
+Preview does not archive, soft-delete, prune, deactivate, delete, or otherwise mutate resources.
+
+## Apply Archive Or Soft-Delete Markers Explicitly
+
+Hosts apply archive and soft-delete markers through explicit operations.
+
+```csharp
+var lifecycleMarkers = serviceProvider.GetRequiredService<IResourceLifecycleMarkerService>();
+var markerResult = await lifecycleMarkers.ApplyAsync(new ResourceLifecycleMarkerRequest
+{
+    ResourceId = "product-1",
+    State = ResourceLifecycleMarkerState.Archived,
+    MarkedAt = new DateTimeOffset(2026, 05, 25, 12, 00, 00, TimeSpan.Zero),
+    Reason = "Archived after policy preview.",
+});
+```
+
+Applying the same marker again is idempotent. Applying soft-delete to an archived resource, or archive to a soft-deleted resource, returns a stable conflict diagnostic and leaves the existing marker unchanged.
+
+Marker writes do not rewrite resource versions, deactivate active versions, or physically delete data.
+
+## Query Lifecycle State Explicitly
+
+Lifecycle markers are not hidden filters. Hosts query them intentionally.
+
+```csharp
+var queryService = serviceProvider.GetRequiredService<IResourceQueryService>();
+var archived = await queryService.QueryAsync(new ResourceQuery
+{
+    DefinitionId = "Product",
+    LifecycleState = ResourceLifecycleMarkerState.Archived,
+    Scope = ResourceVersionScope.Latest,
+});
+```
+
+Omitting `LifecycleState` does not implicitly exclude archived or soft-deleted resources.
+
+Activation-state criteria use the same explicit activation model as queries:
+
+```csharp
+var activeOnlyPolicy = new ResourcePolicyDeclaration
+{
+    PolicyId = "archive-active-products",
+    Kind = ResourcePolicyKind.Archival,
+    Target = ResourcePolicyTarget.Resource,
+    Outcome = ResourcePolicyOutcome.Archive,
+    Criteria = new ResourcePolicyCriteria
+    {
+        ActivationState = ResourcePolicyActivationState.Active,
+        ActivationChannel = "Published",
+        LifecycleState = ResourceLifecycleMarkerState.None,
+    },
+};
+```
+
+## Tenant-Scoped Policy Preview
+
+Tenant-scoped hosts supply tenant scope on the preview request.
+
+```csharp
+var tenantA = TenantScope.FromTenantId("tenant-a");
+
+var tenantPreview = await policyEvaluation.PreviewAsync(new ResourcePolicyEvaluationRequest
+{
+    TenantScope = tenantA,
+    DefinitionIds = ["Product"],
+    EvaluationTimestamp = new DateTimeOffset(2026, 05, 25, 12, 00, 00, TimeSpan.Zero),
+});
+```
+
+Preview results include only resources inside the effective tenant boundary.
+
+## Portability
+
+Policy declarations travel with exported definition versions. Lifecycle markers travel with exported resources.
+
+```csharp
+var export = await portability.ExportAsync(new PortableSnapshotExportRequest
+{
+    ScopeMode = PortableExportScopeMode.DefinitionWithResources,
+    DefinitionIds = ["Product"],
+    ResourceVersionScope = PortableResourceVersionScope.AllVersions,
+});
+
+var snapshot = export.Snapshot!;
+```
+
+Import preview reports policy and lifecycle marker conflicts without applying writes.
+
+## Failure Cases
+
+Unsupported policy criteria fail closed:
+
+```csharp
+var invalid = new ResourcePolicyDeclaration
+{
+    PolicyId = "facet-policy",
+    Kind = ResourcePolicyKind.Archival,
+    Target = ResourcePolicyTarget.Resource,
+    Outcome = ResourcePolicyOutcome.Archive,
+    Criteria = new ResourcePolicyCriteria
+    {
+        UnsupportedFacetPredicate = "Color = 'Red'",
+    },
+};
+```
+
+Expected diagnostic codes include:
+
+- `policy-invalid`
+- `policy-kind-unsupported`
+- `policy-outcome-unsupported`
+- `policy-target-invalid`
+- `policy-criteria-unsupported`
+- `policy-conflict`
+- `policy-evaluation-timestamp-required`
+- `policy-pruning-unsafe`
+- `policy-pruning-preview-only`
+- `lifecycle-marker-conflict`
+- `lifecycle-marker-target-not-found`
+
+## Exclusions
+
+This slice does not add automatic policy execution, background schedulers, hidden retention jobs, authorization policies, cross-tenant policy evaluation, runtime scanning, provider registries, arbitrary facet predicate policy criteria, provider-specific policy languages, public SQL, public `IQueryable<Resource>`, destructive pruning writes, or restore workflows.

--- a/specs/016-policy-foundations/research.md
+++ b/specs/016-policy-foundations/research.md
@@ -1,0 +1,108 @@
+# Research: Policy Foundations
+
+## Decision: Definition-Attached Policy Declarations
+
+**Decision**: Policy declarations attach to `ResourceDefinition` versions and apply to resources of the declaring definition.
+
+**Rationale**: Definitions are already the SDK boundary for resource type metadata. Attaching policies there keeps declarations discoverable, versioned with definition metadata, and visible before evaluation without creating per-resource override semantics.
+
+**Alternatives considered**:
+
+- Per-resource policy declarations: rejected because it creates override and precedence rules before there is a demonstrated need.
+- Definition and resource declarations with overrides: rejected because it requires conflict resolution semantics that are outside this first slice.
+- Runtime discovery or scanning: rejected because it hides behavior and violates explicitness requirements.
+
+## Decision: Explicit Criteria Set Only
+
+**Decision**: This slice supports only age thresholds, retained-version counts, activation state, lifecycle marker state, resource definition identity, and effective tenant boundary as policy criteria.
+
+**Rationale**: These criteria cover retention, archive, soft-delete, and pruning previews without requiring a query planner or policy expression language. They are also portable across the in-memory and SQLite JSON providers.
+
+**Alternatives considered**:
+
+- Arbitrary resource facet predicates: rejected for this slice because they would overlap with query planning and require provider capability negotiation.
+- Expression trees or callbacks: rejected because they are not portable and are hard to persist, validate, or execute provider-side.
+- Raw SQL or provider-specific syntax: rejected by the public query model and provider-agnostic principles.
+
+## Decision: Host-Supplied Evaluation Timestamp
+
+**Decision**: Age-based policy previews require a host-supplied evaluation timestamp and must not read an ambient system clock.
+
+**Rationale**: Retention and pruning previews must be deterministic in tests, repeatable in audits, and explicit in host workflows. A required timestamp also avoids hidden timezone and clock-source assumptions.
+
+**Alternatives considered**:
+
+- Use the system clock by default: rejected because previews would change based on when tests or hosts execute.
+- Optional timestamp override: rejected because it still leaves ambient behavior as the default.
+- Store but do not evaluate age criteria: rejected because preview behavior is a core requirement for this slice.
+
+## Decision: Lifecycle Markers Are Additive State
+
+**Decision**: Archive and soft-delete outcomes are stored as explicit lifecycle marker state separate from immutable resource version snapshots.
+
+**Rationale**: Marker state must be writable without rewriting historical resource versions. A separate marker record follows the existing activation-state pattern: resource history remains append-only while current lifecycle state remains queryable and portable.
+
+**Alternatives considered**:
+
+- Add lifecycle state to `Resource` snapshots: rejected because applying a marker would require rewriting snapshots or creating a misleading resource version.
+- Hide markers as query defaults: rejected because hosts must opt into lifecycle-state filtering explicitly.
+- Physically delete or deactivate resources on soft-delete/archive: rejected because it conflicts with append-only history and channel activation separation.
+
+## Decision: One Effective Lifecycle State
+
+**Decision**: A resource has at most one effective lifecycle marker state in this slice. Reapplying the same marker is idempotent. Applying archive to a soft-deleted resource, or soft-delete to an archived resource, fails with a stable diagnostic.
+
+**Rationale**: A single effective state keeps query behavior and portability clear while restore and lifecycle transition semantics remain undefined.
+
+**Alternatives considered**:
+
+- Allow archive and soft-delete to coexist: rejected because it complicates query semantics and future restore behavior.
+- Latest marker wins: rejected because it creates implicit transitions without an explicit transition model.
+- Always append marker history: rejected for this slice because audit history for marker transitions requires additional requirements.
+
+## Decision: Pruning Preview Only
+
+**Decision**: Version pruning can be declared, validated, and previewed, but destructive pruning writes are out of scope.
+
+**Rationale**: Pruning can permanently remove history. Preview-only behavior lets hosts inspect candidate versions and diagnostics without compromising immutable-versioning guarantees in the first policy slice.
+
+**Alternatives considered**:
+
+- Implement pruning writes now: rejected because it needs stronger audit, backup, lifecycle hook, and restore semantics.
+- Store pruning declarations but skip preview: rejected because previews are required to make pruning intent actionable and testable.
+
+## Decision: Explicit Query Model Extension
+
+**Decision**: Lifecycle-state queries use an explicit SDK query criterion rather than hidden filtering, raw SQL, or public `IQueryable<Resource>`.
+
+**Rationale**: Hosts need to find archived and soft-deleted resources intentionally. Adding a small lifecycle-state criterion preserves the portable query model and lets providers translate behavior locally.
+
+**Alternatives considered**:
+
+- Implicitly hide soft-deleted resources: rejected because it creates surprising behavior and authorization-like filtering.
+- Raw provider queries: rejected because public SQL and provider-specific syntax are out of scope.
+- Reusing facet predicates: rejected because lifecycle state is SDK metadata, not resource payload.
+
+## Decision: Small Core Services Over Policy Engine
+
+**Decision**: Add focused core contracts for validation, preview evaluation, and lifecycle marker state rather than a provider registry, planner, scheduler, or policy engine.
+
+**Rationale**: The current need is explicit declaration, deterministic preview, and marker writes. A small service surface is sufficient and remains easy to delete or replace.
+
+**Alternatives considered**:
+
+- General policy engine: rejected as premature infrastructure.
+- Background retention scheduler: rejected because execution timing and hosting are host responsibilities.
+- Provider registry or runtime scanning: rejected because Aster already uses explicit active provider registration.
+
+## Decision: Provider-Local Storage Support
+
+**Decision**: In-memory and SQLite JSON providers implement lifecycle marker storage and lifecycle-state query filtering locally. Resource definitions persist policy declaration metadata through existing definition storage.
+
+**Rationale**: Policy semantics are core SDK behavior, but storage details belong to providers. This follows existing provider boundaries without adding dependencies or migration infrastructure.
+
+**Alternatives considered**:
+
+- Core-only in-memory marker store for all providers: rejected because SQLite-backed hosts need markers to persist with SQLite data.
+- New storage/provider framework: rejected because existing provider abstractions are sufficient for this slice.
+- Migration framework: rejected because this feature can use idempotent provider initialization or additive schema changes without defining a general migration policy.

--- a/specs/016-policy-foundations/spec.md
+++ b/specs/016-policy-foundations/spec.md
@@ -5,6 +5,16 @@
 **Status**: Draft  
 **Input**: User description: "Introduce explicit policy contracts for retention, archival, soft-delete, and version pruning while preserving append-only resource history by default. Include policy metadata models and validation diagnostics, explicit policy evaluation entry points for hosts and providers, soft-delete/archive markers that remain queryable through declared scopes, version pruning previews before destructive writes, and keep background schedulers, hidden retention jobs, authorization policy engines, runtime scanning, provider registries, public SQL, and IQueryable<Resource> out of scope."
 
+## Clarifications
+
+### Session 2026-05-25
+
+- Q: Where should policy declarations attach in this first slice? → A: Resource definitions only.
+- Q: Should this slice include write behavior for policy outcomes? → A: Explicit host-applied archive and soft-delete marker writes are included; pruning remains preview-only.
+- Q: Which policy condition set should this slice support? → A: Age, count, activation state, lifecycle state, and tenant boundary criteria only.
+- Q: How should repeated or conflicting lifecycle marker writes behave? → A: One effective lifecycle state per resource; same-marker writes are idempotent, different-marker writes are rejected with diagnostics.
+- Q: How should policy preview time be supplied for age-based criteria? → A: Hosts must provide an explicit evaluation timestamp; policy previews must not use an ambient clock.
+
 ## User Scenarios & Testing *(mandatory)*
 
 ### User Story 1 - Declare Resource Policies Explicitly (Priority: P1)
@@ -36,8 +46,9 @@ As a host author, I need to evaluate declared policies and receive a preview of 
 
 1. **Given** resources match an archival policy, **When** the host evaluates policies, **Then** the preview lists the resources that would be archived and explains the matching policy.
 2. **Given** resource versions match a pruning policy, **When** the host evaluates policies, **Then** the preview lists candidate versions and the reason each version is eligible.
-3. **Given** a policy evaluation encounters unsupported or invalid policy metadata, **When** the host requests a preview, **Then** the preview includes diagnostics and no write-side outcome occurs.
-4. **Given** a tenant-scoped host evaluates policies for one tenant, **When** similar resources exist in another tenant, **Then** the preview includes only resources within the effective tenant boundary.
+3. **Given** an age-based policy declaration exists, **When** the host requests a preview with an explicit evaluation timestamp, **Then** age calculations use that timestamp and do not depend on the system clock.
+4. **Given** a policy evaluation encounters unsupported or invalid policy metadata, **When** the host requests a preview, **Then** the preview includes diagnostics and no write-side outcome occurs.
+5. **Given** a tenant-scoped host evaluates policies for one tenant, **When** similar resources exist in another tenant, **Then** the preview includes only resources within the effective tenant boundary.
 
 ---
 
@@ -47,27 +58,33 @@ As a host author, I need soft-delete and archive outcomes to be explicit lifecyc
 
 **Why this priority**: Policy outcomes must be visible and reversible where appropriate. Hidden default filtering would create surprising behavior and make audits harder.
 
-**Independent Test**: Mark resources as archived or soft-deleted, then verify normal resource history remains intact and hosts can query or inspect the lifecycle state through explicit criteria.
+**Independent Test**: Explicitly apply archive and soft-delete markers to resources, then verify normal resource history remains intact and hosts can query or inspect the lifecycle state through explicit criteria.
 
 **Acceptance Scenarios**:
 
-1. **Given** a resource is soft-deleted, **When** the host reads or queries with criteria that include lifecycle state, **Then** the resource can be found with its soft-delete marker and original versions intact.
-2. **Given** a resource is archived, **When** the host inspects resource lifecycle state, **Then** the archive marker is visible without removing activation, version, or portability history.
-3. **Given** a host does not ask for lifecycle-state filtering, **When** it uses existing resource workflows, **Then** policy markers do not introduce hidden background behavior or implicit authorization decisions.
+1. **Given** a host explicitly applies a soft-delete marker to a resource, **When** the host reads or queries with criteria that include lifecycle state, **Then** the resource can be found with its soft-delete marker and original versions intact.
+2. **Given** a host explicitly applies an archive marker to a resource, **When** the host inspects resource lifecycle state, **Then** the archive marker is visible without removing activation, version, or portability history.
+3. **Given** a host applies the same lifecycle marker to a resource more than once, **When** the operation completes, **Then** the resource has one effective lifecycle state and the repeated operation is treated as idempotent.
+4. **Given** a resource already has an archive or soft-delete marker, **When** a host attempts to apply the other lifecycle marker, **Then** the operation is rejected with a stable diagnostic and the existing lifecycle state remains unchanged.
+5. **Given** a host does not ask for lifecycle-state filtering, **When** it uses existing resource workflows, **Then** policy markers do not introduce hidden background behavior or implicit authorization decisions.
 
 ### Edge Cases
 
 - A policy declaration references an unknown target, unsupported outcome, invalid duration, or contradictory settings.
+- A policy declaration attempts to use arbitrary resource facet predicates, expression trees, SQL fragments, provider-specific query syntax, or host code callbacks as matching criteria.
+- A policy declaration exists on a resource definition whose resources span multiple tenants; evaluation still uses the effective tenant boundary.
 - Multiple policy declarations apply to the same resource or version and produce overlapping candidate outcomes.
 - A policy preview includes resources with no active version, multiple active versions, archived state, or soft-deleted state.
 - A pruning preview would include every version of a resource, including the latest or currently active version.
+- A host requests an age-based policy preview without an explicit evaluation timestamp.
 - Policy metadata is present on data exported from one tenant and imported into another tenant.
 - A host evaluates policies with omitted tenant scope after tenant-scoped data exists.
-- A host attempts to apply a policy outcome when only preview behavior is supported in this slice.
+- A host attempts to apply a pruning outcome when only pruning preview behavior is supported in this slice.
+- A host repeats the same lifecycle marker write or attempts to apply an archive marker to a soft-deleted resource, or a soft-delete marker to an archived resource.
 
 ### Constitution Alignment *(mandatory)*
 
-- **Simplicity**: The simplest acceptable behavior is explicit policy declarations, validation diagnostics, preview-only evaluation, and visible lifecycle markers. Automatic execution, schedulers, hidden retention jobs, authorization policy engines, cross-tenant policy workflows, runtime scanning, provider registries, public SQL, and public `IQueryable<Resource>` are out of scope.
+- **Simplicity**: The simplest acceptable behavior is explicit policy declarations, validation diagnostics, preview evaluation, host-applied archive and soft-delete marker writes, and visible lifecycle markers. Automatic execution, pruning writes, schedulers, hidden retention jobs, authorization policy engines, cross-tenant policy workflows, runtime scanning, provider registries, public SQL, and public `IQueryable<Resource>` are out of scope.
 - **Explicitness**: Policy declarations, previews, diagnostics, and lifecycle markers must be visible through host-controlled inputs and outputs. The system must not discover or execute policies through hidden conventions, ambient runtime state, or background processing.
 - **Dependencies**: None.
 - **Operational Impact**: Existing local development, deployment, and debugging remain unchanged. Hosts opt in to policy declaration and preview workflows explicitly; no background workers, timers, external services, or deployment-time policy runner are introduced.
@@ -76,11 +93,15 @@ As a host author, I need soft-delete and archive outcomes to be explicit lifecyc
 
 ### Functional Requirements
 
-- **FR-001**: The system MUST support explicit policy declarations for retention, archival, soft-delete, and version pruning intent.
+- **FR-001**: The system MUST support explicit policy declarations for retention, archival, soft-delete, and version pruning intent on resource definitions.
 - **FR-002**: Policy declarations MUST identify their policy kind, target scope, outcome intent, and host-visible settings in a way that can be inspected before evaluation.
+- **FR-002a**: Policy declarations in this slice MUST apply to resources of the declaring resource definition and MUST NOT be attached directly to individual resources.
+- **FR-002b**: Policy declarations in this slice MUST limit matching criteria to age thresholds, retained-version counts, activation state, lifecycle marker state, resource definition identity, and effective tenant boundary.
+- **FR-002c**: Policy declarations MUST NOT accept arbitrary resource facet predicates, expression trees, SQL fragments, provider-specific query syntax, or host code callbacks as matching criteria in this slice.
 - **FR-003**: The system MUST validate policy declarations and report stable diagnostics for missing, invalid, contradictory, or unsupported policy metadata.
 - **FR-004**: Policy validation MUST NOT mutate resources, versions, activation state, lifecycle markers, definitions, or portable snapshots.
 - **FR-005**: Hosts MUST be able to request a policy evaluation preview for a bounded scope of resources.
+- **FR-005a**: Policy evaluation previews for age-based criteria MUST require a host-supplied evaluation timestamp and MUST NOT read an ambient system clock.
 - **FR-006**: Policy evaluation previews MUST report candidate outcomes, matching policy declarations, affected resource identifiers, affected version identifiers when applicable, and diagnostics when evaluation cannot proceed.
 - **FR-007**: Policy evaluation previews MUST NOT archive, soft-delete, prune, deactivate, delete, or otherwise mutate resource data.
 - **FR-008**: Version pruning behavior in this slice MUST be preview-only and MUST NOT perform destructive writes.
@@ -88,6 +109,11 @@ As a host author, I need soft-delete and archive outcomes to be explicit lifecyc
 - **FR-010**: Soft-delete and archive outcomes MUST be represented as explicit lifecycle markers rather than physical deletion.
 - **FR-011**: Lifecycle markers MUST preserve append-only resource history and MUST NOT rewrite prior resource versions.
 - **FR-012**: Hosts MUST be able to inspect and query resources by lifecycle marker state through explicit criteria.
+- **FR-012a**: Hosts MUST be able to explicitly apply archive and soft-delete lifecycle markers to resources through host-controlled operations.
+- **FR-012b**: Applying archive or soft-delete markers MUST NOT prune versions, physically delete resources, deactivate active versions, or rewrite historical resource data.
+- **FR-012c**: Each resource MUST have at most one effective lifecycle marker state in this slice.
+- **FR-012d**: Applying the same lifecycle marker to an already-marked resource MUST be idempotent.
+- **FR-012e**: Applying an archive marker to a soft-deleted resource, or a soft-delete marker to an archived resource, MUST be rejected with a stable diagnostic and MUST NOT change the existing lifecycle marker state.
 - **FR-013**: Existing resource reads, writes, activation behavior, schema upgrades, portability, and lifecycle hooks MUST remain deterministic when policy metadata exists.
 - **FR-014**: Tenant-scoped policy validation, preview, lifecycle markers, and query behavior MUST operate within one effective tenant boundary.
 - **FR-015**: Omitted tenant scope MUST continue to mean the documented default single-tenant scope.
@@ -98,10 +124,10 @@ As a host author, I need soft-delete and archive outcomes to be explicit lifecyc
 
 ### Key Entities
 
-- **Policy Declaration**: Host-visible metadata describing a policy kind, target scope, outcome intent, and settings. It is declarative and does not execute by itself.
-- **Policy Target Scope**: The bounded set of definitions, resources, versions, tenants, lifecycle states, or activation states a policy declaration is intended to evaluate against.
+- **Policy Declaration**: Host-visible metadata on a resource definition describing a policy kind, target scope, outcome intent, and settings. It is declarative and does not execute by itself.
+- **Policy Target Scope**: The bounded set of definitions, resources, versions, tenants, lifecycle states, activation states, age thresholds, or retained-version counts a policy declaration is intended to evaluate against.
 - **Policy Evaluation Preview**: A host-requested report that identifies candidate outcomes and diagnostics without mutating data.
-- **Policy Candidate Outcome**: A preview item describing a resource or version that would be archived, soft-deleted, retained, or considered for pruning if a future explicit write workflow applies the policy.
+- **Policy Candidate Outcome**: A preview item describing a resource or version that would be archived, soft-deleted, retained, or considered for pruning if a host explicitly applies the outcome.
 - **Lifecycle Marker**: An explicit resource lifecycle state such as archived or soft-deleted. It remains visible for reads, queries, audits, portability, and future restore flows.
 - **Policy Diagnostic**: A stable validation or preview message describing invalid metadata, unsupported behavior, conflicting declarations, unsafe pruning, or preview-only enforcement.
 
@@ -113,14 +139,16 @@ As a host author, I need soft-delete and archive outcomes to be explicit lifecyc
 - **SC-002**: Invalid or unsupported policy declarations produce stable diagnostics that automated tests can assert.
 - **SC-003**: A host can run a policy preview over resources with matching and non-matching data and receive candidate outcomes with no mutations.
 - **SC-004**: A pruning preview can identify eligible versions while preserving all stored resource versions and activation state.
-- **SC-005**: Archived and soft-deleted resources remain discoverable through explicit lifecycle-state criteria.
+- **SC-005**: Hosts can explicitly apply archive and soft-delete markers, and marked resources remain discoverable through explicit lifecycle-state criteria.
 - **SC-006**: Tenant-scoped policy previews and lifecycle marker queries return zero resources from outside the effective tenant boundary.
 - **SC-007**: Existing single-tenant tests and workflows continue to pass without requiring policy declarations.
 
 ## Assumptions
 
-- This slice defines policy foundations and preview behavior, not automatic policy execution.
+- This slice defines policy foundations, preview behavior, and explicit host-applied archive and soft-delete marker writes, not automatic policy execution.
 - Hosts remain responsible for deciding when and whether to apply candidate outcomes.
 - Authorization, permissions, legal compliance interpretation, and scheduling are host responsibilities.
 - Destructive pruning writes, restore workflows, and automatic retention jobs require future specifications.
 - Lifecycle markers are additive state and do not rewrite historical resource versions.
+- Lifecycle marker transitions and restore behavior require future specifications.
+- Arbitrary resource facet predicates and provider-specific query languages require future specifications.

--- a/specs/016-policy-foundations/spec.md
+++ b/specs/016-policy-foundations/spec.md
@@ -1,0 +1,126 @@
+# Feature Specification: Policy Foundations
+
+**Feature Branch**: `016-policy-foundations`  
+**Created**: 2026-05-25  
+**Status**: Draft  
+**Input**: User description: "Introduce explicit policy contracts for retention, archival, soft-delete, and version pruning while preserving append-only resource history by default. Include policy metadata models and validation diagnostics, explicit policy evaluation entry points for hosts and providers, soft-delete/archive markers that remain queryable through declared scopes, version pruning previews before destructive writes, and keep background schedulers, hidden retention jobs, authorization policy engines, runtime scanning, provider registries, public SQL, and IQueryable<Resource> out of scope."
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Declare Resource Policies Explicitly (Priority: P1)
+
+As a host author, I need to declare retention, archival, soft-delete, and pruning intent as explicit resource policy metadata, so policy behavior is discoverable before any host decides to act on it.
+
+**Why this priority**: Policy declarations are the foundation for every later policy workflow. Without explicit declarations, previews, diagnostics, and host execution decisions would be ambiguous.
+
+**Independent Test**: Declare policy metadata for a resource type and verify the declaration can be stored, inspected, validated, and reported without changing any resource history.
+
+**Acceptance Scenarios**:
+
+1. **Given** a resource type has no policy metadata, **When** a host inspects policy information, **Then** the system reports that no policy is declared and leaves resource history unchanged.
+2. **Given** a host declares retention, archival, soft-delete, or pruning intent, **When** the declaration is inspected, **Then** the declared policy name, scope, target, and effective settings are visible to host code.
+3. **Given** a policy declaration is incomplete, contradictory, or unsupported, **When** the host validates it, **Then** the system reports stable diagnostics and does not apply any policy outcome.
+4. **Given** existing resources were created before policies exist, **When** policy metadata is introduced, **Then** existing resource versions remain append-only and are not modified automatically.
+
+---
+
+### User Story 2 - Preview Policy Outcomes Before Action (Priority: P2)
+
+As a host author, I need to evaluate declared policies and receive a preview of candidate outcomes, so I can decide whether to archive, soft-delete, or prune through an explicit host-controlled workflow.
+
+**Why this priority**: Retention and pruning are potentially destructive or compliance-sensitive. The first slice must prove deterministic preview behavior before any write action exists.
+
+**Independent Test**: Create resources and versions that match declared policy conditions, run policy evaluation in preview mode, and verify the preview identifies candidate outcomes without changing stored resources.
+
+**Acceptance Scenarios**:
+
+1. **Given** resources match an archival policy, **When** the host evaluates policies, **Then** the preview lists the resources that would be archived and explains the matching policy.
+2. **Given** resource versions match a pruning policy, **When** the host evaluates policies, **Then** the preview lists candidate versions and the reason each version is eligible.
+3. **Given** a policy evaluation encounters unsupported or invalid policy metadata, **When** the host requests a preview, **Then** the preview includes diagnostics and no write-side outcome occurs.
+4. **Given** a tenant-scoped host evaluates policies for one tenant, **When** similar resources exist in another tenant, **Then** the preview includes only resources within the effective tenant boundary.
+
+---
+
+### User Story 3 - Mark And Query Resource Lifecycle State (Priority: P3)
+
+As a host author, I need soft-delete and archive outcomes to be explicit lifecycle markers that remain queryable, so hosts can build clear restore, audit, and administrative workflows without hidden filtering rules.
+
+**Why this priority**: Policy outcomes must be visible and reversible where appropriate. Hidden default filtering would create surprising behavior and make audits harder.
+
+**Independent Test**: Mark resources as archived or soft-deleted, then verify normal resource history remains intact and hosts can query or inspect the lifecycle state through explicit criteria.
+
+**Acceptance Scenarios**:
+
+1. **Given** a resource is soft-deleted, **When** the host reads or queries with criteria that include lifecycle state, **Then** the resource can be found with its soft-delete marker and original versions intact.
+2. **Given** a resource is archived, **When** the host inspects resource lifecycle state, **Then** the archive marker is visible without removing activation, version, or portability history.
+3. **Given** a host does not ask for lifecycle-state filtering, **When** it uses existing resource workflows, **Then** policy markers do not introduce hidden background behavior or implicit authorization decisions.
+
+### Edge Cases
+
+- A policy declaration references an unknown target, unsupported outcome, invalid duration, or contradictory settings.
+- Multiple policy declarations apply to the same resource or version and produce overlapping candidate outcomes.
+- A policy preview includes resources with no active version, multiple active versions, archived state, or soft-deleted state.
+- A pruning preview would include every version of a resource, including the latest or currently active version.
+- Policy metadata is present on data exported from one tenant and imported into another tenant.
+- A host evaluates policies with omitted tenant scope after tenant-scoped data exists.
+- A host attempts to apply a policy outcome when only preview behavior is supported in this slice.
+
+### Constitution Alignment *(mandatory)*
+
+- **Simplicity**: The simplest acceptable behavior is explicit policy declarations, validation diagnostics, preview-only evaluation, and visible lifecycle markers. Automatic execution, schedulers, hidden retention jobs, authorization policy engines, cross-tenant policy workflows, runtime scanning, provider registries, public SQL, and public `IQueryable<Resource>` are out of scope.
+- **Explicitness**: Policy declarations, previews, diagnostics, and lifecycle markers must be visible through host-controlled inputs and outputs. The system must not discover or execute policies through hidden conventions, ambient runtime state, or background processing.
+- **Dependencies**: None.
+- **Operational Impact**: Existing local development, deployment, and debugging remain unchanged. Hosts opt in to policy declaration and preview workflows explicitly; no background workers, timers, external services, or deployment-time policy runner are introduced.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The system MUST support explicit policy declarations for retention, archival, soft-delete, and version pruning intent.
+- **FR-002**: Policy declarations MUST identify their policy kind, target scope, outcome intent, and host-visible settings in a way that can be inspected before evaluation.
+- **FR-003**: The system MUST validate policy declarations and report stable diagnostics for missing, invalid, contradictory, or unsupported policy metadata.
+- **FR-004**: Policy validation MUST NOT mutate resources, versions, activation state, lifecycle markers, definitions, or portable snapshots.
+- **FR-005**: Hosts MUST be able to request a policy evaluation preview for a bounded scope of resources.
+- **FR-006**: Policy evaluation previews MUST report candidate outcomes, matching policy declarations, affected resource identifiers, affected version identifiers when applicable, and diagnostics when evaluation cannot proceed.
+- **FR-007**: Policy evaluation previews MUST NOT archive, soft-delete, prune, deactivate, delete, or otherwise mutate resource data.
+- **FR-008**: Version pruning behavior in this slice MUST be preview-only and MUST NOT perform destructive writes.
+- **FR-009**: The system MUST prevent or diagnose pruning previews that would remove all retained versions of a resource unless a future feature explicitly defines that behavior.
+- **FR-010**: Soft-delete and archive outcomes MUST be represented as explicit lifecycle markers rather than physical deletion.
+- **FR-011**: Lifecycle markers MUST preserve append-only resource history and MUST NOT rewrite prior resource versions.
+- **FR-012**: Hosts MUST be able to inspect and query resources by lifecycle marker state through explicit criteria.
+- **FR-013**: Existing resource reads, writes, activation behavior, schema upgrades, portability, and lifecycle hooks MUST remain deterministic when policy metadata exists.
+- **FR-014**: Tenant-scoped policy validation, preview, lifecycle markers, and query behavior MUST operate within one effective tenant boundary.
+- **FR-015**: Omitted tenant scope MUST continue to mean the documented default single-tenant scope.
+- **FR-016**: Portable export and import workflows MUST preserve policy declarations and lifecycle markers when they are included in the selected resource scope.
+- **FR-017**: Policy diagnostics MUST be stable enough for hosts and tests to distinguish invalid declaration, unsupported policy kind, unsupported outcome, invalid target, conflicting declaration, and preview-only enforcement failures.
+- **FR-018**: The feature MUST NOT introduce background schedulers, hidden retention jobs, automatic policy execution, authorization or permission policy engines, cross-tenant policy evaluation, runtime scanning, provider registries, public SQL, or public `IQueryable<Resource>`.
+- **FR-019**: Documentation MUST explain explicit policy declaration, validation, preview-only evaluation, lifecycle marker visibility, tenant boundary behavior, portability behavior, and out-of-scope automatic execution.
+
+### Key Entities
+
+- **Policy Declaration**: Host-visible metadata describing a policy kind, target scope, outcome intent, and settings. It is declarative and does not execute by itself.
+- **Policy Target Scope**: The bounded set of definitions, resources, versions, tenants, lifecycle states, or activation states a policy declaration is intended to evaluate against.
+- **Policy Evaluation Preview**: A host-requested report that identifies candidate outcomes and diagnostics without mutating data.
+- **Policy Candidate Outcome**: A preview item describing a resource or version that would be archived, soft-deleted, retained, or considered for pruning if a future explicit write workflow applies the policy.
+- **Lifecycle Marker**: An explicit resource lifecycle state such as archived or soft-deleted. It remains visible for reads, queries, audits, portability, and future restore flows.
+- **Policy Diagnostic**: A stable validation or preview message describing invalid metadata, unsupported behavior, conflicting declarations, unsafe pruning, or preview-only enforcement.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: A host can declare each supported policy kind and inspect the declaration without any resource data changing.
+- **SC-002**: Invalid or unsupported policy declarations produce stable diagnostics that automated tests can assert.
+- **SC-003**: A host can run a policy preview over resources with matching and non-matching data and receive candidate outcomes with no mutations.
+- **SC-004**: A pruning preview can identify eligible versions while preserving all stored resource versions and activation state.
+- **SC-005**: Archived and soft-deleted resources remain discoverable through explicit lifecycle-state criteria.
+- **SC-006**: Tenant-scoped policy previews and lifecycle marker queries return zero resources from outside the effective tenant boundary.
+- **SC-007**: Existing single-tenant tests and workflows continue to pass without requiring policy declarations.
+
+## Assumptions
+
+- This slice defines policy foundations and preview behavior, not automatic policy execution.
+- Hosts remain responsible for deciding when and whether to apply candidate outcomes.
+- Authorization, permissions, legal compliance interpretation, and scheduling are host responsibilities.
+- Destructive pruning writes, restore workflows, and automatic retention jobs require future specifications.
+- Lifecycle markers are additive state and do not rewrite historical resource versions.

--- a/specs/016-policy-foundations/tasks.md
+++ b/specs/016-policy-foundations/tasks.md
@@ -1,0 +1,249 @@
+# Tasks: Policy Foundations
+
+**Input**: Design documents from `/specs/016-policy-foundations/`  
+**Prerequisites**: [plan.md](plan.md), [spec.md](spec.md), [research.md](research.md), [data-model.md](data-model.md), [contracts/policy-foundations.md](contracts/policy-foundations.md), [quickstart.md](quickstart.md)
+
+**Tests**: Included because the feature specification defines independent tests for every user story and this slice changes policy, persistence, query, and portability behavior.
+
+**Organization**: Tasks are grouped by user story so definition-attached policy declarations can ship as the MVP before preview evaluation and lifecycle marker/query workflows.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel because it touches different files and has no dependency on another incomplete task.
+- **[Story]**: Maps the task to a user story from [spec.md](spec.md).
+- Every task includes an exact file path.
+
+## Phase 1: Setup
+
+**Purpose**: Prepare shared source and test locations for the policy-foundations slice.
+
+- [X] T001 Create policy model folder in `src/core/Aster.Core/Models/Policies/`
+- [X] T002 Create policy test folder in `test/Aster.Tests/Policies/`
+- [X] T003 [P] Confirm no new package references are required in `src/core/Aster.Core/Aster.Core.csproj`
+- [X] T004 [P] Confirm no new package references are required in `src/persistence/Aster.Persistence.SqliteJson/Aster.Persistence.SqliteJson.csproj`
+
+---
+
+## Phase 2: Foundational
+
+**Purpose**: Define shared policy, lifecycle marker, and query surfaces that block every user story.
+
+**Critical**: No user story implementation should begin until the public model and service contracts compile.
+
+- [X] T005 [P] Add policy declaration, criteria, target, outcome, and kind models in `src/core/Aster.Core/Models/Policies/ResourcePolicyModels.cs`
+- [X] T006 [P] Add policy validation, preview, candidate outcome, and diagnostic models in `src/core/Aster.Core/Models/Policies/ResourcePolicyResults.cs`
+- [X] T007 [P] Add lifecycle marker state, write request, write result, and marker diagnostics in `src/core/Aster.Core/Models/Instances/ResourceLifecycleMarker.cs`
+- [X] T008 Add policy declaration collection to resource definitions in `src/core/Aster.Core/Models/Definitions/ResourceDefinition.cs`
+- [X] T009 Add lifecycle-state query criterion to the portable query model in `src/core/Aster.Core/Models/Querying/ResourceQuery.cs`
+- [X] T010 [P] Add policy validator contract in `src/core/Aster.Core/Abstractions/IResourcePolicyValidator.cs`
+- [X] T011 [P] Add policy evaluation contract in `src/core/Aster.Core/Abstractions/IResourcePolicyEvaluationService.cs`
+- [X] T012 [P] Add lifecycle marker store and service contracts in `src/core/Aster.Core/Abstractions/IResourceLifecycleMarkerStore.cs`
+- [X] T013 Add minimal compiling policy validator, policy evaluation service, in-memory lifecycle marker store, and lifecycle marker service implementations in `src/core/Aster.Core/Services/ResourcePolicyValidator.cs`, `src/core/Aster.Core/Services/ResourcePolicyEvaluationService.cs`, `src/core/Aster.Core/InMemory/InMemoryResourceLifecycleMarkerStore.cs`, and `src/core/Aster.Core/Services/ResourceLifecycleMarkerService.cs`
+- [X] T014 Register core policy services and in-memory lifecycle marker services in `src/core/Aster.Core/Extensions/AsterCoreServiceCollectionExtensions.cs`
+- [X] T015 Run foundational compile check with `dotnet build Aster.sln /m:1 --no-restore` using `Aster.sln`
+
+**Checkpoint**: Shared policy and marker contracts compile and can be consumed by user story tasks.
+
+---
+
+## Phase 3: User Story 1 - Declare Resource Policies Explicitly (Priority: P1) MVP
+
+**Goal**: Hosts can declare, inspect, store, and validate retention, archive, soft-delete, and pruning intent as resource definition metadata without changing resource history.
+
+**Independent Test**: Declare policy metadata for a resource type and verify the declaration can be stored, inspected, validated, and reported without changing any resource history.
+
+### Tests for User Story 1
+
+- [X] T016 [P] [US1] Add resource definition policy declaration builder tests in `test/Aster.Tests/Policies/PolicyDeclarationBuilderTests.cs`
+- [X] T017 [P] [US1] Add policy validation diagnostics tests in `test/Aster.Tests/Policies/PolicyValidationTests.cs`
+- [X] T018 [P] [US1] Add in-memory policy metadata persistence tests in `test/Aster.Tests/Policies/PolicyDefinitionStoreTests.cs`
+- [X] T019 [P] [US1] Add SQLite JSON policy metadata persistence tests in `test/Aster.Tests/SqliteJson/SqliteJsonPolicyDefinitionTests.cs`
+- [X] T020 [P] [US1] Add no-policy, policy declaration portability, schema upgrade, and lifecycle hook compatibility tests in `test/Aster.Tests/Policies/PolicyCompatibilityTests.cs`
+
+### Implementation for User Story 1
+
+- [X] T021 [US1] Add `WithPolicy` and policy metadata inspection support to `src/core/Aster.Core/Definitions/ResourceDefinitionBuilder.cs`
+- [X] T022 [US1] Complete policy declaration validation rules in `src/core/Aster.Core/Services/ResourcePolicyValidator.cs`
+- [X] T023 [US1] Add stable policy diagnostic codes in `src/core/Aster.Core/Models/Policies/ResourcePolicyResults.cs`
+- [X] T024 [US1] Ensure in-memory definition registration preserves policy declarations in `src/core/Aster.Core/InMemory/InMemoryResourceDefinitionStore.cs`
+- [X] T025 [US1] Ensure SQLite definition persistence preserves policy declarations in `src/persistence/Aster.Persistence.SqliteJson/SqliteJsonResourceStore.cs`
+- [X] T026 [US1] Ensure existing resource create/update flows ignore policy declarations as execution triggers in `src/core/Aster.Core/Services/DefaultResourceManager.cs`
+- [X] T027 [US1] Add policy declaration snippets and validation guidance in `src/core/Aster.Core/README.md`
+- [X] T028 [US1] Run User Story 1 focused tests with `dotnet test Aster.sln --no-restore --filter "FullyQualifiedName~PolicyDeclaration|FullyQualifiedName~PolicyValidation|FullyQualifiedName~PolicyDefinition|FullyQualifiedName~PolicyCompatibility"` using `Aster.sln`
+
+**Checkpoint**: User Story 1 is independently functional as the MVP.
+
+---
+
+## Phase 4: User Story 2 - Preview Policy Outcomes Before Action (Priority: P2)
+
+**Goal**: Hosts can request deterministic policy previews for bounded scopes, including archive, soft-delete, and pruning candidates, with diagnostics and no mutations.
+
+**Independent Test**: Create resources and versions that match declared policy conditions, run policy evaluation in preview mode, and verify the preview identifies candidate outcomes without changing stored resources.
+
+### Tests for User Story 2
+
+- [X] T029 [P] [US2] Add archive and soft-delete preview candidate tests in `test/Aster.Tests/Policies/PolicyEvaluationPreviewTests.cs`
+- [X] T030 [P] [US2] Add version pruning preview and unsafe pruning diagnostics tests in `test/Aster.Tests/Policies/PolicyPruningPreviewTests.cs`
+- [X] T031 [P] [US2] Add explicit evaluation timestamp tests in `test/Aster.Tests/Policies/PolicyEvaluationTimestampTests.cs`
+- [X] T032 [P] [US2] Add preview no-mutation tests in `test/Aster.Tests/Policies/PolicyPreviewNoMutationTests.cs`
+- [X] T033 [P] [US2] Add tenant-scoped policy preview isolation tests in `test/Aster.Tests/Policies/TenantPolicyEvaluationTests.cs`
+
+### Implementation for User Story 2
+
+- [X] T034 [US2] Complete policy preview orchestration in `src/core/Aster.Core/Services/ResourcePolicyEvaluationService.cs`
+- [X] T035 [US2] Implement bounded definition and policy selection in `src/core/Aster.Core/Services/ResourcePolicyEvaluationService.cs`
+- [X] T036 [US2] Implement age-based candidate matching with required evaluation timestamps in `src/core/Aster.Core/Services/ResourcePolicyEvaluationService.cs`
+- [X] T037 [US2] Implement activation-state and lifecycle-state criteria matching in `src/core/Aster.Core/Services/ResourcePolicyEvaluationService.cs`
+- [X] T038 [US2] Implement retained-version count and preview-only pruning candidate selection in `src/core/Aster.Core/Services/ResourcePolicyEvaluationService.cs`
+- [X] T039 [US2] Add unsafe pruning and preview-only diagnostics in `src/core/Aster.Core/Services/ResourcePolicyEvaluationService.cs`
+- [X] T040 [US2] Ensure policy preview reads tenant-scoped candidate versions through `src/core/Aster.Core/Abstractions/IResourceVersionReader.cs`
+- [X] T041 [US2] Ensure policy preview reads lifecycle marker state through the foundational in-memory marker store contract in `src/core/Aster.Core/Abstractions/IResourceLifecycleMarkerStore.cs`
+- [X] T042 [US2] Run User Story 2 focused tests with `dotnet test Aster.sln --no-restore --filter "FullyQualifiedName~PolicyEvaluation|FullyQualifiedName~PolicyPruning|FullyQualifiedName~PolicyPreview|FullyQualifiedName~TenantPolicy"` using `Aster.sln`
+
+**Checkpoint**: User Stories 1 and 2 are independently functional.
+
+---
+
+## Phase 5: User Story 3 - Mark And Query Resource Lifecycle State (Priority: P3)
+
+**Goal**: Hosts can explicitly apply archive and soft-delete markers, inspect/query lifecycle state, and preserve markers through portability without hidden filtering or resource history rewrites.
+
+**Independent Test**: Explicitly apply archive and soft-delete markers to resources, then verify normal resource history remains intact and hosts can query or inspect the lifecycle state through explicit criteria.
+
+### Tests for User Story 3
+
+- [X] T043 [P] [US3] Add lifecycle marker write and idempotency tests in `test/Aster.Tests/Policies/LifecycleMarkerServiceTests.cs`
+- [X] T044 [P] [US3] Add lifecycle marker conflict diagnostic tests in `test/Aster.Tests/Policies/LifecycleMarkerConflictTests.cs`
+- [X] T045 [P] [US3] Add in-memory lifecycle-state query tests in `test/Aster.Tests/Querying/LifecycleStateQueryTests.cs`
+- [X] T046 [P] [US3] Add SQLite JSON lifecycle marker persistence and query tests in `test/Aster.Tests/SqliteJson/SqliteJsonLifecycleMarkerTests.cs`
+- [X] T047 [P] [US3] Add lifecycle marker portability export/import tests in `test/Aster.Tests/Portability/PortabilityLifecycleMarkerTests.cs`
+- [X] T048 [P] [US3] Add tenant-scoped lifecycle marker isolation tests in `test/Aster.Tests/Tenancy/TenantLifecycleMarkerTests.cs`
+
+### Implementation for User Story 3
+
+- [X] T049 [US3] Complete in-memory lifecycle marker storage in `src/core/Aster.Core/InMemory/InMemoryResourceLifecycleMarkerStore.cs`
+- [X] T050 [US3] Complete lifecycle marker service validation, idempotency, and conflict handling in `src/core/Aster.Core/Services/ResourceLifecycleMarkerService.cs`
+- [X] T051 [US3] Add lifecycle marker SQLite schema support in `src/persistence/Aster.Persistence.SqliteJson/SqliteJsonSchema.cs`
+- [X] T052 [US3] Implement SQLite lifecycle marker store operations and registration support in `src/persistence/Aster.Persistence.SqliteJson/SqliteJsonResourceStore.cs` and `src/persistence/Aster.Persistence.SqliteJson/SqliteJsonAsterServiceCollectionExtensions.cs`
+- [X] T053 [US3] Add lifecycle-state capability declaration to in-memory query capabilities in `src/core/Aster.Core/InMemory/InMemoryQueryCapabilitiesProvider.cs`
+- [X] T054 [US3] Add lifecycle-state capability declaration to SQLite query capabilities in `src/persistence/Aster.Persistence.SqliteJson/SqliteJsonQueryCapabilitiesProvider.cs`
+- [X] T055 [US3] Validate lifecycle-state query criteria in `src/core/Aster.Core/Services/ResourceQueryValidator.cs`
+- [X] T056 [US3] Apply lifecycle-state filtering in in-memory queries in `src/core/Aster.Core/InMemory/InMemoryQueryService.cs`
+- [X] T057 [US3] Apply lifecycle-state filtering in SQLite query execution in `src/persistence/Aster.Persistence.SqliteJson/SqliteJsonQueryService.cs`
+- [X] T058 [US3] Add lifecycle marker state to portable snapshots and store models in `src/core/Aster.Core/Models/Portability/PortableSnapshot.cs`
+- [X] T059 [US3] Preserve lifecycle marker state in portability export, preview import, and write import in `src/core/Aster.Core/Services/ResourcePortabilityService.cs`
+- [X] T060 [US3] Preserve lifecycle marker state in in-memory portability storage in `src/core/Aster.Core/InMemory/InMemoryPortabilityStore.cs`
+- [X] T061 [US3] Preserve lifecycle marker state in SQLite portability storage in `src/persistence/Aster.Persistence.SqliteJson/SqliteJsonResourceStore.cs`
+- [X] T062 [US3] Run User Story 3 focused tests with `dotnet test Aster.sln --no-restore --filter "FullyQualifiedName~LifecycleMarker|FullyQualifiedName~LifecycleStateQuery|FullyQualifiedName~PortabilityLifecycleMarker|FullyQualifiedName~TenantLifecycleMarker"` using `Aster.sln`
+
+**Checkpoint**: All policy-foundations user stories are independently functional.
+
+---
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+**Purpose**: Documentation, compatibility, cleanup, and full verification.
+
+- [X] T063 [P] Update SQLite JSON lifecycle marker registration and provider notes in `src/persistence/Aster.Persistence.SqliteJson/README.md`
+- [X] T064 [P] Validate policy quickstart snippets against implemented APIs in `specs/016-policy-foundations/quickstart.md`
+- [X] T065 [P] Update roadmap/status docs for policy foundations in `docs/ExecutionRoadmap.md`
+- [X] T066 [P] Update public roadmap docs for policy foundations in `docs/Roadmap.md`
+- [X] T067 Re-run Constitution Check and remove unnecessary policy abstractions in `specs/016-policy-foundations/plan.md`
+- [X] T068 Run all tests with `dotnet test Aster.sln --no-restore` using `Aster.sln`
+- [X] T069 Run full build with `dotnet build Aster.sln /m:1 --no-restore` using `Aster.sln`
+- [X] T070 Run whitespace validation with `git diff --check` using `/Users/sipke/Projects/ValenceWorks/aster`
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies.
+- **Foundational (Phase 2)**: Depends on Setup and blocks all user stories.
+- **User Story 1 (Phase 3)**: Depends on Foundational and is the MVP.
+- **User Story 2 (Phase 4)**: Depends on Foundational and practically follows US1 because previews evaluate persisted policy declarations.
+- **User Story 3 (Phase 5)**: Depends on Foundational and can proceed after marker contracts exist; query and portability pieces integrate with existing stores.
+- **Polish (Phase 6)**: Depends on all desired user stories.
+
+### User Story Dependencies
+
+- **US1 Declare Resource Policies Explicitly**: Start after Foundational; validates declaration metadata, storage, inspection, and diagnostics.
+- **US2 Preview Policy Outcomes Before Action**: Start after Foundational; practically follows US1 for persisted declaration storage and validation reuse.
+- **US3 Mark And Query Resource Lifecycle State**: Start after Foundational; can be implemented independently of US2, though policy preview can later read marker state.
+
+### Within Each User Story
+
+- Write story tests first and verify they fail.
+- Implement models/contracts before service/provider behavior.
+- Implement in-memory behavior before SQLite provider behavior when both are required.
+- Run focused story tests at the checkpoint before moving to the next story.
+
+### Parallel Opportunities
+
+- Setup tasks T003-T004 can run in parallel.
+- Foundational model and contract tasks T005-T007 and T010-T012 can run in parallel.
+- User Story 1 tests T016-T020 can be written in parallel.
+- User Story 2 tests T029-T033 can be written in parallel.
+- User Story 3 tests T043-T048 can be written in parallel.
+- Documentation tasks T063-T066 can be completed in parallel after implementation stabilizes.
+
+---
+
+## Parallel Example: User Story 1
+
+```text
+Task: "Add resource definition policy declaration builder tests in test/Aster.Tests/Policies/PolicyDeclarationBuilderTests.cs"
+Task: "Add policy validation diagnostics tests in test/Aster.Tests/Policies/PolicyValidationTests.cs"
+Task: "Add in-memory policy metadata persistence tests in test/Aster.Tests/Policies/PolicyDefinitionStoreTests.cs"
+Task: "Add SQLite JSON policy metadata persistence tests in test/Aster.Tests/SqliteJson/SqliteJsonPolicyDefinitionTests.cs"
+Task: "Add no-policy compatibility tests in test/Aster.Tests/Policies/PolicyCompatibilityTests.cs"
+```
+
+## Parallel Example: User Story 2
+
+```text
+Task: "Add archive and soft-delete preview candidate tests in test/Aster.Tests/Policies/PolicyEvaluationPreviewTests.cs"
+Task: "Add version pruning preview and unsafe pruning diagnostics tests in test/Aster.Tests/Policies/PolicyPruningPreviewTests.cs"
+Task: "Add explicit evaluation timestamp tests in test/Aster.Tests/Policies/PolicyEvaluationTimestampTests.cs"
+Task: "Add preview no-mutation tests in test/Aster.Tests/Policies/PolicyPreviewNoMutationTests.cs"
+Task: "Add tenant-scoped policy preview isolation tests in test/Aster.Tests/Policies/TenantPolicyEvaluationTests.cs"
+```
+
+## Parallel Example: User Story 3
+
+```text
+Task: "Add lifecycle marker write and idempotency tests in test/Aster.Tests/Policies/LifecycleMarkerServiceTests.cs"
+Task: "Add lifecycle marker conflict diagnostic tests in test/Aster.Tests/Policies/LifecycleMarkerConflictTests.cs"
+Task: "Add in-memory lifecycle-state query tests in test/Aster.Tests/Querying/LifecycleStateQueryTests.cs"
+Task: "Add SQLite JSON lifecycle marker persistence and query tests in test/Aster.Tests/SqliteJson/SqliteJsonLifecycleMarkerTests.cs"
+Task: "Add lifecycle marker portability export/import tests in test/Aster.Tests/Portability/PortabilityLifecycleMarkerTests.cs"
+Task: "Add tenant-scoped lifecycle marker isolation tests in test/Aster.Tests/Tenancy/TenantLifecycleMarkerTests.cs"
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First
+
+1. Complete Phase 1 setup.
+2. Complete Phase 2 foundational policy and marker contracts.
+3. Complete Phase 3 User Story 1.
+4. Stop and validate policy declaration storage, inspection, and diagnostics independently.
+
+### Incremental Delivery
+
+1. Deliver US1 to establish definition-attached policy declarations and validation.
+2. Add US2 to prove deterministic preview behavior without writes.
+3. Add US3 to add explicit lifecycle marker writes, querying, and portability.
+4. Finish with docs, quickstart validation, full tests, full build, and whitespace validation.
+
+### Quality Bar
+
+- Preserve append-only resource versions throughout.
+- Require explicit host input for policy previews and marker writes.
+- Keep lifecycle filtering explicit; do not hide archived or soft-deleted resources by default.
+- Do not add automatic execution, scheduler, policy engine, provider registry, runtime scanning, public SQL, public `IQueryable<Resource>`, destructive pruning writes, or restore workflows.
+- Prefer direct SDK records and provider-local storage over broad framework abstractions.

--- a/src/core/Aster.Core/Abstractions/IResourceLifecycleMarkerStore.cs
+++ b/src/core/Aster.Core/Abstractions/IResourceLifecycleMarkerStore.cs
@@ -1,0 +1,46 @@
+using Aster.Core.Models.Instances;
+using Aster.Core.Models.Tenancy;
+
+namespace Aster.Core.Abstractions;
+
+/// <summary>
+/// Provider-facing storage for explicit resource lifecycle markers.
+/// </summary>
+public interface IResourceLifecycleMarkerStore
+{
+    /// <summary>
+    /// Reads the effective lifecycle marker for a resource.
+    /// </summary>
+    ValueTask<ResourceLifecycleMarker?> GetMarkerAsync(
+        string resourceId,
+        TenantScope tenantScope,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Reads effective lifecycle markers for the supplied resources.
+    /// </summary>
+    ValueTask<IReadOnlyDictionary<string, ResourceLifecycleMarker>> GetMarkersAsync(
+        IEnumerable<string> resourceIds,
+        TenantScope tenantScope,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Persists the effective lifecycle marker for a resource.
+    /// </summary>
+    ValueTask<ResourceLifecycleMarker> SaveMarkerAsync(
+        ResourceLifecycleMarker marker,
+        CancellationToken cancellationToken = default);
+}
+
+/// <summary>
+/// Host-facing service for explicit archive and soft-delete marker writes.
+/// </summary>
+public interface IResourceLifecycleMarkerService
+{
+    /// <summary>
+    /// Applies an archive or soft-delete marker to a resource.
+    /// </summary>
+    ValueTask<ResourceLifecycleMarkerResult> ApplyAsync(
+        ResourceLifecycleMarkerRequest request,
+        CancellationToken cancellationToken = default);
+}

--- a/src/core/Aster.Core/Abstractions/IResourcePolicyEvaluationService.cs
+++ b/src/core/Aster.Core/Abstractions/IResourcePolicyEvaluationService.cs
@@ -1,0 +1,19 @@
+using Aster.Core.Models.Policies;
+
+namespace Aster.Core.Abstractions;
+
+/// <summary>
+/// Evaluates policy declarations and returns non-mutating preview results.
+/// </summary>
+public interface IResourcePolicyEvaluationService
+{
+    /// <summary>
+    /// Previews candidate policy outcomes without applying writes.
+    /// </summary>
+    /// <param name="request">Preview request.</param>
+    /// <param name="cancellationToken">Token to cancel the operation.</param>
+    /// <returns>Preview result.</returns>
+    ValueTask<ResourcePolicyEvaluationPreview> PreviewAsync(
+        ResourcePolicyEvaluationRequest request,
+        CancellationToken cancellationToken = default);
+}

--- a/src/core/Aster.Core/Abstractions/IResourcePolicyValidator.cs
+++ b/src/core/Aster.Core/Abstractions/IResourcePolicyValidator.cs
@@ -1,0 +1,17 @@
+using Aster.Core.Models.Definitions;
+using Aster.Core.Models.Policies;
+
+namespace Aster.Core.Abstractions;
+
+/// <summary>
+/// Validates resource policy declarations without mutating resources or definitions.
+/// </summary>
+public interface IResourcePolicyValidator
+{
+    /// <summary>
+    /// Validates policy declarations attached to a resource definition.
+    /// </summary>
+    /// <param name="definition">The definition whose policies should be validated.</param>
+    /// <returns>Policy validation result.</returns>
+    ResourcePolicyValidationResult Validate(ResourceDefinition definition);
+}

--- a/src/core/Aster.Core/Definitions/ResourceDefinitionBuilder.cs
+++ b/src/core/Aster.Core/Definitions/ResourceDefinitionBuilder.cs
@@ -1,5 +1,6 @@
 using Aster.Core.Exceptions;
 using Aster.Core.Models.Definitions;
+using Aster.Core.Models.Policies;
 
 namespace Aster.Core.Definitions;
 
@@ -19,6 +20,7 @@ public sealed class ResourceDefinitionBuilder
     private string? definitionId;
     private bool isSingleton;
     private readonly List<(string Key, AspectDefinition Definition)> aspectEntries = [];
+    private readonly List<ResourcePolicyDeclaration> policyDeclarations = [];
 
     /// <summary>
     /// Sets the logical persistent definition identifier.
@@ -97,6 +99,18 @@ public sealed class ResourceDefinitionBuilder
     public ResourceDefinitionBuilder WithTypedAspect<T>() => WithAspect<T>();
 
     /// <summary>
+    /// Attaches an explicit policy declaration to the definition.
+    /// </summary>
+    /// <param name="policy">The policy declaration to attach.</param>
+    /// <returns>This builder for chaining.</returns>
+    public ResourceDefinitionBuilder WithPolicy(ResourcePolicyDeclaration policy)
+    {
+        ArgumentNullException.ThrowIfNull(policy);
+        policyDeclarations.Add(policy);
+        return this;
+    }
+
+    /// <summary>
     /// Adds a typed <see cref="FacetDefinition"/> to the most recently registered aspect,
     /// using <c>typeof(T).Name</c> as the <c>FacetDefinitionId</c>.
     /// </summary>
@@ -153,6 +167,7 @@ public sealed class ResourceDefinitionBuilder
             Id = Guid.NewGuid().ToString(),
             Version = 0, // auto-incremented by the store
             AspectDefinitions = aspectDict,
+            PolicyDeclarations = [.. policyDeclarations],
             IsSingleton = isSingleton,
         };
     }

--- a/src/core/Aster.Core/Extensions/AsterCoreServiceCollectionExtensions.cs
+++ b/src/core/Aster.Core/Extensions/AsterCoreServiceCollectionExtensions.cs
@@ -82,6 +82,8 @@ public static class AsterCoreServiceCollectionExtensions
         services.AddSingleton<IResourceVersionWriter>(sp => sp.GetRequiredService<InMemoryResourceStore>());
         services.AddSingleton<InMemoryPortabilityStore>();
         services.AddSingleton<IResourcePortabilityStore>(sp => sp.GetRequiredService<InMemoryPortabilityStore>());
+        services.AddSingleton<InMemoryResourceLifecycleMarkerStore>();
+        services.AddSingleton<IResourceLifecycleMarkerStore>(sp => sp.GetRequiredService<InMemoryResourceLifecycleMarkerStore>());
 
         // Resource manager
         services.AddSingleton<InMemoryResourceManager>();
@@ -91,6 +93,9 @@ public static class AsterCoreServiceCollectionExtensions
         services.AddSingleton<IResourceManager>(sp => sp.GetRequiredService<DefaultResourceManager>());
         services.AddSingleton<IResourceSchemaVersionService, ResourceSchemaVersionService>();
         services.AddSingleton<IResourcePortabilityService, ResourcePortabilityService>();
+        services.AddSingleton<IResourcePolicyValidator, ResourcePolicyValidator>();
+        services.AddSingleton<IResourcePolicyEvaluationService, ResourcePolicyEvaluationService>();
+        services.AddSingleton<IResourceLifecycleMarkerService, ResourceLifecycleMarkerService>();
 
         // Query service
         services.AddSingleton<InMemoryQueryService>();

--- a/src/core/Aster.Core/InMemory/InMemoryPortabilityStore.cs
+++ b/src/core/Aster.Core/InMemory/InMemoryPortabilityStore.cs
@@ -14,23 +14,27 @@ public sealed class InMemoryPortabilityStore : IResourcePortabilityStore
 {
     private readonly InMemoryResourceDefinitionStore definitionStore;
     private readonly InMemoryResourceStore resourceStore;
+    private readonly InMemoryResourceLifecycleMarkerStore markerStore;
 
     /// <summary>
     /// Initializes a new instance of <see cref="InMemoryPortabilityStore"/>.
     /// </summary>
     public InMemoryPortabilityStore(
         InMemoryResourceDefinitionStore definitionStore,
-        InMemoryResourceStore resourceStore)
+        InMemoryResourceStore resourceStore,
+        InMemoryResourceLifecycleMarkerStore markerStore)
     {
         ArgumentNullException.ThrowIfNull(definitionStore);
         ArgumentNullException.ThrowIfNull(resourceStore);
+        ArgumentNullException.ThrowIfNull(markerStore);
 
         this.definitionStore = definitionStore;
         this.resourceStore = resourceStore;
+        this.markerStore = markerStore;
     }
 
     /// <inheritdoc />
-    public ValueTask<PortableStoreSnapshot> ReadSnapshotAsync(
+    public async ValueTask<PortableStoreSnapshot> ReadSnapshotAsync(
         PortableStoreReadRequest request,
         CancellationToken cancellationToken = default)
     {
@@ -40,18 +44,23 @@ public sealed class InMemoryPortabilityStore : IResourcePortabilityStore
         var resources = SelectResources(request.ExportRequest, tenant, cancellationToken);
         var definitions = SelectDefinitions(request.ExportRequest, tenant, resources, cancellationToken);
         var (activationStates, skippedActivationEntries) = SelectActivationStates(tenant, resources, cancellationToken);
+        var lifecycleMarkers = (await markerStore.GetMarkersAsync(
+            resources.Select(static resource => resource.ResourceId).Distinct(StringComparer.Ordinal),
+            tenant,
+            cancellationToken)).Values.ToList();
 
-        return ValueTask.FromResult(new PortableStoreSnapshot
+        return new PortableStoreSnapshot
         {
             Definitions = definitions,
             Resources = resources,
             ActivationStates = activationStates,
+            LifecycleMarkers = lifecycleMarkers,
             SkippedActivationEntries = skippedActivationEntries,
-        });
+        };
     }
 
     /// <inheritdoc />
-    public ValueTask<PortableTargetState> ReadTargetStateAsync(
+    public async ValueTask<PortableTargetState> ReadTargetStateAsync(
         PortableSnapshot snapshot,
         CancellationToken cancellationToken = default)
     {
@@ -97,12 +106,18 @@ public sealed class InMemoryPortabilityStore : IResourcePortabilityStore
             }
         }
 
-        return ValueTask.FromResult(new PortableTargetState
+        var lifecycleMarkers = (await markerStore.GetMarkersAsync(
+            snapshot.LifecycleMarkers.Select(static marker => marker.ResourceId).ToHashSet(StringComparer.Ordinal),
+            tenant,
+            cancellationToken)).Values.ToList();
+
+        return new PortableTargetState
         {
             Definitions = definitions,
             Resources = resources,
             ActivationStates = activationStates,
-        });
+            LifecycleMarkers = lifecycleMarkers,
+        };
     }
 
     /// <inheritdoc />
@@ -117,6 +132,7 @@ public sealed class InMemoryPortabilityStore : IResourcePortabilityStore
         var appliedDefinitions = new List<ResourceDefinition>();
         var appliedResources = new List<Resource>();
         var appliedActivationStates = new List<(ActivationState State, ActivationState? PreviousState)>();
+        var appliedLifecycleMarkers = new List<(ResourceLifecycleMarker Marker, ResourceLifecycleMarker? PreviousMarker)>();
 
         try
         {
@@ -150,10 +166,20 @@ public sealed class InMemoryPortabilityStore : IResourcePortabilityStore
                 await resourceStore.UpdateActivationAsync(scopedState.ResourceId, scopedState.Channel, scopedState, cancellationToken);
                 appliedActivationStates.Add((scopedState, previous));
             }
+
+            foreach (var marker in plannedSnapshot.LifecycleMarkers
+                .OrderBy(static marker => marker.ResourceId, StringComparer.Ordinal))
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                var scopedMarker = marker with { TenantScope = tenant };
+                var previous = await markerStore.GetMarkerAsync(scopedMarker.ResourceId, tenant, cancellationToken);
+                await markerStore.SaveMarkerAsync(scopedMarker, cancellationToken);
+                appliedLifecycleMarkers.Add((scopedMarker, previous));
+            }
         }
         catch
         {
-            RollBackAppliedChanges(appliedDefinitions, appliedResources, appliedActivationStates);
+            RollBackAppliedChanges(appliedDefinitions, appliedResources, appliedActivationStates, appliedLifecycleMarkers);
             throw;
         }
     }
@@ -161,8 +187,17 @@ public sealed class InMemoryPortabilityStore : IResourcePortabilityStore
     private void RollBackAppliedChanges(
         IReadOnlyList<ResourceDefinition> appliedDefinitions,
         IReadOnlyList<Resource> appliedResources,
-        IReadOnlyList<(ActivationState State, ActivationState? PreviousState)> appliedActivationStates)
+        IReadOnlyList<(ActivationState State, ActivationState? PreviousState)> appliedActivationStates,
+        IReadOnlyList<(ResourceLifecycleMarker Marker, ResourceLifecycleMarker? PreviousMarker)> appliedLifecycleMarkers)
     {
+        foreach (var (marker, previousMarker) in appliedLifecycleMarkers.Reverse())
+        {
+            if (previousMarker is null)
+                markerStore.RemoveMarker(marker.TenantScope, marker.ResourceId);
+            else
+                markerStore.RestoreMarker(previousMarker);
+        }
+
         foreach (var (state, previousState) in appliedActivationStates.Reverse())
             resourceStore.RestoreActivationState(state.ResourceId, state.Channel, state.TenantScope, previousState);
 

--- a/src/core/Aster.Core/InMemory/InMemoryQueryCapabilitiesProvider.cs
+++ b/src/core/Aster.Core/InMemory/InMemoryQueryCapabilitiesProvider.cs
@@ -86,5 +86,8 @@ public sealed class InMemoryQueryCapabilitiesProvider : IResourceQueryCapabiliti
             QueryValueShape.Numeric,
             QueryValueShape.DateTime,
         },
-        UnsupportedFeatures: []);
+        UnsupportedFeatures: [])
+    {
+        SupportsLifecycleStateFiltering = true,
+    };
 }

--- a/src/core/Aster.Core/InMemory/InMemoryQueryService.cs
+++ b/src/core/Aster.Core/InMemory/InMemoryQueryService.cs
@@ -21,6 +21,7 @@ public sealed partial class InMemoryQueryService : IResourceQueryService, IResou
     private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web);
 
     private readonly IResourceVersionReader versionReader;
+    private readonly IResourceLifecycleMarkerStore? markerStore;
     private readonly ILogger<InMemoryQueryService> logger;
     private readonly ResourceQueryValidator validator;
 
@@ -30,14 +31,17 @@ public sealed partial class InMemoryQueryService : IResourceQueryService, IResou
     /// <param name="versionReader">The backing resource version reader.</param>
     /// <param name="logger">The logger.</param>
     /// <param name="capabilityProviders">Registered provider capability declarations.</param>
+    /// <param name="markerStore">Optional lifecycle marker store for explicit lifecycle-state filtering.</param>
     public InMemoryQueryService(
         IResourceVersionReader versionReader,
         ILogger<InMemoryQueryService> logger,
-        IEnumerable<IResourceQueryCapabilitiesProvider>? capabilityProviders = null)
+        IEnumerable<IResourceQueryCapabilitiesProvider>? capabilityProviders = null,
+        IResourceLifecycleMarkerStore? markerStore = null)
     {
         ArgumentNullException.ThrowIfNull(versionReader);
         ArgumentNullException.ThrowIfNull(logger);
         this.versionReader = versionReader;
+        this.markerStore = markerStore;
         this.logger = logger;
         validator = new ResourceQueryValidator(
             capabilityProviders ?? [new InMemoryQueryCapabilitiesProvider()],
@@ -66,6 +70,9 @@ public sealed partial class InMemoryQueryService : IResourceQueryService, IResou
         if (!string.IsNullOrWhiteSpace(query.DefinitionId))
             result = result.Where(r => string.Equals(r.DefinitionId, query.DefinitionId, StringComparison.Ordinal));
 
+        if (query.LifecycleState is not null)
+            result = await ApplyLifecycleStateFilterAsync(result, query, cancellationToken);
+
         // Evaluate the filter expression tree
         if (query.Filter is not null)
             result = result.Where(r => Evaluate(query.Filter, r));
@@ -82,6 +89,31 @@ public sealed partial class InMemoryQueryService : IResourceQueryService, IResou
         var materialized = result.ToList();
         LogQueryExecuted(query.DefinitionId ?? "(all)", materialized.Count);
         return materialized;
+    }
+
+    private async ValueTask<IEnumerable<Resource>> ApplyLifecycleStateFilterAsync(
+        IEnumerable<Resource> resources,
+        ResourceQuery query,
+        CancellationToken cancellationToken)
+    {
+        if (markerStore is null)
+            return resources;
+
+        var materialized = resources.ToList();
+        var tenant = TenantScopeResolver.Resolve(query.TenantScope);
+        var markers = await markerStore.GetMarkersAsync(
+            materialized.Select(static resource => resource.ResourceId).Distinct(StringComparer.Ordinal),
+            tenant,
+            cancellationToken);
+        var expected = query.LifecycleState!.Value;
+
+        return materialized.Where(resource =>
+        {
+            var actual = markers.TryGetValue(resource.ResourceId, out var marker)
+                ? marker.State
+                : ResourceLifecycleMarkerState.None;
+            return actual == expected;
+        });
     }
 
     // ──────────────────────────────────────────────────────────────────────────

--- a/src/core/Aster.Core/InMemory/InMemoryResourceLifecycleMarkerStore.cs
+++ b/src/core/Aster.Core/InMemory/InMemoryResourceLifecycleMarkerStore.cs
@@ -1,0 +1,72 @@
+using System.Collections.Concurrent;
+using Aster.Core.Abstractions;
+using Aster.Core.Models.Instances;
+using Aster.Core.Models.Tenancy;
+using Aster.Core.Services;
+
+namespace Aster.Core.InMemory;
+
+/// <summary>
+/// In-memory lifecycle marker storage.
+/// </summary>
+public sealed class InMemoryResourceLifecycleMarkerStore : IResourceLifecycleMarkerStore
+{
+    private readonly ConcurrentDictionary<(string TenantId, string ResourceId), ResourceLifecycleMarker> markers = [];
+
+    /// <inheritdoc />
+    public ValueTask<ResourceLifecycleMarker?> GetMarkerAsync(
+        string resourceId,
+        TenantScope tenantScope,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(resourceId);
+        cancellationToken.ThrowIfCancellationRequested();
+        var tenant = TenantScopeResolver.Resolve(tenantScope);
+        markers.TryGetValue((tenant.TenantId, resourceId), out var marker);
+        return ValueTask.FromResult(marker);
+    }
+
+    /// <inheritdoc />
+    public ValueTask<IReadOnlyDictionary<string, ResourceLifecycleMarker>> GetMarkersAsync(
+        IEnumerable<string> resourceIds,
+        TenantScope tenantScope,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(resourceIds);
+        cancellationToken.ThrowIfCancellationRequested();
+        var tenant = TenantScopeResolver.Resolve(tenantScope);
+        var results = new Dictionary<string, ResourceLifecycleMarker>(StringComparer.Ordinal);
+
+        foreach (var resourceId in resourceIds.Distinct(StringComparer.Ordinal))
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            if (markers.TryGetValue((tenant.TenantId, resourceId), out var marker))
+                results[resourceId] = marker;
+        }
+
+        return ValueTask.FromResult<IReadOnlyDictionary<string, ResourceLifecycleMarker>>(results);
+    }
+
+    /// <inheritdoc />
+    public ValueTask<ResourceLifecycleMarker> SaveMarkerAsync(
+        ResourceLifecycleMarker marker,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(marker);
+        ArgumentException.ThrowIfNullOrWhiteSpace(marker.ResourceId);
+        cancellationToken.ThrowIfCancellationRequested();
+        var tenant = TenantScopeResolver.Resolve(marker.TenantScope);
+        var scopedMarker = marker with { TenantScope = tenant };
+        markers[(tenant.TenantId, scopedMarker.ResourceId)] = scopedMarker;
+        return ValueTask.FromResult(scopedMarker);
+    }
+
+    internal void RestoreMarker(ResourceLifecycleMarker marker) =>
+        markers[(marker.TenantScope.TenantId, marker.ResourceId)] = marker;
+
+    internal void RemoveMarker(TenantScope tenantScope, string resourceId)
+    {
+        var tenant = TenantScopeResolver.Resolve(tenantScope);
+        markers.TryRemove((tenant.TenantId, resourceId), out _);
+    }
+}

--- a/src/core/Aster.Core/Models/Definitions/ResourceDefinition.cs
+++ b/src/core/Aster.Core/Models/Definitions/ResourceDefinition.cs
@@ -1,4 +1,5 @@
 using Aster.Core.Models.Tenancy;
+using Aster.Core.Models.Policies;
 
 namespace Aster.Core.Models.Definitions;
 
@@ -39,6 +40,12 @@ public sealed record ResourceDefinition
     /// </summary>
     public IReadOnlyDictionary<string, AspectDefinition> AspectDefinitions { get; init; }
         = new Dictionary<string, AspectDefinition>();
+
+    /// <summary>
+    /// Explicit policy declarations attached to this definition version.
+    /// Declarations do not execute automatically.
+    /// </summary>
+    public IReadOnlyList<ResourcePolicyDeclaration> PolicyDeclarations { get; init; } = [];
 
     /// <summary>
     /// If <see langword="true"/>, only one instance can exist for this definition.

--- a/src/core/Aster.Core/Models/Instances/ResourceLifecycleMarker.cs
+++ b/src/core/Aster.Core/Models/Instances/ResourceLifecycleMarker.cs
@@ -1,0 +1,76 @@
+using Aster.Core.Models.Policies;
+using Aster.Core.Models.Tenancy;
+
+namespace Aster.Core.Models.Instances;
+
+/// <summary>
+/// Current lifecycle marker state for a logical resource.
+/// </summary>
+public sealed record ResourceLifecycleMarker
+{
+    /// <summary>Tenant scope that owns this marker.</summary>
+    public TenantScope TenantScope { get; init; } = TenantScope.Default;
+
+    /// <summary>Logical resource identifier.</summary>
+    public required string ResourceId { get; init; }
+
+    /// <summary>Current effective lifecycle marker state.</summary>
+    public required ResourceLifecycleMarkerState State { get; init; }
+
+    /// <summary>Host-supplied marker timestamp.</summary>
+    public required DateTimeOffset MarkedAt { get; init; }
+
+    /// <summary>Optional host-visible marker reason.</summary>
+    public string? Reason { get; init; }
+}
+
+/// <summary>
+/// Lifecycle marker states supported by this slice.
+/// </summary>
+public enum ResourceLifecycleMarkerState
+{
+    /// <summary>No archive or soft-delete marker is present.</summary>
+    None,
+
+    /// <summary>The resource is archived.</summary>
+    Archived,
+
+    /// <summary>The resource is soft-deleted.</summary>
+    SoftDeleted,
+}
+
+/// <summary>
+/// Explicit request to apply a lifecycle marker to a resource.
+/// </summary>
+public sealed class ResourceLifecycleMarkerRequest
+{
+    /// <summary>Tenant scope for the marker write. When omitted, the default single-tenant scope is used.</summary>
+    public TenantScope? TenantScope { get; set; }
+
+    /// <summary>Logical resource identifier.</summary>
+    public required string ResourceId { get; set; }
+
+    /// <summary>Lifecycle state to apply.</summary>
+    public required ResourceLifecycleMarkerState State { get; set; }
+
+    /// <summary>Host-supplied marker timestamp.</summary>
+    public required DateTimeOffset MarkedAt { get; set; }
+
+    /// <summary>Optional host-visible reason.</summary>
+    public string? Reason { get; set; }
+}
+
+/// <summary>
+/// Result of an explicit lifecycle marker write.
+/// </summary>
+public sealed record ResourceLifecycleMarkerResult
+{
+    /// <summary>Whether the marker request succeeded.</summary>
+    public bool Succeeded => Diagnostics.Count == 0;
+
+    /// <summary>Effective marker after the operation when available.</summary>
+    public ResourceLifecycleMarker? Marker { get; init; }
+
+    /// <summary>Stable marker diagnostics.</summary>
+    public IReadOnlyList<ResourcePolicyDiagnostic> Diagnostics { get; init; } = [];
+}

--- a/src/core/Aster.Core/Models/Policies/ResourcePolicyModels.cs
+++ b/src/core/Aster.Core/Models/Policies/ResourcePolicyModels.cs
@@ -1,0 +1,113 @@
+using Aster.Core.Models.Instances;
+
+namespace Aster.Core.Models.Policies;
+
+/// <summary>
+/// Declarative policy intent attached to a resource definition.
+/// </summary>
+public sealed record ResourcePolicyDeclaration
+{
+    /// <summary>Stable identifier unique within the declaring definition.</summary>
+    public required string PolicyId { get; init; }
+
+    /// <summary>Host-visible policy name.</summary>
+    public string? Name { get; init; }
+
+    /// <summary>Policy category.</summary>
+    public required ResourcePolicyKind Kind { get; init; }
+
+    /// <summary>Policy target type.</summary>
+    public required ResourcePolicyTarget Target { get; init; }
+
+    /// <summary>Policy outcome intent.</summary>
+    public required ResourcePolicyOutcome Outcome { get; init; }
+
+    /// <summary>Explicit criteria supported by this policy slice.</summary>
+    public ResourcePolicyCriteria Criteria { get; init; } = new();
+}
+
+/// <summary>
+/// Supported explicit criteria for resource policies.
+/// </summary>
+public sealed record ResourcePolicyCriteria
+{
+    /// <summary>Minimum age relative to the host-supplied evaluation timestamp.</summary>
+    public TimeSpan? MinimumAge { get; init; }
+
+    /// <summary>Maximum number of resource versions to retain during pruning preview.</summary>
+    public int? MaximumRetainedVersions { get; init; }
+
+    /// <summary>Optional activation-state criterion.</summary>
+    public ResourcePolicyActivationState? ActivationState { get; init; }
+
+    /// <summary>Activation channel used when <see cref="ActivationState"/> is <see cref="ResourcePolicyActivationState.Active"/>.</summary>
+    public string? ActivationChannel { get; init; }
+
+    /// <summary>Optional lifecycle marker criterion.</summary>
+    public ResourceLifecycleMarkerState? LifecycleState { get; init; }
+
+    /// <summary>
+    /// Sentinel for unsupported facet predicates. This keeps validation explicit until a future policy criteria model is specified.
+    /// </summary>
+    public string? UnsupportedFacetPredicate { get; init; }
+}
+
+/// <summary>
+/// Supported policy kinds.
+/// </summary>
+public enum ResourcePolicyKind
+{
+    /// <summary>Retention intent.</summary>
+    Retention,
+
+    /// <summary>Archive intent.</summary>
+    Archival,
+
+    /// <summary>Soft-delete intent.</summary>
+    SoftDelete,
+
+    /// <summary>Version pruning intent.</summary>
+    VersionPruning,
+}
+
+/// <summary>
+/// Supported policy target shapes.
+/// </summary>
+public enum ResourcePolicyTarget
+{
+    /// <summary>The policy targets logical resources.</summary>
+    Resource,
+
+    /// <summary>The policy targets individual resource versions.</summary>
+    ResourceVersion,
+}
+
+/// <summary>
+/// Supported policy outcome intents.
+/// </summary>
+public enum ResourcePolicyOutcome
+{
+    /// <summary>Retain matching data.</summary>
+    Retain,
+
+    /// <summary>Archive matching resources through explicit marker writes.</summary>
+    Archive,
+
+    /// <summary>Soft-delete matching resources through explicit marker writes.</summary>
+    SoftDelete,
+
+    /// <summary>Report versions that would be pruned; destructive pruning is out of scope.</summary>
+    PrunePreview,
+}
+
+/// <summary>
+/// Activation-state criteria supported by policy preview.
+/// </summary>
+public enum ResourcePolicyActivationState
+{
+    /// <summary>Resource version is active in the requested activation channel.</summary>
+    Active,
+
+    /// <summary>Resource version is not active in any channel.</summary>
+    Draft,
+}

--- a/src/core/Aster.Core/Models/Policies/ResourcePolicyResults.cs
+++ b/src/core/Aster.Core/Models/Policies/ResourcePolicyResults.cs
@@ -1,0 +1,141 @@
+using Aster.Core.Models.Tenancy;
+
+namespace Aster.Core.Models.Policies;
+
+/// <summary>
+/// Validation result for a set of policy declarations.
+/// </summary>
+public sealed record ResourcePolicyValidationResult
+{
+    /// <summary>Successful validation result.</summary>
+    public static ResourcePolicyValidationResult Success { get; } = new();
+
+    /// <summary>Whether validation found no errors.</summary>
+    public bool IsValid => Diagnostics.Count == 0;
+
+    /// <summary>Stable policy diagnostics.</summary>
+    public IReadOnlyList<ResourcePolicyDiagnostic> Diagnostics { get; init; } = [];
+}
+
+/// <summary>
+/// Request for deterministic policy preview evaluation.
+/// </summary>
+public sealed class ResourcePolicyEvaluationRequest
+{
+    /// <summary>Tenant scope for the preview. When omitted, the default single-tenant scope is used.</summary>
+    public TenantScope? TenantScope { get; set; }
+
+    /// <summary>Optional bounded definition set.</summary>
+    public HashSet<string> DefinitionIds { get; set; } = new(StringComparer.Ordinal);
+
+    /// <summary>Optional bounded policy set.</summary>
+    public HashSet<string> PolicyIds { get; set; } = new(StringComparer.Ordinal);
+
+    /// <summary>Required timestamp used for age-based criteria.</summary>
+    public DateTimeOffset? EvaluationTimestamp { get; set; }
+}
+
+/// <summary>
+/// Non-mutating policy preview result.
+/// </summary>
+public sealed record ResourcePolicyEvaluationPreview
+{
+    /// <summary>Effective tenant that was evaluated.</summary>
+    public TenantScope TenantScope { get; init; } = TenantScope.Default;
+
+    /// <summary>Timestamp used for age calculations, when supplied.</summary>
+    public DateTimeOffset? EvaluationTimestamp { get; init; }
+
+    /// <summary>Candidate policy outcomes.</summary>
+    public IReadOnlyList<ResourcePolicyCandidateOutcome> Candidates { get; init; } = [];
+
+    /// <summary>Validation and preview diagnostics.</summary>
+    public IReadOnlyList<ResourcePolicyDiagnostic> Diagnostics { get; init; } = [];
+}
+
+/// <summary>
+/// Resource or version that matched a policy declaration during preview.
+/// </summary>
+public sealed record ResourcePolicyCandidateOutcome
+{
+    /// <summary>Policy declaration identifier.</summary>
+    public required string PolicyId { get; init; }
+
+    /// <summary>Policy kind.</summary>
+    public required ResourcePolicyKind PolicyKind { get; init; }
+
+    /// <summary>Previewed outcome.</summary>
+    public required ResourcePolicyOutcome Outcome { get; init; }
+
+    /// <summary>Affected logical resource.</summary>
+    public required string ResourceId { get; init; }
+
+    /// <summary>Affected version when the outcome is version-specific.</summary>
+    public int? ResourceVersion { get; init; }
+
+    /// <summary>Host-visible reason for the candidate.</summary>
+    public required string Reason { get; init; }
+}
+
+/// <summary>
+/// Stable policy diagnostic.
+/// </summary>
+public sealed record ResourcePolicyDiagnostic
+{
+    /// <summary>Stable diagnostic code.</summary>
+    public required string Code { get; init; }
+
+    /// <summary>Human-readable diagnostic message.</summary>
+    public required string Message { get; init; }
+
+    /// <summary>Path to the invalid or unsupported value when available.</summary>
+    public string? Path { get; init; }
+
+    /// <summary>Policy identifier when available.</summary>
+    public string? PolicyId { get; init; }
+
+    /// <summary>Resource identifier when available.</summary>
+    public string? ResourceId { get; init; }
+
+    /// <summary>Resource version when available.</summary>
+    public int? ResourceVersion { get; init; }
+}
+
+/// <summary>
+/// Stable policy diagnostic codes.
+/// </summary>
+public static class ResourcePolicyDiagnosticCodes
+{
+    /// <summary>Policy metadata is invalid.</summary>
+    public const string PolicyInvalid = "policy-invalid";
+
+    /// <summary>Policy kind is unsupported.</summary>
+    public const string PolicyKindUnsupported = "policy-kind-unsupported";
+
+    /// <summary>Policy outcome is unsupported.</summary>
+    public const string PolicyOutcomeUnsupported = "policy-outcome-unsupported";
+
+    /// <summary>Policy target is invalid.</summary>
+    public const string PolicyTargetInvalid = "policy-target-invalid";
+
+    /// <summary>Policy criteria are unsupported.</summary>
+    public const string PolicyCriteriaUnsupported = "policy-criteria-unsupported";
+
+    /// <summary>Policy declarations conflict.</summary>
+    public const string PolicyConflict = "policy-conflict";
+
+    /// <summary>Age-based evaluation needs an explicit timestamp.</summary>
+    public const string PolicyEvaluationTimestampRequired = "policy-evaluation-timestamp-required";
+
+    /// <summary>Pruning preview would remove all versions.</summary>
+    public const string PolicyPruningUnsafe = "policy-pruning-unsafe";
+
+    /// <summary>Pruning writes are not supported by this slice.</summary>
+    public const string PolicyPruningPreviewOnly = "policy-pruning-preview-only";
+
+    /// <summary>Lifecycle marker write conflicts with current marker state.</summary>
+    public const string LifecycleMarkerConflict = "lifecycle-marker-conflict";
+
+    /// <summary>Lifecycle marker target resource was not found.</summary>
+    public const string LifecycleMarkerTargetNotFound = "lifecycle-marker-target-not-found";
+}

--- a/src/core/Aster.Core/Models/Portability/PortableImportModels.cs
+++ b/src/core/Aster.Core/Models/Portability/PortableImportModels.cs
@@ -51,6 +51,9 @@ public sealed record PortablePlannedImportCounts
     /// <summary>Activation entries planned for import.</summary>
     public int ActivationEntries { get; init; }
 
+    /// <summary>Lifecycle markers planned for import.</summary>
+    public int LifecycleMarkers { get; init; }
+
     /// <summary>Items expected to be reused because existing content is identical.</summary>
     public int ReusedIdenticalItems { get; init; }
 
@@ -74,6 +77,9 @@ public sealed record PortableActualImportCounts
 
     /// <summary>Activation entries imported.</summary>
     public int ActivationEntries { get; init; }
+
+    /// <summary>Lifecycle markers imported.</summary>
+    public int LifecycleMarkers { get; init; }
 
     /// <summary>Items reused because existing content was identical.</summary>
     public int ReusedIdenticalItems { get; init; }
@@ -127,6 +133,9 @@ public enum PortableEntityKind
 
     /// <summary>Activation entry.</summary>
     ActivationEntry,
+
+    /// <summary>Lifecycle marker.</summary>
+    LifecycleMarker,
 }
 
 /// <summary>

--- a/src/core/Aster.Core/Models/Portability/PortableSnapshot.cs
+++ b/src/core/Aster.Core/Models/Portability/PortableSnapshot.cs
@@ -38,6 +38,11 @@ public sealed record PortableSnapshot
     /// Activation state entries whose referenced resource versions are included.
     /// </summary>
     public IReadOnlyList<ActivationState> ActivationStates { get; init; } = [];
+
+    /// <summary>
+    /// Lifecycle markers whose referenced resources are included.
+    /// </summary>
+    public IReadOnlyList<ResourceLifecycleMarker> LifecycleMarkers { get; init; } = [];
 }
 
 /// <summary>

--- a/src/core/Aster.Core/Models/Portability/PortableStoreModels.cs
+++ b/src/core/Aster.Core/Models/Portability/PortableStoreModels.cs
@@ -35,6 +35,11 @@ public sealed record PortableStoreSnapshot
     public IReadOnlyList<ActivationState> ActivationStates { get; init; } = [];
 
     /// <summary>
+    /// Lifecycle markers whose referenced resources are present.
+    /// </summary>
+    public IReadOnlyList<ResourceLifecycleMarker> LifecycleMarkers { get; init; } = [];
+
+    /// <summary>
     /// Activation entries skipped because referenced resource versions were excluded.
     /// </summary>
     public IReadOnlyList<SkippedActivationEntry> SkippedActivationEntries { get; init; } = [];
@@ -59,6 +64,11 @@ public sealed record PortableTargetState
     /// Existing activation states.
     /// </summary>
     public IReadOnlyList<ActivationState> ActivationStates { get; init; } = [];
+
+    /// <summary>
+    /// Existing lifecycle markers.
+    /// </summary>
+    public IReadOnlyList<ResourceLifecycleMarker> LifecycleMarkers { get; init; } = [];
 }
 
 /// <summary>

--- a/src/core/Aster.Core/Models/Querying/QueryCapabilityDescription.cs
+++ b/src/core/Aster.Core/Models/Querying/QueryCapabilityDescription.cs
@@ -43,6 +43,11 @@ public sealed record QueryCapabilityDescription(
     public IReadOnlyList<IndexProjection> IndexProjections { get; init; } = IndexProjections ?? [];
 
     /// <summary>
+    /// Gets whether the provider supports explicit lifecycle-state filtering.
+    /// </summary>
+    public bool SupportsLifecycleStateFiltering { get; init; }
+
+    /// <summary>
     /// Returns whether the provider supports the supplied comparison operator for the filter type.
     /// </summary>
     /// <param name="filterType">The filter category.</param>

--- a/src/core/Aster.Core/Models/Querying/ResourceQuery.cs
+++ b/src/core/Aster.Core/Models/Querying/ResourceQuery.cs
@@ -1,4 +1,5 @@
 using Aster.Core.Models.Tenancy;
+using Aster.Core.Models.Instances;
 
 namespace Aster.Core.Models.Querying;
 
@@ -27,6 +28,11 @@ public sealed record ResourceQuery
     /// Equivalent to a <see cref="MetadataFilter"/> on the <c>DefinitionId</c> field with <see cref="ComparisonOperator.Equals"/>.
     /// </summary>
     public string? DefinitionId { get; init; }
+
+    /// <summary>
+    /// Optional explicit lifecycle marker state filter. When omitted, lifecycle markers do not affect query results.
+    /// </summary>
+    public ResourceLifecycleMarkerState? LifecycleState { get; init; }
 
     /// <summary>
     /// Optional filter expression tree evaluated against each resource version.

--- a/src/core/Aster.Core/README.md
+++ b/src/core/Aster.Core/README.md
@@ -44,6 +44,10 @@ builder.Services.AddAsterCore();
 | `ResourceQueryValidator` | `IResourceQueryValidator` |
 | `ResourceSchemaVersionService` | `IResourceSchemaVersionService` |
 | `ResourcePortabilityService` | `IResourcePortabilityService` |
+| `ResourcePolicyValidator` | `IResourcePolicyValidator` |
+| `ResourcePolicyEvaluationService` | `IResourcePolicyEvaluationService` |
+| `ResourceLifecycleMarkerService` | `IResourceLifecycleMarkerService` |
+| `InMemoryResourceLifecycleMarkerStore` | `IResourceLifecycleMarkerStore` |
 | `GuidIdentityGenerator` | `IIdentityGenerator` |
 | `SystemTextJsonAspectBinder` | `ITypedAspectBinder` |
 | `SystemTextJsonFacetBinder` | `ITypedFacetBinder` |
@@ -282,7 +286,74 @@ Import is strict by default. Existing identical content is reused, divergent col
 
 ---
 
-### 9. Register lifecycle hooks
+### 9. Declare, preview, and mark policy outcomes
+
+Policy declarations are explicit resource definition metadata. They do not run in the background and they do not mutate resource history when a definition is registered.
+
+```csharp
+var definition = new ResourceDefinitionBuilder()
+    .WithDefinitionId("Product")
+    .WithPolicy(new ResourcePolicyDeclaration
+    {
+        PolicyId = "archive-old-products",
+        Kind = ResourcePolicyKind.Archival,
+        Target = ResourcePolicyTarget.Resource,
+        Outcome = ResourcePolicyOutcome.Archive,
+        Criteria = new ResourcePolicyCriteria
+        {
+            MinimumAge = TimeSpan.FromDays(365),
+            LifecycleState = ResourceLifecycleMarkerState.None,
+        },
+    })
+    .Build();
+```
+
+Hosts can validate declarations before previewing or acting:
+
+```csharp
+var policyValidator = serviceProvider.GetRequiredService<IResourcePolicyValidator>();
+var validation = policyValidator.Validate(definition);
+```
+
+Previews are deterministic and non-mutating. Age-based criteria require a host-supplied timestamp; the SDK does not read an ambient clock for policy evaluation.
+
+```csharp
+var policyEvaluation = serviceProvider.GetRequiredService<IResourcePolicyEvaluationService>();
+var preview = await policyEvaluation.PreviewAsync(new ResourcePolicyEvaluationRequest
+{
+    DefinitionIds = ["Product"],
+    EvaluationTimestamp = new DateTimeOffset(2026, 05, 25, 12, 00, 00, TimeSpan.Zero),
+});
+```
+
+Archive and soft-delete outcomes are represented by explicit lifecycle markers that hosts apply through `IResourceLifecycleMarkerService`. Marker writes are idempotent for the same state, reject conflicting archive/soft-delete state, and do not prune versions, deactivate versions, or physically delete resources.
+
+```csharp
+var lifecycleMarkers = serviceProvider.GetRequiredService<IResourceLifecycleMarkerService>();
+
+await lifecycleMarkers.ApplyAsync(new ResourceLifecycleMarkerRequest
+{
+    ResourceId = "product-1",
+    State = ResourceLifecycleMarkerState.Archived,
+    MarkedAt = new DateTimeOffset(2026, 05, 25, 12, 00, 00, TimeSpan.Zero),
+});
+```
+
+Lifecycle markers are queryable only when requested explicitly:
+
+```csharp
+var archived = await queryService.QueryAsync(new ResourceQuery
+{
+    DefinitionId = "Product",
+    LifecycleState = ResourceLifecycleMarkerState.Archived,
+});
+```
+
+Policy declarations and lifecycle markers are tenant-scoped and are preserved by portability when their definitions/resources are included in the selected snapshot. This slice does not add automatic policy execution, schedulers, authorization policy engines, destructive pruning writes, restore workflows, provider registries, public SQL, or public `IQueryable<Resource>`.
+
+---
+
+### 10. Register lifecycle hooks
 
 Hosts can register explicit lifecycle hooks around resource saves, activation/deactivation, export, preview import, and write import.
 
@@ -321,6 +392,10 @@ IResourceVersionWriter           — low-level version/activation persistence ho
 IResourceVersionReader           — low-level read hook for query candidate version sets
 IResourcePortabilityService  — exports, validates, previews, and imports portable snapshots
 IResourcePortabilityStore    — provider-facing exact snapshot read and atomic import contract
+IResourcePolicyValidator      — validates definition-attached policy declarations
+IResourcePolicyEvaluationService — previews policy outcomes without mutation
+IResourceLifecycleMarkerService — applies explicit archive/soft-delete markers
+IResourceLifecycleMarkerStore — provider-facing lifecycle marker persistence contract
 IResourceQueryService         — portable query service; default is LINQ-based in-memory
 IResourceQueryProviderIdentity — exposes the active query provider key
 IResourceQueryCapabilitiesProvider — declares active provider query support
@@ -339,6 +414,7 @@ Key invariants:
 - `ResourceId` is the **logical** identifier shared across all versions. Each version has its own `Id` (GUID).
 - `DefinitionVersion` records schema lineage for a resource version. Normal updates preserve it; explicit schema upgrades advance it.
 - Activation channels are independent: a resource can be active in `"Published"` at V2 and in `"Staging"` at V3 simultaneously.
+- Policy declarations are metadata only; policy previews and lifecycle marker writes are explicit host-controlled operations.
 - Optimistic concurrency is enforced on `UpdateAsync` (must supply `BaseVersion == current latest Version`) and `ActivateAsync` (must supply the current latest version number).
 
 ---

--- a/src/core/Aster.Core/Services/ResourceLifecycleMarkerService.cs
+++ b/src/core/Aster.Core/Services/ResourceLifecycleMarkerService.cs
@@ -46,7 +46,7 @@ public sealed class ResourceLifecycleMarkerService : IResourceLifecycleMarkerSer
         var resources = await versionReader.ReadVersionsAsync(new ResourceVersionReadRequest
         {
             TenantScope = tenant,
-            Scope = ResourceVersionScope.AllVersions,
+            Scope = ResourceVersionScope.Latest,
         }, cancellationToken);
 
         if (!resources.Any(resource => string.Equals(resource.ResourceId, request.ResourceId, StringComparison.Ordinal)))

--- a/src/core/Aster.Core/Services/ResourceLifecycleMarkerService.cs
+++ b/src/core/Aster.Core/Services/ResourceLifecycleMarkerService.cs
@@ -1,0 +1,103 @@
+using Aster.Core.Abstractions;
+using Aster.Core.Models.Instances;
+using Aster.Core.Models.Policies;
+using Aster.Core.Models.Querying;
+
+namespace Aster.Core.Services;
+
+/// <summary>
+/// Default host-facing lifecycle marker service.
+/// </summary>
+public sealed class ResourceLifecycleMarkerService : IResourceLifecycleMarkerService
+{
+    private readonly IResourceVersionReader versionReader;
+    private readonly IResourceLifecycleMarkerStore markerStore;
+
+    /// <summary>
+    /// Initializes a new instance of <see cref="ResourceLifecycleMarkerService"/>.
+    /// </summary>
+    public ResourceLifecycleMarkerService(
+        IResourceVersionReader versionReader,
+        IResourceLifecycleMarkerStore markerStore)
+    {
+        ArgumentNullException.ThrowIfNull(versionReader);
+        ArgumentNullException.ThrowIfNull(markerStore);
+        this.versionReader = versionReader;
+        this.markerStore = markerStore;
+    }
+
+    /// <inheritdoc />
+    public async ValueTask<ResourceLifecycleMarkerResult> ApplyAsync(
+        ResourceLifecycleMarkerRequest request,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        ArgumentException.ThrowIfNullOrWhiteSpace(request.ResourceId);
+        var tenant = TenantScopeResolver.Resolve(request.TenantScope);
+
+        if (request.State == ResourceLifecycleMarkerState.None || !Enum.IsDefined(request.State))
+        {
+            return Failure(
+                ResourcePolicyDiagnosticCodes.PolicyInvalid,
+                "Lifecycle marker writes must apply Archived or SoftDeleted state.",
+                request.ResourceId);
+        }
+
+        var resources = await versionReader.ReadVersionsAsync(new ResourceVersionReadRequest
+        {
+            TenantScope = tenant,
+            Scope = ResourceVersionScope.AllVersions,
+        }, cancellationToken);
+
+        if (!resources.Any(resource => string.Equals(resource.ResourceId, request.ResourceId, StringComparison.Ordinal)))
+        {
+            return Failure(
+                ResourcePolicyDiagnosticCodes.LifecycleMarkerTargetNotFound,
+                $"Resource '{request.ResourceId}' was not found in tenant '{tenant.TenantId}'.",
+                request.ResourceId);
+        }
+
+        var existing = await markerStore.GetMarkerAsync(request.ResourceId, tenant, cancellationToken);
+        if (existing is not null)
+        {
+            if (existing.State == request.State)
+                return new ResourceLifecycleMarkerResult { Marker = existing };
+
+            return new ResourceLifecycleMarkerResult
+            {
+                Marker = existing,
+                Diagnostics =
+                [
+                    ResourcePolicyValidator.Diagnostic(
+                        ResourcePolicyDiagnosticCodes.LifecycleMarkerConflict,
+                        $"Resource '{request.ResourceId}' is already marked as {existing.State}.",
+                        "state",
+                        resourceId: request.ResourceId),
+                ],
+            };
+        }
+
+        var marker = await markerStore.SaveMarkerAsync(new ResourceLifecycleMarker
+        {
+            TenantScope = tenant,
+            ResourceId = request.ResourceId,
+            State = request.State,
+            MarkedAt = request.MarkedAt,
+            Reason = request.Reason,
+        }, cancellationToken);
+
+        return new ResourceLifecycleMarkerResult { Marker = marker };
+    }
+
+    private static ResourceLifecycleMarkerResult Failure(string code, string message, string resourceId) =>
+        new()
+        {
+            Diagnostics =
+            [
+                ResourcePolicyValidator.Diagnostic(
+                    code,
+                    message,
+                    resourceId: resourceId),
+            ],
+        };
+}

--- a/src/core/Aster.Core/Services/ResourcePolicyEvaluationService.cs
+++ b/src/core/Aster.Core/Services/ResourcePolicyEvaluationService.cs
@@ -1,0 +1,293 @@
+using Aster.Core.Abstractions;
+using Aster.Core.Models.Definitions;
+using Aster.Core.Models.Instances;
+using Aster.Core.Models.Policies;
+using Aster.Core.Models.Querying;
+using Aster.Core.Models.Tenancy;
+
+namespace Aster.Core.Services;
+
+/// <summary>
+/// Default non-mutating policy preview service.
+/// </summary>
+public sealed class ResourcePolicyEvaluationService : IResourcePolicyEvaluationService
+{
+    private readonly IResourceDefinitionStore definitionStore;
+    private readonly IResourceVersionReader versionReader;
+    private readonly IResourceLifecycleMarkerStore markerStore;
+    private readonly IResourcePolicyValidator validator;
+
+    /// <summary>
+    /// Initializes a new instance of <see cref="ResourcePolicyEvaluationService"/>.
+    /// </summary>
+    public ResourcePolicyEvaluationService(
+        IResourceDefinitionStore definitionStore,
+        IResourceVersionReader versionReader,
+        IResourceLifecycleMarkerStore markerStore,
+        IResourcePolicyValidator validator)
+    {
+        ArgumentNullException.ThrowIfNull(definitionStore);
+        ArgumentNullException.ThrowIfNull(versionReader);
+        ArgumentNullException.ThrowIfNull(markerStore);
+        ArgumentNullException.ThrowIfNull(validator);
+        this.definitionStore = definitionStore;
+        this.versionReader = versionReader;
+        this.markerStore = markerStore;
+        this.validator = validator;
+    }
+
+    /// <inheritdoc />
+    public async ValueTask<ResourcePolicyEvaluationPreview> PreviewAsync(
+        ResourcePolicyEvaluationRequest request,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        var tenant = TenantScopeResolver.Resolve(request.TenantScope);
+        var diagnostics = new List<ResourcePolicyDiagnostic>();
+        var candidates = new List<ResourcePolicyCandidateOutcome>();
+        var definitions = (await definitionStore.ListDefinitionsAsync(tenant, cancellationToken)).ToList();
+
+        if (request.DefinitionIds.Count > 0)
+        {
+            definitions = definitions
+                .Where(definition => request.DefinitionIds.Contains(definition.DefinitionId))
+                .ToList();
+        }
+
+        var resources = (await versionReader.ReadVersionsAsync(new ResourceVersionReadRequest
+        {
+            TenantScope = tenant,
+            Scope = ResourceVersionScope.AllVersions,
+        }, cancellationToken)).ToList();
+        var markers = await markerStore.GetMarkersAsync(
+            resources.Select(static resource => resource.ResourceId).Distinct(StringComparer.Ordinal),
+            tenant,
+            cancellationToken);
+        var activeVersionKeysByChannel = new Dictionary<string, IReadOnlySet<ResourceVersionKey>>(StringComparer.Ordinal);
+        IReadOnlySet<ResourceVersionKey>? draftVersionKeys = null;
+
+        foreach (var definition in definitions)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            var validation = validator.Validate(definition);
+            diagnostics.AddRange(validation.Diagnostics);
+
+            if (!validation.IsValid)
+                continue;
+
+            foreach (var policy in SelectPolicies(definition, request))
+            {
+                if (policy.Criteria.MinimumAge is not null && request.EvaluationTimestamp is null)
+                {
+                    diagnostics.Add(ResourcePolicyValidator.Diagnostic(
+                        ResourcePolicyDiagnosticCodes.PolicyEvaluationTimestampRequired,
+                        $"Policy '{policy.PolicyId}' uses age-based criteria and requires an evaluation timestamp.",
+                        "evaluationTimestamp",
+                    policy.PolicyId));
+                    continue;
+                }
+
+                var activationMatches = await GetActivationMatchesAsync(
+                    policy,
+                    tenant,
+                    activeVersionKeysByChannel,
+                    draftVersionKeys,
+                    cancellationToken);
+                if (policy.Criteria.ActivationState == ResourcePolicyActivationState.Draft)
+                    draftVersionKeys = activationMatches;
+
+                var definitionResources = resources
+                    .Where(resource => string.Equals(resource.DefinitionId, definition.DefinitionId, StringComparison.Ordinal))
+                    .ToList();
+
+                if (policy.Kind == ResourcePolicyKind.VersionPruning)
+                    AddPruningCandidates(policy, definitionResources, activationMatches, candidates, diagnostics);
+                else
+                    AddResourceCandidates(policy, definitionResources, request.EvaluationTimestamp, markers, activationMatches, candidates);
+            }
+        }
+
+        return new ResourcePolicyEvaluationPreview
+        {
+            TenantScope = tenant,
+            EvaluationTimestamp = request.EvaluationTimestamp,
+            Candidates = candidates,
+            Diagnostics = diagnostics,
+        };
+    }
+
+    private static IEnumerable<ResourcePolicyDeclaration> SelectPolicies(
+        ResourceDefinition definition,
+        ResourcePolicyEvaluationRequest request) =>
+        request.PolicyIds.Count == 0
+            ? definition.PolicyDeclarations
+            : definition.PolicyDeclarations.Where(policy => request.PolicyIds.Contains(policy.PolicyId));
+
+    private static void AddResourceCandidates(
+        ResourcePolicyDeclaration policy,
+        IReadOnlyList<Resource> resources,
+        DateTimeOffset? evaluationTimestamp,
+        IReadOnlyDictionary<string, ResourceLifecycleMarker> markers,
+        IReadOnlySet<ResourceVersionKey>? activationMatches,
+        ICollection<ResourcePolicyCandidateOutcome> candidates)
+    {
+        foreach (var resource in LatestVersions(resources))
+        {
+            if (!MatchesAge(policy, resource, evaluationTimestamp))
+                continue;
+
+            if (!MatchesActivation(policy, resource, activationMatches))
+                continue;
+
+            if (!MatchesLifecycle(policy, resource.ResourceId, markers))
+                continue;
+
+            candidates.Add(new ResourcePolicyCandidateOutcome
+            {
+                PolicyId = policy.PolicyId,
+                PolicyKind = policy.Kind,
+                Outcome = policy.Outcome,
+                ResourceId = resource.ResourceId,
+                ResourceVersion = resource.Version,
+                Reason = $"Resource '{resource.ResourceId}' matched policy '{policy.PolicyId}'.",
+            });
+        }
+    }
+
+    private static void AddPruningCandidates(
+        ResourcePolicyDeclaration policy,
+        IReadOnlyList<Resource> resources,
+        IReadOnlySet<ResourceVersionKey>? activationMatches,
+        ICollection<ResourcePolicyCandidateOutcome> candidates,
+        ICollection<ResourcePolicyDiagnostic> diagnostics)
+    {
+        var retainedVersions = policy.Criteria.MaximumRetainedVersions.GetValueOrDefault();
+        foreach (var group in resources.GroupBy(static resource => resource.ResourceId, StringComparer.Ordinal))
+        {
+            var ordered = group
+                .Where(resource => MatchesActivation(policy, resource, activationMatches))
+                .OrderByDescending(static resource => resource.Version)
+                .ToList();
+            var pruneCandidates = ordered.Skip(retainedVersions).ToList();
+            if (pruneCandidates.Count == ordered.Count && ordered.Count > 0)
+            {
+                diagnostics.Add(ResourcePolicyValidator.Diagnostic(
+                    ResourcePolicyDiagnosticCodes.PolicyPruningUnsafe,
+                    $"Policy '{policy.PolicyId}' would prune every version of resource '{group.Key}'.",
+                    policyId: policy.PolicyId,
+                    resourceId: group.Key));
+                continue;
+            }
+
+            foreach (var resource in pruneCandidates)
+            {
+                candidates.Add(new ResourcePolicyCandidateOutcome
+                {
+                    PolicyId = policy.PolicyId,
+                    PolicyKind = policy.Kind,
+                    Outcome = ResourcePolicyOutcome.PrunePreview,
+                    ResourceId = resource.ResourceId,
+                    ResourceVersion = resource.Version,
+                    Reason = $"Resource '{resource.ResourceId}' version {resource.Version} is outside the retained version count.",
+                });
+            }
+        }
+    }
+
+    private static IEnumerable<Resource> LatestVersions(IEnumerable<Resource> resources) =>
+        resources
+            .GroupBy(static resource => resource.ResourceId, StringComparer.Ordinal)
+            .Select(static group => group.OrderByDescending(static resource => resource.Version).First());
+
+    private static bool MatchesAge(
+        ResourcePolicyDeclaration policy,
+        Resource resource,
+        DateTimeOffset? evaluationTimestamp)
+    {
+        if (policy.Criteria.MinimumAge is not { } minimumAge)
+            return true;
+
+        var created = new DateTimeOffset(DateTime.SpecifyKind(resource.Created, DateTimeKind.Utc));
+        return evaluationTimestamp!.Value - created >= minimumAge;
+    }
+
+    private static bool MatchesLifecycle(
+        ResourcePolicyDeclaration policy,
+        string resourceId,
+        IReadOnlyDictionary<string, ResourceLifecycleMarker> markers)
+    {
+        if (policy.Criteria.LifecycleState is not { } expected)
+            return true;
+
+        var actual = markers.TryGetValue(resourceId, out var marker)
+            ? marker.State
+            : ResourceLifecycleMarkerState.None;
+
+        return actual == expected;
+    }
+
+    private async ValueTask<IReadOnlySet<ResourceVersionKey>?> GetActivationMatchesAsync(
+        ResourcePolicyDeclaration policy,
+        TenantScope tenant,
+        IDictionary<string, IReadOnlySet<ResourceVersionKey>> activeVersionKeysByChannel,
+        IReadOnlySet<ResourceVersionKey>? draftVersionKeys,
+        CancellationToken cancellationToken)
+    {
+        return policy.Criteria.ActivationState switch
+        {
+            null => null,
+            ResourcePolicyActivationState.Active => await GetActiveVersionKeysAsync(
+                tenant,
+                policy.Criteria.ActivationChannel!,
+                activeVersionKeysByChannel,
+                cancellationToken),
+            ResourcePolicyActivationState.Draft => draftVersionKeys ?? await ReadVersionKeysAsync(
+                tenant,
+                ResourceVersionScope.Draft,
+                activationChannel: null,
+                cancellationToken),
+            _ => null,
+        };
+    }
+
+    private async ValueTask<IReadOnlySet<ResourceVersionKey>> GetActiveVersionKeysAsync(
+        TenantScope tenant,
+        string channel,
+        IDictionary<string, IReadOnlySet<ResourceVersionKey>> activeVersionKeysByChannel,
+        CancellationToken cancellationToken)
+    {
+        if (activeVersionKeysByChannel.TryGetValue(channel, out var cached))
+            return cached;
+
+        var keys = await ReadVersionKeysAsync(tenant, ResourceVersionScope.Active, channel, cancellationToken);
+        activeVersionKeysByChannel[channel] = keys;
+        return keys;
+    }
+
+    private async ValueTask<IReadOnlySet<ResourceVersionKey>> ReadVersionKeysAsync(
+        TenantScope tenant,
+        ResourceVersionScope scope,
+        string? activationChannel,
+        CancellationToken cancellationToken)
+    {
+        var versions = await versionReader.ReadVersionsAsync(new ResourceVersionReadRequest
+        {
+            TenantScope = tenant,
+            Scope = scope,
+            ActivationChannel = activationChannel,
+        }, cancellationToken);
+
+        return versions
+            .Select(static resource => new ResourceVersionKey(resource.ResourceId, resource.Version))
+            .ToHashSet();
+    }
+
+    private static bool MatchesActivation(
+        ResourcePolicyDeclaration policy,
+        Resource resource,
+        IReadOnlySet<ResourceVersionKey>? activationMatches) =>
+        policy.Criteria.ActivationState is null
+        || (activationMatches?.Contains(new ResourceVersionKey(resource.ResourceId, resource.Version)) ?? false);
+
+    private readonly record struct ResourceVersionKey(string ResourceId, int Version);
+}

--- a/src/core/Aster.Core/Services/ResourcePolicyValidator.cs
+++ b/src/core/Aster.Core/Services/ResourcePolicyValidator.cs
@@ -1,0 +1,224 @@
+using Aster.Core.Abstractions;
+using Aster.Core.Models.Definitions;
+using Aster.Core.Models.Policies;
+
+namespace Aster.Core.Services;
+
+/// <summary>
+/// Default validation for definition-attached policy declarations.
+/// </summary>
+public sealed class ResourcePolicyValidator : IResourcePolicyValidator
+{
+    /// <inheritdoc />
+    public ResourcePolicyValidationResult Validate(ResourceDefinition definition)
+    {
+        ArgumentNullException.ThrowIfNull(definition);
+
+        var diagnostics = new List<ResourcePolicyDiagnostic>();
+        var declarations = definition.PolicyDeclarations ?? [];
+        var policyIds = new HashSet<string>(StringComparer.Ordinal);
+
+        for (var index = 0; index < declarations.Count; index++)
+        {
+            var declaration = declarations[index];
+            var path = $"policyDeclarations/{index}";
+
+            if (declaration is null)
+            {
+                diagnostics.Add(Diagnostic(
+                    ResourcePolicyDiagnosticCodes.PolicyInvalid,
+                    "Policy declaration cannot be null.",
+                    path));
+                continue;
+            }
+
+            ValidateDeclarationShape(declaration, path, policyIds, diagnostics);
+            ValidateDeclarationCompatibility(declaration, path, diagnostics);
+            ValidateCriteria(declaration, path, diagnostics);
+        }
+
+        return diagnostics.Count == 0
+            ? ResourcePolicyValidationResult.Success
+            : new ResourcePolicyValidationResult { Diagnostics = diagnostics };
+    }
+
+    private static void ValidateDeclarationShape(
+        ResourcePolicyDeclaration declaration,
+        string path,
+        ISet<string> policyIds,
+        ICollection<ResourcePolicyDiagnostic> diagnostics)
+    {
+        if (string.IsNullOrWhiteSpace(declaration.PolicyId))
+        {
+            diagnostics.Add(Diagnostic(
+                ResourcePolicyDiagnosticCodes.PolicyInvalid,
+                "Policy ID is required.",
+                $"{path}/policyId"));
+        }
+        else if (!policyIds.Add(declaration.PolicyId))
+        {
+            diagnostics.Add(Diagnostic(
+                ResourcePolicyDiagnosticCodes.PolicyConflict,
+                $"Policy ID '{declaration.PolicyId}' is declared more than once.",
+                $"{path}/policyId",
+                declaration.PolicyId));
+        }
+
+        if (!Enum.IsDefined(declaration.Kind))
+        {
+            diagnostics.Add(Diagnostic(
+                ResourcePolicyDiagnosticCodes.PolicyKindUnsupported,
+                $"Policy kind '{declaration.Kind}' is not supported.",
+                $"{path}/kind",
+                declaration.PolicyId));
+        }
+
+        if (!Enum.IsDefined(declaration.Target))
+        {
+            diagnostics.Add(Diagnostic(
+                ResourcePolicyDiagnosticCodes.PolicyTargetInvalid,
+                $"Policy target '{declaration.Target}' is not supported.",
+                $"{path}/target",
+                declaration.PolicyId));
+        }
+
+        if (!Enum.IsDefined(declaration.Outcome))
+        {
+            diagnostics.Add(Diagnostic(
+                ResourcePolicyDiagnosticCodes.PolicyOutcomeUnsupported,
+                $"Policy outcome '{declaration.Outcome}' is not supported.",
+                $"{path}/outcome",
+                declaration.PolicyId));
+        }
+    }
+
+    private static void ValidateDeclarationCompatibility(
+        ResourcePolicyDeclaration declaration,
+        string path,
+        ICollection<ResourcePolicyDiagnostic> diagnostics)
+    {
+        var valid = declaration.Kind switch
+        {
+            ResourcePolicyKind.Retention =>
+                declaration.Target == ResourcePolicyTarget.Resource
+                && declaration.Outcome == ResourcePolicyOutcome.Retain,
+            ResourcePolicyKind.Archival =>
+                declaration.Target == ResourcePolicyTarget.Resource
+                && declaration.Outcome == ResourcePolicyOutcome.Archive,
+            ResourcePolicyKind.SoftDelete =>
+                declaration.Target == ResourcePolicyTarget.Resource
+                && declaration.Outcome == ResourcePolicyOutcome.SoftDelete,
+            ResourcePolicyKind.VersionPruning =>
+                declaration.Target == ResourcePolicyTarget.ResourceVersion
+                && declaration.Outcome == ResourcePolicyOutcome.PrunePreview,
+            _ => true,
+        };
+
+        if (!valid)
+        {
+            diagnostics.Add(Diagnostic(
+                ResourcePolicyDiagnosticCodes.PolicyInvalid,
+                $"Policy '{declaration.PolicyId}' has incompatible kind, target, or outcome.",
+                path,
+                declaration.PolicyId));
+        }
+    }
+
+    private static void ValidateCriteria(
+        ResourcePolicyDeclaration declaration,
+        string path,
+        ICollection<ResourcePolicyDiagnostic> diagnostics)
+    {
+        var criteria = declaration.Criteria;
+        if (criteria is null)
+        {
+            diagnostics.Add(Diagnostic(
+                ResourcePolicyDiagnosticCodes.PolicyInvalid,
+                "Policy criteria are required.",
+                $"{path}/criteria",
+                declaration.PolicyId));
+            return;
+        }
+
+        if (criteria.MinimumAge is { } minimumAge && minimumAge <= TimeSpan.Zero)
+        {
+            diagnostics.Add(Diagnostic(
+                ResourcePolicyDiagnosticCodes.PolicyInvalid,
+                "Minimum age must be greater than zero.",
+                $"{path}/criteria/minimumAge",
+                declaration.PolicyId));
+        }
+
+        if (criteria.MaximumRetainedVersions is { } retainedVersions && retainedVersions <= 0)
+        {
+            diagnostics.Add(Diagnostic(
+                ResourcePolicyDiagnosticCodes.PolicyInvalid,
+                "Maximum retained versions must be greater than zero.",
+                $"{path}/criteria/maximumRetainedVersions",
+                declaration.PolicyId));
+        }
+
+        if (declaration.Kind == ResourcePolicyKind.VersionPruning && criteria.MaximumRetainedVersions is null)
+        {
+            diagnostics.Add(Diagnostic(
+                ResourcePolicyDiagnosticCodes.PolicyInvalid,
+                "Version pruning policies require a maximum retained version count.",
+                $"{path}/criteria/maximumRetainedVersions",
+                declaration.PolicyId));
+        }
+
+        if (criteria.ActivationState == ResourcePolicyActivationState.Active
+            && string.IsNullOrWhiteSpace(criteria.ActivationChannel))
+        {
+            diagnostics.Add(Diagnostic(
+                ResourcePolicyDiagnosticCodes.PolicyInvalid,
+                "Active policy criteria require an activation channel.",
+                $"{path}/criteria/activationChannel",
+                declaration.PolicyId));
+        }
+
+        if (criteria.ActivationState is { } activationState && !Enum.IsDefined(activationState))
+        {
+            diagnostics.Add(Diagnostic(
+                ResourcePolicyDiagnosticCodes.PolicyInvalid,
+                $"Activation state '{activationState}' is not supported.",
+                $"{path}/criteria/activationState",
+                declaration.PolicyId));
+        }
+
+        if (criteria.LifecycleState is { } lifecycleState && !Enum.IsDefined(lifecycleState))
+        {
+            diagnostics.Add(Diagnostic(
+                ResourcePolicyDiagnosticCodes.PolicyInvalid,
+                $"Lifecycle state '{lifecycleState}' is not supported.",
+                $"{path}/criteria/lifecycleState",
+                declaration.PolicyId));
+        }
+
+        if (!string.IsNullOrWhiteSpace(criteria.UnsupportedFacetPredicate))
+        {
+            diagnostics.Add(Diagnostic(
+                ResourcePolicyDiagnosticCodes.PolicyCriteriaUnsupported,
+                "Arbitrary resource facet predicates are not supported by policy declarations in this slice.",
+                $"{path}/criteria/unsupportedFacetPredicate",
+                declaration.PolicyId));
+        }
+    }
+
+    internal static ResourcePolicyDiagnostic Diagnostic(
+        string code,
+        string message,
+        string? path = null,
+        string? policyId = null,
+        string? resourceId = null,
+        int? resourceVersion = null) =>
+        new()
+        {
+            Code = code,
+            Message = message,
+            Path = path,
+            PolicyId = policyId,
+            ResourceId = resourceId,
+            ResourceVersion = resourceVersion,
+        };
+}

--- a/src/core/Aster.Core/Services/ResourcePortabilityService.cs
+++ b/src/core/Aster.Core/Services/ResourcePortabilityService.cs
@@ -104,6 +104,7 @@ public sealed class ResourcePortabilityService : IResourcePortabilityService
                 Definitions = storeSnapshot.Definitions.Select(definition => definition with { TenantScope = sourceTenant }).ToList(),
                 Resources = storeSnapshot.Resources.Select(resource => resource with { TenantScope = sourceTenant }).ToList(),
                 ActivationStates = storeSnapshot.ActivationStates.Select(state => state with { TenantScope = sourceTenant }).ToList(),
+                LifecycleMarkers = storeSnapshot.LifecycleMarkers.Select(marker => marker with { TenantScope = sourceTenant }).ToList(),
             };
 
             result = new PortableSnapshotExportResult
@@ -450,6 +451,7 @@ public sealed class ResourcePortabilityService : IResourcePortabilityService
         var existingDefinitions = targetState.Definitions.ToDictionary(static definition => (definition.DefinitionId, definition.Version));
         var existingResources = targetState.Resources.ToDictionary(static resource => (resource.ResourceId, resource.Version));
         var existingActivationStates = targetState.ActivationStates.ToDictionary(static state => (state.ResourceId, state.Channel));
+        var existingLifecycleMarkers = targetState.LifecycleMarkers.ToDictionary(static marker => marker.ResourceId, StringComparer.Ordinal);
         var definitionIdsToRemap = new HashSet<string>(StringComparer.Ordinal);
         var resourceIdsToRemap = new HashSet<string>(StringComparer.Ordinal);
         var remappedCollisionDiagnostics = new List<RemappedCollisionDiagnostic>();
@@ -577,6 +579,45 @@ public sealed class ResourcePortabilityService : IResourcePortabilityService
                 $"Activation state for resource '{state.ResourceId}' channel '{state.Channel}' already exists with different content."));
         }
 
+        foreach (var marker in snapshot.LifecycleMarkers)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            if (!existingLifecycleMarkers.TryGetValue(marker.ResourceId, out var existing))
+            {
+                if (options.CollisionMode == PortableImportCollisionMode.Strict)
+                    strictFailureIdentityMap.Add(Preserved(PortableEntityKind.LifecycleMarker, LifecycleMarkerId(marker)));
+
+                continue;
+            }
+
+            if (ContentEquals(marker, existing))
+            {
+                if (options.CollisionMode == PortableImportCollisionMode.Strict)
+                    strictFailureIdentityMap.Add(Reused(PortableEntityKind.LifecycleMarker, LifecycleMarkerId(marker)));
+
+                continue;
+            }
+
+            if (options.CollisionMode == PortableImportCollisionMode.Strict)
+            {
+                strictFailureIdentityMap.Add(Collided(PortableEntityKind.LifecycleMarker, LifecycleMarkerId(marker)));
+                diagnostics.Add(DivergentCollision(
+                    $"lifecycleMarkers/{marker.ResourceId}",
+                    $"Lifecycle marker for resource '{marker.ResourceId}' already exists with different content."));
+                continue;
+            }
+
+            resourceIdsToRemap.Add(marker.ResourceId);
+            remappedCollisionDiagnostics.Add(new RemappedCollisionDiagnostic(
+                PortableEntityKind.LifecycleMarker,
+                marker.ResourceId,
+                null,
+                null,
+                $"lifecycleMarkers/{marker.ResourceId}",
+                $"Lifecycle marker for resource '{marker.ResourceId}' already exists with different content."));
+        }
+
         if (diagnostics.Any(static diagnostic => diagnostic.Severity == PortableDiagnosticSeverity.Error))
             return ImportPlan.Failed(diagnostics, strictFailureIdentityMap);
 
@@ -587,8 +628,10 @@ public sealed class ResourcePortabilityService : IResourcePortabilityService
         var resourceIdMap = BuildRemappedIdMap(
             resourceIdsToRemap,
             targetState.Resources.Select(static resource => resource.ResourceId)
-                .Concat(targetState.ActivationStates.Select(static state => state.ResourceId)),
-            snapshot.Resources.Select(static resource => resource.ResourceId));
+                .Concat(targetState.ActivationStates.Select(static state => state.ResourceId))
+                .Concat(targetState.LifecycleMarkers.Select(static marker => marker.ResourceId)),
+            snapshot.Resources.Select(static resource => resource.ResourceId)
+                .Concat(snapshot.LifecycleMarkers.Select(static marker => marker.ResourceId)));
 
         diagnostics.AddRange(remappedCollisionDiagnostics.Select(diagnostic =>
             RemappedCollision(
@@ -599,6 +642,7 @@ public sealed class ResourcePortabilityService : IResourcePortabilityService
         var plannedDefinitions = new List<ResourceDefinition>();
         var plannedResources = new List<Resource>();
         var plannedActivationStates = new List<ActivationState>();
+        var plannedLifecycleMarkers = new List<ResourceLifecycleMarker>();
         var reusedIdenticalItems = 0;
 
         foreach (var definition in snapshot.Definitions)
@@ -687,6 +731,32 @@ public sealed class ResourcePortabilityService : IResourcePortabilityService
             identityMap.Add(Reused(PortableEntityKind.ActivationEntry, ActivationEntryId(state)));
         }
 
+        foreach (var marker in snapshot.LifecycleMarkers)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            if (resourceIdMap.TryGetValue(marker.ResourceId, out var targetResourceId))
+            {
+                var remappedMarker = marker with { ResourceId = targetResourceId };
+                plannedLifecycleMarkers.Add(remappedMarker);
+                identityMap.Add(Remapped(
+                    PortableEntityKind.LifecycleMarker,
+                    LifecycleMarkerId(marker),
+                    LifecycleMarkerId(remappedMarker)));
+                continue;
+            }
+
+            if (!existingLifecycleMarkers.TryGetValue(marker.ResourceId, out _))
+            {
+                plannedLifecycleMarkers.Add(marker);
+                identityMap.Add(Preserved(PortableEntityKind.LifecycleMarker, LifecycleMarkerId(marker)));
+                continue;
+            }
+
+            reusedIdenticalItems++;
+            identityMap.Add(Reused(PortableEntityKind.LifecycleMarker, LifecycleMarkerId(marker)));
+        }
+
         var plannedSnapshot = new PortableSnapshot
         {
             FormatVersion = PortableSnapshot.CurrentFormatVersion,
@@ -694,6 +764,7 @@ public sealed class ResourcePortabilityService : IResourcePortabilityService
             Definitions = plannedDefinitions.Select(definition => definition with { TenantScope = targetTenant }).ToList(),
             Resources = plannedResources.Select(resource => resource with { TenantScope = targetTenant }).ToList(),
             ActivationStates = plannedActivationStates.Select(state => state with { TenantScope = targetTenant }).ToList(),
+            LifecycleMarkers = plannedLifecycleMarkers.Select(marker => marker with { TenantScope = targetTenant }).ToList(),
         };
         var plannedCounts = new PortablePlannedImportCounts
         {
@@ -701,6 +772,7 @@ public sealed class ResourcePortabilityService : IResourcePortabilityService
             Resources = plannedResources.Select(static resource => resource.ResourceId).Distinct(StringComparer.Ordinal).Count(),
             ResourceVersions = plannedResources.Count,
             ActivationEntries = plannedActivationStates.Count,
+            LifecycleMarkers = plannedLifecycleMarkers.Count,
             ReusedIdenticalItems = reusedIdenticalItems,
             RemappedItems = identityMap.Count(static mapping => mapping.Reason == PortableIdentityMappingReason.RemappedDivergent),
         };
@@ -710,6 +782,7 @@ public sealed class ResourcePortabilityService : IResourcePortabilityService
             Resources = plannedCounts.Resources,
             ResourceVersions = plannedCounts.ResourceVersions,
             ActivationEntries = plannedCounts.ActivationEntries,
+            LifecycleMarkers = plannedCounts.LifecycleMarkers,
             ReusedIdenticalItems = plannedCounts.ReusedIdenticalItems,
             RemappedItems = plannedCounts.RemappedItems,
         };
@@ -819,6 +892,7 @@ public sealed class ResourcePortabilityService : IResourcePortabilityService
         var validDefinitions = new List<ResourceDefinition>();
         var validResources = new List<Resource>();
         var validActivationStates = new List<ActivationState>();
+        var validLifecycleMarkers = new List<ResourceLifecycleMarker>();
 
         if (snapshot.FormatVersion != PortableSnapshot.CurrentFormatVersion)
         {
@@ -834,6 +908,7 @@ public sealed class ResourcePortabilityService : IResourcePortabilityService
         var definitions = snapshot.Definitions;
         var resources = snapshot.Resources;
         var activationStates = snapshot.ActivationStates;
+        var lifecycleMarkers = snapshot.LifecycleMarkers;
 
         if (definitions is null)
         {
@@ -851,6 +926,12 @@ public sealed class ResourcePortabilityService : IResourcePortabilityService
         {
             diagnostics.Add(MalformedSnapshot("activationStates", "Snapshot activation states collection cannot be null."));
             activationStates = [];
+        }
+
+        if (lifecycleMarkers is null)
+        {
+            diagnostics.Add(MalformedSnapshot("lifecycleMarkers", "Snapshot lifecycle markers collection cannot be null."));
+            lifecycleMarkers = [];
         }
 
         for (var i = 0; i < definitions.Count; i++)
@@ -987,7 +1068,36 @@ public sealed class ResourcePortabilityService : IResourcePortabilityService
             }
         }
 
-        diagnostics.AddRange(ValidateSnapshotIdentityUniqueness(validDefinitions, validResources, validActivationStates));
+        for (var i = 0; i < lifecycleMarkers.Count; i++)
+        {
+            var marker = lifecycleMarkers[i];
+            if (marker is null)
+            {
+                diagnostics.Add(MalformedSnapshot($"lifecycleMarkers/{i}", "Snapshot lifecycle marker entry cannot be null."));
+                continue;
+            }
+
+            var isMalformed = false;
+            if (string.IsNullOrWhiteSpace(marker.ResourceId))
+            {
+                diagnostics.Add(MalformedSnapshot($"lifecycleMarkers/{i}/resourceId", "Snapshot lifecycle marker resource ID is required."));
+                isMalformed = true;
+            }
+
+            if (marker.State is ResourceLifecycleMarkerState.None || !Enum.IsDefined(marker.State))
+            {
+                diagnostics.Add(MalformedSnapshot($"lifecycleMarkers/{i}/state", "Snapshot lifecycle marker state must be archived or soft-deleted."));
+                isMalformed = true;
+            }
+
+            if (!isMalformed)
+            {
+                validLifecycleMarkers.Add(marker);
+                ValidateEntityTenant(marker.TenantScope, sourceTenant, $"lifecycleMarkers/{i}/tenantScope", diagnostics);
+            }
+        }
+
+        diagnostics.AddRange(ValidateSnapshotIdentityUniqueness(validDefinitions, validResources, validActivationStates, validLifecycleMarkers));
 
         var definitionVersions = validDefinitions
             .Select(static definition => (definition.DefinitionId, definition.Version))
@@ -1031,13 +1141,32 @@ public sealed class ResourcePortabilityService : IResourcePortabilityService
             }
         }
 
+        var resourceIds = validResources
+            .Select(static resource => resource.ResourceId)
+            .ToHashSet(StringComparer.Ordinal);
+
+        foreach (var marker in validLifecycleMarkers)
+        {
+            if (resourceIds.Contains(marker.ResourceId))
+                continue;
+
+            diagnostics.Add(new PortableDiagnostic
+            {
+                Code = PortableDiagnosticCodes.MissingResourceReference,
+                Severity = PortableDiagnosticSeverity.Error,
+                Path = $"lifecycleMarkers/{marker.ResourceId}",
+                Message = $"Lifecycle marker for resource '{marker.ResourceId}' references a missing resource.",
+            });
+        }
+
         return diagnostics;
     }
 
     private static List<PortableDiagnostic> ValidateSnapshotIdentityUniqueness(
         IReadOnlyList<ResourceDefinition> definitions,
         IReadOnlyList<Resource> resources,
-        IReadOnlyList<ActivationState> activationStates)
+        IReadOnlyList<ActivationState> activationStates,
+        IReadOnlyList<ResourceLifecycleMarker> lifecycleMarkers)
     {
         var diagnostics = new List<PortableDiagnostic>();
 
@@ -1057,6 +1186,10 @@ public sealed class ResourcePortabilityService : IResourcePortabilityService
             activationStates.Select(static state => ActivationEntryId(state)),
             "activationStates",
             "Snapshot contains duplicate activation state identities."));
+        diagnostics.AddRange(FindDuplicateKeys(
+            lifecycleMarkers.Select(static marker => LifecycleMarkerId(marker)),
+            "lifecycleMarkers",
+            "Snapshot contains duplicate lifecycle marker identities."));
 
         return diagnostics;
     }
@@ -1145,6 +1278,9 @@ public sealed class ResourcePortabilityService : IResourcePortabilityService
             PortableEntityKind.ActivationEntry => JsonSerializer.Serialize(
                 new object[] { resourceIdMap[diagnostic.SourceLogicalId], diagnostic.Channel! },
                 JsonOptions),
+            PortableEntityKind.LifecycleMarker => JsonSerializer.Serialize(
+                new object[] { resourceIdMap[diagnostic.SourceLogicalId] },
+                JsonOptions),
             _ => throw new InvalidOperationException($"Unsupported remapped collision entity kind '{diagnostic.EntityKind}'."),
         };
 
@@ -1232,6 +1368,7 @@ public sealed class ResourcePortabilityService : IResourcePortabilityService
             Definitions = snapshot.Definitions.Select(definition => definition with { TenantScope = tenantScope }).ToList(),
             Resources = snapshot.Resources.Select(resource => resource with { TenantScope = tenantScope }).ToList(),
             ActivationStates = snapshot.ActivationStates.Select(state => state with { TenantScope = tenantScope }).ToList(),
+            LifecycleMarkers = snapshot.LifecycleMarkers.Select(marker => marker with { TenantScope = tenantScope }).ToList(),
         };
 
     private static bool ContentEquals<T>(T left, T right) =>
@@ -1240,6 +1377,7 @@ public sealed class ResourcePortabilityService : IResourcePortabilityService
             (ResourceDefinition leftDefinition, ResourceDefinition rightDefinition) => ContentEquals(leftDefinition, rightDefinition),
             (Resource leftResource, Resource rightResource) => ContentEquals(leftResource, rightResource),
             (ActivationState leftState, ActivationState rightState) => ContentEquals(leftState, rightState),
+            (ResourceLifecycleMarker leftMarker, ResourceLifecycleMarker rightMarker) => ContentEquals(leftMarker, rightMarker),
             _ => JsonContentEquals(left, right),
         };
 
@@ -1248,7 +1386,12 @@ public sealed class ResourcePortabilityService : IResourcePortabilityService
         && string.Equals(left.Id, right.Id, StringComparison.Ordinal)
         && left.Version == right.Version
         && left.IsSingleton == right.IsSingleton
-        && DictionaryContentEquals(left.AspectDefinitions, right.AspectDefinitions);
+        && DictionaryContentEquals(left.AspectDefinitions, right.AspectDefinitions)
+        && left.PolicyDeclarations.Count == right.PolicyDeclarations.Count
+        && left.PolicyDeclarations
+            .OrderBy(static policy => policy.PolicyId, StringComparer.Ordinal)
+            .Zip(right.PolicyDeclarations.OrderBy(static policy => policy.PolicyId, StringComparer.Ordinal))
+            .All(pair => JsonContentEquals(pair.First, pair.Second));
 
     private static bool ContentEquals(Resource left, Resource right) =>
         string.Equals(left.ResourceId, right.ResourceId, StringComparison.Ordinal)
@@ -1266,6 +1409,12 @@ public sealed class ResourcePortabilityService : IResourcePortabilityService
         && string.Equals(left.Channel, right.Channel, StringComparison.Ordinal)
         && left.LastUpdated == right.LastUpdated
         && left.ActiveVersions.Distinct().Order().SequenceEqual(right.ActiveVersions.Distinct().Order());
+
+    private static bool ContentEquals(ResourceLifecycleMarker left, ResourceLifecycleMarker right) =>
+        string.Equals(left.ResourceId, right.ResourceId, StringComparison.Ordinal)
+        && left.State == right.State
+        && left.MarkedAt == right.MarkedAt
+        && string.Equals(left.Reason, right.Reason, StringComparison.Ordinal);
 
     private static bool DictionaryContentEquals<TValue>(
         IReadOnlyDictionary<string, TValue> left,
@@ -1349,6 +1498,9 @@ public sealed class ResourcePortabilityService : IResourcePortabilityService
     private static string ActivationEntryId(ActivationState state) =>
         JsonSerializer.Serialize(new object[] { state.ResourceId, state.Channel }, JsonOptions);
 
+    private static string LifecycleMarkerId(ResourceLifecycleMarker marker) =>
+        JsonSerializer.Serialize(new object[] { marker.ResourceId }, JsonOptions);
+
     private sealed record RemappedCollisionDiagnostic(
         PortableEntityKind EntityKind,
         string SourceLogicalId,
@@ -1367,7 +1519,8 @@ public sealed class ResourcePortabilityService : IResourcePortabilityService
         public bool HasWrites =>
             PlannedCounts.Definitions > 0
             || PlannedCounts.ResourceVersions > 0
-            || PlannedCounts.ActivationEntries > 0;
+            || PlannedCounts.ActivationEntries > 0
+            || PlannedCounts.LifecycleMarkers > 0;
 
         public static ImportPlan Failed(
             IReadOnlyList<PortableDiagnostic> diagnostics,

--- a/src/core/Aster.Core/Services/ResourceQueryValidator.cs
+++ b/src/core/Aster.Core/Services/ResourceQueryValidator.cs
@@ -71,6 +71,7 @@ public sealed class ResourceQueryValidator : IResourceQueryValidator
 
         var failures = new List<QueryValidationFailure>();
         ValidateTenantScope(query, failures);
+        ValidateLifecycleState(query, failures);
         ValidateScope(query, failures);
         ValidatePaging(query, failures);
 
@@ -82,6 +83,31 @@ public sealed class ResourceQueryValidator : IResourceQueryValidator
         return failures.Count == 0
             ? QueryValidationResult.Success
             : new(failures);
+    }
+
+    private void ValidateLifecycleState(ResourceQuery query, List<QueryValidationFailure> failures)
+    {
+        if (query.LifecycleState is null)
+            return;
+
+        if (!Enum.IsDefined(query.LifecycleState.Value))
+        {
+            failures.Add(Failure(
+                "unsupported-lifecycle-state",
+                $"Lifecycle state '{query.LifecycleState}' is not supported.",
+                "LifecycleState",
+                "lifecycle state"));
+            return;
+        }
+
+        if (capabilities!.SupportsLifecycleStateFiltering)
+            return;
+
+        failures.Add(Failure(
+            "unsupported-lifecycle-state-filter",
+            $"Lifecycle-state filtering is not supported by {capabilities.ProviderName}.",
+            "LifecycleState",
+            "lifecycle state"));
     }
 
     private static void ValidateTenantScope(ResourceQuery query, List<QueryValidationFailure> failures)

--- a/src/persistence/Aster.Persistence.SqliteJson/Querying/SqliteQueryBuilder.cs
+++ b/src/persistence/Aster.Persistence.SqliteJson/Querying/SqliteQueryBuilder.cs
@@ -37,8 +37,10 @@ internal sealed class SqliteQueryBuilder(ResourceQuery query)
         sql.AppendJoin(", ", ["rv.payload", .. projections]);
         sql.AppendLine();
         sql.Append(baseSql);
+        sql.Append(BuildLifecycleMarkerJoin());
         predicates.Add($"rv.tenant_id = {tenantId}");
         predicates.AddRange(scopePredicates);
+        AddLifecycleStatePredicate();
 
         if (!string.IsNullOrWhiteSpace(query.DefinitionId))
         {
@@ -78,6 +80,25 @@ internal sealed class SqliteQueryBuilder(ResourceQuery query)
 
         sql.Append(';');
         return sql.ToString();
+    }
+
+    private string BuildLifecycleMarkerJoin() =>
+        query.LifecycleState is null
+            ? string.Empty
+            : """
+
+            LEFT JOIN lifecycle_markers lifecycle_marker
+                ON lifecycle_marker.tenant_id = rv.tenant_id
+                AND lifecycle_marker.resource_id = rv.resource_id
+            """;
+
+    private void AddLifecycleStatePredicate()
+    {
+        if (query.LifecycleState is not { } lifecycleState)
+            return;
+
+        var parameter = Parameters.Add((int)lifecycleState);
+        predicates.Add($"CAST(COALESCE(json_extract(lifecycle_marker.payload, '$.state'), 0) AS INTEGER) = {parameter}");
     }
 
     private IEnumerable<string> Orderings() =>

--- a/src/persistence/Aster.Persistence.SqliteJson/README.md
+++ b/src/persistence/Aster.Persistence.SqliteJson/README.md
@@ -10,10 +10,11 @@ This package currently provides:
 - `IResourceVersionReader`
 - `IResourceVersionWriter`
 - `IResourcePortabilityStore`
+- `IResourceLifecycleMarkerStore`
 - `IResourceQueryService`
 - `IResourceQueryCapabilitiesProvider`
 
-It persists resource definitions, resource version snapshots, and activation state using SQLite tables with JSON payload columns.
+It persists resource definitions, resource version snapshots, activation state, and explicit lifecycle markers using SQLite tables with JSON payload columns.
 Query execution is provider-backed: `ResourceQuery` ASTs are translated to parameterized SQLite SQL and JSON1 expressions instead of materializing the full store in memory.
 Portability support is provider-backed too: the SQLite JSON resource store implements exact snapshot reads, target-state comparison reads, and atomic import apply for `IResourcePortabilityService`.
 All provider tables include `tenant_id`; fresh databases use tenant-aware primary keys, and provider initialization adds a default-scope `tenant_id` column to pre-tenant tables so existing rows remain visible to omitted-scope callers.
@@ -51,7 +52,7 @@ var preview = await portability.PreviewImportAsync(
     });
 ```
 
-SQLite import apply is all-or-nothing for a planned snapshot. Strict imports fail before writing on divergent identity collisions; explicit `RemapDivergent` mode writes deterministic remapped identifiers and keeps definition lineage, resource versions, and activation entries consistent. No SQLite schema migration or physical indexing is introduced by portability primitives.
+SQLite import apply is all-or-nothing for a planned snapshot. Strict imports fail before writing on divergent identity collisions; explicit `RemapDivergent` mode writes deterministic remapped identifiers and keeps definition lineage, resource versions, activation entries, and lifecycle markers consistent. No SQLite physical indexing is introduced by portability primitives.
 
 Supported query shapes:
 
@@ -67,6 +68,7 @@ Supported query shapes:
 - facet `Exists`
 - numeric/date-like facet `Range`
 - `And`, `Or`, and single-operand `Not`
+- explicit `LifecycleState` filtering for archived, soft-deleted, or unmarked resources
 
 Date-like facet ranges match JSON string scalar values in the ISO-8601-style shape emitted by `System.Text.Json` for `DateTime` or `DateTimeOffset`. Date-only strings, malformed strings, numbers, booleans, objects, arrays, nulls, and missing facets do not match date-like range predicates.
 
@@ -75,3 +77,5 @@ Unsupported query shapes throw `UnsupportedQueryFeatureException` with stable `C
 The provider also declares this support through `SqliteJsonQueryCapabilitiesProvider` with provider key `sqlite-json`, so callers can inspect capabilities or use `IResourceQueryValidator` before execution. Execution runs shared validation first and remains authoritative if validation is skipped.
 
 Tenant scope is applied as a provider-owned predicate before user query predicates. Latest, active, and draft scopes all include tenant-aware joins so matching resource IDs or activation channels in another tenant cannot affect results.
+
+Lifecycle markers are explicit state. `AddAsterSqliteJson(...)` replaces the core in-memory `IResourceLifecycleMarkerStore` with the SQLite-backed store so archive and soft-delete markers persist across service provider instances, participate in portability export/import, and can be queried through `ResourceQuery.LifecycleState`. Omitting `LifecycleState` does not hide archived or soft-deleted resources.

--- a/src/persistence/Aster.Persistence.SqliteJson/SqliteJsonAsterServiceCollectionExtensions.cs
+++ b/src/persistence/Aster.Persistence.SqliteJson/SqliteJsonAsterServiceCollectionExtensions.cs
@@ -33,6 +33,7 @@ public static class SqliteJsonAsterServiceCollectionExtensions
         services.AddSingleton<IResourceVersionReader>(sp => sp.GetRequiredService<SqliteJsonResourceStore>());
         services.AddSingleton<IResourceVersionWriter>(sp => sp.GetRequiredService<SqliteJsonResourceStore>());
         services.AddSingleton<IResourcePortabilityStore>(sp => sp.GetRequiredService<SqliteJsonResourceStore>());
+        services.AddSingleton<IResourceLifecycleMarkerStore>(sp => sp.GetRequiredService<SqliteJsonResourceStore>());
         services.AddSingleton<IResourceQueryService>(sp => sp.GetRequiredService<SqliteJsonQueryService>());
         services.AddSingleton<IResourceQueryProviderIdentity>(sp => sp.GetRequiredService<SqliteJsonQueryProviderIdentity>());
         services.AddSingleton<IResourceQueryCapabilitiesProvider>(sp => sp.GetRequiredService<SqliteJsonQueryCapabilitiesProvider>());

--- a/src/persistence/Aster.Persistence.SqliteJson/SqliteJsonQueryCapabilitiesProvider.cs
+++ b/src/persistence/Aster.Persistence.SqliteJson/SqliteJsonQueryCapabilitiesProvider.cs
@@ -88,5 +88,8 @@ public sealed class SqliteJsonQueryCapabilitiesProvider : IResourceQueryCapabili
         UnsupportedFeatures:
         [
             "Metadata range filters",
-        ]);
+        ])
+    {
+        SupportsLifecycleStateFiltering = true,
+    };
 }

--- a/src/persistence/Aster.Persistence.SqliteJson/SqliteJsonQueryService.cs
+++ b/src/persistence/Aster.Persistence.SqliteJson/SqliteJsonQueryService.cs
@@ -17,6 +17,7 @@ public sealed class SqliteJsonQueryService : IResourceQueryService, IResourceQue
     private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web);
 
     private readonly string connectionString;
+    private readonly IResourceLifecycleMarkerStore? markerStore;
     private readonly ResourceQueryValidator validator;
 
     /// <summary>
@@ -24,14 +25,17 @@ public sealed class SqliteJsonQueryService : IResourceQueryService, IResourceQue
     /// </summary>
     /// <param name="options">Provider options.</param>
     /// <param name="capabilityProviders">Registered provider capability declarations.</param>
+    /// <param name="markerStore">Optional lifecycle marker store for explicit lifecycle-state filtering.</param>
     public SqliteJsonQueryService(
         SqliteJsonAsterOptions options,
-        IEnumerable<IResourceQueryCapabilitiesProvider>? capabilityProviders = null)
+        IEnumerable<IResourceQueryCapabilitiesProvider>? capabilityProviders = null,
+        IResourceLifecycleMarkerStore? markerStore = null)
     {
         ArgumentNullException.ThrowIfNull(options);
         ArgumentException.ThrowIfNullOrWhiteSpace(options.ConnectionString);
 
         connectionString = options.ConnectionString;
+        this.markerStore = markerStore;
         validator = new ResourceQueryValidator(
             capabilityProviders ?? [new SqliteJsonQueryCapabilitiesProvider()],
             this);
@@ -70,7 +74,34 @@ public sealed class SqliteJsonQueryService : IResourceQueryService, IResourceQue
         command.CommandText = builder.Build();
         builder.Parameters.ApplyTo(command);
 
-        return await ReadResourcesAsync(command, cancellationToken);
+        var resources = await ReadResourcesAsync(command, cancellationToken);
+        return query.LifecycleState is null
+            ? resources
+            : await ApplyLifecycleStateFilterAsync(resources, query, cancellationToken);
+    }
+
+    private async ValueTask<IEnumerable<Resource>> ApplyLifecycleStateFilterAsync(
+        IReadOnlyList<Resource> resources,
+        ResourceQuery query,
+        CancellationToken cancellationToken)
+    {
+        if (markerStore is null)
+            return resources;
+
+        var tenant = TenantScopeResolver.Resolve(query.TenantScope);
+        var markers = await markerStore.GetMarkersAsync(
+            resources.Select(static resource => resource.ResourceId).Distinct(StringComparer.Ordinal),
+            tenant,
+            cancellationToken);
+        var expected = query.LifecycleState!.Value;
+
+        return resources.Where(resource =>
+        {
+            var actual = markers.TryGetValue(resource.ResourceId, out var marker)
+                ? marker.State
+                : ResourceLifecycleMarkerState.None;
+            return actual == expected;
+        }).ToList();
     }
 
     private static async Task<List<Resource>> ReadResourcesAsync(

--- a/src/persistence/Aster.Persistence.SqliteJson/SqliteJsonQueryService.cs
+++ b/src/persistence/Aster.Persistence.SqliteJson/SqliteJsonQueryService.cs
@@ -17,7 +17,6 @@ public sealed class SqliteJsonQueryService : IResourceQueryService, IResourceQue
     private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web);
 
     private readonly string connectionString;
-    private readonly IResourceLifecycleMarkerStore? markerStore;
     private readonly ResourceQueryValidator validator;
 
     /// <summary>
@@ -25,17 +24,14 @@ public sealed class SqliteJsonQueryService : IResourceQueryService, IResourceQue
     /// </summary>
     /// <param name="options">Provider options.</param>
     /// <param name="capabilityProviders">Registered provider capability declarations.</param>
-    /// <param name="markerStore">Optional lifecycle marker store for explicit lifecycle-state filtering.</param>
     public SqliteJsonQueryService(
         SqliteJsonAsterOptions options,
-        IEnumerable<IResourceQueryCapabilitiesProvider>? capabilityProviders = null,
-        IResourceLifecycleMarkerStore? markerStore = null)
+        IEnumerable<IResourceQueryCapabilitiesProvider>? capabilityProviders = null)
     {
         ArgumentNullException.ThrowIfNull(options);
         ArgumentException.ThrowIfNullOrWhiteSpace(options.ConnectionString);
 
         connectionString = options.ConnectionString;
-        this.markerStore = markerStore;
         validator = new ResourceQueryValidator(
             capabilityProviders ?? [new SqliteJsonQueryCapabilitiesProvider()],
             this);
@@ -74,34 +70,7 @@ public sealed class SqliteJsonQueryService : IResourceQueryService, IResourceQue
         command.CommandText = builder.Build();
         builder.Parameters.ApplyTo(command);
 
-        var resources = await ReadResourcesAsync(command, cancellationToken);
-        return query.LifecycleState is null
-            ? resources
-            : await ApplyLifecycleStateFilterAsync(resources, query, cancellationToken);
-    }
-
-    private async ValueTask<IEnumerable<Resource>> ApplyLifecycleStateFilterAsync(
-        IReadOnlyList<Resource> resources,
-        ResourceQuery query,
-        CancellationToken cancellationToken)
-    {
-        if (markerStore is null)
-            return resources;
-
-        var tenant = TenantScopeResolver.Resolve(query.TenantScope);
-        var markers = await markerStore.GetMarkersAsync(
-            resources.Select(static resource => resource.ResourceId).Distinct(StringComparer.Ordinal),
-            tenant,
-            cancellationToken);
-        var expected = query.LifecycleState!.Value;
-
-        return resources.Where(resource =>
-        {
-            var actual = markers.TryGetValue(resource.ResourceId, out var marker)
-                ? marker.State
-                : ResourceLifecycleMarkerState.None;
-            return actual == expected;
-        }).ToList();
+        return await ReadResourcesAsync(command, cancellationToken);
     }
 
     private static async Task<List<Resource>> ReadResourcesAsync(

--- a/src/persistence/Aster.Persistence.SqliteJson/SqliteJsonResourceStore.cs
+++ b/src/persistence/Aster.Persistence.SqliteJson/SqliteJsonResourceStore.cs
@@ -17,7 +17,8 @@ public sealed class SqliteJsonResourceStore :
     IResourceDefinitionStore,
     IResourceVersionReader,
     IResourceVersionWriter,
-    IResourcePortabilityStore
+    IResourcePortabilityStore,
+    IResourceLifecycleMarkerStore
 {
     private const int MaxSqliteParametersPerQuery = 500;
 
@@ -261,6 +262,78 @@ public sealed class SqliteJsonResourceStore :
     }
 
     /// <inheritdoc />
+    public async ValueTask<ResourceLifecycleMarker?> GetMarkerAsync(
+        string resourceId,
+        TenantScope tenantScope,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(resourceId);
+        var tenant = TenantScopeResolver.Resolve(tenantScope);
+
+        await using var connection = await OpenConnectionAsync(cancellationToken);
+        await using var command = connection.CreateCommand();
+        command.CommandText = """
+            SELECT payload
+            FROM lifecycle_markers
+            WHERE tenant_id = $tenantId AND resource_id = $resourceId;
+            """;
+        command.Parameters.AddWithValue("$tenantId", tenant.TenantId);
+        command.Parameters.AddWithValue("$resourceId", resourceId);
+
+        var payload = await command.ExecuteScalarAsync(cancellationToken) as string;
+        return payload is null ? null : Deserialize<ResourceLifecycleMarker>(payload);
+    }
+
+    /// <inheritdoc />
+    public async ValueTask<IReadOnlyDictionary<string, ResourceLifecycleMarker>> GetMarkersAsync(
+        IEnumerable<string> resourceIds,
+        TenantScope tenantScope,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(resourceIds);
+        var tenant = TenantScopeResolver.Resolve(tenantScope);
+        var ids = resourceIds
+            .Where(static id => !string.IsNullOrWhiteSpace(id))
+            .Distinct(StringComparer.Ordinal)
+            .ToHashSet(StringComparer.Ordinal);
+        var markers = await ReadPayloadsByTextIdsAsync<ResourceLifecycleMarker>(
+            tableName: "lifecycle_markers",
+            columnName: "resource_id",
+            tenant: tenant,
+            ids: ids,
+            orderBy: "resource_id",
+            cancellationToken);
+
+        return markers.ToDictionary(static marker => marker.ResourceId, StringComparer.Ordinal);
+    }
+
+    /// <inheritdoc />
+    public async ValueTask<ResourceLifecycleMarker> SaveMarkerAsync(
+        ResourceLifecycleMarker marker,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(marker);
+        ArgumentException.ThrowIfNullOrWhiteSpace(marker.ResourceId);
+        var tenant = TenantScopeResolver.Resolve(marker.TenantScope);
+        var scopedMarker = marker with { TenantScope = tenant };
+
+        await using var connection = await OpenConnectionAsync(cancellationToken);
+        await using var command = connection.CreateCommand();
+        command.CommandText = """
+            INSERT INTO lifecycle_markers (tenant_id, resource_id, payload)
+            VALUES ($tenantId, $resourceId, $payload)
+            ON CONFLICT(tenant_id, resource_id)
+            DO UPDATE SET payload = excluded.payload;
+            """;
+        command.Parameters.AddWithValue("$tenantId", tenant.TenantId);
+        command.Parameters.AddWithValue("$resourceId", scopedMarker.ResourceId);
+        command.Parameters.AddWithValue("$payload", Serialize(scopedMarker));
+
+        await command.ExecuteNonQueryAsync(cancellationToken);
+        return scopedMarker;
+    }
+
+    /// <inheritdoc />
     public async ValueTask<IEnumerable<Resource>> ReadVersionsAsync(
         ResourceVersionReadRequest request,
         CancellationToken cancellationToken = default)
@@ -302,6 +375,10 @@ public sealed class SqliteJsonResourceStore :
             tenant,
             resources.Select(static resource => resource.ResourceId).ToHashSet(StringComparer.Ordinal),
             cancellationToken);
+        var lifecycleMarkers = await ReadScopedLifecycleMarkersAsync(
+            tenant,
+            resources.Select(static resource => resource.ResourceId).ToHashSet(StringComparer.Ordinal),
+            cancellationToken);
         var (includedActivationStates, skippedActivationEntries) = SelectActivationStates(resources, activationStates);
 
         return new PortableStoreSnapshot
@@ -309,6 +386,7 @@ public sealed class SqliteJsonResourceStore :
             Definitions = definitions,
             Resources = resources,
             ActivationStates = includedActivationStates,
+            LifecycleMarkers = lifecycleMarkers,
             SkippedActivationEntries = skippedActivationEntries,
         };
     }
@@ -333,12 +411,14 @@ public sealed class SqliteJsonResourceStore :
             tenant,
             cancellationToken);
         var activationStates = await ReadSpecificActivationStatesAsync(snapshot.ActivationStates, tenant, cancellationToken);
+        var lifecycleMarkers = await ReadSpecificLifecycleMarkersAsync(snapshot.LifecycleMarkers, tenant, cancellationToken);
 
         return new PortableTargetState
         {
             Definitions = definitions,
             Resources = resources,
             ActivationStates = activationStates,
+            LifecycleMarkers = lifecycleMarkers,
         };
     }
 
@@ -363,6 +443,9 @@ public sealed class SqliteJsonResourceStore :
 
             foreach (var state in plannedSnapshot.ActivationStates)
                 await InsertActivationStateAsync(connection, transaction, state with { TenantScope = tenant }, cancellationToken);
+
+            foreach (var marker in plannedSnapshot.LifecycleMarkers)
+                await InsertLifecycleMarkerAsync(connection, transaction, marker with { TenantScope = tenant }, cancellationToken);
 
             await transaction.CommitAsync(cancellationToken);
         }
@@ -570,6 +653,32 @@ public sealed class SqliteJsonResourceStore :
             ids: resourceIds,
             orderBy: "resource_id, channel",
             cancellationToken);
+
+    private async Task<List<ResourceLifecycleMarker>> ReadScopedLifecycleMarkersAsync(
+        TenantScope tenant,
+        IReadOnlyCollection<string> resourceIds,
+        CancellationToken cancellationToken) =>
+        await ReadPayloadsByTextIdsAsync<ResourceLifecycleMarker>(
+            tableName: "lifecycle_markers",
+            columnName: "resource_id",
+            tenant: tenant,
+            ids: resourceIds,
+            orderBy: "resource_id",
+            cancellationToken);
+
+    private async Task<List<ResourceLifecycleMarker>> ReadSpecificLifecycleMarkersAsync(
+        IReadOnlyCollection<ResourceLifecycleMarker> lifecycleMarkers,
+        TenantScope tenant,
+        CancellationToken cancellationToken)
+    {
+        if (lifecycleMarkers.Count == 0)
+            return [];
+
+        return await ReadScopedLifecycleMarkersAsync(
+            tenant,
+            lifecycleMarkers.Select(static marker => marker.ResourceId).ToHashSet(StringComparer.Ordinal),
+            cancellationToken);
+    }
 
     private async Task<List<Resource>> ReadScopedResourceVersionsAsync(
         PortableSnapshotExportRequest request,
@@ -986,6 +1095,27 @@ public sealed class SqliteJsonResourceStore :
         command.Parameters.AddWithValue("$resourceId", state.ResourceId);
         command.Parameters.AddWithValue("$channel", state.Channel);
         command.Parameters.AddWithValue("$payload", Serialize(state));
+
+        await command.ExecuteNonQueryAsync(cancellationToken);
+    }
+
+    private async Task InsertLifecycleMarkerAsync(
+        SqliteConnection connection,
+        SqliteTransaction transaction,
+        ResourceLifecycleMarker marker,
+        CancellationToken cancellationToken)
+    {
+        await using var command = connection.CreateCommand();
+        command.Transaction = transaction;
+        command.CommandText = """
+            INSERT INTO lifecycle_markers (tenant_id, resource_id, payload)
+            VALUES ($tenantId, $resourceId, $payload)
+            ON CONFLICT(tenant_id, resource_id)
+            DO UPDATE SET payload = excluded.payload;
+            """;
+        command.Parameters.AddWithValue("$tenantId", TenantScopeResolver.Resolve(marker.TenantScope).TenantId);
+        command.Parameters.AddWithValue("$resourceId", marker.ResourceId);
+        command.Parameters.AddWithValue("$payload", Serialize(marker));
 
         await command.ExecuteNonQueryAsync(cancellationToken);
     }

--- a/src/persistence/Aster.Persistence.SqliteJson/SqliteJsonSchema.cs
+++ b/src/persistence/Aster.Persistence.SqliteJson/SqliteJsonSchema.cs
@@ -44,6 +44,15 @@ internal static class SqliteJsonSchema
         );
         """;
 
+    private static readonly string CreateLifecycleMarkersSql = $$"""
+        CREATE TABLE IF NOT EXISTS lifecycle_markers (
+            tenant_id TEXT NOT NULL DEFAULT {{DefaultTenantSqlLiteral}},
+            resource_id TEXT NOT NULL,
+            payload TEXT NOT NULL,
+            PRIMARY KEY (tenant_id, resource_id)
+        );
+        """;
+
     public static void Initialize(string connectionString)
     {
         using var connection = new SqliteConnection(connectionString);
@@ -78,6 +87,13 @@ internal static class SqliteJsonSchema
             CreateActivationStatesSql,
             ["tenant_id", "resource_id", "channel", "payload"],
             ["tenant_id", "resource_id", "channel"]);
+        EnsureTenantAwareTable(
+            connection,
+            transaction,
+            "lifecycle_markers",
+            CreateLifecycleMarkersSql,
+            ["tenant_id", "resource_id", "payload"],
+            ["tenant_id", "resource_id"]);
 
         using var index = connection.CreateCommand();
         index.Transaction = transaction;

--- a/test/Aster.Tests/Policies/LifecycleMarkerConflictTests.cs
+++ b/test/Aster.Tests/Policies/LifecycleMarkerConflictTests.cs
@@ -1,0 +1,39 @@
+using Aster.Core.Abstractions;
+using Aster.Core.Models.Instances;
+using Aster.Core.Models.Policies;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Aster.Tests.Policies;
+
+public sealed class LifecycleMarkerConflictTests : IDisposable
+{
+    private readonly ServiceProvider provider = PolicyTestFixtures.CreateCoreProvider();
+
+    public void Dispose() => provider.Dispose();
+
+    [Fact]
+    public async Task ApplyAsync_DifferentMarkerState_ReturnsConflictDiagnostic()
+    {
+        await PolicyTestFixtures.RegisterProductDefinitionAsync(provider);
+        await PolicyTestFixtures.SaveResourceAsync(provider, "product-1");
+        var service = provider.GetRequiredService<IResourceLifecycleMarkerService>();
+
+        await service.ApplyAsync(new ResourceLifecycleMarkerRequest
+        {
+            ResourceId = "product-1",
+            State = ResourceLifecycleMarkerState.Archived,
+            MarkedAt = DateTimeOffset.UtcNow,
+        });
+        var conflict = await service.ApplyAsync(new ResourceLifecycleMarkerRequest
+        {
+            ResourceId = "product-1",
+            State = ResourceLifecycleMarkerState.SoftDeleted,
+            MarkedAt = DateTimeOffset.UtcNow,
+        });
+
+        Assert.False(conflict.Succeeded);
+        var diagnostic = Assert.Single(conflict.Diagnostics);
+        Assert.Equal(ResourcePolicyDiagnosticCodes.LifecycleMarkerConflict, diagnostic.Code);
+        Assert.Equal(ResourceLifecycleMarkerState.Archived, conflict.Marker!.State);
+    }
+}

--- a/test/Aster.Tests/Policies/LifecycleMarkerServiceTests.cs
+++ b/test/Aster.Tests/Policies/LifecycleMarkerServiceTests.cs
@@ -1,0 +1,37 @@
+using Aster.Core.Abstractions;
+using Aster.Core.Models.Instances;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Aster.Tests.Policies;
+
+public sealed class LifecycleMarkerServiceTests : IDisposable
+{
+    private readonly ServiceProvider provider = PolicyTestFixtures.CreateCoreProvider();
+
+    public void Dispose() => provider.Dispose();
+
+    [Fact]
+    public async Task ApplyAsync_WritesMarkerAndRepeatedSameMarkerIsIdempotent()
+    {
+        await PolicyTestFixtures.RegisterProductDefinitionAsync(provider);
+        await PolicyTestFixtures.SaveResourceAsync(provider, "product-1");
+        var service = provider.GetRequiredService<IResourceLifecycleMarkerService>();
+
+        var first = await service.ApplyAsync(new ResourceLifecycleMarkerRequest
+        {
+            ResourceId = "product-1",
+            State = ResourceLifecycleMarkerState.Archived,
+            MarkedAt = new DateTimeOffset(2026, 5, 25, 0, 0, 0, TimeSpan.Zero),
+        });
+        var second = await service.ApplyAsync(new ResourceLifecycleMarkerRequest
+        {
+            ResourceId = "product-1",
+            State = ResourceLifecycleMarkerState.Archived,
+            MarkedAt = new DateTimeOffset(2026, 5, 26, 0, 0, 0, TimeSpan.Zero),
+        });
+
+        Assert.True(first.Succeeded);
+        Assert.True(second.Succeeded);
+        Assert.Equal(first.Marker, second.Marker);
+    }
+}

--- a/test/Aster.Tests/Policies/PolicyCompatibilityTests.cs
+++ b/test/Aster.Tests/Policies/PolicyCompatibilityTests.cs
@@ -1,0 +1,91 @@
+using Aster.Core.Abstractions;
+using Aster.Core.Extensions;
+using Aster.Core.Models.Instances;
+using Aster.Core.Models.Lifecycle;
+using Aster.Core.Models.Portability;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Aster.Tests.Policies;
+
+public sealed class PolicyCompatibilityTests
+{
+    [Fact]
+    public async Task ExistingResourceWrites_DoNotApplyPolicyMarkersAutomatically()
+    {
+        await using var provider = PolicyTestFixtures.CreateCoreProvider();
+        await PolicyTestFixtures.RegisterProductDefinitionAsync(provider, policies: [PolicyTestFixtures.ArchivePolicy()]);
+
+        await PolicyTestFixtures.SaveResourceAsync(provider, "product-1", created: new DateTime(2025, 1, 1, 0, 0, 0, DateTimeKind.Utc));
+
+        var marker = await provider.GetRequiredService<IResourceLifecycleMarkerStore>()
+            .GetMarkerAsync("product-1", Aster.Core.Models.Tenancy.TenantScope.Default);
+        Assert.Null(marker);
+    }
+
+    [Fact]
+    public async Task ExportAsync_PreservesPolicyDeclarationsOnDefinitions()
+    {
+        await using var provider = PolicyTestFixtures.CreateCoreProvider();
+        await PolicyTestFixtures.RegisterProductDefinitionAsync(provider, policies: [PolicyTestFixtures.ArchivePolicy()]);
+
+        var result = await provider.GetRequiredService<IResourcePortabilityService>().ExportAsync(new PortableSnapshotExportRequest
+        {
+            ScopeMode = PortableExportScopeMode.DefinitionsOnly,
+            DefinitionIds = ["Product"],
+        });
+
+        var definition = Assert.Single(result.Snapshot!.Definitions);
+        Assert.Single(definition.PolicyDeclarations);
+    }
+
+    [Fact]
+    public async Task SchemaUpgrade_WorksWhenDefinitionHasPolicyMetadata()
+    {
+        await using var provider = PolicyTestFixtures.CreateCoreProvider();
+        var definitions = provider.GetRequiredService<IResourceDefinitionStore>();
+        var manager = provider.GetRequiredService<IResourceManager>();
+        var schema = provider.GetRequiredService<IResourceSchemaVersionService>();
+        await definitions.RegisterDefinitionAsync(PolicyTestFixtures.ProductDefinition(PolicyTestFixtures.ArchivePolicy()));
+        var resource = await manager.CreateAsync("Product", new CreateResourceRequest());
+        await definitions.RegisterDefinitionAsync(PolicyTestFixtures.ProductDefinition(PolicyTestFixtures.ArchivePolicy()));
+
+        var result = await schema.UpgradeAsync(resource.ResourceId, new ResourceSchemaUpgradeRequest
+        {
+            BaseVersion = resource.Version,
+        });
+
+        Assert.Equal(ResourceSchemaUpgradeStatus.Upgraded, result.Status);
+        Assert.Equal(2, result.Resource!.DefinitionVersion);
+    }
+
+    [Fact]
+    public async Task LifecycleHooks_StillRunWhenPolicyMetadataExists()
+    {
+        await using var provider = new ServiceCollection()
+            .AddAsterCore()
+            .AddSingleton<Recorder>()
+            .AddResourceLifecycleHook<RecordingHook>()
+            .BuildServiceProvider();
+        await PolicyTestFixtures.RegisterProductDefinitionAsync(provider, policies: [PolicyTestFixtures.ArchivePolicy()]);
+
+        await provider.GetRequiredService<IResourceManager>().CreateAsync("Product", new CreateResourceRequest());
+
+        Assert.Equal(1, provider.GetRequiredService<Recorder>().BeforeSaveCount);
+    }
+
+    private sealed class Recorder
+    {
+        public int BeforeSaveCount { get; set; }
+    }
+
+    private sealed class RecordingHook(Recorder recorder) : ResourceLifecycleHook
+    {
+        public override ValueTask<LifecycleHookOutcome> OnBeforeSaveAsync(
+            ResourceSaveLifecycleContext context,
+            CancellationToken cancellationToken = default)
+        {
+            recorder.BeforeSaveCount++;
+            return ValueTask.FromResult(LifecycleHookOutcome.Continue());
+        }
+    }
+}

--- a/test/Aster.Tests/Policies/PolicyDeclarationBuilderTests.cs
+++ b/test/Aster.Tests/Policies/PolicyDeclarationBuilderTests.cs
@@ -1,0 +1,19 @@
+using Aster.Core.Definitions;
+
+namespace Aster.Tests.Policies;
+
+public sealed class PolicyDeclarationBuilderTests
+{
+    [Fact]
+    public void WithPolicy_AttachesPolicyDeclarationsToDefinition()
+    {
+        var definition = new ResourceDefinitionBuilder()
+            .WithDefinitionId("Product")
+            .WithPolicy(PolicyTestFixtures.ArchivePolicy())
+            .WithPolicy(PolicyTestFixtures.PruningPolicy())
+            .Build();
+
+        Assert.Equal(2, definition.PolicyDeclarations.Count);
+        Assert.Equal(["archive-old", "keep-latest"], definition.PolicyDeclarations.Select(static policy => policy.PolicyId).ToList());
+    }
+}

--- a/test/Aster.Tests/Policies/PolicyDefinitionStoreTests.cs
+++ b/test/Aster.Tests/Policies/PolicyDefinitionStoreTests.cs
@@ -1,0 +1,24 @@
+using Aster.Core.Abstractions;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Aster.Tests.Policies;
+
+public sealed class PolicyDefinitionStoreTests : IDisposable
+{
+    private readonly ServiceProvider provider = PolicyTestFixtures.CreateCoreProvider();
+
+    public void Dispose() => provider.Dispose();
+
+    [Fact]
+    public async Task RegisterDefinitionAsync_PreservesPolicyDeclarations()
+    {
+        var store = provider.GetRequiredService<IResourceDefinitionStore>();
+        await store.RegisterDefinitionAsync(PolicyTestFixtures.ProductDefinition(PolicyTestFixtures.ArchivePolicy()));
+
+        var definition = await store.GetDefinitionAsync("Product");
+
+        Assert.NotNull(definition);
+        var policy = Assert.Single(definition.PolicyDeclarations);
+        Assert.Equal("archive-old", policy.PolicyId);
+    }
+}

--- a/test/Aster.Tests/Policies/PolicyEvaluationPreviewTests.cs
+++ b/test/Aster.Tests/Policies/PolicyEvaluationPreviewTests.cs
@@ -1,0 +1,80 @@
+using Aster.Core.Abstractions;
+using Aster.Core.Models.Instances;
+using Aster.Core.Models.Policies;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Aster.Tests.Policies;
+
+public sealed class PolicyEvaluationPreviewTests : IDisposable
+{
+    private readonly ServiceProvider provider = PolicyTestFixtures.CreateCoreProvider();
+
+    public void Dispose() => provider.Dispose();
+
+    [Fact]
+    public async Task PreviewAsync_ReturnsArchiveAndSoftDeleteCandidates()
+    {
+        await PolicyTestFixtures.RegisterProductDefinitionAsync(
+            provider,
+            policies:
+            [
+                PolicyTestFixtures.ArchivePolicy("archive"),
+                PolicyTestFixtures.SoftDeletePolicy("soft-delete"),
+            ]);
+        await PolicyTestFixtures.SaveResourceAsync(provider, "old-product", created: new DateTime(2025, 1, 1, 0, 0, 0, DateTimeKind.Utc));
+        var evaluation = provider.GetRequiredService<IResourcePolicyEvaluationService>();
+
+        var preview = await evaluation.PreviewAsync(new ResourcePolicyEvaluationRequest
+        {
+            EvaluationTimestamp = new DateTimeOffset(2026, 5, 25, 0, 0, 0, TimeSpan.Zero),
+        });
+
+        Assert.Empty(preview.Diagnostics);
+        Assert.Contains(preview.Candidates, static candidate => candidate.PolicyId == "archive" && candidate.Outcome == ResourcePolicyOutcome.Archive);
+        Assert.Contains(preview.Candidates, static candidate => candidate.PolicyId == "soft-delete" && candidate.Outcome == ResourcePolicyOutcome.SoftDelete);
+    }
+
+    [Fact]
+    public async Task PreviewAsync_AppliesActivationStateCriteria()
+    {
+        await PolicyTestFixtures.RegisterProductDefinitionAsync(
+            provider,
+            policies:
+            [
+                PolicyTestFixtures.ArchivePolicy("archive-active") with
+                {
+                    Criteria = new ResourcePolicyCriteria
+                    {
+                        MinimumAge = TimeSpan.FromDays(30),
+                        ActivationState = ResourcePolicyActivationState.Active,
+                        ActivationChannel = "Published",
+                        LifecycleState = ResourceLifecycleMarkerState.None,
+                    },
+                },
+                PolicyTestFixtures.ArchivePolicy("archive-draft") with
+                {
+                    Criteria = new ResourcePolicyCriteria
+                    {
+                        MinimumAge = TimeSpan.FromDays(30),
+                        ActivationState = ResourcePolicyActivationState.Draft,
+                        LifecycleState = ResourceLifecycleMarkerState.None,
+                    },
+                },
+            ]);
+        await PolicyTestFixtures.SaveResourceAsync(provider, "active-product", created: new DateTime(2025, 1, 1, 0, 0, 0, DateTimeKind.Utc));
+        await PolicyTestFixtures.SaveResourceAsync(provider, "draft-product", created: new DateTime(2025, 1, 1, 0, 0, 0, DateTimeKind.Utc));
+        await provider.GetRequiredService<IResourceManager>().ActivateAsync("active-product", 1, "Published");
+        var evaluation = provider.GetRequiredService<IResourcePolicyEvaluationService>();
+
+        var preview = await evaluation.PreviewAsync(new ResourcePolicyEvaluationRequest
+        {
+            EvaluationTimestamp = new DateTimeOffset(2026, 5, 25, 0, 0, 0, TimeSpan.Zero),
+        });
+
+        Assert.Empty(preview.Diagnostics);
+        Assert.Contains(preview.Candidates, static candidate => candidate.PolicyId == "archive-active" && candidate.ResourceId == "active-product");
+        Assert.DoesNotContain(preview.Candidates, static candidate => candidate.PolicyId == "archive-active" && candidate.ResourceId == "draft-product");
+        Assert.Contains(preview.Candidates, static candidate => candidate.PolicyId == "archive-draft" && candidate.ResourceId == "draft-product");
+        Assert.DoesNotContain(preview.Candidates, static candidate => candidate.PolicyId == "archive-draft" && candidate.ResourceId == "active-product");
+    }
+}

--- a/test/Aster.Tests/Policies/PolicyEvaluationTimestampTests.cs
+++ b/test/Aster.Tests/Policies/PolicyEvaluationTimestampTests.cs
@@ -1,0 +1,26 @@
+using Aster.Core.Abstractions;
+using Aster.Core.Models.Policies;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Aster.Tests.Policies;
+
+public sealed class PolicyEvaluationTimestampTests : IDisposable
+{
+    private readonly ServiceProvider provider = PolicyTestFixtures.CreateCoreProvider();
+
+    public void Dispose() => provider.Dispose();
+
+    [Fact]
+    public async Task PreviewAsync_AgePolicyWithoutEvaluationTimestamp_ReturnsStableDiagnostic()
+    {
+        await PolicyTestFixtures.RegisterProductDefinitionAsync(provider, policies: [PolicyTestFixtures.ArchivePolicy()]);
+        await PolicyTestFixtures.SaveResourceAsync(provider, "old-product", created: new DateTime(2025, 1, 1, 0, 0, 0, DateTimeKind.Utc));
+        var evaluation = provider.GetRequiredService<IResourcePolicyEvaluationService>();
+
+        var preview = await evaluation.PreviewAsync(new ResourcePolicyEvaluationRequest());
+
+        var diagnostic = Assert.Single(preview.Diagnostics);
+        Assert.Equal(ResourcePolicyDiagnosticCodes.PolicyEvaluationTimestampRequired, diagnostic.Code);
+        Assert.Empty(preview.Candidates);
+    }
+}

--- a/test/Aster.Tests/Policies/PolicyPreviewNoMutationTests.cs
+++ b/test/Aster.Tests/Policies/PolicyPreviewNoMutationTests.cs
@@ -1,0 +1,28 @@
+using Aster.Core.Abstractions;
+using Aster.Core.Models.Policies;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Aster.Tests.Policies;
+
+public sealed class PolicyPreviewNoMutationTests : IDisposable
+{
+    private readonly ServiceProvider provider = PolicyTestFixtures.CreateCoreProvider();
+
+    public void Dispose() => provider.Dispose();
+
+    [Fact]
+    public async Task PreviewAsync_DoesNotWriteLifecycleMarkers()
+    {
+        await PolicyTestFixtures.RegisterProductDefinitionAsync(provider, policies: [PolicyTestFixtures.ArchivePolicy()]);
+        await PolicyTestFixtures.SaveResourceAsync(provider, "old-product", created: new DateTime(2025, 1, 1, 0, 0, 0, DateTimeKind.Utc));
+        var evaluation = provider.GetRequiredService<IResourcePolicyEvaluationService>();
+        var markerStore = provider.GetRequiredService<IResourceLifecycleMarkerStore>();
+
+        await evaluation.PreviewAsync(new ResourcePolicyEvaluationRequest
+        {
+            EvaluationTimestamp = new DateTimeOffset(2026, 5, 25, 0, 0, 0, TimeSpan.Zero),
+        });
+
+        Assert.Null(await markerStore.GetMarkerAsync("old-product", Aster.Core.Models.Tenancy.TenantScope.Default));
+    }
+}

--- a/test/Aster.Tests/Policies/PolicyPruningPreviewTests.cs
+++ b/test/Aster.Tests/Policies/PolicyPruningPreviewTests.cs
@@ -1,0 +1,29 @@
+using Aster.Core.Abstractions;
+using Aster.Core.Models.Policies;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Aster.Tests.Policies;
+
+public sealed class PolicyPruningPreviewTests : IDisposable
+{
+    private readonly ServiceProvider provider = PolicyTestFixtures.CreateCoreProvider();
+
+    public void Dispose() => provider.Dispose();
+
+    [Fact]
+    public async Task PreviewAsync_ReturnsPruningCandidatesOutsideRetainedVersionCount()
+    {
+        await PolicyTestFixtures.RegisterProductDefinitionAsync(provider, policies: [PolicyTestFixtures.PruningPolicy(retainedVersions: 2)]);
+        await PolicyTestFixtures.SaveResourceAsync(provider, "versioned", version: 1);
+        await PolicyTestFixtures.SaveResourceAsync(provider, "versioned", version: 2);
+        await PolicyTestFixtures.SaveResourceAsync(provider, "versioned", version: 3);
+        var evaluation = provider.GetRequiredService<IResourcePolicyEvaluationService>();
+
+        var preview = await evaluation.PreviewAsync(new ResourcePolicyEvaluationRequest());
+
+        var candidate = Assert.Single(preview.Candidates);
+        Assert.Equal(ResourcePolicyOutcome.PrunePreview, candidate.Outcome);
+        Assert.Equal(1, candidate.ResourceVersion);
+        Assert.Empty(preview.Diagnostics);
+    }
+}

--- a/test/Aster.Tests/Policies/PolicyTestFixtures.cs
+++ b/test/Aster.Tests/Policies/PolicyTestFixtures.cs
@@ -1,0 +1,143 @@
+using Aster.Core.Abstractions;
+using Aster.Core.Definitions;
+using Aster.Core.Extensions;
+using Aster.Core.Models.Definitions;
+using Aster.Core.Models.Instances;
+using Aster.Core.Models.Policies;
+using Aster.Core.Models.Tenancy;
+using Aster.Persistence.SqliteJson;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Aster.Tests.Policies;
+
+internal static class PolicyTestFixtures
+{
+    public static ServiceProvider CreateCoreProvider() =>
+        new ServiceCollection()
+            .AddAsterCore()
+            .BuildServiceProvider();
+
+    public static ServiceProvider CreateSqliteProvider(string databasePath) =>
+        new ServiceCollection()
+            .AddAsterCore()
+            .AddAsterSqliteJson(options => options.ConnectionString = $"Data Source={databasePath}")
+            .BuildServiceProvider();
+
+    public static ResourcePolicyDeclaration ArchivePolicy(
+        string policyId = "archive-old",
+        TimeSpan? minimumAge = null) =>
+        new()
+        {
+            PolicyId = policyId,
+            Name = "Archive old resources",
+            Kind = ResourcePolicyKind.Archival,
+            Target = ResourcePolicyTarget.Resource,
+            Outcome = ResourcePolicyOutcome.Archive,
+            Criteria = new ResourcePolicyCriteria
+            {
+                MinimumAge = minimumAge ?? TimeSpan.FromDays(30),
+                LifecycleState = ResourceLifecycleMarkerState.None,
+            },
+        };
+
+    public static ResourcePolicyDeclaration SoftDeletePolicy(string policyId = "soft-delete-old") =>
+        new()
+        {
+            PolicyId = policyId,
+            Kind = ResourcePolicyKind.SoftDelete,
+            Target = ResourcePolicyTarget.Resource,
+            Outcome = ResourcePolicyOutcome.SoftDelete,
+            Criteria = new ResourcePolicyCriteria
+            {
+                MinimumAge = TimeSpan.FromDays(30),
+                LifecycleState = ResourceLifecycleMarkerState.None,
+            },
+        };
+
+    public static ResourcePolicyDeclaration PruningPolicy(int retainedVersions = 2) =>
+        new()
+        {
+            PolicyId = "keep-latest",
+            Kind = ResourcePolicyKind.VersionPruning,
+            Target = ResourcePolicyTarget.ResourceVersion,
+            Outcome = ResourcePolicyOutcome.PrunePreview,
+            Criteria = new ResourcePolicyCriteria
+            {
+                MaximumRetainedVersions = retainedVersions,
+            },
+        };
+
+    public static ResourceDefinition ProductDefinition(params ResourcePolicyDeclaration[] policies) =>
+        new ResourceDefinitionBuilder()
+            .WithDefinitionId("Product")
+            .ApplyPolicies(policies)
+            .Build();
+
+    public static async Task RegisterProductDefinitionAsync(
+        IServiceProvider provider,
+        TenantScope? tenantScope = null,
+        params ResourcePolicyDeclaration[] policies)
+    {
+        var store = provider.GetRequiredService<IResourceDefinitionStore>();
+        var definition = ProductDefinition(policies);
+        if (tenantScope is null)
+            await store.RegisterDefinitionAsync(definition);
+        else
+            await store.RegisterDefinitionAsync(definition, tenantScope, CancellationToken.None);
+    }
+
+    public static async Task<Resource> SaveResourceAsync(
+        IServiceProvider provider,
+        string resourceId,
+        int version = 1,
+        DateTime? created = null,
+        TenantScope? tenantScope = null)
+    {
+        var writer = provider.GetRequiredService<IResourceVersionWriter>();
+        var resource = new Resource
+        {
+            TenantScope = tenantScope ?? TenantScope.Default,
+            ResourceId = resourceId,
+            Id = $"{resourceId}-{version}",
+            DefinitionId = "Product",
+            DefinitionVersion = 1,
+            Version = version,
+            Created = created ?? DateTime.UtcNow,
+            Aspects = new Dictionary<string, object>
+            {
+                ["Title"] = new { Title = resourceId },
+            },
+        };
+
+        return await writer.SaveVersionAsync(resource);
+    }
+
+    public static void DeleteSqliteFiles(string databasePath)
+    {
+        TryDelete(databasePath);
+        TryDelete($"{databasePath}-shm");
+        TryDelete($"{databasePath}-wal");
+    }
+
+    private static ResourceDefinitionBuilder ApplyPolicies(
+        this ResourceDefinitionBuilder builder,
+        IEnumerable<ResourcePolicyDeclaration> policies)
+    {
+        foreach (var policy in policies)
+            builder.WithPolicy(policy);
+
+        return builder;
+    }
+
+    private static void TryDelete(string path)
+    {
+        try
+        {
+            if (File.Exists(path))
+                File.Delete(path);
+        }
+        catch (IOException)
+        {
+        }
+    }
+}

--- a/test/Aster.Tests/Policies/PolicyValidationTests.cs
+++ b/test/Aster.Tests/Policies/PolicyValidationTests.cs
@@ -1,0 +1,82 @@
+using Aster.Core.Abstractions;
+using Aster.Core.Definitions;
+using Aster.Core.Extensions;
+using Aster.Core.Models.Policies;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Aster.Tests.Policies;
+
+public sealed class PolicyValidationTests : IDisposable
+{
+    private readonly ServiceProvider provider = PolicyTestFixtures.CreateCoreProvider();
+    private readonly IResourcePolicyValidator validator;
+
+    public PolicyValidationTests() => validator = provider.GetRequiredService<IResourcePolicyValidator>();
+
+    public void Dispose() => provider.Dispose();
+
+    [Fact]
+    public void Validate_ValidPolicyDeclarations_ReturnsSuccess()
+    {
+        var definition = PolicyTestFixtures.ProductDefinition(
+            PolicyTestFixtures.ArchivePolicy(),
+            PolicyTestFixtures.SoftDeletePolicy(),
+            PolicyTestFixtures.PruningPolicy());
+
+        var result = validator.Validate(definition);
+
+        Assert.True(result.IsValid);
+        Assert.Empty(result.Diagnostics);
+    }
+
+    [Fact]
+    public void Validate_UnsupportedFacetPredicate_ReturnsStableDiagnostic()
+    {
+        var definition = new ResourceDefinitionBuilder()
+            .WithDefinitionId("Product")
+            .WithPolicy(PolicyTestFixtures.ArchivePolicy() with
+            {
+                Criteria = new ResourcePolicyCriteria
+                {
+                    UnsupportedFacetPredicate = "Color = 'Red'",
+                },
+            })
+            .Build();
+
+        var result = validator.Validate(definition);
+
+        var diagnostic = Assert.Single(result.Diagnostics);
+        Assert.Equal(ResourcePolicyDiagnosticCodes.PolicyCriteriaUnsupported, diagnostic.Code);
+    }
+
+    [Fact]
+    public void Validate_DuplicatePolicyIds_ReturnsConflictDiagnostic()
+    {
+        var definition = PolicyTestFixtures.ProductDefinition(
+            PolicyTestFixtures.ArchivePolicy("duplicate"),
+            PolicyTestFixtures.SoftDeletePolicy("duplicate"));
+
+        var result = validator.Validate(definition);
+
+        Assert.Contains(result.Diagnostics, static diagnostic => diagnostic.Code == ResourcePolicyDiagnosticCodes.PolicyConflict);
+    }
+
+    [Fact]
+    public void Validate_PrunePolicyWithoutRetainedVersionCount_ReturnsInvalidDiagnostic()
+    {
+        var definition = new ResourceDefinitionBuilder()
+            .WithDefinitionId("Product")
+            .WithPolicy(new ResourcePolicyDeclaration
+            {
+                PolicyId = "bad-prune",
+                Kind = ResourcePolicyKind.VersionPruning,
+                Target = ResourcePolicyTarget.ResourceVersion,
+                Outcome = ResourcePolicyOutcome.PrunePreview,
+            })
+            .Build();
+
+        var result = validator.Validate(definition);
+
+        Assert.Contains(result.Diagnostics, static diagnostic => diagnostic.Code == ResourcePolicyDiagnosticCodes.PolicyInvalid);
+    }
+}

--- a/test/Aster.Tests/Policies/TenantPolicyEvaluationTests.cs
+++ b/test/Aster.Tests/Policies/TenantPolicyEvaluationTests.cs
@@ -1,0 +1,32 @@
+using Aster.Core.Abstractions;
+using Aster.Core.Models.Policies;
+using Aster.Tests.Tenancy;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Aster.Tests.Policies;
+
+public sealed class TenantPolicyEvaluationTests : IDisposable
+{
+    private readonly ServiceProvider provider = PolicyTestFixtures.CreateCoreProvider();
+
+    public void Dispose() => provider.Dispose();
+
+    [Fact]
+    public async Task PreviewAsync_ReturnsOnlyCandidatesWithinTenant()
+    {
+        await PolicyTestFixtures.RegisterProductDefinitionAsync(provider, TenantScopeTestFixtures.TenantA, PolicyTestFixtures.ArchivePolicy());
+        await PolicyTestFixtures.RegisterProductDefinitionAsync(provider, TenantScopeTestFixtures.TenantB, PolicyTestFixtures.ArchivePolicy());
+        await PolicyTestFixtures.SaveResourceAsync(provider, "tenant-a-product", created: new DateTime(2025, 1, 1, 0, 0, 0, DateTimeKind.Utc), tenantScope: TenantScopeTestFixtures.TenantA);
+        await PolicyTestFixtures.SaveResourceAsync(provider, "tenant-b-product", created: new DateTime(2025, 1, 1, 0, 0, 0, DateTimeKind.Utc), tenantScope: TenantScopeTestFixtures.TenantB);
+        var evaluation = provider.GetRequiredService<IResourcePolicyEvaluationService>();
+
+        var preview = await evaluation.PreviewAsync(new ResourcePolicyEvaluationRequest
+        {
+            TenantScope = TenantScopeTestFixtures.TenantA,
+            EvaluationTimestamp = new DateTimeOffset(2026, 5, 25, 0, 0, 0, TimeSpan.Zero),
+        });
+
+        var candidate = Assert.Single(preview.Candidates);
+        Assert.Equal("tenant-a-product", candidate.ResourceId);
+    }
+}

--- a/test/Aster.Tests/Portability/PortabilityLifecycleMarkerTests.cs
+++ b/test/Aster.Tests/Portability/PortabilityLifecycleMarkerTests.cs
@@ -1,0 +1,39 @@
+using Aster.Core.Abstractions;
+using Aster.Core.Extensions;
+using Aster.Core.Models.Instances;
+using Aster.Core.Models.Portability;
+using Aster.Tests.Policies;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Aster.Tests.Portability;
+
+public sealed class PortabilityLifecycleMarkerTests
+{
+    [Fact]
+    public async Task ExportAndImport_PreservesLifecycleMarkers()
+    {
+        await using var source = PolicyTestFixtures.CreateCoreProvider();
+        await PolicyTestFixtures.RegisterProductDefinitionAsync(source);
+        await PolicyTestFixtures.SaveResourceAsync(source, "product-1");
+        await source.GetRequiredService<IResourceLifecycleMarkerService>().ApplyAsync(new ResourceLifecycleMarkerRequest
+        {
+            ResourceId = "product-1",
+            State = ResourceLifecycleMarkerState.Archived,
+            MarkedAt = new DateTimeOffset(2026, 5, 25, 0, 0, 0, TimeSpan.Zero),
+        });
+        var snapshot = (await source.GetRequiredService<IResourcePortabilityService>().ExportAsync(new PortableSnapshotExportRequest
+        {
+            ScopeMode = PortableExportScopeMode.SelectedResources,
+            ResourceIds = ["product-1"],
+            ResourceVersionScope = PortableResourceVersionScope.AllVersions,
+        })).Snapshot!;
+
+        await using var target = new ServiceCollection().AddAsterCore().BuildServiceProvider();
+        await target.GetRequiredService<IResourcePortabilityService>().ImportAsync(snapshot);
+
+        var marker = await target.GetRequiredService<IResourceLifecycleMarkerStore>()
+            .GetMarkerAsync("product-1", Aster.Core.Models.Tenancy.TenantScope.Default);
+        Assert.NotNull(marker);
+        Assert.Equal(ResourceLifecycleMarkerState.Archived, marker.State);
+    }
+}

--- a/test/Aster.Tests/Querying/LifecycleStateQueryTests.cs
+++ b/test/Aster.Tests/Querying/LifecycleStateQueryTests.cs
@@ -1,0 +1,44 @@
+using Aster.Core.Abstractions;
+using Aster.Core.Models.Instances;
+using Aster.Core.Models.Querying;
+using Aster.Tests.Policies;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Aster.Tests.Querying;
+
+public sealed class LifecycleStateQueryTests : IDisposable
+{
+    private readonly ServiceProvider provider = PolicyTestFixtures.CreateCoreProvider();
+
+    public void Dispose() => provider.Dispose();
+
+    [Fact]
+    public async Task QueryAsync_WithLifecycleState_ReturnsMatchingResourcesOnly()
+    {
+        await PolicyTestFixtures.RegisterProductDefinitionAsync(provider);
+        await PolicyTestFixtures.SaveResourceAsync(provider, "archived");
+        await PolicyTestFixtures.SaveResourceAsync(provider, "unmarked");
+        var markerService = provider.GetRequiredService<IResourceLifecycleMarkerService>();
+        await markerService.ApplyAsync(new ResourceLifecycleMarkerRequest
+        {
+            ResourceId = "archived",
+            State = ResourceLifecycleMarkerState.Archived,
+            MarkedAt = DateTimeOffset.UtcNow,
+        });
+        var query = provider.GetRequiredService<IResourceQueryService>();
+
+        var archived = (await query.QueryAsync(new ResourceQuery
+        {
+            LifecycleState = ResourceLifecycleMarkerState.Archived,
+            Sorts = [new SortExpression("ResourceId")],
+        })).ToList();
+        var unmarked = (await query.QueryAsync(new ResourceQuery
+        {
+            LifecycleState = ResourceLifecycleMarkerState.None,
+            Sorts = [new SortExpression("ResourceId")],
+        })).ToList();
+
+        Assert.Equal(["archived"], archived.Select(static resource => resource.ResourceId).ToList());
+        Assert.Equal(["unmarked"], unmarked.Select(static resource => resource.ResourceId).ToList());
+    }
+}

--- a/test/Aster.Tests/SqliteJson/SqliteJsonLifecycleMarkerTests.cs
+++ b/test/Aster.Tests/SqliteJson/SqliteJsonLifecycleMarkerTests.cs
@@ -39,4 +39,29 @@ public sealed class SqliteJsonLifecycleMarkerTests : IDisposable
         var result = Assert.Single(results);
         Assert.Equal("archived", result.ResourceId);
     }
+
+    [Fact]
+    public async Task QueryAsync_LifecycleStateFilterRunsBeforePaging()
+    {
+        await using var provider = PolicyTestFixtures.CreateSqliteProvider(databasePath);
+        await PolicyTestFixtures.RegisterProductDefinitionAsync(provider);
+        await PolicyTestFixtures.SaveResourceAsync(provider, "a-unmarked");
+        await PolicyTestFixtures.SaveResourceAsync(provider, "b-archived");
+        await provider.GetRequiredService<IResourceLifecycleMarkerService>().ApplyAsync(new ResourceLifecycleMarkerRequest
+        {
+            ResourceId = "b-archived",
+            State = ResourceLifecycleMarkerState.Archived,
+            MarkedAt = DateTimeOffset.UtcNow,
+        });
+        var query = provider.GetRequiredService<IResourceQueryService>();
+
+        var results = (await query.QueryAsync(new ResourceQuery
+        {
+            LifecycleState = ResourceLifecycleMarkerState.Archived,
+            Take = 1,
+        })).ToList();
+
+        var result = Assert.Single(results);
+        Assert.Equal("b-archived", result.ResourceId);
+    }
 }

--- a/test/Aster.Tests/SqliteJson/SqliteJsonLifecycleMarkerTests.cs
+++ b/test/Aster.Tests/SqliteJson/SqliteJsonLifecycleMarkerTests.cs
@@ -1,0 +1,42 @@
+using Aster.Core.Abstractions;
+using Aster.Core.Models.Instances;
+using Aster.Core.Models.Querying;
+using Aster.Tests.Policies;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Aster.Tests.SqliteJson;
+
+public sealed class SqliteJsonLifecycleMarkerTests : IDisposable
+{
+    private readonly string databasePath = Path.Combine(Path.GetTempPath(), $"aster-marker-{Guid.NewGuid():N}.db");
+
+    public void Dispose() => PolicyTestFixtures.DeleteSqliteFiles(databasePath);
+
+    [Fact]
+    public async Task LifecycleMarkers_PersistAndCanBeQueried()
+    {
+        await using (var provider = PolicyTestFixtures.CreateSqliteProvider(databasePath))
+        {
+            await PolicyTestFixtures.RegisterProductDefinitionAsync(provider);
+            await PolicyTestFixtures.SaveResourceAsync(provider, "archived");
+            await PolicyTestFixtures.SaveResourceAsync(provider, "unmarked");
+            await provider.GetRequiredService<IResourceLifecycleMarkerService>().ApplyAsync(new ResourceLifecycleMarkerRequest
+            {
+                ResourceId = "archived",
+                State = ResourceLifecycleMarkerState.Archived,
+                MarkedAt = DateTimeOffset.UtcNow,
+            });
+        }
+
+        await using var secondProvider = PolicyTestFixtures.CreateSqliteProvider(databasePath);
+        var query = secondProvider.GetRequiredService<IResourceQueryService>();
+
+        var results = (await query.QueryAsync(new ResourceQuery
+        {
+            LifecycleState = ResourceLifecycleMarkerState.Archived,
+        })).ToList();
+
+        var result = Assert.Single(results);
+        Assert.Equal("archived", result.ResourceId);
+    }
+}

--- a/test/Aster.Tests/SqliteJson/SqliteJsonPolicyDefinitionTests.cs
+++ b/test/Aster.Tests/SqliteJson/SqliteJsonPolicyDefinitionTests.cs
@@ -1,0 +1,31 @@
+using Aster.Core.Abstractions;
+using Aster.Tests.Policies;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Aster.Tests.SqliteJson;
+
+public sealed class SqliteJsonPolicyDefinitionTests : IDisposable
+{
+    private readonly string databasePath = Path.Combine(Path.GetTempPath(), $"aster-policy-{Guid.NewGuid():N}.db");
+
+    public void Dispose() => PolicyTestFixtures.DeleteSqliteFiles(databasePath);
+
+    [Fact]
+    public async Task RegisterDefinitionAsync_PreservesPolicyDeclarationsAcrossProviders()
+    {
+        await using (var provider = PolicyTestFixtures.CreateSqliteProvider(databasePath))
+        {
+            var store = provider.GetRequiredService<IResourceDefinitionStore>();
+            await store.RegisterDefinitionAsync(PolicyTestFixtures.ProductDefinition(PolicyTestFixtures.ArchivePolicy()));
+        }
+
+        await using var secondProvider = PolicyTestFixtures.CreateSqliteProvider(databasePath);
+        var secondStore = secondProvider.GetRequiredService<IResourceDefinitionStore>();
+
+        var definition = await secondStore.GetDefinitionAsync("Product");
+
+        Assert.NotNull(definition);
+        var policy = Assert.Single(definition.PolicyDeclarations);
+        Assert.Equal("archive-old", policy.PolicyId);
+    }
+}

--- a/test/Aster.Tests/Tenancy/TenantLifecycleMarkerTests.cs
+++ b/test/Aster.Tests/Tenancy/TenantLifecycleMarkerTests.cs
@@ -1,0 +1,45 @@
+using Aster.Core.Abstractions;
+using Aster.Core.Models.Instances;
+using Aster.Core.Models.Querying;
+using Aster.Tests.Policies;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Aster.Tests.Tenancy;
+
+public sealed class TenantLifecycleMarkerTests : IDisposable
+{
+    private readonly ServiceProvider provider = PolicyTestFixtures.CreateCoreProvider();
+
+    public void Dispose() => provider.Dispose();
+
+    [Fact]
+    public async Task LifecycleMarkers_AreTenantScoped()
+    {
+        await PolicyTestFixtures.RegisterProductDefinitionAsync(provider, TenantScopeTestFixtures.TenantA);
+        await PolicyTestFixtures.RegisterProductDefinitionAsync(provider, TenantScopeTestFixtures.TenantB);
+        await PolicyTestFixtures.SaveResourceAsync(provider, "shared", tenantScope: TenantScopeTestFixtures.TenantA);
+        await PolicyTestFixtures.SaveResourceAsync(provider, "shared", tenantScope: TenantScopeTestFixtures.TenantB);
+        await provider.GetRequiredService<IResourceLifecycleMarkerService>().ApplyAsync(new ResourceLifecycleMarkerRequest
+        {
+            TenantScope = TenantScopeTestFixtures.TenantA,
+            ResourceId = "shared",
+            State = ResourceLifecycleMarkerState.Archived,
+            MarkedAt = DateTimeOffset.UtcNow,
+        });
+        var query = provider.GetRequiredService<IResourceQueryService>();
+
+        var tenantA = (await query.QueryAsync(new ResourceQuery
+        {
+            TenantScope = TenantScopeTestFixtures.TenantA,
+            LifecycleState = ResourceLifecycleMarkerState.Archived,
+        })).ToList();
+        var tenantB = (await query.QueryAsync(new ResourceQuery
+        {
+            TenantScope = TenantScopeTestFixtures.TenantB,
+            LifecycleState = ResourceLifecycleMarkerState.Archived,
+        })).ToList();
+
+        Assert.Single(tenantA);
+        Assert.Empty(tenantB);
+    }
+}


### PR DESCRIPTION
## Summary
- add definition-attached policy declarations, validation, and non-mutating policy previews
- add explicit archive/soft-delete lifecycle markers with query filtering and SQLite persistence
- preserve policy declarations and lifecycle markers through portability

## Validation
- dotnet test Aster.sln --no-restore
- dotnet build Aster.sln /m:1 --no-restore
- git diff --check