### PR TITLE
Add lifecycle restore workflows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,6 +64,7 @@ BenchmarkDotNet.Artifacts/
 project.lock.json
 project.fragment.lock.json
 artifacts/
+packages/
 
 # Tye
 .tye/

--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "featureDir": "specs/017-policy-application-orchestration"
+  "featureDir": "specs/018-lifecycle-restore-workflows"
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 <!-- SPECKIT START -->
 For additional context about technologies to be used, project structure,
-shell commands, and other important information, read `specs/016-policy-foundations/plan.md`.
+shell commands, and other important information, read `specs/018-lifecycle-restore-workflows/plan.md`.
 <!-- SPECKIT END -->
 
 ## Active Technologies
@@ -20,8 +20,12 @@ shell commands, and other important information, read `specs/016-policy-foundati
 - Existing resource definitions gain policy declaration metadata; resource lifecycle markers are stored as additive state separate from immutable resource versions; portable snapshots include policy declarations and lifecycle markers; SQLite JSON adds policy/marker storage without a general migration framework (016-policy-foundations)
 - C# latest, .NET 8.0 / 9.0 / 10.0 multi-targeting + Existing core SDK, policy declaration/preview models, lifecycle marker service/store, resource definition store, resource version reader, in-memory store, SQLite JSON provider through existing abstractions, xUnit test stack; no new dependencies (017-policy-application-orchestration)
 - No schema or storage changes. Application orchestration writes only existing lifecycle marker state through `IResourceLifecycleMarkerStore` after validation and conflict preflight; definitions, resources, activation state, portability snapshots, and SQLite tables remain unchanged. (017-policy-application-orchestration)
+- C# latest, .NET 8.0 / 9.0 / 10.0 multi-targeting + Existing core SDK, lifecycle marker service/store, resource version reader, in-memory store, SQLite JSON provider through existing abstractions, query capability stack, xUnit test stack; no new dependencies (018-lifecycle-restore-workflows)
+- Existing lifecycle marker storage only. Restore clears existing archive/soft-delete marker rows or in-memory entries; no resource version, activation state, policy declaration, portability snapshot format, or SQLite schema changes. (018-lifecycle-restore-workflows)
 
 ## Recent Changes
+- 018-lifecycle-restore-workflows: Added lifecycle restore workflow planning for host-controlled preview and application over archive/soft-delete markers; no resource version rewrites, activation changes, schedulers, authorization engines, provider registries, public SQL, public IQueryable<Resource>, destructive pruning writes, or schema changes
+- 017-policy-application-orchestration: Added host-controlled policy application orchestration for selected archive/soft-delete preview outcomes with per-candidate results, stale/policy validation, tenant scoping, and bounded provider reads
 - 016-policy-foundations: Added explicit policy foundations planning for definition-attached policy declarations, deterministic previews, archive/soft-delete lifecycle markers, lifecycle-state queries, portability, and provider support; no automatic execution, pruning writes, scheduler, policy engine, provider registry, public SQL, or public IQueryable<Resource>
 - 015-tenant-scoping: Added explicit tenant boundary planning for definitions, resources, activation state, queries, schema upgrades, portability, and lifecycle hooks; no automatic migration policy or tenant registry
 - 014-host-lifecycle-hooks: Added explicit host lifecycle hook planning over save, activation, deactivation, export, preview import, and write import; no schema migration or persisted hook state

--- a/docs/ExecutionRoadmap.md
+++ b/docs/ExecutionRoadmap.md
@@ -1,14 +1,14 @@
 # Aster Execution Roadmap
 
-Last updated: 2026-05-25
+Last updated: 2026-05-27
 
 This roadmap tracks the implementation trail we have already cut through the repo and the next product slices that should stay small enough for Spec Kit-driven PRs. It is intentionally execution-oriented; the broader architecture narrative remains in `docs/Roadmap.md` and the wiki.
 
 ## Current Position
 
-Aster now has a working Core SDK, in-memory runtime, SQLite JSON persistence/querying, provider capability discovery, provider validation alignment, provider authoring ergonomics, a reusable provider conformance harness, SQLite facet sorting, portable operator expansion, SQLite date-like ranges, explicit provider-declared index projections, explicit definition schema upgrade behavior, deterministic portability primitives, explicit host lifecycle hooks, explicit tenant scoping, and policy foundations.
+Aster now has a working Core SDK, in-memory runtime, SQLite JSON persistence/querying, provider capability discovery, provider validation alignment, provider authoring ergonomics, a reusable provider conformance harness, SQLite facet sorting, portable operator expansion, SQLite date-like ranges, explicit provider-declared index projections, explicit definition schema upgrade behavior, deterministic portability primitives, explicit host lifecycle hooks, explicit tenant scoping, policy foundations, host-controlled policy application orchestration, and host-controlled lifecycle restore workflows.
 
-The Phase 4 core workstream is complete enough to defer optional recipes. The active workstream is now **Phase 5: Multi-tenancy, Policies, Advanced Versioning**. Explicit tenant-aware boundaries and policy foundations have landed; the next slices should stay focused on either policy execution affordances or advanced tenant/versioning behavior, not both at once.
+The Phase 4 core workstream is complete enough to defer optional recipes. The active workstream is now **Phase 5: Multi-tenancy, Policies, Advanced Versioning**. Explicit tenant-aware boundaries, policy foundations, policy application orchestration, and reversible lifecycle restore have landed; the next slices should stay focused on advanced tenant/versioning behavior or a deliberately bounded policy follow-up, not both at once.
 
 ## Landed Slices
 
@@ -30,20 +30,21 @@ The Phase 4 core workstream is complete enough to defer optional recipes. The ac
 | `014-host-lifecycle-hooks` | Landed | Explicit before/after hooks for save, activation, deactivation, schema upgrades, export, preview import, and write import with deterministic ordering and fail-closed diagnostics. |
 | `015-tenant-scoping` | Landed | Explicit tenant boundaries for definitions, resources, activation state, queries, schema upgrades, portability snapshots, and lifecycle hook contexts with default single-tenant compatibility. |
 | `016-policy-foundations` | Landed | Definition-attached policy declarations, validation diagnostics, deterministic non-mutating previews, explicit archive/soft-delete lifecycle markers, lifecycle-state querying, and portability preservation. |
+| `017-policy-application-orchestration` | Landed | Host-controlled application of selected archive/soft-delete preview outcomes with per-candidate results, stale/policy validation, tenant scoping, and bounded provider reads. |
+| `018-lifecycle-restore-workflows` | Landed | Host-controlled preview and application for restoring archive/soft-delete markers with tenant scoping, idempotent already-restored outcomes, stable diagnostics, and no version or activation mutation. |
 
 ## Near-Term Roadmap
 
-### 017 — Policy Application Orchestration
+### 019 — Next Bounded Phase 5 Slice
 
-**Goal:** Add host-controlled affordances for applying previewed policy outcomes without introducing schedulers, hidden retention jobs, or destructive pruning writes.
+**Goal:** Choose one small continuation slice that builds on tenant-aware lifecycle and policy primitives without broadening the architecture.
 
 Candidate scope:
 
-- Batch application request/response models for archive and soft-delete preview candidates.
-- Idempotent application over explicit lifecycle marker writes.
-- Structured partial-failure diagnostics for stale/missing resources.
-- Optional lifecycle-hook context coverage for policy-applied marker writes if the existing hook surfaces are insufficient.
-- Keep background schedulers, hidden retention jobs, authorization policy engines, destructive pruning writes, provider registries, public SQL, and `IQueryable<Resource>` out of scope.
+- Advanced versioning behavior that is explicit, append-only, and provider-agnostic.
+- A deliberately bounded policy follow-up, such as pruning write semantics, only after a separate spec defines safety checks and rollback expectations.
+- Tenant extension behavior, such as shared definitions or administrative workflows, only if the boundaries stay explicit.
+- Keep automatic jobs, ambient authorization, provider registries, public SQL, public `IQueryable<Resource>`, and broad workflow/state-machine infrastructure out of scope unless a future spec justifies them directly.
 
 ## Later Roadmap
 
@@ -51,7 +52,7 @@ Candidate scope:
 |---|---|
 | Optional recipes | Separate `Aster.Recipes` package for hosts that want recipe execution over portability primitives. |
 | Multi-tenancy extensions | Shared definitions, tenant hierarchy, and cross-tenant administrative workflows after explicit tenant boundaries exist. |
-| Policies | Host-controlled policy application, restore workflows, and eventual pruning write semantics after separate specs. |
+| Policies | Restore workflows and eventual pruning write semantics after separate specs. |
 | Operational hardening | Benchmarks, migration idempotency, concurrency hardening, and large-data test suites. |
 
 ## Guardrails

--- a/docs/ExecutionRoadmap.md
+++ b/docs/ExecutionRoadmap.md
@@ -52,7 +52,7 @@ Candidate scope:
 |---|---|
 | Optional recipes | Separate `Aster.Recipes` package for hosts that want recipe execution over portability primitives. |
 | Multi-tenancy extensions | Shared definitions, tenant hierarchy, and cross-tenant administrative workflows after explicit tenant boundaries exist. |
-| Policies | Restore workflows and eventual pruning write semantics after separate specs. |
+| Policies | Eventual pruning write semantics after a separate spec defines safety checks and rollback expectations. |
 | Operational hardening | Benchmarks, migration idempotency, concurrency hardening, and large-data test suites. |
 
 ## Guardrails

--- a/docs/Roadmap.md
+++ b/docs/Roadmap.md
@@ -777,7 +777,8 @@ Define the minimal contracts needed for portable export/import of definitions/re
 - Explicit archive and soft-delete lifecycle markers
 - Lifecycle-state query criteria
 - Portability preservation for policy declarations and lifecycle markers
-- Future specs: host-controlled policy application orchestration, restore workflows, and destructive pruning semantics
+- Landed follow-up: host-controlled policy application orchestration for selected archive and soft-delete preview outcomes
+- Future specs: restore workflows and destructive pruning semantics
 
 **DoD**
 - Host can inspect and validate policy intent without hidden execution

--- a/docs/Roadmap.md
+++ b/docs/Roadmap.md
@@ -778,7 +778,8 @@ Define the minimal contracts needed for portable export/import of definitions/re
 - Lifecycle-state query criteria
 - Portability preservation for policy declarations and lifecycle markers
 - Landed follow-up: host-controlled policy application orchestration for selected archive and soft-delete preview outcomes
-- Future specs: restore workflows and destructive pruning semantics
+- Landed follow-up: host-controlled lifecycle restore workflows for archive and soft-delete markers
+- Future specs: destructive pruning semantics
 
 **DoD**
 - Host can inspect and validate policy intent without hidden execution

--- a/specs/018-lifecycle-restore-workflows/checklists/requirements.md
+++ b/specs/018-lifecycle-restore-workflows/checklists/requirements.md
@@ -1,0 +1,34 @@
+# Specification Quality Checklist: Lifecycle Restore Workflows
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-05-27
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Initial validation passed. The specification is ready for clarification or planning.

--- a/specs/018-lifecycle-restore-workflows/contracts/lifecycle-restore-workflows.md
+++ b/specs/018-lifecycle-restore-workflows/contracts/lifecycle-restore-workflows.md
@@ -57,15 +57,16 @@ public interface IResourceLifecycleMarkerClearStore : IResourceLifecycleMarkerSt
     ValueTask<bool> ClearMarkerAsync(
         string resourceId,
         TenantScope tenantScope,
+        ResourceLifecycleMarkerState expectedState,
         CancellationToken cancellationToken = default);
 }
 ```
 
 Contract rules:
 
-- `ClearMarkerAsync` MUST remove the effective lifecycle marker for the resource in the supplied tenant.
-- `ClearMarkerAsync` MUST return `true` when a marker existed and was removed.
-- `ClearMarkerAsync` MUST return `false` when no marker existed.
+- `ClearMarkerAsync` MUST remove the effective lifecycle marker for the resource in the supplied tenant only when its state matches `expectedState`.
+- `ClearMarkerAsync` MUST return `true` when a matching marker existed and was removed.
+- `ClearMarkerAsync` MUST return `false` when no marker existed or the current marker state did not match `expectedState`.
 - `ClearMarkerAsync` MUST NOT remove resource versions, activation state, definitions, policy declarations, or markers in other tenants.
 - Providers SHOULD implement clear through the existing lifecycle marker storage mechanism without schema changes.
 - Providers that do not implement the clear capability do not support lifecycle restore workflows.

--- a/specs/018-lifecycle-restore-workflows/contracts/lifecycle-restore-workflows.md
+++ b/specs/018-lifecycle-restore-workflows/contracts/lifecycle-restore-workflows.md
@@ -1,0 +1,130 @@
+# Contract: Lifecycle Restore Workflows
+
+## Public SDK Behavior
+
+Lifecycle restore workflows provide host-controlled, tenant-scoped preview and application for archive and soft-delete marker restoration.
+
+The SDK MUST:
+
+- let hosts preview selected restore candidates without writes;
+- let hosts apply selected restore candidates explicitly;
+- clear only existing archive or soft-delete lifecycle marker state;
+- return exactly one ordered result per input candidate;
+- preserve resource versions, activation state, resource definitions, policy declarations, and portability snapshot format;
+- keep omitted tenant scope mapped to the default single-tenant scope;
+- fail closed when current marker state differs from the candidate's expected state.
+
+The SDK MUST NOT:
+
+- restore automatically from policy declarations or preview results;
+- clear markers outside the effective tenant;
+- rewrite versions, deactivate active versions, delete resources, or perform pruning writes;
+- add public SQL, public `IQueryable<Resource>`, runtime scanning, provider registries, schedulers, hidden jobs, authorization engines, or a general lifecycle state machine.
+
+## Proposed Host-Facing Contract
+
+The restore workflow uses a focused host-facing service.
+
+```csharp
+public interface IResourceLifecycleRestoreService
+{
+    ValueTask<ResourceLifecycleRestorePreviewResult> PreviewRestoreAsync(
+        ResourceLifecycleRestoreRequest request,
+        CancellationToken cancellationToken = default);
+
+    ValueTask<ResourceLifecycleRestoreApplicationResult> RestoreAsync(
+        ResourceLifecycleRestoreRequest request,
+        CancellationToken cancellationToken = default);
+}
+```
+
+Contract rules:
+
+- `PreviewRestoreAsync` MUST be non-mutating.
+- `RestoreAsync` MUST re-read current target and marker state; it MUST NOT trust an earlier preview result.
+- Both methods MUST resolve one effective tenant per request.
+- Both methods MUST batch target resource and marker reads by distinct candidate resource IDs where possible.
+- Both methods MUST return empty results for empty candidate lists.
+- Both methods MUST produce one result per input candidate in input order.
+
+## Proposed Provider-Facing Contract
+
+The lifecycle marker storage layer adds a narrow clear capability.
+
+```csharp
+public interface IResourceLifecycleMarkerClearStore : IResourceLifecycleMarkerStore
+{
+    ValueTask<bool> ClearMarkerAsync(
+        string resourceId,
+        TenantScope tenantScope,
+        CancellationToken cancellationToken = default);
+}
+```
+
+Contract rules:
+
+- `ClearMarkerAsync` MUST remove the effective lifecycle marker for the resource in the supplied tenant.
+- `ClearMarkerAsync` MUST return `true` when a marker existed and was removed.
+- `ClearMarkerAsync` MUST return `false` when no marker existed.
+- `ClearMarkerAsync` MUST NOT remove resource versions, activation state, definitions, policy declarations, or markers in other tenants.
+- Providers SHOULD implement clear through the existing lifecycle marker storage mechanism without schema changes.
+- Providers that do not implement the clear capability do not support lifecycle restore workflows.
+
+## Restore Candidate Semantics
+
+Required candidate fields:
+
+- `ResourceId`
+- `ExpectedState`
+
+Supported expected states:
+
+- `Archived`
+- `SoftDeleted`
+
+Unsupported expected states:
+
+- `None`
+- unknown enum values
+- pruning outcomes or other policy outcomes
+- activation or retained concepts
+
+## Result Semantics
+
+Preview result statuses:
+
+- `Restorable`: current marker matches expected state.
+- `AlreadyRestored`: target exists and no marker is present.
+- `Skipped`: no write is required because a prior duplicate outcome already determined the result.
+- `Failed`: invalid candidate, unsupported state, missing target, or marker mismatch.
+
+Application result statuses:
+
+- `Restored`: marker matched expected state and was cleared.
+- `AlreadyRestored`: target exists and no marker is present, including retry after prior success.
+- `Skipped`: no write is required because a prior duplicate outcome already determined the result.
+- `Failed`: invalid candidate, unsupported state, missing target, or marker mismatch.
+
+## Stable Diagnostics
+
+The implementation MUST expose stable diagnostic codes for:
+
+- invalid restore candidate shape;
+- unsupported restore state;
+- missing target resource;
+- marker-state mismatch.
+
+Existing `lifecycle-marker-target-not-found` MAY be reused for missing target resources to preserve current lifecycle diagnostic semantics.
+
+## Compatibility
+
+Existing behavior MUST remain unchanged for:
+
+- direct lifecycle marker apply;
+- policy preview;
+- policy application;
+- resource write/update;
+- activation/deactivation;
+- lifecycle-state queries except that restored resources no longer match archived/soft-deleted filters after marker clearing;
+- portability export/import of marker state;
+- lifecycle hooks.

--- a/specs/018-lifecycle-restore-workflows/data-model.md
+++ b/specs/018-lifecycle-restore-workflows/data-model.md
@@ -1,0 +1,136 @@
+# Data Model: Lifecycle Restore Workflows
+
+## Lifecycle Restore Request
+
+Host-provided request for previewing or applying restore candidates.
+
+Fields:
+
+- `TenantScope`: optional tenant scope; omitted means the default single-tenant scope.
+- `Candidates`: ordered list of lifecycle restore candidates.
+- `RestoredAt`: optional host timestamp for application reporting if implementation chooses to expose it; it does not create resource history.
+
+Validation rules:
+
+- A null request is invalid.
+- Empty candidates are valid and return an empty result.
+- The effective tenant is resolved once per request.
+- The request must not imply cross-tenant restore.
+
+## Lifecycle Restore Candidate
+
+Host-selected restore target.
+
+Fields:
+
+- `ResourceId`: logical resource identifier.
+- `ExpectedState`: lifecycle marker state expected to be cleared.
+
+Validation rules:
+
+- `ResourceId` is required and must not be empty or whitespace.
+- `ExpectedState` must be `Archived` or `SoftDeleted`.
+- `None`, unknown enum values, active/retained concepts, pruning outcomes, and arbitrary states are unsupported.
+
+## Lifecycle Restore Preview Result
+
+Non-mutating response for a restore preview request.
+
+Fields:
+
+- `TenantScope`: effective tenant used for the preview.
+- `Candidates`: ordered preview candidate results, one per input candidate.
+- Aggregate counts for restorable, already restored, skipped, and failed candidates.
+
+Validation rules:
+
+- Preview must not clear marker state.
+- Preview must read current target resources and marker state in the effective tenant only.
+- Preview must report missing target resources separately from already-restored resources.
+
+## Lifecycle Restore Application Result
+
+Write response for a restore application request.
+
+Fields:
+
+- `TenantScope`: effective tenant used for application.
+- `Candidates`: ordered application candidate results, one per input candidate.
+- Aggregate counts for restored, already restored, skipped, and failed candidates.
+
+Validation rules:
+
+- Application revalidates current resource existence and marker state.
+- Application clears marker state only when the current marker matches the expected state.
+- Application allows partial success for unrelated candidates.
+- Application updates its in-memory marker view after clearing a marker so duplicates are deterministic.
+
+## Restore Candidate Result
+
+Per-candidate outcome for preview or application.
+
+Fields:
+
+- `Index`: zero-based input index.
+- `ResourceId`: input resource identifier when available.
+- `ExpectedState`: expected marker state when valid.
+- `Status`: candidate status.
+- `Diagnostics`: stable diagnostics for failed or skipped candidates.
+
+Preview statuses:
+
+- `Restorable`: target exists and current marker matches expected state.
+- `AlreadyRestored`: target exists and no marker is present.
+- `Skipped`: duplicate or unsupported candidate that did not fail.
+- `Failed`: invalid shape, missing target, unsupported state, or marker mismatch.
+
+Application statuses:
+
+- `Restored`: target existed, marker matched expected state, and marker state was cleared.
+- `AlreadyRestored`: target exists and no matching marker remains.
+- `Skipped`: deterministic duplicate after a prior result where no write is needed.
+- `Failed`: invalid shape, missing target, unsupported state, or marker mismatch.
+
+## Restore Diagnostic
+
+Stable per-candidate diagnostic.
+
+Diagnostic needs:
+
+- `lifecycle-restore-candidate-invalid`: missing resource identity, missing expected state, or malformed candidate.
+- `lifecycle-restore-state-unsupported`: expected state is not archive or soft-delete.
+- `lifecycle-marker-target-not-found`: resource does not exist in the effective tenant.
+- `lifecycle-restore-marker-mismatch`: current marker state differs from expected state.
+
+Diagnostic rules:
+
+- Diagnostics must be stable enough for tests and host UI branching.
+- Tenant-scoped target misses use the same not-found behavior as existing lifecycle marker writes.
+- Marker mismatch must include the resource identity and a path that identifies expected/current state when available.
+
+## State Transitions
+
+```text
+No marker
+  -- preview restore archive/soft-delete --> AlreadyRestored
+  -- apply restore archive/soft-delete --> AlreadyRestored
+
+Archived marker
+  -- preview restore Archived --> Restorable
+  -- apply restore Archived --> No marker
+  -- preview/apply restore SoftDeleted --> Failed(marker mismatch)
+
+SoftDeleted marker
+  -- preview restore SoftDeleted --> Restorable
+  -- apply restore SoftDeleted --> No marker
+  -- preview/apply restore Archived --> Failed(marker mismatch)
+```
+
+Prohibited transitions:
+
+- Restore rewriting resource versions.
+- Restore changing activation state.
+- Restore clearing markers in another tenant.
+- Restore clearing a different state than the candidate expected.
+- Restore applying or pruning policy outcomes.
+- Restore running automatically without a host request.

--- a/specs/018-lifecycle-restore-workflows/data-model.md
+++ b/specs/018-lifecycle-restore-workflows/data-model.md
@@ -75,13 +75,13 @@ Fields:
 - `ResourceId`: input resource identifier when available.
 - `ExpectedState`: expected marker state when valid.
 - `Status`: candidate status.
-- `Diagnostics`: stable diagnostics for failed or skipped candidates.
+- `Diagnostics`: stable diagnostics for failed candidates.
 
 Preview statuses:
 
 - `Restorable`: target exists and current marker matches expected state.
 - `AlreadyRestored`: target exists and no marker is present.
-- `Skipped`: duplicate or unsupported candidate that did not fail.
+- `Skipped`: deterministic duplicate after a prior result where no additional outcome is needed.
 - `Failed`: invalid shape, missing target, unsupported state, or marker mismatch.
 
 Application statuses:

--- a/specs/018-lifecycle-restore-workflows/plan.md
+++ b/specs/018-lifecycle-restore-workflows/plan.md
@@ -1,0 +1,126 @@
+# Implementation Plan: Lifecycle Restore Workflows
+
+**Branch**: `018-lifecycle-restore-workflows` | **Date**: 2026-05-27 | **Spec**: [spec.md](spec.md)  
+**Input**: Feature specification from `/specs/018-lifecycle-restore-workflows/spec.md`
+
+## Summary
+
+Add host-controlled lifecycle restore workflows for archive and soft-delete markers. The implementation adds a small restore service with explicit restore preview and restore application operations, adds request/result models with stable per-candidate diagnostics, and adds a narrow provider-facing marker clear capability so restore can remove existing marker state without rewriting resource versions, changing activation state, adding schedulers, or introducing a general lifecycle state machine.
+
+## Technical Context
+
+**Language/Version**: C# latest, .NET 8.0 / 9.0 / 10.0 multi-targeting  
+**Primary Dependencies**: Existing core SDK, lifecycle marker service/store, resource version reader, in-memory store, SQLite JSON provider through existing abstractions, query capability stack, xUnit test stack; no new dependencies  
+**Storage**: Existing lifecycle marker storage only. Restore clears existing archive/soft-delete marker rows or in-memory entries; no resource version, activation state, policy declaration, portability snapshot format, or SQLite schema changes.  
+**Testing**: `dotnet test Aster.sln`, focused lifecycle restore tests, tenant-scoped restore tests, lifecycle-state query regression tests, SQLite JSON restore compatibility tests, `dotnet build Aster.sln /m:1`, `git diff --check`  
+**Target Platform**: .NET SDK/library consumers and local test environment  
+**Project Type**: SDK/library with provider packages and tests  
+**Performance Goals**: Restore preview and application work are bounded by submitted candidate resource IDs in the effective tenant; marker and latest-resource reads are batched by candidate IDs; duplicate handling avoids repeated marker writes.  
+**Constraints**: Hosts explicitly submit restore candidates; archive and soft-delete are the only reversible marker states; preview is non-mutating; application clears only the expected marker state; marker-state mismatches fail closed; no resource version rewrites, activation changes, policy declaration mutation, destructive pruning writes, automatic restore, lifecycle hook behavior changes, provider registries, runtime scanning, public SQL, public `IQueryable<Resource>`, schedulers, or hidden jobs.  
+**Scale/Scope**: Core SDK models/service/store contract updates plus in-memory and SQLite JSON provider support, docs, and focused tests; no provider-specific restore executor or new storage package.
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+- **SDK-first/headless**: PASS - Adds SDK/library contracts only; no UI, CMS, scheduler, authorization, or host framework coupling.
+- **Immutable versioning**: PASS - Restore clears lifecycle marker state only and never rewrites resource versions.
+- **Channel activation**: PASS - Activation state remains unchanged and separate from marker restore behavior.
+- **Typed/queryable**: PASS - Existing lifecycle-state query semantics are preserved; no public SQL or `IQueryable` is introduced.
+- **Provider agnostic**: PASS - Core restore logic composes existing resource reader and marker store abstractions; provider details stay in provider packages.
+- **Simplicity first**: PASS - A small restore service and marker clear capability are simpler than a workflow engine, registry, or generalized state machine.
+- **Modern C# idioms**: PASS - Records, collection expressions, nullable-safe request models, and async APIs match current SDK style.
+- **Readability over cleverness**: PASS - Restore preview, validation, and application are direct per-candidate service steps.
+- **Explicitness over magic**: PASS - Hosts submit candidates and expected marker states explicitly; no hidden discovery or background behavior.
+- **Abstractions justified**: PASS - The restore service groups preview/application behavior without broadening the marker apply contract; the clear capability is required because current storage can save/read markers but cannot remove them through a provider-facing contract.
+- **Optimize for deletion**: PASS - Restore models and service methods are additive and localized around lifecycle markers.
+- **Composition over inheritance**: PASS - Uses data records and existing composed services; no inheritance hierarchy.
+- **Intentional dependencies**: PASS - No new third-party dependencies.
+- **Operational simplicity**: PASS - Existing build/test workflows remain sufficient; no worker, migration framework, or external service is introduced.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/018-lifecycle-restore-workflows/
++-- spec.md
++-- plan.md
++-- research.md
++-- data-model.md
++-- quickstart.md
++-- checklists/
+|   +-- requirements.md
++-- contracts/
+    +-- lifecycle-restore-workflows.md
+```
+
+### Source Code (repository root)
+
+```text
+src/
++-- core/Aster.Core/
+|   +-- Abstractions/
+|   |   +-- lifecycle restore service and marker clear capability contracts
+|   +-- Models/Instances/
+|   |   +-- lifecycle restore request/result models
+|   +-- Models/Policies/
+|   |   +-- restore diagnostic codes
+|   +-- Services/
+|       +-- default lifecycle restore service
+|
++-- persistence/Aster.Persistence.SqliteJson/
+|   +-- lifecycle marker clear implementation over existing table
+|
++-- apps/Aster.Web/
+    +-- no feature-specific host UI
+
+test/
++-- Aster.Tests/
+    +-- Lifecycle/
+    +-- Tenancy/
+    +-- Querying/
+    +-- SqliteJson/
+```
+
+**Structure Decision**: Keep restore workflows in `Aster.Core` because restore is lifecycle marker SDK behavior over existing provider abstractions. Providers only implement marker removal behind a narrow clear capability. Do not add a restore provider registry, scheduler, lifecycle hook pipeline, authorization layer, state-machine package, or new dependency.
+
+## Complexity Tracking
+
+No constitution violations.
+
+## Phase 0 Research Summary
+
+Research decisions are captured in [research.md](research.md). Key outcomes:
+
+- Add a small lifecycle restore service instead of expanding direct marker writes or adding a workflow engine.
+- Add a narrow provider-facing marker clear capability for stores that support restore.
+- Use explicit restore candidates with resource ID and expected archive/soft-delete state.
+- Provide non-mutating preview and write-side restore application with parallel result shapes.
+- Treat absent markers as already restored, but marker-state mismatches as fail-closed.
+- Keep restore tenant-scoped, candidate-bounded, and free of lifecycle hook behavior changes.
+
+## Phase 1 Design Summary
+
+Design artifacts:
+
+- [data-model.md](data-model.md)
+- [contracts/lifecycle-restore-workflows.md](contracts/lifecycle-restore-workflows.md)
+- [quickstart.md](quickstart.md)
+
+## Post-Design Constitution Check
+
+- **SDK-first/headless**: PASS - Design exposes SDK contracts only and leaves operator decisions and authorization to hosts.
+- **Immutable versioning**: PASS - Restore deletes marker state only; resource versions are untouched.
+- **Channel activation**: PASS - Activation is neither read as a side effect nor mutated by restore.
+- **Typed/queryable**: PASS - Restored resources naturally leave lifecycle-state query results because marker state is cleared; no query API expansion is needed.
+- **Provider agnostic**: PASS - Core service depends on existing resource reader and marker store contracts; SQLite details remain provider-local.
+- **Simplicity first**: PASS - A focused restore service satisfies current needs without a broader workflow abstraction.
+- **Modern C# idioms**: PASS - Planned records/enums/async APIs fit existing code.
+- **Readability over cleverness**: PASS - Result models make every restore outcome inspectable.
+- **Explicitness over magic**: PASS - Restore only happens through host-submitted candidates.
+- **Abstractions justified**: PASS - The restore service avoids widening direct marker writes and the clear capability maps to a concrete storage operation needed by restore.
+- **Optimize for deletion**: PASS - Removing restore would remove additive models, service registration, and one narrow clear capability.
+- **Composition over inheritance**: PASS - The design composes existing services and records.
+- **Intentional dependencies**: PASS - No new dependencies.
+- **Operational simplicity**: PASS - No background worker, migration framework, external service, or deployment-time runner is introduced.

--- a/specs/018-lifecycle-restore-workflows/quickstart.md
+++ b/specs/018-lifecycle-restore-workflows/quickstart.md
@@ -1,0 +1,127 @@
+# Quickstart: Lifecycle Restore Workflows
+
+## Register Services
+
+Use the existing core or provider registration path.
+
+```csharp
+var services = new ServiceCollection();
+services.AddAsterCore();
+// Optional provider replacement:
+// services.AddAsterSqliteJson(options => options.ConnectionString = "Data Source=aster.db");
+
+await using var provider = services.BuildServiceProvider();
+```
+
+## Mark A Resource
+
+```csharp
+var markers = provider.GetRequiredService<IResourceLifecycleMarkerService>();
+var restore = provider.GetRequiredService<IResourceLifecycleRestoreService>();
+
+await markers.ApplyAsync(new ResourceLifecycleMarkerRequest
+{
+    ResourceId = "product-1",
+    State = ResourceLifecycleMarkerState.Archived,
+    MarkedAt = DateTimeOffset.UtcNow,
+    Reason = "No longer sold",
+});
+```
+
+## Preview Restore
+
+```csharp
+var preview = await restore.PreviewRestoreAsync(new ResourceLifecycleRestoreRequest
+{
+    Candidates =
+    [
+        new ResourceLifecycleRestoreCandidate
+        {
+            ResourceId = "product-1",
+            ExpectedState = ResourceLifecycleMarkerState.Archived,
+        },
+    ],
+});
+
+foreach (var candidate in preview.Candidates)
+{
+    Console.WriteLine($"{candidate.ResourceId}: {candidate.Status}");
+}
+```
+
+Expected behavior:
+
+- `Restorable` means the marker exists and matches the expected state.
+- `AlreadyRestored` means the resource exists and no marker is present.
+- `Failed` includes diagnostics for invalid input, missing target, unsupported state, or marker mismatch.
+- Preview does not clear marker state.
+
+## Apply Restore
+
+```csharp
+var result = await restore.RestoreAsync(new ResourceLifecycleRestoreRequest
+{
+    Candidates =
+    [
+        new ResourceLifecycleRestoreCandidate
+        {
+            ResourceId = "product-1",
+            ExpectedState = ResourceLifecycleMarkerState.Archived,
+        },
+    ],
+});
+
+var restored = result.Candidates.Single();
+Console.WriteLine($"{restored.ResourceId}: {restored.Status}");
+```
+
+Expected behavior:
+
+- `Restored` means the expected marker was cleared.
+- `AlreadyRestored` means the resource already had no marker.
+- Marker mismatch fails and leaves the current marker untouched.
+- Resource versions and activation state are unchanged.
+
+## Query After Restore
+
+```csharp
+var query = provider.GetRequiredService<IResourceQueryService>();
+var archived = await query.QueryAsync(new ResourceQuery
+{
+    LifecycleState = ResourceLifecycleMarkerState.Archived,
+});
+```
+
+After successful restore, the restored resource no longer appears in archived or soft-deleted lifecycle-state query results.
+
+## Tenant-Scoped Restore
+
+```csharp
+await restore.RestoreAsync(new ResourceLifecycleRestoreRequest
+{
+    TenantScope = new TenantScope("tenant-a"),
+    Candidates =
+    [
+        new ResourceLifecycleRestoreCandidate
+        {
+            ResourceId = "shared-product",
+            ExpectedState = ResourceLifecycleMarkerState.SoftDeleted,
+        },
+    ],
+});
+```
+
+Only marker state inside the effective tenant is considered or cleared.
+
+## Non-Goals
+
+Restore workflows do not:
+
+- run automatically;
+- authorize operators;
+- rewrite resource versions;
+- alter activation state;
+- delete resources;
+- prune versions;
+- add lifecycle hooks;
+- expose raw SQL or public `IQueryable<Resource>`.

--- a/specs/018-lifecycle-restore-workflows/research.md
+++ b/specs/018-lifecycle-restore-workflows/research.md
@@ -1,0 +1,95 @@
+# Research: Lifecycle Restore Workflows
+
+## Decision: Add A Small Lifecycle Restore Service
+
+Decision: Add a focused host-facing lifecycle restore service for restore preview and restore application.
+
+Rationale: Restore is related to lifecycle markers, but it has batch preview, batch application, per-candidate diagnostics, and expected-state validation that differ from direct single-marker writes. A small service keeps restore behavior cohesive and avoids broadening the existing marker apply contract.
+
+Alternatives considered:
+
+- Add methods to the existing lifecycle marker service: rejected because it would widen the direct marker write contract and make a single-resource apply service carry batch restore workflow behavior.
+- Add a generic lifecycle workflow service: rejected because restore does not need a broad state-transition framework.
+- Ask hosts to clear provider state directly: rejected because hosts need consistent validation, tenant scoping, idempotency, and diagnostics.
+
+## Decision: Add A Narrow Marker Clear Capability
+
+Decision: Add a narrow provider-facing capability for clearing the marker for a resource in a tenant.
+
+Rationale: Current provider-facing storage can read and save effective marker state, but restore needs to remove marker state so lifecycle-state queries and portability see the resource as unmarked. Persisting `None` as a marker would create a second representation for the same state and complicate provider queries. A dedicated capability lets built-in providers support restore without changing read/write semantics.
+
+Alternatives considered:
+
+- Save a marker with `State = None`: rejected because absence already represents no marker and persisted none-state rows would make querying and portability ambiguous.
+- Make restore service call provider-specific delete APIs: rejected because core must stay provider-agnostic.
+- Reuse internal in-memory rollback helpers: rejected because SQLite and future providers need the same public provider-facing contract.
+
+## Decision: Use Explicit Restore Candidates
+
+Decision: Restore requests contain selected candidates with resource ID and expected lifecycle marker state.
+
+Rationale: Expected state makes restore fail closed when an operator acts on stale UI data. It also lets hosts restore a subset of resources without hidden discovery or re-evaluation.
+
+Alternatives considered:
+
+- Accept only resource IDs: rejected because a resource might have changed from archived to soft-deleted between preview and application.
+- Accept policy IDs from the original policy application: rejected because restore reverses marker state, not policy intent, and should not require policy declarations to still exist.
+- Restore all currently marked resources: rejected because it would violate explicit host intent.
+
+## Decision: Provide Preview And Application Workflows
+
+Decision: Restore preview is non-mutating and reports candidate outcomes; restore application revalidates current state and clears markers when the expected state matches.
+
+Rationale: Preview supports operator review, while application remains safe when marker state changes after preview. Revalidation during application prevents stale restore candidates from clearing unrelated current marker state.
+
+Alternatives considered:
+
+- Application only: rejected because hosts need non-mutating reporting before restore.
+- Preview token that application trusts: rejected because marker state can change between preview and application and the current requirements do not need token infrastructure.
+- All-or-nothing batch: rejected because unrelated valid restore candidates should still succeed when one candidate fails.
+
+## Decision: Treat Missing Markers As Already Restored
+
+Decision: A candidate for an existing resource with no lifecycle marker reports already restored.
+
+Rationale: Restore is naturally idempotent. Retrying a restore after success or after an external clear should not fail solely because the marker is absent.
+
+Alternatives considered:
+
+- Fail missing markers: rejected because it makes safe retries noisy and does not reflect the desired end state.
+- Skip missing markers without a status: rejected because every input must receive a deterministic result.
+
+## Decision: Fail Marker-State Mismatches
+
+Decision: If the current marker state differs from the candidate's expected state, preview and application fail that candidate with a stable marker-mismatch diagnostic.
+
+Rationale: Clearing a different marker than the host expected can undo a newer operator decision. Fail-closed behavior preserves explicitness and prevents stale UI selections from clearing current lifecycle state.
+
+Alternatives considered:
+
+- Clear whatever marker exists: rejected because it can erase newer state accidentally.
+- Treat mismatch as already restored: rejected because a marker still exists and the resource is not restored.
+- Auto-transition between archive and soft-delete: rejected as a broader lifecycle state-machine feature.
+
+## Decision: Preserve Lifecycle Hook Behavior
+
+Decision: Restore workflows do not add lifecycle hook coverage in this slice.
+
+Rationale: Existing hook contexts cover existing resource save, activation, schema, and portability workflows. Adding restore hooks would broaden public contracts before a demonstrated host need.
+
+Alternatives considered:
+
+- Invoke hooks around every marker clear: rejected because direct marker writes do not currently define a hook pipeline.
+- Add before/after restore hooks: rejected as unnecessary infrastructure for this slice.
+
+## Decision: Preserve Provider And Operational Simplicity
+
+Decision: Restore remains core SDK behavior over existing abstractions with no provider registry, runtime scanning, scheduler, public SQL, public `IQueryable<Resource>`, storage migration, destructive pruning write, or authorization system.
+
+Rationale: Restore is an explicit host operation over current marker state. Keeping it bounded preserves the architecture established by tenant scoping, policy foundations, and policy application orchestration.
+
+Alternatives considered:
+
+- Background restore runner: rejected because automatic execution is out of scope.
+- Authorization-integrated restore: rejected because host authorization remains outside the SDK.
+- Provider-specific restore executors: rejected because restore rules are provider-agnostic.

--- a/specs/018-lifecycle-restore-workflows/spec.md
+++ b/specs/018-lifecycle-restore-workflows/spec.md
@@ -1,0 +1,136 @@
+# Feature Specification: Lifecycle Restore Workflows
+
+**Feature Branch**: `018-lifecycle-restore-workflows`  
+**Created**: 2026-05-27  
+**Status**: Draft  
+**Input**: User description: "Add host-controlled lifecycle restore workflows for archive and soft-delete markers. Hosts should be able to preview and explicitly restore archived or soft-deleted resources by clearing lifecycle marker state without rewriting resource versions, changing activation state, adding schedulers, authorization engines, provider registries, public SQL, IQueryable<Resource>, or destructive pruning writes."
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Restore Marked Resources Explicitly (Priority: P1)
+
+As a host author, I need to explicitly restore archived or soft-deleted resources, so operators can reverse a lifecycle marker without mutating resource history or activation state.
+
+**Why this priority**: Policy foundations and application orchestration can mark resources as archived or soft-deleted. The smallest useful next step is the matching host-controlled way to clear those reversible marker states.
+
+**Independent Test**: Mark resources as archived and soft-deleted, submit selected restore candidates, and verify the matching lifecycle markers are cleared while resource versions and activation state remain unchanged.
+
+**Acceptance Scenarios**:
+
+1. **Given** a resource has an archive marker, **When** the host submits an archive restore candidate, **Then** the marker is cleared and the resource is no longer considered archived.
+2. **Given** a resource has a soft-delete marker, **When** the host submits a soft-delete restore candidate, **Then** the marker is cleared and the resource is no longer considered soft-deleted.
+3. **Given** a host restores only a subset of marked resources, **When** restoration completes, **Then** only the selected resources are restored and unselected markers remain unchanged.
+4. **Given** a host restores lifecycle markers, **When** resource history and activation state are inspected, **Then** stored resource versions and activation channels remain intact.
+
+---
+
+### User Story 2 - Preview Restore Outcomes Before Writing (Priority: P2)
+
+As a host author, I need to preview restore candidates before applying them, so an operator can see which resources can be restored, are already unmarked, are missing, or have mismatched marker state.
+
+**Why this priority**: Restore is operator-facing and should mirror the explicit policy preview/application model. A dry-run preview prevents accidental marker removal and gives hosts stable UI/reporting data.
+
+**Independent Test**: Submit a mixed restore preview request containing restorable resources, already-restored resources, missing resources, and marker-state mismatches; verify each input receives a stable preview outcome without changing marker state.
+
+**Acceptance Scenarios**:
+
+1. **Given** a resource has the expected lifecycle marker, **When** restore preview runs, **Then** the response reports it as restorable and no marker is cleared.
+2. **Given** a resource has no lifecycle marker, **When** restore preview runs, **Then** the response reports it as already restored.
+3. **Given** a resource has a different lifecycle marker than the requested restore state, **When** restore preview runs, **Then** the response reports a stable marker-mismatch diagnostic.
+4. **Given** a host previews restore candidates, **When** normal resource workflows run afterward, **Then** no lifecycle state changes have occurred from preview alone.
+
+---
+
+### User Story 3 - Report Deterministic Restore Results (Priority: P3)
+
+As a host author, I need per-candidate restore results and stable diagnostics, so restore workflows can show exactly what changed, what was already satisfied, and what failed.
+
+**Why this priority**: Restore requests can be batched across many resources. Hosts need deterministic partial-success reporting and retries without hidden behavior.
+
+**Independent Test**: Submit a mixed restore application request with valid candidates, duplicates, missing targets, already-restored resources, tenant misses, and mismatched marker state; verify each input receives exactly one stable result.
+
+**Acceptance Scenarios**:
+
+1. **Given** duplicate restore candidates for the same resource and marker state, **When** application runs, **Then** marker state is cleared at most once and duplicate results are deterministic.
+2. **Given** some restore candidates fail and others are valid, **When** the host submits them together, **Then** valid candidates may still restore and every candidate receives its own result.
+3. **Given** matching resource identifiers exist in multiple tenants, **When** a tenant-scoped restore request runs, **Then** only the effective tenant is considered.
+4. **Given** no restore request is submitted, **When** policy declarations, previews, or normal lifecycle operations are used, **Then** no lifecycle marker is cleared automatically.
+
+### Edge Cases
+
+- A restore request contains zero candidates.
+- A candidate is missing resource identity or expected lifecycle marker state.
+- A candidate requests restore for an unsupported state such as active, retained, pruning, or an unknown outcome.
+- A resource has no lifecycle marker when restore is requested.
+- A resource has archive state when soft-delete restore is requested, or soft-delete state when archive restore is requested.
+- A resource no longer exists in the effective tenant, but a stale restore candidate is submitted.
+- A tenant-scoped request references a resource outside the tenant boundary.
+- The same candidate appears more than once in one request.
+- Preview is run and then marker state changes before application.
+- Restore is retried after a partial failure.
+
+### Constitution Alignment *(mandatory)*
+
+- **Simplicity**: The simplest acceptable behavior is a host-invoked preview and application operation over explicit restore candidates. Schedulers, policy engines, automatic restore, destructive pruning writes, provider registries, and broad state-transition frameworks are out of scope.
+- **Explicitness**: Hosts choose when to preview restore candidates, when to apply them, which resources to restore, and which marker state is expected. The system MUST NOT discover, schedule, authorize, or execute restore behavior through hidden conventions or background processing.
+- **Dependencies**: None.
+- **Operational Impact**: Existing local development, deployment, and debugging remain unchanged. No worker process, timer, external service, migration framework, provider infrastructure, or new storage engine is introduced.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The system MUST provide a host-controlled way to preview lifecycle restore candidates before applying writes.
+- **FR-002**: The system MUST provide a host-controlled way to apply selected lifecycle restore candidates.
+- **FR-003**: Restore MUST support clearing archive and soft-delete lifecycle marker states.
+- **FR-004**: Restore MUST NOT support destructive version pruning, resource deletion, resource-version rewrites, activation changes, or policy declaration mutation.
+- **FR-005**: Restore requests MUST be bounded by one effective tenant scope.
+- **FR-006**: Omitted tenant scope MUST continue to mean the documented default single-tenant scope.
+- **FR-007**: Restore MUST NOT clear markers outside the effective tenant boundary.
+- **FR-008**: Each restore preview input MUST produce a per-candidate preview outcome.
+- **FR-009**: Each restore application input MUST produce a per-candidate application result.
+- **FR-010**: Restore preview outcomes MUST distinguish restorable, already restored, skipped, and failed candidates.
+- **FR-011**: Restore application results MUST distinguish restored, already restored, skipped, and failed candidates.
+- **FR-012**: Restore diagnostics MUST be stable enough for hosts and tests to distinguish invalid candidate shape, unsupported restore state, missing target, tenant-scoped target-not-found behavior, and marker-state mismatch.
+- **FR-013**: A restore candidate MUST identify the target resource and the expected lifecycle marker state to clear.
+- **FR-014**: A candidate with missing resource identity, missing expected state, unsupported state, or unknown state MUST fail with diagnostics and without clearing any marker.
+- **FR-015**: A candidate for a resource without a lifecycle marker MUST report already restored and MUST NOT fail solely because the marker is absent.
+- **FR-016**: A candidate whose current marker state differs from the expected state MUST fail with a stable marker-mismatch diagnostic and MUST NOT clear the current marker.
+- **FR-017**: Duplicate restore candidates in one request MUST NOT create nondeterministic results and MUST clear marker state at most once.
+- **FR-018**: Restore preview MUST be non-mutating.
+- **FR-019**: Restore application MUST allow partial success while still returning exactly one result for every candidate.
+- **FR-020**: Restore MUST integrate with existing lifecycle-state query behavior so restored resources no longer match archived or soft-deleted lifecycle filters after marker removal.
+- **FR-021**: Restore MUST preserve existing direct lifecycle marker writes, policy previews, policy application, resource writes, activation behavior, queries, portability, and lifecycle hooks unless this feature explicitly defines a restore behavior.
+- **FR-022**: Restore MUST NOT introduce background schedulers, hidden retention jobs, authorization or permission policy engines, cross-tenant restore, runtime scanning, provider registries, public SQL, public `IQueryable<Resource>`, destructive pruning writes, or a general state-transition framework.
+- **FR-023**: Documentation MUST explain host-controlled restore preview, restore application, idempotency, tenant boundary behavior, marker mismatch behavior, non-mutating preview, lifecycle hook non-goals, and out-of-scope automatic execution.
+
+### Key Entities *(include if feature involves data)*
+
+- **Lifecycle Restore Request**: Host-provided request containing tenant scope and selected restore candidates.
+- **Lifecycle Restore Candidate**: Host-selected item identifying a resource and the expected archive or soft-delete marker state to clear.
+- **Lifecycle Restore Preview Result**: Non-mutating response containing one preview outcome per candidate.
+- **Lifecycle Restore Application Result**: Write response containing one application outcome per candidate.
+- **Restore Candidate Result**: Per-candidate status describing whether the candidate is restorable/restored, already restored, skipped, or failed.
+- **Restore Diagnostic**: Stable diagnostic describing invalid input, unsupported state, missing target, marker mismatch, or tenant-scoped target-not-found behavior.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: A host can preview restore candidates and receive exactly one non-mutating outcome for every submitted candidate.
+- **SC-002**: A host can restore selected archived and soft-deleted resources and observe that only selected lifecycle markers are cleared.
+- **SC-003**: Restoring lifecycle markers does not change resource version history or activation state.
+- **SC-004**: Restored resources no longer match archived or soft-deleted lifecycle-state query criteria.
+- **SC-005**: Already-restored resources produce idempotent already-restored outcomes without error or marker writes.
+- **SC-006**: Marker-state mismatch candidates fail with stable diagnostics and do not clear the current marker.
+- **SC-007**: Tenant-scoped restore returns zero marker changes outside the effective tenant boundary.
+- **SC-008**: Restore preview performs no writes.
+- **SC-009**: Existing policy application, direct lifecycle marker, query, portability, and resource version tests continue to pass.
+
+## Assumptions
+
+- Restore means clearing an archive or soft-delete lifecycle marker, not creating a new resource version or changing activation channels.
+- Hosts remain responsible for deciding whether an operator is allowed to restore a resource.
+- Restore candidates require an expected marker state so stale or mismatched UI selections fail closed.
+- Archive and soft-delete are the only reversible lifecycle marker states in this slice.
+- Resource deletion, destructive pruning, scheduler behavior, automatic policy execution, authorization, and broad workflow/state-machine behavior remain future or host responsibilities.

--- a/specs/018-lifecycle-restore-workflows/tasks.md
+++ b/specs/018-lifecycle-restore-workflows/tasks.md
@@ -1,0 +1,202 @@
+# Tasks: Lifecycle Restore Workflows
+
+**Input**: Design documents from `/specs/018-lifecycle-restore-workflows/`
+**Prerequisites**: [plan.md](plan.md), [spec.md](spec.md), [research.md](research.md), [data-model.md](data-model.md), [contracts/](contracts/), [quickstart.md](quickstart.md)
+
+**Tests**: Required by the feature specification's independent tests. Write story tests before implementation and confirm they fail for the expected missing behavior before making them pass.
+
+**Organization**: Tasks are grouped by user story so each story can be implemented and validated independently.
+
+## Phase 1: Setup
+
+**Purpose**: Confirm baseline and feature context before shared implementation.
+
+- [X] T001 Read lifecycle restore requirements in `/Users/sipke/Projects/ValenceWorks/aster/specs/018-lifecycle-restore-workflows/spec.md`
+- [X] T002 Read restore planning and contract decisions in `/Users/sipke/Projects/ValenceWorks/aster/specs/018-lifecycle-restore-workflows/plan.md`
+- [X] T003 Inspect existing lifecycle marker service/store contracts in `/Users/sipke/Projects/ValenceWorks/aster/src/core/Aster.Core/Abstractions/IResourceLifecycleMarkerStore.cs`
+- [X] T004 Inspect existing lifecycle marker implementation in `/Users/sipke/Projects/ValenceWorks/aster/src/core/Aster.Core/Services/ResourceLifecycleMarkerService.cs`
+- [X] T005 Run baseline restore/build with `/usr/local/share/dotnet/dotnet restore /Users/sipke/Projects/ValenceWorks/aster/Aster.sln`
+
+---
+
+## Phase 2: Foundational
+
+**Purpose**: Shared contracts, models, diagnostics, and provider clear capability required by all restore stories.
+
+**CRITICAL**: No user story implementation should begin until these are complete.
+
+- [X] T006 [P] Add `IResourceLifecycleRestoreService` contract in `/Users/sipke/Projects/ValenceWorks/aster/src/core/Aster.Core/Abstractions/IResourceLifecycleRestoreService.cs`
+- [X] T007 Add `IResourceLifecycleMarkerClearStore` provider capability in `/Users/sipke/Projects/ValenceWorks/aster/src/core/Aster.Core/Abstractions/IResourceLifecycleMarkerStore.cs`
+- [X] T008 [P] Add lifecycle restore request/result/status models in `/Users/sipke/Projects/ValenceWorks/aster/src/core/Aster.Core/Models/Instances/ResourceLifecycleRestore.cs`
+- [X] T009 [P] Add stable restore diagnostic codes in `/Users/sipke/Projects/ValenceWorks/aster/src/core/Aster.Core/Models/Policies/ResourcePolicyResults.cs`
+- [X] T010 Implement `IResourceLifecycleMarkerClearStore.ClearMarkerAsync` for in-memory markers in `/Users/sipke/Projects/ValenceWorks/aster/src/core/Aster.Core/InMemory/InMemoryResourceLifecycleMarkerStore.cs`
+- [X] T011 Implement `IResourceLifecycleMarkerClearStore.ClearMarkerAsync` for SQLite JSON markers in `/Users/sipke/Projects/ValenceWorks/aster/src/persistence/Aster.Persistence.SqliteJson/SqliteJsonResourceStore.cs`
+- [X] T012 Register `IResourceLifecycleMarkerClearStore` and `IResourceLifecycleRestoreService` in `/Users/sipke/Projects/ValenceWorks/aster/src/core/Aster.Core/Extensions/AsterCoreServiceCollectionExtensions.cs`
+- [X] T013 Register SQLite JSON `IResourceLifecycleMarkerClearStore` replacement in `/Users/sipke/Projects/ValenceWorks/aster/src/persistence/Aster.Persistence.SqliteJson/SqliteJsonAsterServiceCollectionExtensions.cs`
+- [X] T014 Run foundational compile with `/usr/local/share/dotnet/dotnet build /Users/sipke/Projects/ValenceWorks/aster/Aster.sln /m:1`
+
+**Checkpoint**: Contracts and provider clear capability compile; user story implementation can proceed.
+
+---
+
+## Phase 3: User Story 1 - Restore Marked Resources Explicitly (Priority: P1) MVP
+
+**Goal**: Hosts can explicitly restore selected archived or soft-deleted resources by clearing only matching lifecycle markers while resource versions and activation state remain unchanged.
+
+**Independent Test**: Mark resources archived/soft-deleted, restore selected candidates, verify selected markers are cleared, unselected markers remain, versions remain intact, and activation state remains unchanged.
+
+### Tests for User Story 1
+
+- [X] T015 [P] [US1] Add archive and soft-delete restore success tests in `/Users/sipke/Projects/ValenceWorks/aster/test/Aster.Tests/Lifecycle/LifecycleRestoreServiceTests.cs`
+- [X] T016 [US1] Add subset restore and unselected marker preservation tests in `/Users/sipke/Projects/ValenceWorks/aster/test/Aster.Tests/Lifecycle/LifecycleRestoreServiceTests.cs`
+- [X] T017 [P] [US1] Add resource version and activation preservation tests in `/Users/sipke/Projects/ValenceWorks/aster/test/Aster.Tests/Lifecycle/LifecycleRestoreActivationTests.cs`
+- [X] T018 [P] [US1] Add lifecycle-state query after restore regression test in `/Users/sipke/Projects/ValenceWorks/aster/test/Aster.Tests/Querying/LifecycleStateQueryTests.cs`
+
+### Implementation for User Story 1
+
+- [X] T019 [US1] Implement `ResourceLifecycleRestoreService.RestoreAsync` success path in `/Users/sipke/Projects/ValenceWorks/aster/src/core/Aster.Core/Services/ResourceLifecycleRestoreService.cs`
+- [X] T020 [US1] Add candidate-bounded latest-resource and marker reads by distinct candidate resource IDs to restore application in `/Users/sipke/Projects/ValenceWorks/aster/src/core/Aster.Core/Services/ResourceLifecycleRestoreService.cs`
+- [X] T021 [US1] Clear matching archive and soft-delete markers through `IResourceLifecycleMarkerClearStore` in `/Users/sipke/Projects/ValenceWorks/aster/src/core/Aster.Core/Services/ResourceLifecycleRestoreService.cs`
+- [X] T022 [US1] Preserve versions and activation state by avoiding resource writer and activation dependencies in `/Users/sipke/Projects/ValenceWorks/aster/src/core/Aster.Core/Services/ResourceLifecycleRestoreService.cs`
+- [X] T023 [US1] Run focused P1 tests with `/usr/local/share/dotnet/dotnet test /Users/sipke/Projects/ValenceWorks/aster/Aster.sln --filter "LifecycleRestore|LifecycleStateQuery"`
+
+**Checkpoint**: User Story 1 is independently functional and testable.
+
+---
+
+## Phase 4: User Story 2 - Preview Restore Outcomes Before Writing (Priority: P2)
+
+**Goal**: Hosts can preview restore candidates and receive non-mutating outcomes for restorable, already-restored, missing, and mismatched resources.
+
+**Independent Test**: Submit mixed preview candidates and verify one stable non-mutating preview outcome per input while marker state remains unchanged.
+
+### Tests for User Story 2
+
+- [X] T024 [P] [US2] Add preview restorable, already-restored, duplicate-skipped, and empty-request tests in `/Users/sipke/Projects/ValenceWorks/aster/test/Aster.Tests/Lifecycle/LifecycleRestorePreviewTests.cs`
+- [X] T025 [US2] Add preview marker-mismatch and missing-target diagnostic tests in `/Users/sipke/Projects/ValenceWorks/aster/test/Aster.Tests/Lifecycle/LifecycleRestorePreviewTests.cs`
+- [X] T026 [US2] Add preview no-mutation regression tests, including invalid and unsupported candidate no-clear assertions, in `/Users/sipke/Projects/ValenceWorks/aster/test/Aster.Tests/Lifecycle/LifecycleRestorePreviewTests.cs`
+
+### Implementation for User Story 2
+
+- [X] T027 [US2] Implement `ResourceLifecycleRestoreService.PreviewRestoreAsync` in `/Users/sipke/Projects/ValenceWorks/aster/src/core/Aster.Core/Services/ResourceLifecycleRestoreService.cs`
+- [X] T028 [US2] Extract shared candidate validation/evaluation helper for preview and application in `/Users/sipke/Projects/ValenceWorks/aster/src/core/Aster.Core/Services/ResourceLifecycleRestoreService.cs`
+- [X] T029 [US2] Ensure preview never calls `ClearMarkerAsync` in `/Users/sipke/Projects/ValenceWorks/aster/src/core/Aster.Core/Services/ResourceLifecycleRestoreService.cs`
+- [X] T030 [US2] Run focused P2 tests with `/usr/local/share/dotnet/dotnet test /Users/sipke/Projects/ValenceWorks/aster/Aster.sln --filter "LifecycleRestorePreview|LifecycleRestore"`
+
+**Checkpoint**: User Stories 1 and 2 both work independently.
+
+---
+
+## Phase 5: User Story 3 - Report Deterministic Restore Results (Priority: P3)
+
+**Goal**: Restore application returns deterministic per-candidate results and stable diagnostics for duplicates, invalid input, unsupported states, missing targets, already-restored resources, tenant misses, and marker mismatches.
+
+**Independent Test**: Submit a mixed restore request and verify every candidate receives exactly one stable result; valid unrelated candidates still restore.
+
+### Tests for User Story 3
+
+- [X] T031 [P] [US3] Add restore aggregate counts, empty-request, and one-result-per-input tests in `/Users/sipke/Projects/ValenceWorks/aster/test/Aster.Tests/Lifecycle/LifecycleRestoreResultTests.cs`
+- [X] T032 [US3] Add duplicate candidate determinism tests in `/Users/sipke/Projects/ValenceWorks/aster/test/Aster.Tests/Lifecycle/LifecycleRestoreResultTests.cs`
+- [X] T033 [P] [US3] Add invalid candidate and unsupported state diagnostic tests with no-marker-cleared assertions in `/Users/sipke/Projects/ValenceWorks/aster/test/Aster.Tests/Lifecycle/LifecycleRestoreDiagnosticsTests.cs`
+- [X] T034 [US3] Add missing target, marker-mismatch, and stale-preview-before-apply application diagnostic tests in `/Users/sipke/Projects/ValenceWorks/aster/test/Aster.Tests/Lifecycle/LifecycleRestoreDiagnosticsTests.cs`
+- [X] T035 [P] [US3] Add tenant-scoped restore isolation and omitted default tenant scope tests in `/Users/sipke/Projects/ValenceWorks/aster/test/Aster.Tests/Tenancy/TenantLifecycleRestoreTests.cs`
+- [X] T036 [P] [US3] Add SQLite JSON restore compatibility tests in `/Users/sipke/Projects/ValenceWorks/aster/test/Aster.Tests/SqliteJson/SqliteJsonLifecycleRestoreTests.cs`
+
+### Implementation for User Story 3
+
+- [X] T037 [US3] Implement invalid candidate and unsupported state diagnostics in `/Users/sipke/Projects/ValenceWorks/aster/src/core/Aster.Core/Services/ResourceLifecycleRestoreService.cs`
+- [X] T038 [US3] Implement missing target and tenant-scoped target-not-found diagnostics in `/Users/sipke/Projects/ValenceWorks/aster/src/core/Aster.Core/Services/ResourceLifecycleRestoreService.cs`
+- [X] T039 [US3] Implement marker-state mismatch diagnostics that leave current markers untouched in `/Users/sipke/Projects/ValenceWorks/aster/src/core/Aster.Core/Services/ResourceLifecycleRestoreService.cs`
+- [X] T040 [US3] Implement duplicate candidate memoization and deterministic skipped/already-restored behavior in `/Users/sipke/Projects/ValenceWorks/aster/src/core/Aster.Core/Services/ResourceLifecycleRestoreService.cs`
+- [X] T041 [US3] Compute preview and application aggregate counts from candidate results in `/Users/sipke/Projects/ValenceWorks/aster/src/core/Aster.Core/Models/Instances/ResourceLifecycleRestore.cs`
+- [X] T042 [US3] Ensure SQLite JSON lifecycle marker deletes are tenant-scoped in `/Users/sipke/Projects/ValenceWorks/aster/src/persistence/Aster.Persistence.SqliteJson/SqliteJsonResourceStore.cs`
+- [X] T043 [US3] Run focused P3 tests with `/usr/local/share/dotnet/dotnet test /Users/sipke/Projects/ValenceWorks/aster/Aster.sln --filter "LifecycleRestore|TenantLifecycleRestore|SqliteJsonLifecycleRestore"`
+
+**Checkpoint**: All user stories are independently functional.
+
+---
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+**Purpose**: Documentation, compatibility, and final verification.
+
+- [X] T044 [P] Update lifecycle marker documentation in `/Users/sipke/Projects/ValenceWorks/aster/src/core/Aster.Core/README.md`
+- [X] T045 [P] Update SQLite JSON provider documentation in `/Users/sipke/Projects/ValenceWorks/aster/src/persistence/Aster.Persistence.SqliteJson/README.md`
+- [X] T046 [P] Update roadmap/status documentation in `/Users/sipke/Projects/ValenceWorks/aster/docs/ExecutionRoadmap.md`
+- [X] T047 Validate quickstart examples against implemented APIs in `/Users/sipke/Projects/ValenceWorks/aster/specs/018-lifecycle-restore-workflows/quickstart.md`
+- [X] T048 Run all tests with `/usr/local/share/dotnet/dotnet test /Users/sipke/Projects/ValenceWorks/aster/Aster.sln`
+- [X] T049 Run full build with `/usr/local/share/dotnet/dotnet build /Users/sipke/Projects/ValenceWorks/aster/Aster.sln /m:1`
+- [X] T050 Run whitespace validation with `git diff --check` in `/Users/sipke/Projects/ValenceWorks/aster`
+- [X] T051 Re-run constitution check and remove unnecessary abstractions or dependencies in `/Users/sipke/Projects/ValenceWorks/aster/specs/018-lifecycle-restore-workflows/plan.md`
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies.
+- **Foundational (Phase 2)**: Depends on Setup and blocks all user stories.
+- **User Story 1 (Phase 3)**: Depends on Foundational and is the MVP.
+- **User Story 2 (Phase 4)**: Depends on Foundational; can be implemented after or alongside US1 if shared restore helpers stay compatible.
+- **User Story 3 (Phase 5)**: Depends on Foundational and should follow US1/US2 because it hardens shared result and diagnostic behavior.
+- **Polish (Phase 6)**: Depends on selected user stories being complete.
+
+### User Story Dependencies
+
+- **US1 Restore Marked Resources**: No dependency on other user stories after Foundational.
+- **US2 Preview Restore Outcomes**: No product dependency on US1, but implementation should reuse shared validation/evaluation helpers from US1 where available.
+- **US3 Deterministic Results**: Builds on shared result models and restore service behavior from US1/US2.
+
+### Parallel Opportunities
+
+- T006, T008, and T009 can be done in parallel after setup.
+- T010 and T011 can be done in parallel after T007.
+- US1 tests T015, T017, and T018 can be written in parallel.
+- US2 test file T024-T026 should be edited serially because all tasks share one file.
+- US3 tests T031, T033, T035, and T036 can be written in parallel.
+- Documentation tasks T044-T046 can be done in parallel after implementation behavior is stable.
+
+---
+
+## Parallel Example: User Story 1
+
+```text
+Task: "T015 [P] [US1] Add archive and soft-delete restore success tests in /Users/sipke/Projects/ValenceWorks/aster/test/Aster.Tests/Lifecycle/LifecycleRestoreServiceTests.cs"
+Task: "T017 [P] [US1] Add resource version and activation preservation tests in /Users/sipke/Projects/ValenceWorks/aster/test/Aster.Tests/Lifecycle/LifecycleRestoreActivationTests.cs"
+Task: "T018 [P] [US1] Add lifecycle-state query after restore regression test in /Users/sipke/Projects/ValenceWorks/aster/test/Aster.Tests/Querying/LifecycleStateQueryTests.cs"
+```
+
+## Parallel Example: User Story 3
+
+```text
+Task: "T033 [P] [US3] Add invalid candidate and unsupported state diagnostic tests in /Users/sipke/Projects/ValenceWorks/aster/test/Aster.Tests/Lifecycle/LifecycleRestoreDiagnosticsTests.cs"
+Task: "T035 [P] [US3] Add tenant-scoped restore isolation tests in /Users/sipke/Projects/ValenceWorks/aster/test/Aster.Tests/Tenancy/TenantLifecycleRestoreTests.cs"
+Task: "T036 [P] [US3] Add SQLite JSON restore compatibility tests in /Users/sipke/Projects/ValenceWorks/aster/test/Aster.Tests/SqliteJson/SqliteJsonLifecycleRestoreTests.cs"
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 Only)
+
+1. Complete Phase 1 setup.
+2. Complete Phase 2 foundational contracts, models, clear capability, and DI registration.
+3. Write failing US1 tests.
+4. Implement restore application success path.
+5. Validate with focused US1 tests before moving to preview or diagnostic hardening.
+
+### Incremental Delivery
+
+1. Add US1 restore application for explicit archive/soft-delete marker clearing.
+2. Add US2 non-mutating preview over the same candidate evaluation rules.
+3. Add US3 deterministic diagnostics, duplicates, tenant isolation, and SQLite compatibility.
+4. Complete docs and full-suite validation.
+
+### Guardrails
+
+- Do not add a scheduler, policy engine, authorization system, provider registry, public SQL, public `IQueryable<Resource>`, destructive pruning writes, or a lifecycle state machine.
+- Do not rewrite resource versions or change activation state.
+- Keep restore behavior candidate-bounded and tenant-scoped.
+- Keep provider changes limited to marker clear support over existing marker storage.

--- a/specs/018-lifecycle-restore-workflows/tasks.md
+++ b/specs/018-lifecycle-restore-workflows/tasks.md
@@ -11,11 +11,11 @@
 
 **Purpose**: Confirm baseline and feature context before shared implementation.
 
-- [X] T001 Read lifecycle restore requirements in `/Users/sipke/Projects/ValenceWorks/aster/specs/018-lifecycle-restore-workflows/spec.md`
-- [X] T002 Read restore planning and contract decisions in `/Users/sipke/Projects/ValenceWorks/aster/specs/018-lifecycle-restore-workflows/plan.md`
-- [X] T003 Inspect existing lifecycle marker service/store contracts in `/Users/sipke/Projects/ValenceWorks/aster/src/core/Aster.Core/Abstractions/IResourceLifecycleMarkerStore.cs`
-- [X] T004 Inspect existing lifecycle marker implementation in `/Users/sipke/Projects/ValenceWorks/aster/src/core/Aster.Core/Services/ResourceLifecycleMarkerService.cs`
-- [X] T005 Run baseline restore/build with `/usr/local/share/dotnet/dotnet restore /Users/sipke/Projects/ValenceWorks/aster/Aster.sln`
+- [X] T001 Read lifecycle restore requirements in `specs/018-lifecycle-restore-workflows/spec.md`
+- [X] T002 Read restore planning and contract decisions in `specs/018-lifecycle-restore-workflows/plan.md`
+- [X] T003 Inspect existing lifecycle marker service/store contracts in `src/core/Aster.Core/Abstractions/IResourceLifecycleMarkerStore.cs`
+- [X] T004 Inspect existing lifecycle marker implementation in `src/core/Aster.Core/Services/ResourceLifecycleMarkerService.cs`
+- [X] T005 Run baseline restore/build with `dotnet restore Aster.sln`
 
 ---
 
@@ -25,15 +25,15 @@
 
 **CRITICAL**: No user story implementation should begin until these are complete.
 
-- [X] T006 [P] Add `IResourceLifecycleRestoreService` contract in `/Users/sipke/Projects/ValenceWorks/aster/src/core/Aster.Core/Abstractions/IResourceLifecycleRestoreService.cs`
-- [X] T007 Add `IResourceLifecycleMarkerClearStore` provider capability in `/Users/sipke/Projects/ValenceWorks/aster/src/core/Aster.Core/Abstractions/IResourceLifecycleMarkerStore.cs`
-- [X] T008 [P] Add lifecycle restore request/result/status models in `/Users/sipke/Projects/ValenceWorks/aster/src/core/Aster.Core/Models/Instances/ResourceLifecycleRestore.cs`
-- [X] T009 [P] Add stable restore diagnostic codes in `/Users/sipke/Projects/ValenceWorks/aster/src/core/Aster.Core/Models/Policies/ResourcePolicyResults.cs`
-- [X] T010 Implement `IResourceLifecycleMarkerClearStore.ClearMarkerAsync` for in-memory markers in `/Users/sipke/Projects/ValenceWorks/aster/src/core/Aster.Core/InMemory/InMemoryResourceLifecycleMarkerStore.cs`
-- [X] T011 Implement `IResourceLifecycleMarkerClearStore.ClearMarkerAsync` for SQLite JSON markers in `/Users/sipke/Projects/ValenceWorks/aster/src/persistence/Aster.Persistence.SqliteJson/SqliteJsonResourceStore.cs`
-- [X] T012 Register `IResourceLifecycleMarkerClearStore` and `IResourceLifecycleRestoreService` in `/Users/sipke/Projects/ValenceWorks/aster/src/core/Aster.Core/Extensions/AsterCoreServiceCollectionExtensions.cs`
-- [X] T013 Register SQLite JSON `IResourceLifecycleMarkerClearStore` replacement in `/Users/sipke/Projects/ValenceWorks/aster/src/persistence/Aster.Persistence.SqliteJson/SqliteJsonAsterServiceCollectionExtensions.cs`
-- [X] T014 Run foundational compile with `/usr/local/share/dotnet/dotnet build /Users/sipke/Projects/ValenceWorks/aster/Aster.sln /m:1`
+- [X] T006 [P] Add `IResourceLifecycleRestoreService` contract in `src/core/Aster.Core/Abstractions/IResourceLifecycleRestoreService.cs`
+- [X] T007 Add `IResourceLifecycleMarkerClearStore` provider capability in `src/core/Aster.Core/Abstractions/IResourceLifecycleMarkerStore.cs`
+- [X] T008 [P] Add lifecycle restore request/result/status models in `src/core/Aster.Core/Models/Instances/ResourceLifecycleRestore.cs`
+- [X] T009 [P] Add stable restore diagnostic codes in `src/core/Aster.Core/Models/Policies/ResourcePolicyResults.cs`
+- [X] T010 Implement `IResourceLifecycleMarkerClearStore.ClearMarkerAsync` for in-memory markers in `src/core/Aster.Core/InMemory/InMemoryResourceLifecycleMarkerStore.cs`
+- [X] T011 Implement `IResourceLifecycleMarkerClearStore.ClearMarkerAsync` for SQLite JSON markers in `src/persistence/Aster.Persistence.SqliteJson/SqliteJsonResourceStore.cs`
+- [X] T012 Register `IResourceLifecycleMarkerClearStore` and `IResourceLifecycleRestoreService` in `src/core/Aster.Core/Extensions/AsterCoreServiceCollectionExtensions.cs`
+- [X] T013 Register SQLite JSON `IResourceLifecycleMarkerClearStore` replacement in `src/persistence/Aster.Persistence.SqliteJson/SqliteJsonAsterServiceCollectionExtensions.cs`
+- [X] T014 Run foundational compile with `dotnet build Aster.sln /m:1`
 
 **Checkpoint**: Contracts and provider clear capability compile; user story implementation can proceed.
 
@@ -47,18 +47,18 @@
 
 ### Tests for User Story 1
 
-- [X] T015 [P] [US1] Add archive and soft-delete restore success tests in `/Users/sipke/Projects/ValenceWorks/aster/test/Aster.Tests/Lifecycle/LifecycleRestoreServiceTests.cs`
-- [X] T016 [US1] Add subset restore and unselected marker preservation tests in `/Users/sipke/Projects/ValenceWorks/aster/test/Aster.Tests/Lifecycle/LifecycleRestoreServiceTests.cs`
-- [X] T017 [P] [US1] Add resource version and activation preservation tests in `/Users/sipke/Projects/ValenceWorks/aster/test/Aster.Tests/Lifecycle/LifecycleRestoreActivationTests.cs`
-- [X] T018 [P] [US1] Add lifecycle-state query after restore regression test in `/Users/sipke/Projects/ValenceWorks/aster/test/Aster.Tests/Querying/LifecycleStateQueryTests.cs`
+- [X] T015 [P] [US1] Add archive and soft-delete restore success tests in `test/Aster.Tests/Lifecycle/LifecycleRestoreServiceTests.cs`
+- [X] T016 [US1] Add subset restore and unselected marker preservation tests in `test/Aster.Tests/Lifecycle/LifecycleRestoreServiceTests.cs`
+- [X] T017 [P] [US1] Add resource version and activation preservation tests in `test/Aster.Tests/Lifecycle/LifecycleRestoreActivationTests.cs`
+- [X] T018 [P] [US1] Add lifecycle-state query after restore regression test in `test/Aster.Tests/Querying/LifecycleStateQueryTests.cs`
 
 ### Implementation for User Story 1
 
-- [X] T019 [US1] Implement `ResourceLifecycleRestoreService.RestoreAsync` success path in `/Users/sipke/Projects/ValenceWorks/aster/src/core/Aster.Core/Services/ResourceLifecycleRestoreService.cs`
-- [X] T020 [US1] Add candidate-bounded latest-resource and marker reads by distinct candidate resource IDs to restore application in `/Users/sipke/Projects/ValenceWorks/aster/src/core/Aster.Core/Services/ResourceLifecycleRestoreService.cs`
-- [X] T021 [US1] Clear matching archive and soft-delete markers through `IResourceLifecycleMarkerClearStore` in `/Users/sipke/Projects/ValenceWorks/aster/src/core/Aster.Core/Services/ResourceLifecycleRestoreService.cs`
-- [X] T022 [US1] Preserve versions and activation state by avoiding resource writer and activation dependencies in `/Users/sipke/Projects/ValenceWorks/aster/src/core/Aster.Core/Services/ResourceLifecycleRestoreService.cs`
-- [X] T023 [US1] Run focused P1 tests with `/usr/local/share/dotnet/dotnet test /Users/sipke/Projects/ValenceWorks/aster/Aster.sln --filter "LifecycleRestore|LifecycleStateQuery"`
+- [X] T019 [US1] Implement `ResourceLifecycleRestoreService.RestoreAsync` success path in `src/core/Aster.Core/Services/ResourceLifecycleRestoreService.cs`
+- [X] T020 [US1] Add candidate-bounded latest-resource and marker reads by distinct candidate resource IDs to restore application in `src/core/Aster.Core/Services/ResourceLifecycleRestoreService.cs`
+- [X] T021 [US1] Clear matching archive and soft-delete markers through `IResourceLifecycleMarkerClearStore` in `src/core/Aster.Core/Services/ResourceLifecycleRestoreService.cs`
+- [X] T022 [US1] Preserve versions and activation state by avoiding resource writer and activation dependencies in `src/core/Aster.Core/Services/ResourceLifecycleRestoreService.cs`
+- [X] T023 [US1] Run focused P1 tests with `dotnet test Aster.sln --filter "LifecycleRestore|LifecycleStateQuery"`
 
 **Checkpoint**: User Story 1 is independently functional and testable.
 
@@ -72,16 +72,16 @@
 
 ### Tests for User Story 2
 
-- [X] T024 [P] [US2] Add preview restorable, already-restored, duplicate-skipped, and empty-request tests in `/Users/sipke/Projects/ValenceWorks/aster/test/Aster.Tests/Lifecycle/LifecycleRestorePreviewTests.cs`
-- [X] T025 [US2] Add preview marker-mismatch and missing-target diagnostic tests in `/Users/sipke/Projects/ValenceWorks/aster/test/Aster.Tests/Lifecycle/LifecycleRestorePreviewTests.cs`
-- [X] T026 [US2] Add preview no-mutation regression tests, including invalid and unsupported candidate no-clear assertions, in `/Users/sipke/Projects/ValenceWorks/aster/test/Aster.Tests/Lifecycle/LifecycleRestorePreviewTests.cs`
+- [X] T024 [P] [US2] Add preview restorable, already-restored, duplicate-skipped, and empty-request tests in `test/Aster.Tests/Lifecycle/LifecycleRestorePreviewTests.cs`
+- [X] T025 [US2] Add preview marker-mismatch and missing-target diagnostic tests in `test/Aster.Tests/Lifecycle/LifecycleRestorePreviewTests.cs`
+- [X] T026 [US2] Add preview no-mutation regression tests, including invalid and unsupported candidate no-clear assertions, in `test/Aster.Tests/Lifecycle/LifecycleRestorePreviewTests.cs`
 
 ### Implementation for User Story 2
 
-- [X] T027 [US2] Implement `ResourceLifecycleRestoreService.PreviewRestoreAsync` in `/Users/sipke/Projects/ValenceWorks/aster/src/core/Aster.Core/Services/ResourceLifecycleRestoreService.cs`
-- [X] T028 [US2] Extract shared candidate validation/evaluation helper for preview and application in `/Users/sipke/Projects/ValenceWorks/aster/src/core/Aster.Core/Services/ResourceLifecycleRestoreService.cs`
-- [X] T029 [US2] Ensure preview never calls `ClearMarkerAsync` in `/Users/sipke/Projects/ValenceWorks/aster/src/core/Aster.Core/Services/ResourceLifecycleRestoreService.cs`
-- [X] T030 [US2] Run focused P2 tests with `/usr/local/share/dotnet/dotnet test /Users/sipke/Projects/ValenceWorks/aster/Aster.sln --filter "LifecycleRestorePreview|LifecycleRestore"`
+- [X] T027 [US2] Implement `ResourceLifecycleRestoreService.PreviewRestoreAsync` in `src/core/Aster.Core/Services/ResourceLifecycleRestoreService.cs`
+- [X] T028 [US2] Extract shared candidate validation/evaluation helper for preview and application in `src/core/Aster.Core/Services/ResourceLifecycleRestoreService.cs`
+- [X] T029 [US2] Ensure preview never calls `ClearMarkerAsync` in `src/core/Aster.Core/Services/ResourceLifecycleRestoreService.cs`
+- [X] T030 [US2] Run focused P2 tests with `dotnet test Aster.sln --filter "LifecycleRestorePreview|LifecycleRestore"`
 
 **Checkpoint**: User Stories 1 and 2 both work independently.
 
@@ -95,22 +95,22 @@
 
 ### Tests for User Story 3
 
-- [X] T031 [P] [US3] Add restore aggregate counts, empty-request, and one-result-per-input tests in `/Users/sipke/Projects/ValenceWorks/aster/test/Aster.Tests/Lifecycle/LifecycleRestoreResultTests.cs`
-- [X] T032 [US3] Add duplicate candidate determinism tests in `/Users/sipke/Projects/ValenceWorks/aster/test/Aster.Tests/Lifecycle/LifecycleRestoreResultTests.cs`
-- [X] T033 [P] [US3] Add invalid candidate and unsupported state diagnostic tests with no-marker-cleared assertions in `/Users/sipke/Projects/ValenceWorks/aster/test/Aster.Tests/Lifecycle/LifecycleRestoreDiagnosticsTests.cs`
-- [X] T034 [US3] Add missing target, marker-mismatch, and stale-preview-before-apply application diagnostic tests in `/Users/sipke/Projects/ValenceWorks/aster/test/Aster.Tests/Lifecycle/LifecycleRestoreDiagnosticsTests.cs`
-- [X] T035 [P] [US3] Add tenant-scoped restore isolation and omitted default tenant scope tests in `/Users/sipke/Projects/ValenceWorks/aster/test/Aster.Tests/Tenancy/TenantLifecycleRestoreTests.cs`
-- [X] T036 [P] [US3] Add SQLite JSON restore compatibility tests in `/Users/sipke/Projects/ValenceWorks/aster/test/Aster.Tests/SqliteJson/SqliteJsonLifecycleRestoreTests.cs`
+- [X] T031 [P] [US3] Add restore aggregate counts, empty-request, and one-result-per-input tests in `test/Aster.Tests/Lifecycle/LifecycleRestoreResultTests.cs`
+- [X] T032 [US3] Add duplicate candidate determinism tests in `test/Aster.Tests/Lifecycle/LifecycleRestoreResultTests.cs`
+- [X] T033 [P] [US3] Add invalid candidate and unsupported state diagnostic tests with no-marker-cleared assertions in `test/Aster.Tests/Lifecycle/LifecycleRestoreDiagnosticsTests.cs`
+- [X] T034 [US3] Add missing target, marker-mismatch, and stale-preview-before-apply application diagnostic tests in `test/Aster.Tests/Lifecycle/LifecycleRestoreDiagnosticsTests.cs`
+- [X] T035 [P] [US3] Add tenant-scoped restore isolation and omitted default tenant scope tests in `test/Aster.Tests/Tenancy/TenantLifecycleRestoreTests.cs`
+- [X] T036 [P] [US3] Add SQLite JSON restore compatibility tests in `test/Aster.Tests/SqliteJson/SqliteJsonLifecycleRestoreTests.cs`
 
 ### Implementation for User Story 3
 
-- [X] T037 [US3] Implement invalid candidate and unsupported state diagnostics in `/Users/sipke/Projects/ValenceWorks/aster/src/core/Aster.Core/Services/ResourceLifecycleRestoreService.cs`
-- [X] T038 [US3] Implement missing target and tenant-scoped target-not-found diagnostics in `/Users/sipke/Projects/ValenceWorks/aster/src/core/Aster.Core/Services/ResourceLifecycleRestoreService.cs`
-- [X] T039 [US3] Implement marker-state mismatch diagnostics that leave current markers untouched in `/Users/sipke/Projects/ValenceWorks/aster/src/core/Aster.Core/Services/ResourceLifecycleRestoreService.cs`
-- [X] T040 [US3] Implement duplicate candidate memoization and deterministic skipped/already-restored behavior in `/Users/sipke/Projects/ValenceWorks/aster/src/core/Aster.Core/Services/ResourceLifecycleRestoreService.cs`
-- [X] T041 [US3] Compute preview and application aggregate counts from candidate results in `/Users/sipke/Projects/ValenceWorks/aster/src/core/Aster.Core/Models/Instances/ResourceLifecycleRestore.cs`
-- [X] T042 [US3] Ensure SQLite JSON lifecycle marker deletes are tenant-scoped in `/Users/sipke/Projects/ValenceWorks/aster/src/persistence/Aster.Persistence.SqliteJson/SqliteJsonResourceStore.cs`
-- [X] T043 [US3] Run focused P3 tests with `/usr/local/share/dotnet/dotnet test /Users/sipke/Projects/ValenceWorks/aster/Aster.sln --filter "LifecycleRestore|TenantLifecycleRestore|SqliteJsonLifecycleRestore"`
+- [X] T037 [US3] Implement invalid candidate and unsupported state diagnostics in `src/core/Aster.Core/Services/ResourceLifecycleRestoreService.cs`
+- [X] T038 [US3] Implement missing target and tenant-scoped target-not-found diagnostics in `src/core/Aster.Core/Services/ResourceLifecycleRestoreService.cs`
+- [X] T039 [US3] Implement marker-state mismatch diagnostics that leave current markers untouched in `src/core/Aster.Core/Services/ResourceLifecycleRestoreService.cs`
+- [X] T040 [US3] Implement duplicate candidate memoization and deterministic skipped/already-restored behavior in `src/core/Aster.Core/Services/ResourceLifecycleRestoreService.cs`
+- [X] T041 [US3] Compute preview and application aggregate counts from candidate results in `src/core/Aster.Core/Models/Instances/ResourceLifecycleRestore.cs`
+- [X] T042 [US3] Ensure SQLite JSON lifecycle marker deletes are tenant-scoped in `src/persistence/Aster.Persistence.SqliteJson/SqliteJsonResourceStore.cs`
+- [X] T043 [US3] Run focused P3 tests with `dotnet test Aster.sln --filter "LifecycleRestore|TenantLifecycleRestore|SqliteJsonLifecycleRestore"`
 
 **Checkpoint**: All user stories are independently functional.
 
@@ -120,14 +120,14 @@
 
 **Purpose**: Documentation, compatibility, and final verification.
 
-- [X] T044 [P] Update lifecycle marker documentation in `/Users/sipke/Projects/ValenceWorks/aster/src/core/Aster.Core/README.md`
-- [X] T045 [P] Update SQLite JSON provider documentation in `/Users/sipke/Projects/ValenceWorks/aster/src/persistence/Aster.Persistence.SqliteJson/README.md`
-- [X] T046 [P] Update roadmap/status documentation in `/Users/sipke/Projects/ValenceWorks/aster/docs/ExecutionRoadmap.md`
-- [X] T047 Validate quickstart examples against implemented APIs in `/Users/sipke/Projects/ValenceWorks/aster/specs/018-lifecycle-restore-workflows/quickstart.md`
-- [X] T048 Run all tests with `/usr/local/share/dotnet/dotnet test /Users/sipke/Projects/ValenceWorks/aster/Aster.sln`
-- [X] T049 Run full build with `/usr/local/share/dotnet/dotnet build /Users/sipke/Projects/ValenceWorks/aster/Aster.sln /m:1`
-- [X] T050 Run whitespace validation with `git diff --check` in `/Users/sipke/Projects/ValenceWorks/aster`
-- [X] T051 Re-run constitution check and remove unnecessary abstractions or dependencies in `/Users/sipke/Projects/ValenceWorks/aster/specs/018-lifecycle-restore-workflows/plan.md`
+- [X] T044 [P] Update lifecycle marker documentation in `src/core/Aster.Core/README.md`
+- [X] T045 [P] Update SQLite JSON provider documentation in `src/persistence/Aster.Persistence.SqliteJson/README.md`
+- [X] T046 [P] Update roadmap/status documentation in `docs/ExecutionRoadmap.md`
+- [X] T047 Validate quickstart examples against implemented APIs in `specs/018-lifecycle-restore-workflows/quickstart.md`
+- [X] T048 Run all tests with `dotnet test Aster.sln`
+- [X] T049 Run full build with `dotnet build Aster.sln /m:1`
+- [X] T050 Run whitespace validation with `git diff --check`
+- [X] T051 Re-run constitution check and remove unnecessary abstractions or dependencies in `specs/018-lifecycle-restore-workflows/plan.md`
 
 ---
 
@@ -162,17 +162,17 @@
 ## Parallel Example: User Story 1
 
 ```text
-Task: "T015 [P] [US1] Add archive and soft-delete restore success tests in /Users/sipke/Projects/ValenceWorks/aster/test/Aster.Tests/Lifecycle/LifecycleRestoreServiceTests.cs"
-Task: "T017 [P] [US1] Add resource version and activation preservation tests in /Users/sipke/Projects/ValenceWorks/aster/test/Aster.Tests/Lifecycle/LifecycleRestoreActivationTests.cs"
-Task: "T018 [P] [US1] Add lifecycle-state query after restore regression test in /Users/sipke/Projects/ValenceWorks/aster/test/Aster.Tests/Querying/LifecycleStateQueryTests.cs"
+Task: "T015 [P] [US1] Add archive and soft-delete restore success tests in test/Aster.Tests/Lifecycle/LifecycleRestoreServiceTests.cs"
+Task: "T017 [P] [US1] Add resource version and activation preservation tests in test/Aster.Tests/Lifecycle/LifecycleRestoreActivationTests.cs"
+Task: "T018 [P] [US1] Add lifecycle-state query after restore regression test in test/Aster.Tests/Querying/LifecycleStateQueryTests.cs"
 ```
 
 ## Parallel Example: User Story 3
 
 ```text
-Task: "T033 [P] [US3] Add invalid candidate and unsupported state diagnostic tests in /Users/sipke/Projects/ValenceWorks/aster/test/Aster.Tests/Lifecycle/LifecycleRestoreDiagnosticsTests.cs"
-Task: "T035 [P] [US3] Add tenant-scoped restore isolation tests in /Users/sipke/Projects/ValenceWorks/aster/test/Aster.Tests/Tenancy/TenantLifecycleRestoreTests.cs"
-Task: "T036 [P] [US3] Add SQLite JSON restore compatibility tests in /Users/sipke/Projects/ValenceWorks/aster/test/Aster.Tests/SqliteJson/SqliteJsonLifecycleRestoreTests.cs"
+Task: "T033 [P] [US3] Add invalid candidate and unsupported state diagnostic tests in test/Aster.Tests/Lifecycle/LifecycleRestoreDiagnosticsTests.cs"
+Task: "T035 [P] [US3] Add tenant-scoped restore isolation tests in test/Aster.Tests/Tenancy/TenantLifecycleRestoreTests.cs"
+Task: "T036 [P] [US3] Add SQLite JSON restore compatibility tests in test/Aster.Tests/SqliteJson/SqliteJsonLifecycleRestoreTests.cs"
 ```
 
 ---

--- a/src/core/Aster.Core/Abstractions/IResourceLifecycleMarkerStore.cs
+++ b/src/core/Aster.Core/Abstractions/IResourceLifecycleMarkerStore.cs
@@ -38,12 +38,13 @@ public interface IResourceLifecycleMarkerStore
 public interface IResourceLifecycleMarkerClearStore : IResourceLifecycleMarkerStore
 {
     /// <summary>
-    /// Removes the effective lifecycle marker for a resource in the supplied tenant.
+    /// Removes the effective lifecycle marker for a resource in the supplied tenant when its state matches the expected state.
     /// </summary>
-    /// <returns><see langword="true" /> when a marker existed and was removed; otherwise <see langword="false" />.</returns>
+    /// <returns><see langword="true" /> when a matching marker existed and was removed; otherwise <see langword="false" />.</returns>
     ValueTask<bool> ClearMarkerAsync(
         string resourceId,
         TenantScope tenantScope,
+        ResourceLifecycleMarkerState expectedState,
         CancellationToken cancellationToken = default);
 }
 

--- a/src/core/Aster.Core/Abstractions/IResourceLifecycleMarkerStore.cs
+++ b/src/core/Aster.Core/Abstractions/IResourceLifecycleMarkerStore.cs
@@ -33,6 +33,21 @@ public interface IResourceLifecycleMarkerStore
 }
 
 /// <summary>
+/// Provider-facing storage capability for removing explicit lifecycle markers.
+/// </summary>
+public interface IResourceLifecycleMarkerClearStore : IResourceLifecycleMarkerStore
+{
+    /// <summary>
+    /// Removes the effective lifecycle marker for a resource in the supplied tenant.
+    /// </summary>
+    /// <returns><see langword="true" /> when a marker existed and was removed; otherwise <see langword="false" />.</returns>
+    ValueTask<bool> ClearMarkerAsync(
+        string resourceId,
+        TenantScope tenantScope,
+        CancellationToken cancellationToken = default);
+}
+
+/// <summary>
 /// Host-facing service for explicit archive and soft-delete marker writes.
 /// </summary>
 public interface IResourceLifecycleMarkerService

--- a/src/core/Aster.Core/Abstractions/IResourceLifecycleRestoreService.cs
+++ b/src/core/Aster.Core/Abstractions/IResourceLifecycleRestoreService.cs
@@ -1,0 +1,23 @@
+using Aster.Core.Models.Instances;
+
+namespace Aster.Core.Abstractions;
+
+/// <summary>
+/// Host-facing lifecycle restore workflow service.
+/// </summary>
+public interface IResourceLifecycleRestoreService
+{
+    /// <summary>
+    /// Previews lifecycle marker restoration without mutating marker state.
+    /// </summary>
+    ValueTask<ResourceLifecycleRestorePreviewResult> PreviewRestoreAsync(
+        ResourceLifecycleRestoreRequest request,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Restores selected archive or soft-delete markers by clearing matching marker state.
+    /// </summary>
+    ValueTask<ResourceLifecycleRestoreApplicationResult> RestoreAsync(
+        ResourceLifecycleRestoreRequest request,
+        CancellationToken cancellationToken = default);
+}

--- a/src/core/Aster.Core/Extensions/AsterCoreServiceCollectionExtensions.cs
+++ b/src/core/Aster.Core/Extensions/AsterCoreServiceCollectionExtensions.cs
@@ -84,6 +84,7 @@ public static class AsterCoreServiceCollectionExtensions
         services.AddSingleton<IResourcePortabilityStore>(sp => sp.GetRequiredService<InMemoryPortabilityStore>());
         services.AddSingleton<InMemoryResourceLifecycleMarkerStore>();
         services.AddSingleton<IResourceLifecycleMarkerStore>(sp => sp.GetRequiredService<InMemoryResourceLifecycleMarkerStore>());
+        services.AddSingleton<IResourceLifecycleMarkerClearStore>(sp => sp.GetRequiredService<InMemoryResourceLifecycleMarkerStore>());
 
         // Resource manager
         services.AddSingleton<InMemoryResourceManager>();
@@ -97,6 +98,7 @@ public static class AsterCoreServiceCollectionExtensions
         services.AddSingleton<IResourcePolicyEvaluationService, ResourcePolicyEvaluationService>();
         services.AddSingleton<IResourcePolicyApplicationService, ResourcePolicyApplicationService>();
         services.AddSingleton<IResourceLifecycleMarkerService, ResourceLifecycleMarkerService>();
+        services.AddSingleton<IResourceLifecycleRestoreService, ResourceLifecycleRestoreService>();
 
         // Query service
         services.AddSingleton<InMemoryQueryService>();

--- a/src/core/Aster.Core/Extensions/AsterCoreServiceCollectionExtensions.cs
+++ b/src/core/Aster.Core/Extensions/AsterCoreServiceCollectionExtensions.cs
@@ -84,7 +84,7 @@ public static class AsterCoreServiceCollectionExtensions
         services.AddSingleton<IResourcePortabilityStore>(sp => sp.GetRequiredService<InMemoryPortabilityStore>());
         services.AddSingleton<InMemoryResourceLifecycleMarkerStore>();
         services.AddSingleton<IResourceLifecycleMarkerStore>(sp => sp.GetRequiredService<InMemoryResourceLifecycleMarkerStore>());
-        services.AddSingleton<IResourceLifecycleMarkerClearStore>(sp => sp.GetRequiredService<InMemoryResourceLifecycleMarkerStore>());
+        services.AddSingleton<IResourceLifecycleMarkerClearStore>(ResolveResourceLifecycleMarkerClearStore);
 
         // Resource manager
         services.AddSingleton<InMemoryResourceManager>();
@@ -116,5 +116,13 @@ public static class AsterCoreServiceCollectionExtensions
         services.AddSingleton<ITypedFacetBinder>(sp => sp.GetRequiredService<SystemTextJsonFacetBinder>());
 
         return services;
+    }
+
+    private static IResourceLifecycleMarkerClearStore ResolveResourceLifecycleMarkerClearStore(IServiceProvider serviceProvider)
+    {
+        var markerStore = serviceProvider.GetRequiredService<IResourceLifecycleMarkerStore>();
+        return markerStore as IResourceLifecycleMarkerClearStore
+            ?? throw new InvalidOperationException(
+                $"The active {nameof(IResourceLifecycleMarkerStore)} registration must also implement {nameof(IResourceLifecycleMarkerClearStore)} to use lifecycle restore workflows.");
     }
 }

--- a/src/core/Aster.Core/InMemory/InMemoryResourceLifecycleMarkerStore.cs
+++ b/src/core/Aster.Core/InMemory/InMemoryResourceLifecycleMarkerStore.cs
@@ -9,7 +9,7 @@ namespace Aster.Core.InMemory;
 /// <summary>
 /// In-memory lifecycle marker storage.
 /// </summary>
-public sealed class InMemoryResourceLifecycleMarkerStore : IResourceLifecycleMarkerStore
+public sealed class InMemoryResourceLifecycleMarkerStore : IResourceLifecycleMarkerClearStore
 {
     private readonly ConcurrentDictionary<(string TenantId, string ResourceId), ResourceLifecycleMarker> markers = [];
 
@@ -59,6 +59,18 @@ public sealed class InMemoryResourceLifecycleMarkerStore : IResourceLifecycleMar
         var scopedMarker = marker with { TenantScope = tenant };
         markers[(tenant.TenantId, scopedMarker.ResourceId)] = scopedMarker;
         return ValueTask.FromResult(scopedMarker);
+    }
+
+    /// <inheritdoc />
+    public ValueTask<bool> ClearMarkerAsync(
+        string resourceId,
+        TenantScope tenantScope,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(resourceId);
+        cancellationToken.ThrowIfCancellationRequested();
+        var tenant = TenantScopeResolver.Resolve(tenantScope);
+        return ValueTask.FromResult(markers.TryRemove((tenant.TenantId, resourceId), out _));
     }
 
     internal void RestoreMarker(ResourceLifecycleMarker marker) =>

--- a/src/core/Aster.Core/InMemory/InMemoryResourceLifecycleMarkerStore.cs
+++ b/src/core/Aster.Core/InMemory/InMemoryResourceLifecycleMarkerStore.cs
@@ -65,12 +65,27 @@ public sealed class InMemoryResourceLifecycleMarkerStore : IResourceLifecycleMar
     public ValueTask<bool> ClearMarkerAsync(
         string resourceId,
         TenantScope tenantScope,
+        ResourceLifecycleMarkerState expectedState,
         CancellationToken cancellationToken = default)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(resourceId);
         cancellationToken.ThrowIfCancellationRequested();
         var tenant = TenantScopeResolver.Resolve(tenantScope);
-        return ValueTask.FromResult(markers.TryRemove((tenant.TenantId, resourceId), out _));
+        var key = (tenant.TenantId, resourceId);
+
+        while (markers.TryGetValue(key, out var current))
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            if (current.State != expectedState)
+                return ValueTask.FromResult(false);
+
+            var removed = ((ICollection<KeyValuePair<(string TenantId, string ResourceId), ResourceLifecycleMarker>>)markers)
+                .Remove(new KeyValuePair<(string TenantId, string ResourceId), ResourceLifecycleMarker>(key, current));
+            if (removed)
+                return ValueTask.FromResult(true);
+        }
+
+        return ValueTask.FromResult(false);
     }
 
     internal void RestoreMarker(ResourceLifecycleMarker marker) =>

--- a/src/core/Aster.Core/Models/Instances/ResourceLifecycleRestore.cs
+++ b/src/core/Aster.Core/Models/Instances/ResourceLifecycleRestore.cs
@@ -107,7 +107,7 @@ public sealed record ResourceLifecycleRestoreCandidateResult
     /// <summary>Marker observed before the candidate outcome, when available.</summary>
     public ResourceLifecycleMarker? Marker { get; init; }
 
-    /// <summary>Stable diagnostics for failed or skipped candidates.</summary>
+    /// <summary>Stable diagnostics for failed candidates.</summary>
     public IReadOnlyList<ResourcePolicyDiagnostic> Diagnostics { get; init; } = [];
 }
 

--- a/src/core/Aster.Core/Models/Instances/ResourceLifecycleRestore.cs
+++ b/src/core/Aster.Core/Models/Instances/ResourceLifecycleRestore.cs
@@ -1,0 +1,133 @@
+using Aster.Core.Models.Policies;
+using Aster.Core.Models.Tenancy;
+
+namespace Aster.Core.Models.Instances;
+
+/// <summary>
+/// Host-provided lifecycle restore request.
+/// </summary>
+public sealed class ResourceLifecycleRestoreRequest
+{
+    /// <summary>Tenant scope for restore. When omitted, the default single-tenant scope is used.</summary>
+    public TenantScope? TenantScope { get; set; }
+
+    /// <summary>Selected restore candidates in input order.</summary>
+    public List<ResourceLifecycleRestoreCandidate> Candidates { get; set; } = [];
+
+    /// <summary>Optional host timestamp for application reporting.</summary>
+    public DateTimeOffset? RestoredAt { get; set; }
+}
+
+/// <summary>
+/// Host-selected lifecycle marker restore target.
+/// </summary>
+public sealed class ResourceLifecycleRestoreCandidate
+{
+    /// <summary>Logical resource identifier.</summary>
+    public string? ResourceId { get; set; }
+
+    /// <summary>Lifecycle marker state expected to be cleared.</summary>
+    public ResourceLifecycleMarkerState? ExpectedState { get; set; }
+}
+
+/// <summary>
+/// Non-mutating lifecycle restore preview result.
+/// </summary>
+public sealed record ResourceLifecycleRestorePreviewResult
+{
+    /// <summary>Effective tenant used for preview.</summary>
+    public TenantScope TenantScope { get; init; } = TenantScope.Default;
+
+    /// <summary>Ordered preview candidate results.</summary>
+    public IReadOnlyList<ResourceLifecycleRestoreCandidateResult> Candidates { get; init; } = [];
+
+    /// <summary>Number of candidates that can be restored.</summary>
+    public int RestorableCount => Count(ResourceLifecycleRestoreCandidateStatus.Restorable);
+
+    /// <summary>Number of candidates already in the restored state.</summary>
+    public int AlreadyRestoredCount => Count(ResourceLifecycleRestoreCandidateStatus.AlreadyRestored);
+
+    /// <summary>Number of candidates skipped deterministically.</summary>
+    public int SkippedCount => Count(ResourceLifecycleRestoreCandidateStatus.Skipped);
+
+    /// <summary>Number of candidates that failed validation or state checks.</summary>
+    public int FailedCount => Count(ResourceLifecycleRestoreCandidateStatus.Failed);
+
+    private int Count(ResourceLifecycleRestoreCandidateStatus status) =>
+        Candidates.Count(candidate => candidate.Status == status);
+}
+
+/// <summary>
+/// Write-side lifecycle restore application result.
+/// </summary>
+public sealed record ResourceLifecycleRestoreApplicationResult
+{
+    /// <summary>Effective tenant used for application.</summary>
+    public TenantScope TenantScope { get; init; } = TenantScope.Default;
+
+    /// <summary>Optional host timestamp for application reporting.</summary>
+    public DateTimeOffset? RestoredAt { get; init; }
+
+    /// <summary>Ordered application candidate results.</summary>
+    public IReadOnlyList<ResourceLifecycleRestoreCandidateResult> Candidates { get; init; } = [];
+
+    /// <summary>Number of candidates restored by this application request.</summary>
+    public int RestoredCount => Count(ResourceLifecycleRestoreCandidateStatus.Restored);
+
+    /// <summary>Number of candidates already in the restored state.</summary>
+    public int AlreadyRestoredCount => Count(ResourceLifecycleRestoreCandidateStatus.AlreadyRestored);
+
+    /// <summary>Number of candidates skipped deterministically.</summary>
+    public int SkippedCount => Count(ResourceLifecycleRestoreCandidateStatus.Skipped);
+
+    /// <summary>Number of candidates that failed validation or state checks.</summary>
+    public int FailedCount => Count(ResourceLifecycleRestoreCandidateStatus.Failed);
+
+    private int Count(ResourceLifecycleRestoreCandidateStatus status) =>
+        Candidates.Count(candidate => candidate.Status == status);
+}
+
+/// <summary>
+/// Per-candidate lifecycle restore outcome.
+/// </summary>
+public sealed record ResourceLifecycleRestoreCandidateResult
+{
+    /// <summary>Zero-based input index.</summary>
+    public required int Index { get; init; }
+
+    /// <summary>Input resource identifier when available.</summary>
+    public string? ResourceId { get; init; }
+
+    /// <summary>Expected marker state when supplied.</summary>
+    public ResourceLifecycleMarkerState? ExpectedState { get; init; }
+
+    /// <summary>Candidate outcome status.</summary>
+    public required ResourceLifecycleRestoreCandidateStatus Status { get; init; }
+
+    /// <summary>Marker observed before the candidate outcome, when available.</summary>
+    public ResourceLifecycleMarker? Marker { get; init; }
+
+    /// <summary>Stable diagnostics for failed or skipped candidates.</summary>
+    public IReadOnlyList<ResourcePolicyDiagnostic> Diagnostics { get; init; } = [];
+}
+
+/// <summary>
+/// Lifecycle restore candidate status.
+/// </summary>
+public enum ResourceLifecycleRestoreCandidateStatus
+{
+    /// <summary>Preview found a matching marker that can be restored.</summary>
+    Restorable,
+
+    /// <summary>Application cleared a matching marker.</summary>
+    Restored,
+
+    /// <summary>The target resource exists and no marker is present.</summary>
+    AlreadyRestored,
+
+    /// <summary>A prior duplicate candidate already determined the outcome.</summary>
+    Skipped,
+
+    /// <summary>The candidate failed validation or current-state checks.</summary>
+    Failed,
+}

--- a/src/core/Aster.Core/Models/Policies/ResourcePolicyResults.cs
+++ b/src/core/Aster.Core/Models/Policies/ResourcePolicyResults.cs
@@ -156,4 +156,13 @@ public static class ResourcePolicyDiagnosticCodes
 
     /// <summary>Lifecycle marker target resource was not found.</summary>
     public const string LifecycleMarkerTargetNotFound = "lifecycle-marker-target-not-found";
+
+    /// <summary>Lifecycle restore candidate shape is invalid.</summary>
+    public const string LifecycleRestoreCandidateInvalid = "lifecycle-restore-candidate-invalid";
+
+    /// <summary>Lifecycle restore expected state is unsupported.</summary>
+    public const string LifecycleRestoreStateUnsupported = "lifecycle-restore-state-unsupported";
+
+    /// <summary>Lifecycle restore candidate expected state differs from current marker state.</summary>
+    public const string LifecycleRestoreMarkerMismatch = "lifecycle-restore-marker-mismatch";
 }

--- a/src/core/Aster.Core/README.md
+++ b/src/core/Aster.Core/README.md
@@ -47,7 +47,8 @@ builder.Services.AddAsterCore();
 | `ResourcePolicyValidator` | `IResourcePolicyValidator` |
 | `ResourcePolicyEvaluationService` | `IResourcePolicyEvaluationService` |
 | `ResourceLifecycleMarkerService` | `IResourceLifecycleMarkerService` |
-| `InMemoryResourceLifecycleMarkerStore` | `IResourceLifecycleMarkerStore` |
+| `ResourceLifecycleRestoreService` | `IResourceLifecycleRestoreService` |
+| `InMemoryResourceLifecycleMarkerStore` | `IResourceLifecycleMarkerStore`, `IResourceLifecycleMarkerClearStore` |
 | `GuidIdentityGenerator` | `IIdentityGenerator` |
 | `SystemTextJsonAspectBinder` | `ITypedAspectBinder` |
 | `SystemTextJsonFacetBinder` | `ITypedFacetBinder` |
@@ -349,7 +350,40 @@ var archived = await queryService.QueryAsync(new ResourceQuery
 });
 ```
 
-Policy declarations and lifecycle markers are tenant-scoped and are preserved by portability when their definitions/resources are included in the selected snapshot. This slice does not add automatic policy execution, schedulers, authorization policy engines, destructive pruning writes, restore workflows, provider registries, public SQL, or public `IQueryable<Resource>`.
+Hosts can preview and explicitly restore archive or soft-delete markers through `IResourceLifecycleRestoreService`. Restore clears only the expected marker state, returns one result per submitted candidate, treats missing markers as already restored, and fails closed when current marker state differs from the expected state.
+
+```csharp
+var restore = serviceProvider.GetRequiredService<IResourceLifecycleRestoreService>();
+
+var preview = await restore.PreviewRestoreAsync(new ResourceLifecycleRestoreRequest
+{
+    Candidates =
+    [
+        new ResourceLifecycleRestoreCandidate
+        {
+            ResourceId = "product-1",
+            ExpectedState = ResourceLifecycleMarkerState.Archived,
+        },
+    ],
+});
+
+if (preview.Candidates.Single().Status == ResourceLifecycleRestoreCandidateStatus.Restorable)
+{
+    await restore.RestoreAsync(new ResourceLifecycleRestoreRequest
+    {
+        Candidates =
+        [
+            new ResourceLifecycleRestoreCandidate
+            {
+                ResourceId = "product-1",
+                ExpectedState = ResourceLifecycleMarkerState.Archived,
+            },
+        ],
+    });
+}
+```
+
+Restore preview is non-mutating. Restore application re-reads current marker state before clearing, does not rewrite resource versions, does not change activation state, and does not invoke lifecycle hooks. Policy declarations and lifecycle markers are tenant-scoped and are preserved by portability when their definitions/resources are included in the selected snapshot. This slice does not add automatic policy execution, automatic restore, schedulers, authorization policy engines, destructive pruning writes, provider registries, public SQL, or public `IQueryable<Resource>`.
 
 ---
 
@@ -396,6 +430,8 @@ IResourcePolicyValidator      — validates definition-attached policy declarati
 IResourcePolicyEvaluationService — previews policy outcomes without mutation
 IResourceLifecycleMarkerService — applies explicit archive/soft-delete markers
 IResourceLifecycleMarkerStore — provider-facing lifecycle marker persistence contract
+IResourceLifecycleMarkerClearStore — provider-facing lifecycle marker removal contract
+IResourceLifecycleRestoreService — previews and applies explicit archive/soft-delete marker restoration
 IResourceQueryService         — portable query service; default is LINQ-based in-memory
 IResourceQueryProviderIdentity — exposes the active query provider key
 IResourceQueryCapabilitiesProvider — declares active provider query support

--- a/src/core/Aster.Core/Services/ResourceLifecycleRestoreService.cs
+++ b/src/core/Aster.Core/Services/ResourceLifecycleRestoreService.cs
@@ -35,7 +35,7 @@ public sealed class ResourceLifecycleRestoreService : IResourceLifecycleRestoreS
         ArgumentNullException.ThrowIfNull(request);
         var tenant = TenantScopeResolver.Resolve(request.TenantScope);
         var results = await EvaluateAsync(
-            request.Candidates,
+            ResolveCandidates(request),
             tenant,
             apply: false,
             cancellationToken);
@@ -55,7 +55,7 @@ public sealed class ResourceLifecycleRestoreService : IResourceLifecycleRestoreS
         ArgumentNullException.ThrowIfNull(request);
         var tenant = TenantScopeResolver.Resolve(request.TenantScope);
         var results = await EvaluateAsync(
-            request.Candidates,
+            ResolveCandidates(request),
             tenant,
             apply: true,
             cancellationToken);
@@ -67,6 +67,9 @@ public sealed class ResourceLifecycleRestoreService : IResourceLifecycleRestoreS
             Candidates = results,
         };
     }
+
+    private static IReadOnlyList<ResourceLifecycleRestoreCandidate> ResolveCandidates(ResourceLifecycleRestoreRequest request) =>
+        request.Candidates ?? [];
 
     private async ValueTask<IReadOnlyList<ResourceLifecycleRestoreCandidateResult>> EvaluateAsync(
         IReadOnlyList<ResourceLifecycleRestoreCandidate> candidates,

--- a/src/core/Aster.Core/Services/ResourceLifecycleRestoreService.cs
+++ b/src/core/Aster.Core/Services/ResourceLifecycleRestoreService.cs
@@ -82,7 +82,7 @@ public sealed class ResourceLifecycleRestoreService : IResourceLifecycleRestoreS
             .ToArray();
         var resourceIds = candidates
             .Where((candidate, index) => shapeFailures[index] is null && !string.IsNullOrWhiteSpace(candidate.ResourceId))
-            .Select(static candidate => candidate.ResourceId!)
+            .Select(static candidate => candidate!.ResourceId!)
             .ToHashSet(StringComparer.Ordinal);
         var latestResources = resourceIds.Count == 0
             ? new Dictionary<string, Resource>(StringComparer.Ordinal)
@@ -111,7 +111,7 @@ public sealed class ResourceLifecycleRestoreService : IResourceLifecycleRestoreS
                 continue;
             }
 
-            var expectedState = candidate.ExpectedState!.Value;
+            var expectedState = candidate!.ExpectedState!.Value;
             var key = new RestoreCandidateKey(candidate.ResourceId!, expectedState);
             if (!processed.Add(key))
             {
@@ -188,8 +188,18 @@ public sealed class ResourceLifecycleRestoreService : IResourceLifecycleRestoreS
 
     private static ResourceLifecycleRestoreCandidateResult? ValidateShape(
         int index,
-        ResourceLifecycleRestoreCandidate candidate)
+        ResourceLifecycleRestoreCandidate? candidate)
     {
+        if (candidate is null)
+        {
+            return Failure(
+                index,
+                candidate,
+                ResourcePolicyDiagnosticCodes.LifecycleRestoreCandidateInvalid,
+                "Lifecycle restore candidates must not be null.",
+                "candidate");
+        }
+
         if (string.IsNullOrWhiteSpace(candidate.ResourceId))
         {
             return Failure(
@@ -250,7 +260,7 @@ public sealed class ResourceLifecycleRestoreService : IResourceLifecycleRestoreS
 
     private static ResourceLifecycleRestoreCandidateResult Failure(
         int index,
-        ResourceLifecycleRestoreCandidate candidate,
+        ResourceLifecycleRestoreCandidate? candidate,
         string code,
         string message,
         string? path = null,
@@ -265,20 +275,20 @@ public sealed class ResourceLifecycleRestoreService : IResourceLifecycleRestoreS
                     code,
                     message,
                     path,
-                    resourceId: candidate.ResourceId),
+                    resourceId: candidate?.ResourceId),
             ]);
 
     private static ResourceLifecycleRestoreCandidateResult CandidateResult(
         int index,
-        ResourceLifecycleRestoreCandidate candidate,
+        ResourceLifecycleRestoreCandidate? candidate,
         ResourceLifecycleRestoreCandidateStatus status,
         ResourceLifecycleMarker? marker = null,
         IReadOnlyList<ResourcePolicyDiagnostic>? diagnostics = null) =>
         new()
         {
             Index = index,
-            ResourceId = candidate.ResourceId,
-            ExpectedState = candidate.ExpectedState,
+            ResourceId = candidate?.ResourceId,
+            ExpectedState = candidate?.ExpectedState,
             Status = status,
             Marker = marker,
             Diagnostics = diagnostics ?? [],

--- a/src/core/Aster.Core/Services/ResourceLifecycleRestoreService.cs
+++ b/src/core/Aster.Core/Services/ResourceLifecycleRestoreService.cs
@@ -149,14 +149,22 @@ public sealed class ResourceLifecycleRestoreService : IResourceLifecycleRestoreS
         if (marker.State != expectedState)
             return MarkerMismatch(index, candidate, expectedState, marker);
 
-        var removed = await markerStore.ClearMarkerAsync(candidate.ResourceId!, tenant, cancellationToken);
-        markers.Remove(candidate.ResourceId!);
+        var removed = await markerStore.ClearMarkerAsync(candidate.ResourceId!, tenant, expectedState, cancellationToken);
+        if (removed)
+        {
+            markers.Remove(candidate.ResourceId!);
+            return CandidateResult(index, candidate, ResourceLifecycleRestoreCandidateStatus.Restored, marker);
+        }
 
-        return CandidateResult(
-            index,
-            candidate,
-            removed ? ResourceLifecycleRestoreCandidateStatus.Restored : ResourceLifecycleRestoreCandidateStatus.AlreadyRestored,
-            marker);
+        var current = await markerStore.GetMarkerAsync(candidate.ResourceId!, tenant, cancellationToken);
+        if (current is null)
+        {
+            markers.Remove(candidate.ResourceId!);
+            return CandidateResult(index, candidate, ResourceLifecycleRestoreCandidateStatus.AlreadyRestored);
+        }
+
+        markers[candidate.ResourceId!] = current;
+        return MarkerMismatch(index, candidate, expectedState, current);
     }
 
     private static ResourceLifecycleRestoreCandidateResult PreviewCandidate(

--- a/src/core/Aster.Core/Services/ResourceLifecycleRestoreService.cs
+++ b/src/core/Aster.Core/Services/ResourceLifecycleRestoreService.cs
@@ -1,0 +1,280 @@
+using Aster.Core.Abstractions;
+using Aster.Core.Models.Instances;
+using Aster.Core.Models.Policies;
+using Aster.Core.Models.Querying;
+using Aster.Core.Models.Tenancy;
+
+namespace Aster.Core.Services;
+
+/// <summary>
+/// Default host-controlled lifecycle restore workflow service.
+/// </summary>
+public sealed class ResourceLifecycleRestoreService : IResourceLifecycleRestoreService
+{
+    private readonly IResourceVersionReader versionReader;
+    private readonly IResourceLifecycleMarkerClearStore markerStore;
+
+    /// <summary>
+    /// Initializes a new instance of <see cref="ResourceLifecycleRestoreService"/>.
+    /// </summary>
+    public ResourceLifecycleRestoreService(
+        IResourceVersionReader versionReader,
+        IResourceLifecycleMarkerClearStore markerStore)
+    {
+        ArgumentNullException.ThrowIfNull(versionReader);
+        ArgumentNullException.ThrowIfNull(markerStore);
+        this.versionReader = versionReader;
+        this.markerStore = markerStore;
+    }
+
+    /// <inheritdoc />
+    public async ValueTask<ResourceLifecycleRestorePreviewResult> PreviewRestoreAsync(
+        ResourceLifecycleRestoreRequest request,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        var tenant = TenantScopeResolver.Resolve(request.TenantScope);
+        var results = await EvaluateAsync(
+            request.Candidates,
+            tenant,
+            apply: false,
+            cancellationToken);
+
+        return new ResourceLifecycleRestorePreviewResult
+        {
+            TenantScope = tenant,
+            Candidates = results,
+        };
+    }
+
+    /// <inheritdoc />
+    public async ValueTask<ResourceLifecycleRestoreApplicationResult> RestoreAsync(
+        ResourceLifecycleRestoreRequest request,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        var tenant = TenantScopeResolver.Resolve(request.TenantScope);
+        var results = await EvaluateAsync(
+            request.Candidates,
+            tenant,
+            apply: true,
+            cancellationToken);
+
+        return new ResourceLifecycleRestoreApplicationResult
+        {
+            TenantScope = tenant,
+            RestoredAt = request.RestoredAt,
+            Candidates = results,
+        };
+    }
+
+    private async ValueTask<IReadOnlyList<ResourceLifecycleRestoreCandidateResult>> EvaluateAsync(
+        IReadOnlyList<ResourceLifecycleRestoreCandidate> candidates,
+        TenantScope tenant,
+        bool apply,
+        CancellationToken cancellationToken)
+    {
+        if (candidates.Count == 0)
+            return [];
+
+        var shapeFailures = candidates
+            .Select((candidate, index) => ValidateShape(index, candidate))
+            .ToArray();
+        var resourceIds = candidates
+            .Where((candidate, index) => shapeFailures[index] is null && !string.IsNullOrWhiteSpace(candidate.ResourceId))
+            .Select(static candidate => candidate.ResourceId!)
+            .ToHashSet(StringComparer.Ordinal);
+        var latestResources = resourceIds.Count == 0
+            ? new Dictionary<string, Resource>(StringComparer.Ordinal)
+            : (await versionReader.ReadVersionsAsync(new ResourceVersionReadRequest
+            {
+                TenantScope = tenant,
+                Scope = ResourceVersionScope.Latest,
+                ResourceIds = resourceIds,
+            }, cancellationToken)).ToDictionary(static resource => resource.ResourceId, StringComparer.Ordinal);
+        var markers = resourceIds.Count == 0
+            ? new Dictionary<string, ResourceLifecycleMarker>(StringComparer.Ordinal)
+            : new Dictionary<string, ResourceLifecycleMarker>(
+                await markerStore.GetMarkersAsync(resourceIds, tenant, cancellationToken),
+                StringComparer.Ordinal);
+        var results = new ResourceLifecycleRestoreCandidateResult?[candidates.Count];
+        var processed = new HashSet<RestoreCandidateKey>();
+
+        for (var index = 0; index < candidates.Count; index++)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            var candidate = candidates[index];
+
+            if (shapeFailures[index] is not null)
+            {
+                results[index] = shapeFailures[index];
+                continue;
+            }
+
+            var expectedState = candidate.ExpectedState!.Value;
+            var key = new RestoreCandidateKey(candidate.ResourceId!, expectedState);
+            if (!processed.Add(key))
+            {
+                results[index] = CandidateResult(
+                    index,
+                    candidate,
+                    ResourceLifecycleRestoreCandidateStatus.Skipped,
+                    marker: markers.GetValueOrDefault(candidate.ResourceId!));
+                continue;
+            }
+
+            results[index] = apply
+                ? await ApplyCandidateAsync(index, candidate, expectedState, tenant, markers, latestResources, cancellationToken)
+                : PreviewCandidate(index, candidate, expectedState, tenant, markers, latestResources);
+        }
+
+        return results.Select(static result => result!).ToList();
+    }
+
+    private async ValueTask<ResourceLifecycleRestoreCandidateResult> ApplyCandidateAsync(
+        int index,
+        ResourceLifecycleRestoreCandidate candidate,
+        ResourceLifecycleMarkerState expectedState,
+        TenantScope tenant,
+        IDictionary<string, ResourceLifecycleMarker> markers,
+        IReadOnlyDictionary<string, Resource> latestResources,
+        CancellationToken cancellationToken)
+    {
+        if (!latestResources.ContainsKey(candidate.ResourceId!))
+            return TargetNotFound(index, candidate, tenant);
+
+        if (!markers.TryGetValue(candidate.ResourceId!, out var marker))
+            return CandidateResult(index, candidate, ResourceLifecycleRestoreCandidateStatus.AlreadyRestored);
+
+        if (marker.State != expectedState)
+            return MarkerMismatch(index, candidate, expectedState, marker);
+
+        var removed = await markerStore.ClearMarkerAsync(candidate.ResourceId!, tenant, cancellationToken);
+        markers.Remove(candidate.ResourceId!);
+
+        return CandidateResult(
+            index,
+            candidate,
+            removed ? ResourceLifecycleRestoreCandidateStatus.Restored : ResourceLifecycleRestoreCandidateStatus.AlreadyRestored,
+            marker);
+    }
+
+    private static ResourceLifecycleRestoreCandidateResult PreviewCandidate(
+        int index,
+        ResourceLifecycleRestoreCandidate candidate,
+        ResourceLifecycleMarkerState expectedState,
+        TenantScope tenant,
+        IReadOnlyDictionary<string, ResourceLifecycleMarker> markers,
+        IReadOnlyDictionary<string, Resource> latestResources)
+    {
+        if (!latestResources.ContainsKey(candidate.ResourceId!))
+            return TargetNotFound(index, candidate, tenant);
+
+        if (!markers.TryGetValue(candidate.ResourceId!, out var marker))
+            return CandidateResult(index, candidate, ResourceLifecycleRestoreCandidateStatus.AlreadyRestored);
+
+        return marker.State == expectedState
+            ? CandidateResult(index, candidate, ResourceLifecycleRestoreCandidateStatus.Restorable, marker)
+            : MarkerMismatch(index, candidate, expectedState, marker);
+    }
+
+    private static ResourceLifecycleRestoreCandidateResult? ValidateShape(
+        int index,
+        ResourceLifecycleRestoreCandidate candidate)
+    {
+        if (string.IsNullOrWhiteSpace(candidate.ResourceId))
+        {
+            return Failure(
+                index,
+                candidate,
+                ResourcePolicyDiagnosticCodes.LifecycleRestoreCandidateInvalid,
+                "Lifecycle restore candidates require a resource identifier.",
+                "resourceId");
+        }
+
+        if (candidate.ExpectedState is null)
+        {
+            return Failure(
+                index,
+                candidate,
+                ResourcePolicyDiagnosticCodes.LifecycleRestoreCandidateInvalid,
+                "Lifecycle restore candidates require an expected lifecycle marker state.",
+                "expectedState");
+        }
+
+        if (!Enum.IsDefined(candidate.ExpectedState.Value)
+            || candidate.ExpectedState.Value is not (ResourceLifecycleMarkerState.Archived or ResourceLifecycleMarkerState.SoftDeleted))
+        {
+            return Failure(
+                index,
+                candidate,
+                ResourcePolicyDiagnosticCodes.LifecycleRestoreStateUnsupported,
+                $"Lifecycle restore expected state '{candidate.ExpectedState.Value}' is not supported.",
+                "expectedState");
+        }
+
+        return null;
+    }
+
+    private static ResourceLifecycleRestoreCandidateResult TargetNotFound(
+        int index,
+        ResourceLifecycleRestoreCandidate candidate,
+        TenantScope tenant) =>
+        Failure(
+            index,
+            candidate,
+            ResourcePolicyDiagnosticCodes.LifecycleMarkerTargetNotFound,
+            $"Resource '{candidate.ResourceId}' was not found in tenant '{tenant.TenantId}'.",
+            "resourceId");
+
+    private static ResourceLifecycleRestoreCandidateResult MarkerMismatch(
+        int index,
+        ResourceLifecycleRestoreCandidate candidate,
+        ResourceLifecycleMarkerState expectedState,
+        ResourceLifecycleMarker marker) =>
+        Failure(
+            index,
+            candidate,
+            ResourcePolicyDiagnosticCodes.LifecycleRestoreMarkerMismatch,
+            $"Resource '{candidate.ResourceId}' is marked as {marker.State}; expected {expectedState}.",
+            "expectedState",
+            marker);
+
+    private static ResourceLifecycleRestoreCandidateResult Failure(
+        int index,
+        ResourceLifecycleRestoreCandidate candidate,
+        string code,
+        string message,
+        string? path = null,
+        ResourceLifecycleMarker? marker = null) =>
+        CandidateResult(
+            index,
+            candidate,
+            ResourceLifecycleRestoreCandidateStatus.Failed,
+            marker,
+            [
+                ResourcePolicyValidator.Diagnostic(
+                    code,
+                    message,
+                    path,
+                    resourceId: candidate.ResourceId),
+            ]);
+
+    private static ResourceLifecycleRestoreCandidateResult CandidateResult(
+        int index,
+        ResourceLifecycleRestoreCandidate candidate,
+        ResourceLifecycleRestoreCandidateStatus status,
+        ResourceLifecycleMarker? marker = null,
+        IReadOnlyList<ResourcePolicyDiagnostic>? diagnostics = null) =>
+        new()
+        {
+            Index = index,
+            ResourceId = candidate.ResourceId,
+            ExpectedState = candidate.ExpectedState,
+            Status = status,
+            Marker = marker,
+            Diagnostics = diagnostics ?? [],
+        };
+
+    private readonly record struct RestoreCandidateKey(string ResourceId, ResourceLifecycleMarkerState ExpectedState);
+}

--- a/src/persistence/Aster.Persistence.SqliteJson/README.md
+++ b/src/persistence/Aster.Persistence.SqliteJson/README.md
@@ -11,6 +11,7 @@ This package currently provides:
 - `IResourceVersionWriter`
 - `IResourcePortabilityStore`
 - `IResourceLifecycleMarkerStore`
+- `IResourceLifecycleMarkerClearStore`
 - `IResourceQueryService`
 - `IResourceQueryCapabilitiesProvider`
 
@@ -78,4 +79,4 @@ The provider also declares this support through `SqliteJsonQueryCapabilitiesProv
 
 Tenant scope is applied as a provider-owned predicate before user query predicates. Latest, active, and draft scopes all include tenant-aware joins so matching resource IDs or activation channels in another tenant cannot affect results.
 
-Lifecycle markers are explicit state. `AddAsterSqliteJson(...)` replaces the core in-memory `IResourceLifecycleMarkerStore` with the SQLite-backed store so archive and soft-delete markers persist across service provider instances, participate in portability export/import, and can be queried through `ResourceQuery.LifecycleState`. Omitting `LifecycleState` does not hide archived or soft-deleted resources.
+Lifecycle markers are explicit state. `AddAsterSqliteJson(...)` replaces the core in-memory `IResourceLifecycleMarkerStore` and `IResourceLifecycleMarkerClearStore` with the SQLite-backed store so archive and soft-delete markers persist across service provider instances, participate in portability export/import, can be queried through `ResourceQuery.LifecycleState`, and can be explicitly restored through `IResourceLifecycleRestoreService`. Restore deletes only the tenant-scoped marker row for the selected resource; it does not rewrite resource versions, change activation state, mutate policy declarations, or change the portability snapshot format. Omitting `LifecycleState` does not hide archived or soft-deleted resources.

--- a/src/persistence/Aster.Persistence.SqliteJson/SqliteJsonAsterServiceCollectionExtensions.cs
+++ b/src/persistence/Aster.Persistence.SqliteJson/SqliteJsonAsterServiceCollectionExtensions.cs
@@ -34,6 +34,7 @@ public static class SqliteJsonAsterServiceCollectionExtensions
         services.AddSingleton<IResourceVersionWriter>(sp => sp.GetRequiredService<SqliteJsonResourceStore>());
         services.AddSingleton<IResourcePortabilityStore>(sp => sp.GetRequiredService<SqliteJsonResourceStore>());
         services.AddSingleton<IResourceLifecycleMarkerStore>(sp => sp.GetRequiredService<SqliteJsonResourceStore>());
+        services.AddSingleton<IResourceLifecycleMarkerClearStore>(sp => sp.GetRequiredService<SqliteJsonResourceStore>());
         services.AddSingleton<IResourceQueryService>(sp => sp.GetRequiredService<SqliteJsonQueryService>());
         services.AddSingleton<IResourceQueryProviderIdentity>(sp => sp.GetRequiredService<SqliteJsonQueryProviderIdentity>());
         services.AddSingleton<IResourceQueryCapabilitiesProvider>(sp => sp.GetRequiredService<SqliteJsonQueryCapabilitiesProvider>());

--- a/src/persistence/Aster.Persistence.SqliteJson/SqliteJsonResourceStore.cs
+++ b/src/persistence/Aster.Persistence.SqliteJson/SqliteJsonResourceStore.cs
@@ -337,6 +337,7 @@ public sealed class SqliteJsonResourceStore :
     public async ValueTask<bool> ClearMarkerAsync(
         string resourceId,
         TenantScope tenantScope,
+        ResourceLifecycleMarkerState expectedState,
         CancellationToken cancellationToken = default)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(resourceId);
@@ -346,10 +347,13 @@ public sealed class SqliteJsonResourceStore :
         await using var command = connection.CreateCommand();
         command.CommandText = """
             DELETE FROM lifecycle_markers
-            WHERE tenant_id = $tenantId AND resource_id = $resourceId;
+            WHERE tenant_id = $tenantId
+                AND resource_id = $resourceId
+                AND json_extract(payload, '$.state') = $expectedState;
             """;
         command.Parameters.AddWithValue("$tenantId", tenant.TenantId);
         command.Parameters.AddWithValue("$resourceId", resourceId);
+        command.Parameters.AddWithValue("$expectedState", (int)expectedState);
 
         return await command.ExecuteNonQueryAsync(cancellationToken) > 0;
     }

--- a/src/persistence/Aster.Persistence.SqliteJson/SqliteJsonResourceStore.cs
+++ b/src/persistence/Aster.Persistence.SqliteJson/SqliteJsonResourceStore.cs
@@ -18,7 +18,7 @@ public sealed class SqliteJsonResourceStore :
     IResourceVersionReader,
     IResourceVersionWriter,
     IResourcePortabilityStore,
-    IResourceLifecycleMarkerStore
+    IResourceLifecycleMarkerClearStore
 {
     private const int MaxSqliteParametersPerQuery = 500;
 
@@ -331,6 +331,27 @@ public sealed class SqliteJsonResourceStore :
 
         await command.ExecuteNonQueryAsync(cancellationToken);
         return scopedMarker;
+    }
+
+    /// <inheritdoc />
+    public async ValueTask<bool> ClearMarkerAsync(
+        string resourceId,
+        TenantScope tenantScope,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(resourceId);
+        var tenant = TenantScopeResolver.Resolve(tenantScope);
+
+        await using var connection = await OpenConnectionAsync(cancellationToken);
+        await using var command = connection.CreateCommand();
+        command.CommandText = """
+            DELETE FROM lifecycle_markers
+            WHERE tenant_id = $tenantId AND resource_id = $resourceId;
+            """;
+        command.Parameters.AddWithValue("$tenantId", tenant.TenantId);
+        command.Parameters.AddWithValue("$resourceId", resourceId);
+
+        return await command.ExecuteNonQueryAsync(cancellationToken) > 0;
     }
 
     /// <inheritdoc />

--- a/test/Aster.Tests/Lifecycle/LifecycleRestoreActivationTests.cs
+++ b/test/Aster.Tests/Lifecycle/LifecycleRestoreActivationTests.cs
@@ -1,0 +1,38 @@
+using Aster.Core.Abstractions;
+using Aster.Core.Models.Instances;
+using Aster.Core.Models.Querying;
+using Aster.Tests.Policies;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Aster.Tests.Lifecycle;
+
+public sealed class LifecycleRestoreActivationTests : IDisposable
+{
+    private readonly ServiceProvider provider = LifecycleRestoreTestFixtures.CreateCoreProvider();
+
+    public void Dispose() => provider.Dispose();
+
+    [Fact]
+    public async Task RestoreAsync_DoesNotRewriteVersionsOrChangeActivationState()
+    {
+        await PolicyTestFixtures.RegisterProductDefinitionAsync(provider);
+        var manager = provider.GetRequiredService<IResourceManager>();
+        await manager.CreateAsync("Product", new CreateResourceRequest { ResourceId = "product-1" });
+        await manager.UpdateAsync("product-1", new UpdateResourceRequest { BaseVersion = 1 });
+        await manager.ActivateAsync("product-1", 2, "Published");
+        await LifecycleRestoreTestFixtures.MarkAsync(provider, "product-1", ResourceLifecycleMarkerState.Archived);
+        var restore = provider.GetRequiredService<IResourceLifecycleRestoreService>();
+
+        await restore.RestoreAsync(new ResourceLifecycleRestoreRequest
+        {
+            Candidates = [LifecycleRestoreTestFixtures.Candidate("product-1", ResourceLifecycleMarkerState.Archived)],
+        });
+
+        var versions = (await manager.GetVersionsAsync("product-1")).OrderBy(static resource => resource.Version).ToList();
+        var active = (await manager.GetActiveVersionsAsync("product-1", "Published")).ToList();
+
+        Assert.Equal([1, 2], versions.Select(static resource => resource.Version).ToList());
+        var activeVersion = Assert.Single(active);
+        Assert.Equal(2, activeVersion.Version);
+    }
+}

--- a/test/Aster.Tests/Lifecycle/LifecycleRestoreDiagnosticsTests.cs
+++ b/test/Aster.Tests/Lifecycle/LifecycleRestoreDiagnosticsTests.cs
@@ -27,6 +27,7 @@ public sealed class LifecycleRestoreDiagnosticsTests : IDisposable
         {
             Candidates =
             [
+                null!,
                 LifecycleRestoreTestFixtures.Candidate(null, ResourceLifecycleMarkerState.Archived),
                 LifecycleRestoreTestFixtures.Candidate("missing-state", null),
                 LifecycleRestoreTestFixtures.Candidate("unsupported-state", (ResourceLifecycleMarkerState)999),
@@ -36,9 +37,27 @@ public sealed class LifecycleRestoreDiagnosticsTests : IDisposable
         Assert.All(result.Candidates, candidate => Assert.Equal(ResourceLifecycleRestoreCandidateStatus.Failed, candidate.Status));
         Assert.Contains(result.Candidates[0].Diagnostics, diagnostic => diagnostic.Code == ResourcePolicyDiagnosticCodes.LifecycleRestoreCandidateInvalid);
         Assert.Contains(result.Candidates[1].Diagnostics, diagnostic => diagnostic.Code == ResourcePolicyDiagnosticCodes.LifecycleRestoreCandidateInvalid);
-        Assert.Contains(result.Candidates[2].Diagnostics, diagnostic => diagnostic.Code == ResourcePolicyDiagnosticCodes.LifecycleRestoreStateUnsupported);
+        Assert.Contains(result.Candidates[2].Diagnostics, diagnostic => diagnostic.Code == ResourcePolicyDiagnosticCodes.LifecycleRestoreCandidateInvalid);
+        Assert.Contains(result.Candidates[3].Diagnostics, diagnostic => diagnostic.Code == ResourcePolicyDiagnosticCodes.LifecycleRestoreStateUnsupported);
         Assert.NotNull(await LifecycleRestoreTestFixtures.ReadMarkerAsync(provider, "missing-state"));
         Assert.NotNull(await LifecycleRestoreTestFixtures.ReadMarkerAsync(provider, "unsupported-state"));
+    }
+
+    [Fact]
+    public async Task PreviewRestoreAsync_NullCandidateFailsWithDiagnostic()
+    {
+        var restore = provider.GetRequiredService<IResourceLifecycleRestoreService>();
+
+        var result = await restore.PreviewRestoreAsync(new ResourceLifecycleRestoreRequest
+        {
+            Candidates = [null!],
+        });
+
+        var candidate = Assert.Single(result.Candidates);
+        Assert.Equal(ResourceLifecycleRestoreCandidateStatus.Failed, candidate.Status);
+        Assert.Null(candidate.ResourceId);
+        Assert.Null(candidate.ExpectedState);
+        Assert.Contains(candidate.Diagnostics, diagnostic => diagnostic.Code == ResourcePolicyDiagnosticCodes.LifecycleRestoreCandidateInvalid);
     }
 
     [Fact]

--- a/test/Aster.Tests/Lifecycle/LifecycleRestoreDiagnosticsTests.cs
+++ b/test/Aster.Tests/Lifecycle/LifecycleRestoreDiagnosticsTests.cs
@@ -1,4 +1,5 @@
 using Aster.Core.Abstractions;
+using Aster.Core.Extensions;
 using Aster.Core.Models.Instances;
 using Aster.Core.Models.Policies;
 using Aster.Core.Models.Querying;
@@ -61,6 +62,21 @@ public sealed class LifecycleRestoreDiagnosticsTests : IDisposable
     }
 
     [Fact]
+    public void AddAsterCore_WhenActiveMarkerStoreCannotClearMarkersFailsFastForRestore()
+    {
+        using var customProvider = new ServiceCollection()
+            .AddAsterCore()
+            .AddSingleton<IResourceLifecycleMarkerStore, MarkerStoreWithoutClear>()
+            .BuildServiceProvider();
+
+        var exception = Assert.Throws<InvalidOperationException>(
+            () => customProvider.GetRequiredService<IResourceLifecycleRestoreService>());
+
+        Assert.Contains(nameof(IResourceLifecycleMarkerStore), exception.Message);
+        Assert.Contains(nameof(IResourceLifecycleMarkerClearStore), exception.Message);
+    }
+
+    [Fact]
     public async Task RestoreAsync_MissingTargetMismatchAndStalePreviewFailClosed()
     {
         await LifecycleRestoreTestFixtures.SaveProductAsync(provider, "archived");
@@ -113,6 +129,27 @@ public sealed class LifecycleRestoreDiagnosticsTests : IDisposable
         Assert.Equal(ResourceLifecycleRestoreCandidateStatus.Failed, candidate.Status);
         Assert.Contains(candidate.Diagnostics, diagnostic => diagnostic.Code == ResourcePolicyDiagnosticCodes.LifecycleRestoreMarkerMismatch);
         Assert.Equal(ResourceLifecycleMarkerState.SoftDeleted, store.Current.State);
+    }
+
+    private sealed class MarkerStoreWithoutClear : IResourceLifecycleMarkerStore
+    {
+        public ValueTask<ResourceLifecycleMarker?> GetMarkerAsync(
+            string resourceId,
+            TenantScope tenantScope,
+            CancellationToken cancellationToken = default) =>
+            ValueTask.FromResult<ResourceLifecycleMarker?>(null);
+
+        public ValueTask<IReadOnlyDictionary<string, ResourceLifecycleMarker>> GetMarkersAsync(
+            IEnumerable<string> resourceIds,
+            TenantScope tenantScope,
+            CancellationToken cancellationToken = default) =>
+            ValueTask.FromResult<IReadOnlyDictionary<string, ResourceLifecycleMarker>>(
+                new Dictionary<string, ResourceLifecycleMarker>(StringComparer.Ordinal));
+
+        public ValueTask<ResourceLifecycleMarker> SaveMarkerAsync(
+            ResourceLifecycleMarker marker,
+            CancellationToken cancellationToken = default) =>
+            ValueTask.FromResult(marker);
     }
 
     private sealed class SingleResourceVersionReader : IResourceVersionReader

--- a/test/Aster.Tests/Lifecycle/LifecycleRestoreDiagnosticsTests.cs
+++ b/test/Aster.Tests/Lifecycle/LifecycleRestoreDiagnosticsTests.cs
@@ -1,0 +1,79 @@
+using Aster.Core.Abstractions;
+using Aster.Core.Models.Instances;
+using Aster.Core.Models.Policies;
+using Aster.Core.Models.Tenancy;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Aster.Tests.Lifecycle;
+
+public sealed class LifecycleRestoreDiagnosticsTests : IDisposable
+{
+    private readonly ServiceProvider provider = LifecycleRestoreTestFixtures.CreateCoreProvider();
+
+    public void Dispose() => provider.Dispose();
+
+    [Fact]
+    public async Task RestoreAsync_InvalidAndUnsupportedCandidatesFailWithoutClearingMarkers()
+    {
+        await LifecycleRestoreTestFixtures.SaveProductAsync(provider, "missing-state");
+        await LifecycleRestoreTestFixtures.SaveProductAsync(provider, "unsupported-state");
+        await LifecycleRestoreTestFixtures.MarkAsync(provider, "missing-state", ResourceLifecycleMarkerState.Archived);
+        await LifecycleRestoreTestFixtures.MarkAsync(provider, "unsupported-state", ResourceLifecycleMarkerState.Archived);
+        var restore = provider.GetRequiredService<IResourceLifecycleRestoreService>();
+
+        var result = await restore.RestoreAsync(new ResourceLifecycleRestoreRequest
+        {
+            Candidates =
+            [
+                LifecycleRestoreTestFixtures.Candidate(null, ResourceLifecycleMarkerState.Archived),
+                LifecycleRestoreTestFixtures.Candidate("missing-state", null),
+                LifecycleRestoreTestFixtures.Candidate("unsupported-state", (ResourceLifecycleMarkerState)999),
+            ],
+        });
+
+        Assert.All(result.Candidates, candidate => Assert.Equal(ResourceLifecycleRestoreCandidateStatus.Failed, candidate.Status));
+        Assert.Contains(result.Candidates[0].Diagnostics, diagnostic => diagnostic.Code == ResourcePolicyDiagnosticCodes.LifecycleRestoreCandidateInvalid);
+        Assert.Contains(result.Candidates[1].Diagnostics, diagnostic => diagnostic.Code == ResourcePolicyDiagnosticCodes.LifecycleRestoreCandidateInvalid);
+        Assert.Contains(result.Candidates[2].Diagnostics, diagnostic => diagnostic.Code == ResourcePolicyDiagnosticCodes.LifecycleRestoreStateUnsupported);
+        Assert.NotNull(await LifecycleRestoreTestFixtures.ReadMarkerAsync(provider, "missing-state"));
+        Assert.NotNull(await LifecycleRestoreTestFixtures.ReadMarkerAsync(provider, "unsupported-state"));
+    }
+
+    [Fact]
+    public async Task RestoreAsync_MissingTargetMismatchAndStalePreviewFailClosed()
+    {
+        await LifecycleRestoreTestFixtures.SaveProductAsync(provider, "archived");
+        await LifecycleRestoreTestFixtures.MarkAsync(provider, "archived", ResourceLifecycleMarkerState.Archived);
+        var restore = provider.GetRequiredService<IResourceLifecycleRestoreService>();
+        var store = provider.GetRequiredService<IResourceLifecycleMarkerStore>();
+
+        var preview = await restore.PreviewRestoreAsync(new ResourceLifecycleRestoreRequest
+        {
+            Candidates = [LifecycleRestoreTestFixtures.Candidate("archived", ResourceLifecycleMarkerState.Archived)],
+        });
+        await store.SaveMarkerAsync(new ResourceLifecycleMarker
+        {
+            TenantScope = TenantScope.Default,
+            ResourceId = "archived",
+            State = ResourceLifecycleMarkerState.SoftDeleted,
+            MarkedAt = DateTimeOffset.UtcNow,
+        });
+
+        var result = await restore.RestoreAsync(new ResourceLifecycleRestoreRequest
+        {
+            Candidates =
+            [
+                LifecycleRestoreTestFixtures.Candidate("missing", ResourceLifecycleMarkerState.Archived),
+                LifecycleRestoreTestFixtures.Candidate("archived", ResourceLifecycleMarkerState.Archived),
+            ],
+        });
+
+        Assert.Equal(ResourceLifecycleRestoreCandidateStatus.Restorable, Assert.Single(preview.Candidates).Status);
+        Assert.Collection(
+            result.Candidates,
+            first => Assert.Contains(first.Diagnostics, diagnostic => diagnostic.Code == ResourcePolicyDiagnosticCodes.LifecycleMarkerTargetNotFound),
+            second => Assert.Contains(second.Diagnostics, diagnostic => diagnostic.Code == ResourcePolicyDiagnosticCodes.LifecycleRestoreMarkerMismatch));
+        var current = await LifecycleRestoreTestFixtures.ReadMarkerAsync(provider, "archived");
+        Assert.Equal(ResourceLifecycleMarkerState.SoftDeleted, current?.State);
+    }
+}

--- a/test/Aster.Tests/Lifecycle/LifecycleRestoreDiagnosticsTests.cs
+++ b/test/Aster.Tests/Lifecycle/LifecycleRestoreDiagnosticsTests.cs
@@ -62,6 +62,32 @@ public sealed class LifecycleRestoreDiagnosticsTests : IDisposable
     }
 
     [Fact]
+    public async Task PreviewRestoreAsync_NullCandidatesCollectionReturnsEmptyResult()
+    {
+        var restore = provider.GetRequiredService<IResourceLifecycleRestoreService>();
+
+        var result = await restore.PreviewRestoreAsync(new ResourceLifecycleRestoreRequest
+        {
+            Candidates = null!,
+        });
+
+        Assert.Empty(result.Candidates);
+    }
+
+    [Fact]
+    public async Task RestoreAsync_NullCandidatesCollectionReturnsEmptyResult()
+    {
+        var restore = provider.GetRequiredService<IResourceLifecycleRestoreService>();
+
+        var result = await restore.RestoreAsync(new ResourceLifecycleRestoreRequest
+        {
+            Candidates = null!,
+        });
+
+        Assert.Empty(result.Candidates);
+    }
+
+    [Fact]
     public void AddAsterCore_WhenActiveMarkerStoreCannotClearMarkersFailsFastForRestore()
     {
         using var customProvider = new ServiceCollection()

--- a/test/Aster.Tests/Lifecycle/LifecycleRestoreDiagnosticsTests.cs
+++ b/test/Aster.Tests/Lifecycle/LifecycleRestoreDiagnosticsTests.cs
@@ -1,7 +1,9 @@
 using Aster.Core.Abstractions;
 using Aster.Core.Models.Instances;
 using Aster.Core.Models.Policies;
+using Aster.Core.Models.Querying;
 using Aster.Core.Models.Tenancy;
+using Aster.Core.Services;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Aster.Tests.Lifecycle;
@@ -75,5 +77,90 @@ public sealed class LifecycleRestoreDiagnosticsTests : IDisposable
             second => Assert.Contains(second.Diagnostics, diagnostic => diagnostic.Code == ResourcePolicyDiagnosticCodes.LifecycleRestoreMarkerMismatch));
         var current = await LifecycleRestoreTestFixtures.ReadMarkerAsync(provider, "archived");
         Assert.Equal(ResourceLifecycleMarkerState.SoftDeleted, current?.State);
+    }
+
+    [Fact]
+    public async Task RestoreAsync_WhenMarkerChangesBeforeClearDoesNotClearNewState()
+    {
+        var store = new ChangingMarkerClearStore();
+        var restore = new ResourceLifecycleRestoreService(new SingleResourceVersionReader(), store);
+
+        var result = await restore.RestoreAsync(new ResourceLifecycleRestoreRequest
+        {
+            Candidates = [LifecycleRestoreTestFixtures.Candidate("product-1", ResourceLifecycleMarkerState.Archived)],
+        });
+
+        var candidate = Assert.Single(result.Candidates);
+        Assert.Equal(ResourceLifecycleRestoreCandidateStatus.Failed, candidate.Status);
+        Assert.Contains(candidate.Diagnostics, diagnostic => diagnostic.Code == ResourcePolicyDiagnosticCodes.LifecycleRestoreMarkerMismatch);
+        Assert.Equal(ResourceLifecycleMarkerState.SoftDeleted, store.Current.State);
+    }
+
+    private sealed class SingleResourceVersionReader : IResourceVersionReader
+    {
+        public ValueTask<IEnumerable<Resource>> ReadVersionsAsync(
+            ResourceVersionReadRequest request,
+            CancellationToken cancellationToken = default) =>
+            ValueTask.FromResult<IEnumerable<Resource>>(
+            [
+                new Resource
+                {
+                    ResourceId = "product-1",
+                    Id = "product-1-1",
+                    DefinitionId = "Product",
+                    Version = 1,
+                    Created = DateTime.UtcNow,
+                },
+            ]);
+    }
+
+    private sealed class ChangingMarkerClearStore : IResourceLifecycleMarkerClearStore
+    {
+        private ResourceLifecycleMarker current = Marker(ResourceLifecycleMarkerState.Archived);
+
+        public ResourceLifecycleMarker Current => current;
+
+        public ValueTask<ResourceLifecycleMarker?> GetMarkerAsync(
+            string resourceId,
+            TenantScope tenantScope,
+            CancellationToken cancellationToken = default) =>
+            ValueTask.FromResult<ResourceLifecycleMarker?>(current);
+
+        public ValueTask<IReadOnlyDictionary<string, ResourceLifecycleMarker>> GetMarkersAsync(
+            IEnumerable<string> resourceIds,
+            TenantScope tenantScope,
+            CancellationToken cancellationToken = default) =>
+            ValueTask.FromResult<IReadOnlyDictionary<string, ResourceLifecycleMarker>>(
+                new Dictionary<string, ResourceLifecycleMarker>(StringComparer.Ordinal)
+                {
+                    ["product-1"] = current,
+                });
+
+        public ValueTask<ResourceLifecycleMarker> SaveMarkerAsync(
+            ResourceLifecycleMarker marker,
+            CancellationToken cancellationToken = default)
+        {
+            current = marker;
+            return ValueTask.FromResult(marker);
+        }
+
+        public ValueTask<bool> ClearMarkerAsync(
+            string resourceId,
+            TenantScope tenantScope,
+            ResourceLifecycleMarkerState expectedState,
+            CancellationToken cancellationToken = default)
+        {
+            current = Marker(ResourceLifecycleMarkerState.SoftDeleted);
+            return ValueTask.FromResult(false);
+        }
+
+        private static ResourceLifecycleMarker Marker(ResourceLifecycleMarkerState state) =>
+            new()
+            {
+                TenantScope = TenantScope.Default,
+                ResourceId = "product-1",
+                State = state,
+                MarkedAt = DateTimeOffset.UtcNow,
+            };
     }
 }

--- a/test/Aster.Tests/Lifecycle/LifecycleRestorePreviewTests.cs
+++ b/test/Aster.Tests/Lifecycle/LifecycleRestorePreviewTests.cs
@@ -1,0 +1,91 @@
+using Aster.Core.Abstractions;
+using Aster.Core.Models.Instances;
+using Aster.Core.Models.Policies;
+using Aster.Core.Models.Tenancy;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Aster.Tests.Lifecycle;
+
+public sealed class LifecycleRestorePreviewTests : IDisposable
+{
+    private readonly ServiceProvider provider = LifecycleRestoreTestFixtures.CreateCoreProvider();
+
+    public void Dispose() => provider.Dispose();
+
+    [Fact]
+    public async Task PreviewRestoreAsync_ReturnsRestorableAlreadyRestoredSkippedAndEmptyResults()
+    {
+        await LifecycleRestoreTestFixtures.SaveProductAsync(provider, "archived");
+        await LifecycleRestoreTestFixtures.SaveProductAsync(provider, "unmarked");
+        await LifecycleRestoreTestFixtures.MarkAsync(provider, "archived", ResourceLifecycleMarkerState.Archived);
+        var restore = provider.GetRequiredService<IResourceLifecycleRestoreService>();
+
+        var preview = await restore.PreviewRestoreAsync(new ResourceLifecycleRestoreRequest
+        {
+            Candidates =
+            [
+                LifecycleRestoreTestFixtures.Candidate("archived", ResourceLifecycleMarkerState.Archived),
+                LifecycleRestoreTestFixtures.Candidate("unmarked", ResourceLifecycleMarkerState.Archived),
+                LifecycleRestoreTestFixtures.Candidate("archived", ResourceLifecycleMarkerState.Archived),
+            ],
+        });
+        var empty = await restore.PreviewRestoreAsync(new ResourceLifecycleRestoreRequest());
+
+        Assert.Equal(1, preview.RestorableCount);
+        Assert.Equal(1, preview.AlreadyRestoredCount);
+        Assert.Equal(1, preview.SkippedCount);
+        Assert.Empty(empty.Candidates);
+    }
+
+    [Fact]
+    public async Task PreviewRestoreAsync_ReturnsMarkerMismatchAndMissingTargetDiagnostics()
+    {
+        await LifecycleRestoreTestFixtures.SaveProductAsync(provider, "archived");
+        await LifecycleRestoreTestFixtures.MarkAsync(provider, "archived", ResourceLifecycleMarkerState.Archived);
+        var restore = provider.GetRequiredService<IResourceLifecycleRestoreService>();
+
+        var preview = await restore.PreviewRestoreAsync(new ResourceLifecycleRestoreRequest
+        {
+            Candidates =
+            [
+                LifecycleRestoreTestFixtures.Candidate("archived", ResourceLifecycleMarkerState.SoftDeleted),
+                LifecycleRestoreTestFixtures.Candidate("missing", ResourceLifecycleMarkerState.Archived),
+            ],
+        });
+
+        Assert.Collection(
+            preview.Candidates,
+            first => AssertDiagnostic(first, ResourcePolicyDiagnosticCodes.LifecycleRestoreMarkerMismatch),
+            second => AssertDiagnostic(second, ResourcePolicyDiagnosticCodes.LifecycleMarkerTargetNotFound));
+    }
+
+    [Fact]
+    public async Task PreviewRestoreAsync_DoesNotClearMarkersForValidInvalidOrUnsupportedCandidates()
+    {
+        await LifecycleRestoreTestFixtures.SaveProductAsync(provider, "archived");
+        await LifecycleRestoreTestFixtures.SaveProductAsync(provider, "unsupported");
+        await LifecycleRestoreTestFixtures.MarkAsync(provider, "archived", ResourceLifecycleMarkerState.Archived);
+        await LifecycleRestoreTestFixtures.MarkAsync(provider, "unsupported", ResourceLifecycleMarkerState.Archived);
+        var restore = provider.GetRequiredService<IResourceLifecycleRestoreService>();
+
+        var preview = await restore.PreviewRestoreAsync(new ResourceLifecycleRestoreRequest
+        {
+            Candidates =
+            [
+                LifecycleRestoreTestFixtures.Candidate("archived", ResourceLifecycleMarkerState.Archived),
+                LifecycleRestoreTestFixtures.Candidate("unsupported", ResourceLifecycleMarkerState.None),
+                LifecycleRestoreTestFixtures.Candidate(null, ResourceLifecycleMarkerState.Archived),
+            ],
+        });
+
+        Assert.Equal(1, preview.RestorableCount);
+        Assert.NotNull(await LifecycleRestoreTestFixtures.ReadMarkerAsync(provider, "archived"));
+        Assert.NotNull(await LifecycleRestoreTestFixtures.ReadMarkerAsync(provider, "unsupported"));
+    }
+
+    private static void AssertDiagnostic(ResourceLifecycleRestoreCandidateResult result, string code)
+    {
+        Assert.Equal(ResourceLifecycleRestoreCandidateStatus.Failed, result.Status);
+        Assert.Contains(result.Diagnostics, diagnostic => diagnostic.Code == code);
+    }
+}

--- a/test/Aster.Tests/Lifecycle/LifecycleRestoreResultTests.cs
+++ b/test/Aster.Tests/Lifecycle/LifecycleRestoreResultTests.cs
@@ -1,0 +1,64 @@
+using Aster.Core.Abstractions;
+using Aster.Core.Models.Instances;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Aster.Tests.Lifecycle;
+
+public sealed class LifecycleRestoreResultTests : IDisposable
+{
+    private readonly ServiceProvider provider = LifecycleRestoreTestFixtures.CreateCoreProvider();
+
+    public void Dispose() => provider.Dispose();
+
+    [Fact]
+    public async Task RestoreAsync_ReturnsAggregateCountsEmptyResultsAndOneResultPerInput()
+    {
+        await LifecycleRestoreTestFixtures.SaveProductAsync(provider, "archived");
+        await LifecycleRestoreTestFixtures.SaveProductAsync(provider, "unmarked");
+        await LifecycleRestoreTestFixtures.MarkAsync(provider, "archived", ResourceLifecycleMarkerState.Archived);
+        var restore = provider.GetRequiredService<IResourceLifecycleRestoreService>();
+
+        var result = await restore.RestoreAsync(new ResourceLifecycleRestoreRequest
+        {
+            Candidates =
+            [
+                LifecycleRestoreTestFixtures.Candidate("archived", ResourceLifecycleMarkerState.Archived),
+                LifecycleRestoreTestFixtures.Candidate("unmarked", ResourceLifecycleMarkerState.Archived),
+                LifecycleRestoreTestFixtures.Candidate("missing", ResourceLifecycleMarkerState.Archived),
+            ],
+        });
+        var empty = await restore.RestoreAsync(new ResourceLifecycleRestoreRequest());
+
+        Assert.Equal(3, result.Candidates.Count);
+        Assert.Equal(1, result.RestoredCount);
+        Assert.Equal(1, result.AlreadyRestoredCount);
+        Assert.Equal(1, result.FailedCount);
+        Assert.Empty(empty.Candidates);
+    }
+
+    [Fact]
+    public async Task RestoreAsync_DuplicateCandidatesAreDeterministicAndClearAtMostOnce()
+    {
+        await LifecycleRestoreTestFixtures.SaveProductAsync(provider, "archived");
+        await LifecycleRestoreTestFixtures.MarkAsync(provider, "archived", ResourceLifecycleMarkerState.Archived);
+        var restore = provider.GetRequiredService<IResourceLifecycleRestoreService>();
+
+        var result = await restore.RestoreAsync(new ResourceLifecycleRestoreRequest
+        {
+            Candidates =
+            [
+                LifecycleRestoreTestFixtures.Candidate("archived", ResourceLifecycleMarkerState.Archived),
+                LifecycleRestoreTestFixtures.Candidate("archived", ResourceLifecycleMarkerState.Archived),
+            ],
+        });
+        var retry = await restore.RestoreAsync(new ResourceLifecycleRestoreRequest
+        {
+            Candidates = [LifecycleRestoreTestFixtures.Candidate("archived", ResourceLifecycleMarkerState.Archived)],
+        });
+
+        Assert.Equal(1, result.RestoredCount);
+        Assert.Equal(1, result.SkippedCount);
+        Assert.Null(await LifecycleRestoreTestFixtures.ReadMarkerAsync(provider, "archived"));
+        Assert.Equal(ResourceLifecycleRestoreCandidateStatus.AlreadyRestored, Assert.Single(retry.Candidates).Status);
+    }
+}

--- a/test/Aster.Tests/Lifecycle/LifecycleRestoreServiceTests.cs
+++ b/test/Aster.Tests/Lifecycle/LifecycleRestoreServiceTests.cs
@@ -1,0 +1,53 @@
+using Aster.Core.Abstractions;
+using Aster.Core.Models.Instances;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Aster.Tests.Lifecycle;
+
+public sealed class LifecycleRestoreServiceTests : IDisposable
+{
+    private readonly ServiceProvider provider = LifecycleRestoreTestFixtures.CreateCoreProvider();
+
+    public void Dispose() => provider.Dispose();
+
+    [Fact]
+    public async Task RestoreAsync_ClearsArchivedAndSoftDeletedMarkers()
+    {
+        await LifecycleRestoreTestFixtures.SaveProductAsync(provider, "archived");
+        await LifecycleRestoreTestFixtures.SaveProductAsync(provider, "soft-deleted");
+        await LifecycleRestoreTestFixtures.MarkAsync(provider, "archived", ResourceLifecycleMarkerState.Archived);
+        await LifecycleRestoreTestFixtures.MarkAsync(provider, "soft-deleted", ResourceLifecycleMarkerState.SoftDeleted);
+        var restore = provider.GetRequiredService<IResourceLifecycleRestoreService>();
+
+        var result = await restore.RestoreAsync(new ResourceLifecycleRestoreRequest
+        {
+            Candidates =
+            [
+                LifecycleRestoreTestFixtures.Candidate("archived", ResourceLifecycleMarkerState.Archived),
+                LifecycleRestoreTestFixtures.Candidate("soft-deleted", ResourceLifecycleMarkerState.SoftDeleted),
+            ],
+        });
+
+        Assert.Equal(2, result.RestoredCount);
+        Assert.Null(await LifecycleRestoreTestFixtures.ReadMarkerAsync(provider, "archived"));
+        Assert.Null(await LifecycleRestoreTestFixtures.ReadMarkerAsync(provider, "soft-deleted"));
+    }
+
+    [Fact]
+    public async Task RestoreAsync_ClearsOnlySelectedMarkers()
+    {
+        await LifecycleRestoreTestFixtures.SaveProductAsync(provider, "selected");
+        await LifecycleRestoreTestFixtures.SaveProductAsync(provider, "unselected");
+        await LifecycleRestoreTestFixtures.MarkAsync(provider, "selected", ResourceLifecycleMarkerState.Archived);
+        await LifecycleRestoreTestFixtures.MarkAsync(provider, "unselected", ResourceLifecycleMarkerState.Archived);
+        var restore = provider.GetRequiredService<IResourceLifecycleRestoreService>();
+
+        await restore.RestoreAsync(new ResourceLifecycleRestoreRequest
+        {
+            Candidates = [LifecycleRestoreTestFixtures.Candidate("selected", ResourceLifecycleMarkerState.Archived)],
+        });
+
+        Assert.Null(await LifecycleRestoreTestFixtures.ReadMarkerAsync(provider, "selected"));
+        Assert.NotNull(await LifecycleRestoreTestFixtures.ReadMarkerAsync(provider, "unselected"));
+    }
+}

--- a/test/Aster.Tests/Lifecycle/LifecycleRestoreTestFixtures.cs
+++ b/test/Aster.Tests/Lifecycle/LifecycleRestoreTestFixtures.cs
@@ -1,0 +1,59 @@
+using Aster.Core.Abstractions;
+using Aster.Core.Models.Instances;
+using Aster.Core.Models.Tenancy;
+using Aster.Tests.Policies;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Aster.Tests.Lifecycle;
+
+internal static class LifecycleRestoreTestFixtures
+{
+    public static ServiceProvider CreateCoreProvider() => PolicyTestFixtures.CreateCoreProvider();
+
+    public static ServiceProvider CreateSqliteProvider(string databasePath) =>
+        PolicyTestFixtures.CreateSqliteProvider(databasePath);
+
+    public static async Task SaveProductAsync(
+        IServiceProvider provider,
+        string resourceId,
+        TenantScope? tenantScope = null,
+        int version = 1)
+    {
+        await PolicyTestFixtures.RegisterProductDefinitionAsync(provider, tenantScope);
+        await PolicyTestFixtures.SaveResourceAsync(provider, resourceId, version: version, tenantScope: tenantScope);
+    }
+
+    public static async Task MarkAsync(
+        IServiceProvider provider,
+        string resourceId,
+        ResourceLifecycleMarkerState state,
+        TenantScope? tenantScope = null)
+    {
+        var markers = provider.GetRequiredService<IResourceLifecycleMarkerService>();
+        await markers.ApplyAsync(new ResourceLifecycleMarkerRequest
+        {
+            TenantScope = tenantScope,
+            ResourceId = resourceId,
+            State = state,
+            MarkedAt = new DateTimeOffset(2026, 5, 27, 0, 0, 0, TimeSpan.Zero),
+        });
+    }
+
+    public static ResourceLifecycleRestoreCandidate Candidate(
+        string? resourceId,
+        ResourceLifecycleMarkerState? expectedState) =>
+        new()
+        {
+            ResourceId = resourceId,
+            ExpectedState = expectedState,
+        };
+
+    public static async Task<ResourceLifecycleMarker?> ReadMarkerAsync(
+        IServiceProvider provider,
+        string resourceId,
+        TenantScope? tenantScope = null)
+    {
+        var store = provider.GetRequiredService<IResourceLifecycleMarkerStore>();
+        return await store.GetMarkerAsync(resourceId, tenantScope ?? TenantScope.Default);
+    }
+}

--- a/test/Aster.Tests/Querying/LifecycleStateQueryTests.cs
+++ b/test/Aster.Tests/Querying/LifecycleStateQueryTests.cs
@@ -1,6 +1,7 @@
 using Aster.Core.Abstractions;
 using Aster.Core.Models.Instances;
 using Aster.Core.Models.Querying;
+using Aster.Tests.Lifecycle;
 using Aster.Tests.Policies;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -40,5 +41,30 @@ public sealed class LifecycleStateQueryTests : IDisposable
 
         Assert.Equal(["archived"], archived.Select(static resource => resource.ResourceId).ToList());
         Assert.Equal(["unmarked"], unmarked.Select(static resource => resource.ResourceId).ToList());
+    }
+
+    [Fact]
+    public async Task QueryAsync_AfterRestore_DoesNotReturnRestoredLifecycleState()
+    {
+        await PolicyTestFixtures.RegisterProductDefinitionAsync(provider);
+        await PolicyTestFixtures.SaveResourceAsync(provider, "archived");
+        await provider.GetRequiredService<IResourceLifecycleMarkerService>().ApplyAsync(new ResourceLifecycleMarkerRequest
+        {
+            ResourceId = "archived",
+            State = ResourceLifecycleMarkerState.Archived,
+            MarkedAt = DateTimeOffset.UtcNow,
+        });
+        await provider.GetRequiredService<IResourceLifecycleRestoreService>().RestoreAsync(new ResourceLifecycleRestoreRequest
+        {
+            Candidates = [LifecycleRestoreTestFixtures.Candidate("archived", ResourceLifecycleMarkerState.Archived)],
+        });
+        var query = provider.GetRequiredService<IResourceQueryService>();
+
+        var archived = (await query.QueryAsync(new ResourceQuery
+        {
+            LifecycleState = ResourceLifecycleMarkerState.Archived,
+        })).ToList();
+
+        Assert.Empty(archived);
     }
 }

--- a/test/Aster.Tests/SqliteJson/SqliteJsonLifecycleRestoreTests.cs
+++ b/test/Aster.Tests/SqliteJson/SqliteJsonLifecycleRestoreTests.cs
@@ -1,0 +1,60 @@
+using Aster.Core.Abstractions;
+using Aster.Core.Models.Instances;
+using Aster.Core.Models.Querying;
+using Aster.Tests.Lifecycle;
+using Aster.Tests.Policies;
+using Aster.Tests.Tenancy;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Aster.Tests.SqliteJson;
+
+public sealed class SqliteJsonLifecycleRestoreTests : IDisposable
+{
+    private readonly string databasePath = Path.Combine(Path.GetTempPath(), $"aster-restore-{Guid.NewGuid():N}.db");
+
+    public void Dispose() => PolicyTestFixtures.DeleteSqliteFiles(databasePath);
+
+    [Fact]
+    public async Task RestoreAsync_ClearsPersistedMarkerAndUpdatesLifecycleQueries()
+    {
+        await using (var provider = LifecycleRestoreTestFixtures.CreateSqliteProvider(databasePath))
+        {
+            await LifecycleRestoreTestFixtures.SaveProductAsync(provider, "archived");
+            await LifecycleRestoreTestFixtures.MarkAsync(provider, "archived", ResourceLifecycleMarkerState.Archived);
+            await provider.GetRequiredService<IResourceLifecycleRestoreService>().RestoreAsync(new ResourceLifecycleRestoreRequest
+            {
+                Candidates = [LifecycleRestoreTestFixtures.Candidate("archived", ResourceLifecycleMarkerState.Archived)],
+            });
+        }
+
+        await using var secondProvider = LifecycleRestoreTestFixtures.CreateSqliteProvider(databasePath);
+        var query = secondProvider.GetRequiredService<IResourceQueryService>();
+
+        var archived = (await query.QueryAsync(new ResourceQuery
+        {
+            LifecycleState = ResourceLifecycleMarkerState.Archived,
+        })).ToList();
+
+        Assert.Empty(archived);
+    }
+
+    [Fact]
+    public async Task RestoreAsync_SqliteMarkerDeletesAreTenantScoped()
+    {
+        await using var provider = LifecycleRestoreTestFixtures.CreateSqliteProvider(databasePath);
+        await LifecycleRestoreTestFixtures.SaveProductAsync(provider, "shared", TenantScopeTestFixtures.TenantA);
+        await LifecycleRestoreTestFixtures.SaveProductAsync(provider, "shared", TenantScopeTestFixtures.TenantB);
+        await LifecycleRestoreTestFixtures.MarkAsync(provider, "shared", ResourceLifecycleMarkerState.SoftDeleted, TenantScopeTestFixtures.TenantA);
+        await LifecycleRestoreTestFixtures.MarkAsync(provider, "shared", ResourceLifecycleMarkerState.SoftDeleted, TenantScopeTestFixtures.TenantB);
+        var restore = provider.GetRequiredService<IResourceLifecycleRestoreService>();
+
+        await restore.RestoreAsync(new ResourceLifecycleRestoreRequest
+        {
+            TenantScope = TenantScopeTestFixtures.TenantA,
+            Candidates = [LifecycleRestoreTestFixtures.Candidate("shared", ResourceLifecycleMarkerState.SoftDeleted)],
+        });
+
+        Assert.Null(await LifecycleRestoreTestFixtures.ReadMarkerAsync(provider, "shared", TenantScopeTestFixtures.TenantA));
+        Assert.NotNull(await LifecycleRestoreTestFixtures.ReadMarkerAsync(provider, "shared", TenantScopeTestFixtures.TenantB));
+    }
+}

--- a/test/Aster.Tests/SqliteJson/SqliteJsonLifecycleRestoreTests.cs
+++ b/test/Aster.Tests/SqliteJson/SqliteJsonLifecycleRestoreTests.cs
@@ -1,6 +1,7 @@
 using Aster.Core.Abstractions;
 using Aster.Core.Models.Instances;
 using Aster.Core.Models.Querying;
+using Aster.Core.Models.Tenancy;
 using Aster.Tests.Lifecycle;
 using Aster.Tests.Policies;
 using Aster.Tests.Tenancy;
@@ -56,5 +57,26 @@ public sealed class SqliteJsonLifecycleRestoreTests : IDisposable
 
         Assert.Null(await LifecycleRestoreTestFixtures.ReadMarkerAsync(provider, "shared", TenantScopeTestFixtures.TenantA));
         Assert.NotNull(await LifecycleRestoreTestFixtures.ReadMarkerAsync(provider, "shared", TenantScopeTestFixtures.TenantB));
+    }
+
+    [Fact]
+    public async Task ClearMarkerAsync_OnlyDeletesMatchingExpectedState()
+    {
+        await using var provider = LifecycleRestoreTestFixtures.CreateSqliteProvider(databasePath);
+        await LifecycleRestoreTestFixtures.SaveProductAsync(provider, "archived");
+        await LifecycleRestoreTestFixtures.MarkAsync(provider, "archived", ResourceLifecycleMarkerState.Archived);
+        var clearStore = provider.GetRequiredService<IResourceLifecycleMarkerClearStore>();
+
+        var wrongStateRemoved = await clearStore.ClearMarkerAsync(
+            "archived",
+            TenantScope.Default,
+            ResourceLifecycleMarkerState.SoftDeleted);
+        var rightStateRemoved = await clearStore.ClearMarkerAsync(
+            "archived",
+            TenantScope.Default,
+            ResourceLifecycleMarkerState.Archived);
+
+        Assert.False(wrongStateRemoved);
+        Assert.True(rightStateRemoved);
     }
 }

--- a/test/Aster.Tests/Tenancy/TenantLifecycleRestoreTests.cs
+++ b/test/Aster.Tests/Tenancy/TenantLifecycleRestoreTests.cs
@@ -1,0 +1,48 @@
+using Aster.Core.Abstractions;
+using Aster.Core.Models.Instances;
+using Aster.Tests.Lifecycle;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Aster.Tests.Tenancy;
+
+public sealed class TenantLifecycleRestoreTests : IDisposable
+{
+    private readonly ServiceProvider provider = LifecycleRestoreTestFixtures.CreateCoreProvider();
+
+    public void Dispose() => provider.Dispose();
+
+    [Fact]
+    public async Task RestoreAsync_ClearsOnlyMarkersInsideEffectiveTenant()
+    {
+        await LifecycleRestoreTestFixtures.SaveProductAsync(provider, "shared", TenantScopeTestFixtures.TenantA);
+        await LifecycleRestoreTestFixtures.SaveProductAsync(provider, "shared", TenantScopeTestFixtures.TenantB);
+        await LifecycleRestoreTestFixtures.MarkAsync(provider, "shared", ResourceLifecycleMarkerState.Archived, TenantScopeTestFixtures.TenantA);
+        await LifecycleRestoreTestFixtures.MarkAsync(provider, "shared", ResourceLifecycleMarkerState.Archived, TenantScopeTestFixtures.TenantB);
+        var restore = provider.GetRequiredService<IResourceLifecycleRestoreService>();
+
+        await restore.RestoreAsync(new ResourceLifecycleRestoreRequest
+        {
+            TenantScope = TenantScopeTestFixtures.TenantA,
+            Candidates = [LifecycleRestoreTestFixtures.Candidate("shared", ResourceLifecycleMarkerState.Archived)],
+        });
+
+        Assert.Null(await LifecycleRestoreTestFixtures.ReadMarkerAsync(provider, "shared", TenantScopeTestFixtures.TenantA));
+        Assert.NotNull(await LifecycleRestoreTestFixtures.ReadMarkerAsync(provider, "shared", TenantScopeTestFixtures.TenantB));
+    }
+
+    [Fact]
+    public async Task RestoreAsync_OmittedTenantScopeUsesDefaultTenant()
+    {
+        await LifecycleRestoreTestFixtures.SaveProductAsync(provider, "default-product");
+        await LifecycleRestoreTestFixtures.MarkAsync(provider, "default-product", ResourceLifecycleMarkerState.SoftDeleted);
+        var restore = provider.GetRequiredService<IResourceLifecycleRestoreService>();
+
+        var result = await restore.RestoreAsync(new ResourceLifecycleRestoreRequest
+        {
+            Candidates = [LifecycleRestoreTestFixtures.Candidate("default-product", ResourceLifecycleMarkerState.SoftDeleted)],
+        });
+
+        Assert.True(result.TenantScope.IsDefault);
+        Assert.Null(await LifecycleRestoreTestFixtures.ReadMarkerAsync(provider, "default-product"));
+    }
+}

--- a/wiki/Roadmap.md
+++ b/wiki/Roadmap.md
@@ -2,7 +2,7 @@
 
 Aster is delivered in six phases. Each phase builds on the last, with clean extension points so earlier work is not thrown away.
 
-> **Current status:** Phase 5 in progress — Core SDK, in-memory engine, SQLite JSON persistence/querying, query capability discovery, preflight validation, typed query authoring helpers, provider authoring/conformance support, SQLite facet sorting, portable operators, SQLite date-like ranges, explicit index projection contracts, explicit definition schema upgrade behavior, portability primitives, host lifecycle hooks, explicit tenant scoping, policy foundations, and host-controlled policy application orchestration are available.
+> **Current status:** Phase 5 in progress — Core SDK, in-memory engine, SQLite JSON persistence/querying, query capability discovery, preflight validation, typed query authoring helpers, provider authoring/conformance support, SQLite facet sorting, portable operators, SQLite date-like ranges, explicit index projection contracts, explicit definition schema upgrade behavior, portability primitives, host lifecycle hooks, explicit tenant scoping, policy foundations, host-controlled policy application orchestration, and lifecycle restore workflows are available.
 >
 > For the current implementation trail and next Spec Kit slices, see [`docs/ExecutionRoadmap.md`](../docs/ExecutionRoadmap.md).
 
@@ -33,7 +33,7 @@ Aster is delivered in six phases. Each phase builds on the last, with clean exte
 | **015 Tenant Scoping** | Landed | Add explicit tenant boundaries for definitions, resources, activation, queries, portability, and lifecycle hooks. |
 | **016 Policy Foundations** | Landed | Introduce explicit retention, archival, soft-delete, and pruning policy contracts without hidden background processing. |
 | **017 Policy Application Orchestration** | Landed | Apply selected archive and soft-delete policy preview outcomes through host-controlled workflows. |
-| **018 Lifecycle Restore Workflows** | Next | Preview and explicitly restore archive and soft-delete lifecycle markers without hidden execution or resource version rewrites. |
+| **018 Lifecycle Restore Workflows** | Landed | Preview and explicitly restore archive and soft-delete lifecycle markers without hidden execution or resource version rewrites. |
 
 ---
 

--- a/wiki/Roadmap.md
+++ b/wiki/Roadmap.md
@@ -2,7 +2,7 @@
 
 Aster is delivered in six phases. Each phase builds on the last, with clean extension points so earlier work is not thrown away.
 
-> **Current status:** Phase 5 in progress — Core SDK, in-memory engine, SQLite JSON persistence/querying, query capability discovery, preflight validation, typed query authoring helpers, provider authoring/conformance support, SQLite facet sorting, portable operators, SQLite date-like ranges, explicit index projection contracts, explicit definition schema upgrade behavior, portability primitives, host lifecycle hooks, and explicit tenant scoping are available.
+> **Current status:** Phase 5 in progress — Core SDK, in-memory engine, SQLite JSON persistence/querying, query capability discovery, preflight validation, typed query authoring helpers, provider authoring/conformance support, SQLite facet sorting, portable operators, SQLite date-like ranges, explicit index projection contracts, explicit definition schema upgrade behavior, portability primitives, host lifecycle hooks, explicit tenant scoping, policy foundations, and host-controlled policy application orchestration are available.
 >
 > For the current implementation trail and next Spec Kit slices, see [`docs/ExecutionRoadmap.md`](../docs/ExecutionRoadmap.md).
 
@@ -31,7 +31,9 @@ Aster is delivered in six phases. Each phase builds on the last, with clean exte
 | **013 Portability Primitives** | Landed | Add deterministic export/import primitives for definitions and resources. |
 | **014 Host Lifecycle Hooks** | Landed | Add explicit hooks around save, activation, deactivation, and import/export without hidden runtime scanning. |
 | **015 Tenant Scoping** | Landed | Add explicit tenant boundaries for definitions, resources, activation, queries, portability, and lifecycle hooks. |
-| **016 Policy Foundations** | Next | Introduce explicit retention, archival, soft-delete, and pruning policy contracts without hidden background processing. |
+| **016 Policy Foundations** | Landed | Introduce explicit retention, archival, soft-delete, and pruning policy contracts without hidden background processing. |
+| **017 Policy Application Orchestration** | Landed | Apply selected archive and soft-delete policy preview outcomes through host-controlled workflows. |
+| **018 Lifecycle Restore Workflows** | Next | Preview and explicitly restore archive and soft-delete lifecycle markers without hidden execution or resource version rewrites. |
 
 ---
 


### PR DESCRIPTION
## Summary
- add host-controlled lifecycle restore preview and application APIs
- add provider marker clear capability for in-memory and SQLite JSON stores
- cover restore behavior across lifecycle, query, tenant, and SQLite tests

## Validation
- dotnet test Aster.sln
- dotnet build Aster.sln /m:1
- git diff --check