### PR TITLE
Add version history inspection

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "featureDir": "specs/019-policy-pruning-application"
+  "featureDir": "specs/020-version-history-inspection"
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 <!-- SPECKIT START -->
 For additional context about technologies to be used, project structure,
-shell commands, and other important information, read `specs/019-policy-pruning-application/plan.md`.
+shell commands, and other important information, read `specs/020-version-history-inspection/plan.md`.
 <!-- SPECKIT END -->
 
 ## Active Technologies
@@ -24,8 +24,11 @@ shell commands, and other important information, read `specs/019-policy-pruning-
 - Existing lifecycle marker storage only. Restore clears existing archive/soft-delete marker rows or in-memory entries; no resource version, activation state, policy declaration, portability snapshot format, or SQLite schema changes. (018-lifecycle-restore-workflows)
 - C# latest, .NET 8.0 / 9.0 / 10.0 multi-targeting + Existing core SDK, resource definition store, resource version reader, lifecycle marker store, policy validation/evaluation models, in-memory store, SQLite JSON provider, xUnit test stack; no new dependencies (019-policy-pruning-application)
 - Existing resource version storage only. Pruning removes selected resource version snapshots from in-memory and SQLite JSON stores; no schema migration, policy declaration mutation, lifecycle marker mutation, activation mutation, or portability snapshot format change. (019-policy-pruning-application)
+- C# latest, .NET 8.0 / 9.0 / 10.0 multi-targeting + Existing core SDK, resource version reader, lifecycle marker store, in-memory store, SQLite JSON provider, xUnit test stack; no new dependencies (020-version-history-inspection)
+- Existing resource versions, activation state, and lifecycle marker storage only. No schema migration, data rewrite, portability snapshot format change, or physical index creation. (020-version-history-inspection)
 
 ## Recent Changes
+- 020-version-history-inspection: Added read-only host-facing resource version history inspection with latest/draft/active-channel summaries, lifecycle marker state, conservative maintenance hints, tenant scoping, SQLite parity, and no storage migrations, query planner, provider registry, public SQL, public IQueryable<Resource>, background jobs, or mutation behavior
 - 019-policy-pruning-application: Added host-controlled policy pruning application for selected version-pruning preview outcomes with safety preflight, tenant scoping, stable diagnostics, in-memory/SQLite removal support, and no schedulers, authorization engines, provider registries, public SQL, public IQueryable<Resource>, broad workflow/state-machine infrastructure, or schema migrations
 - 018-lifecycle-restore-workflows: Added lifecycle restore workflow planning for host-controlled preview and application over archive/soft-delete markers; no resource version rewrites, activation changes, schedulers, authorization engines, provider registries, public SQL, public IQueryable<Resource>, destructive pruning writes, or schema changes
 - 017-policy-application-orchestration: Added host-controlled policy application orchestration for selected archive/soft-delete preview outcomes with per-candidate results, stale/policy validation, tenant scoping, and bounded provider reads

--- a/docs/ExecutionRoadmap.md
+++ b/docs/ExecutionRoadmap.md
@@ -6,9 +6,9 @@ This roadmap tracks the implementation trail we have already cut through the rep
 
 ## Current Position
 
-Aster now has a working Core SDK, in-memory runtime, SQLite JSON persistence/querying, provider capability discovery, provider validation alignment, provider authoring ergonomics, a reusable provider conformance harness, SQLite facet sorting, portable operator expansion, SQLite date-like ranges, explicit provider-declared index projections, explicit definition schema upgrade behavior, deterministic portability primitives, explicit host lifecycle hooks, explicit tenant scoping, policy foundations, host-controlled policy application orchestration, host-controlled lifecycle restore workflows, and host-controlled policy pruning application.
+Aster now has a working Core SDK, in-memory runtime, SQLite JSON persistence/querying, provider capability discovery, provider validation alignment, provider authoring ergonomics, a reusable provider conformance harness, SQLite facet sorting, portable operator expansion, SQLite date-like ranges, explicit provider-declared index projections, explicit definition schema upgrade behavior, deterministic portability primitives, explicit host lifecycle hooks, explicit tenant scoping, policy foundations, host-controlled policy application orchestration, host-controlled lifecycle restore workflows, host-controlled policy pruning application, and read-only version history inspection.
 
-The Phase 4 core workstream is complete enough to defer optional recipes. The active workstream is now **Phase 5: Multi-tenancy, Policies, Advanced Versioning**. Explicit tenant-aware boundaries, policy foundations, policy application orchestration, reversible lifecycle restore, and destructive pruning application have landed; the next slices should stay focused on advanced tenant/versioning behavior or bounded operational hardening, not both at once.
+The Phase 4 core workstream is complete enough to defer optional recipes. The active workstream is now **Phase 5: Multi-tenancy, Policies, Advanced Versioning**. Explicit tenant-aware boundaries, policy foundations, policy application orchestration, reversible lifecycle restore, destructive pruning application, and version history inspection have landed; the next slices should stay focused on advanced tenant/versioning behavior or bounded operational hardening, not both at once.
 
 ## Landed Slices
 
@@ -33,10 +33,11 @@ The Phase 4 core workstream is complete enough to defer optional recipes. The ac
 | `017-policy-application-orchestration` | Landed | Host-controlled application of selected archive/soft-delete preview outcomes with per-candidate results, stale/policy validation, tenant scoping, and bounded provider reads. |
 | `018-lifecycle-restore-workflows` | Landed | Host-controlled preview and application for restoring archive/soft-delete markers with tenant scoping, idempotent already-restored outcomes, stable diagnostics, and no version or activation mutation. |
 | `019-policy-pruning-application` | Landed | Host-controlled application of selected version-pruning preview outcomes with latest/active protection, policy revalidation, tenant scoping, deterministic retries, provider fallback diagnostics, and no schema or portability format changes. |
+| `020-version-history-inspection` | Landed | Read-only host-facing version history inspection with latest/draft/active-channel summaries, lifecycle marker visibility, conservative maintenance hints, tenant scoping, and in-memory/SQLite parity without schema changes or query-surface expansion. |
 
 ## Near-Term Roadmap
 
-### 020 — Next Bounded Phase 5 Slice
+### 021 — Next Bounded Phase 5 Slice
 
 **Goal:** Choose one small continuation slice that builds on tenant-aware lifecycle and policy primitives without broadening the architecture.
 

--- a/specs/020-version-history-inspection/checklists/requirements.md
+++ b/specs/020-version-history-inspection/checklists/requirements.md
@@ -1,0 +1,34 @@
+# Specification Quality Checklist: Resource Version History Inspection
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-05-29
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Specification is ready for planning.

--- a/specs/020-version-history-inspection/contracts/version-history-inspection.md
+++ b/specs/020-version-history-inspection/contracts/version-history-inspection.md
@@ -1,0 +1,121 @@
+# Contract: Resource Version History Inspection
+
+Version history inspection provides read-only, tenant-scoped resource timeline summaries for hosts.
+
+## Host-Facing Behavior
+
+Hosts can:
+
+- request the history for one logical resource ID in one tenant;
+- display version order, latest state, draft state, active channels, lifecycle state, and conservative maintenance hints;
+- treat a missing resource in the effective tenant as an empty history result.
+
+The SDK must:
+
+- resolve one effective tenant per request;
+- return summaries ordered by version number;
+- report active channels without requiring the host to know channel names first;
+- report current resource-level lifecycle marker state;
+- identify latest or active versions as protected from destructive pruning;
+- avoid mutations and side effects.
+
+The SDK must not:
+
+- evaluate policy eligibility as part of history inspection;
+- run automatic policy execution or pruning;
+- leak state from another tenant;
+- introduce public SQL, public `IQueryable<Resource>`, provider registries, runtime scanning, schedulers, or schema migrations.
+
+## Proposed Public SDK Contract
+
+```csharp
+public interface IResourceVersionHistoryService
+{
+    ValueTask<ResourceVersionHistoryResult> GetHistoryAsync(
+        ResourceVersionHistoryRequest request,
+        CancellationToken cancellationToken = default);
+}
+```
+
+Request shape:
+
+```csharp
+public sealed class ResourceVersionHistoryRequest
+{
+    public TenantScope? TenantScope { get; set; }
+    public string? ResourceId { get; set; }
+}
+```
+
+Result shape:
+
+```csharp
+public sealed record ResourceVersionHistoryResult
+{
+    public TenantScope TenantScope { get; init; } = TenantScope.Default;
+    public required string ResourceId { get; init; }
+    public IReadOnlyList<ResourceVersionSummary> Versions { get; init; } = [];
+}
+
+public sealed record ResourceVersionSummary
+{
+    public required string ResourceVersionId { get; init; }
+    public required int Version { get; init; }
+    public required string DefinitionId { get; init; }
+    public int? DefinitionVersion { get; init; }
+    public required DateTime Created { get; init; }
+    public required bool IsLatest { get; init; }
+    public required bool IsDraft { get; init; }
+    public IReadOnlyList<string> ActiveChannels { get; init; } = [];
+    public ResourceLifecycleMarkerState LifecycleState { get; init; } = ResourceLifecycleMarkerState.None;
+    public required bool IsProtectedFromPruning { get; init; }
+    public required ResourceVersionMaintenanceDisposition MaintenanceDisposition { get; init; }
+}
+
+public enum ResourceVersionMaintenanceDisposition
+{
+    Protected,
+    PossibleCandidate,
+}
+```
+
+## Provider-Facing Contract
+
+Providers expose activation state enumeration through a narrow reader.
+
+```csharp
+public interface IResourceActivationStateReader
+{
+    ValueTask<IReadOnlyList<ActivationState>> ReadActivationStatesAsync(
+        IEnumerable<string> resourceIds,
+        TenantScope tenantScope,
+        CancellationToken cancellationToken = default);
+}
+```
+
+Provider rules:
+
+- Return activation states only for the supplied tenant.
+- Return activation states only for normalized non-empty resource IDs supplied by the caller.
+- Return an empty list when no matching activation states exist.
+- Preserve the existing activation state payload semantics.
+- Do not mutate activation state while reading.
+
+## Validation Rules
+
+History inspection must reject invalid request shape when:
+
+- request is null;
+- resource ID is null, empty, or whitespace.
+
+History inspection must not fail when:
+
+- the resource does not exist in the effective tenant;
+- the resource has versions but no activation states;
+- the resource has no lifecycle marker.
+
+## Ordering Rules
+
+- Version summaries are ordered by `Version` ascending.
+- Active channel names are ordered ordinally.
+- Results for missing resources contain an empty `Versions` list.

--- a/specs/020-version-history-inspection/data-model.md
+++ b/specs/020-version-history-inspection/data-model.md
@@ -1,0 +1,91 @@
+# Data Model: Resource Version History Inspection
+
+## Version History Request
+
+Host-provided request for one resource timeline.
+
+Fields:
+
+- `TenantScope? TenantScope`: Optional tenant scope. Omitted means the default single-tenant scope.
+- `string? ResourceId`: Logical resource identifier whose versions should be inspected.
+
+Validation:
+
+- `ResourceId` is required and must not be null, empty, or whitespace.
+- Exactly one effective tenant is resolved for the request.
+
+## Version History Result
+
+Read-only response for one resource timeline.
+
+Fields:
+
+- `TenantScope TenantScope`: Effective tenant used for all reads.
+- `string ResourceId`: Requested logical resource identifier.
+- `IReadOnlyList<ResourceVersionSummary> Versions`: Ordered summaries for each version found in the effective tenant.
+
+Rules:
+
+- Missing resources return an empty `Versions` collection.
+- Results are ordered by resource version number ascending.
+- The result must not expose state from any other tenant.
+
+## Resource Version Summary
+
+Read-only description of one resource version.
+
+Fields:
+
+- `string ResourceVersionId`: Version snapshot identifier.
+- `int Version`: Resource version number.
+- `string DefinitionId`: Logical resource definition identifier.
+- `int? DefinitionVersion`: Resource definition version captured by the resource version.
+- `DateTime Created`: Version creation timestamp.
+- `bool IsLatest`: Whether this is the highest version currently present for the resource.
+- `bool IsDraft`: Whether this version is absent from all active channel state.
+- `IReadOnlyList<string> ActiveChannels`: Active channel names containing this version.
+- `ResourceLifecycleMarkerState LifecycleState`: Current lifecycle marker state for the logical resource, or `None` when no marker exists.
+- `bool IsProtectedFromPruning`: Whether destructive pruning must protect this version because it is latest or active.
+- `ResourceVersionMaintenanceDisposition MaintenanceDisposition`: Conservative maintenance hint for host displays.
+
+Rules:
+
+- `IsLatest` is true only for the highest returned version number.
+- `IsDraft` is true when `ActiveChannels` is empty.
+- `ActiveChannels` are deterministic and sorted ordinally.
+- `LifecycleState` is resource-level current state, not a per-version marker.
+- `IsProtectedFromPruning` is true when `IsLatest` is true or `ActiveChannels` is non-empty.
+
+## Maintenance Disposition
+
+Conservative host-facing signal describing obvious maintenance safety.
+
+Values:
+
+- `Protected`: Version is latest or active and must not be destructively pruned.
+- `PossibleCandidate`: Version is historical, inactive, and not latest; policy evaluation is still required before any pruning.
+
+Rules:
+
+- The disposition does not apply policy retention counts.
+- The disposition does not authorize mutation.
+- The disposition does not replace policy preview/application diagnostics.
+
+## Activation State Read
+
+Provider-facing read model for active channels.
+
+Input:
+
+- Effective tenant.
+- One or more logical resource identifiers.
+
+Output:
+
+- Activation states for those resource identifiers in the effective tenant.
+
+Rules:
+
+- Empty, null, or whitespace resource identifiers are ignored.
+- Reads must not return activation states outside the effective tenant.
+- Providers may return no states for resources that do not exist or have no active channels.

--- a/specs/020-version-history-inspection/plan.md
+++ b/specs/020-version-history-inspection/plan.md
@@ -1,0 +1,122 @@
+# Implementation Plan: Resource Version History Inspection
+
+**Branch**: `020-version-history-inspection` | **Date**: 2026-05-29 | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from `/specs/020-version-history-inspection/spec.md`
+
+## Summary
+
+Add a read-only, host-facing resource version history inspection service. The implementation composes existing resource version reads, lifecycle marker reads, and a narrow activation-state reader so hosts can inspect one tenant-scoped resource timeline with latest, draft, active-channel, lifecycle, and conservative maintenance signals. The feature adds no storage schema changes, no mutation behavior, no public SQL, no public `IQueryable<Resource>`, no provider registry, no scheduler, and no query planner.
+
+## Technical Context
+
+**Language/Version**: C# latest, .NET 8.0 / 9.0 / 10.0 multi-targeting
+**Primary Dependencies**: Existing core SDK, resource version reader, lifecycle marker store, in-memory store, SQLite JSON provider, xUnit test stack; no new dependencies
+**Storage**: Existing resource versions, activation state, and lifecycle marker storage only. No schema migration, data rewrite, portability snapshot format change, or physical index creation.
+**Testing**: `dotnet test Aster.sln`, focused version history tests, tenant isolation tests, SQLite JSON parity tests, existing policy/restore/pruning/query/portability regression tests, `dotnet build Aster.sln /m:1`, `git diff --check`
+**Target Platform**: .NET SDK/library consumers and local test environment
+**Project Type**: SDK/library with provider packages and tests
+**Performance Goals**: History inspection is bounded to one resource ID in one effective tenant and should use existing scoped reads rather than scanning unrelated tenants.
+**Constraints**: Read-only behavior; one effective tenant per request; deterministic version ordering; active channels must be enumerated for the requested resource; lifecycle state is resource-level current marker state; maintenance hints are conservative and not policy eligibility decisions; no scheduler, authorization engine, provider registry, runtime scanning, public SQL, public `IQueryable<Resource>`, broad workflow/state-machine infrastructure, or schema migration.
+**Scale/Scope**: Core SDK request/result models, one history service, a narrow activation-state reader contract implemented by in-memory and SQLite JSON stores, DI registration, docs, and focused tests.
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+- **SDK-first/headless**: PASS - Adds host-facing SDK contracts only; no UI, CMS, or host authorization behavior.
+- **Immutable versioning**: PASS - Inspection is read-only and does not mutate resource versions.
+- **Channel activation**: PASS - Activation remains separate from resource payloads; history only reports active channels.
+- **Typed/queryable**: PASS - Existing typed aspects and query AST remain unchanged; no public SQL or `IQueryable` is introduced.
+- **Provider agnostic**: PASS - Core service composes abstractions; provider-specific reads remain in provider packages.
+- **Simplicity first**: PASS - One read-only service plus one narrow state reader is simpler than a query planner, registry, or reporting framework.
+- **Modern C# idioms**: PASS - Records, collection expressions, nullable-safe request handling, async APIs, and pattern matching fit existing style.
+- **Readability over cleverness**: PASS - History assembly is an explicit orchestration over versions, activation states, and marker state.
+- **Explicitness over magic**: PASS - Hosts submit resource ID and tenant scope explicitly; no scanning or ambient tenant discovery.
+- **Abstractions justified**: PASS - Active channel enumeration is not available through existing public reads; a narrow reader solves a demonstrated current need.
+- **Optimize for deletion**: PASS - Models, service, and reader contract are additive and localized.
+- **Composition over inheritance**: PASS - Uses services, records, and explicit collaborators; no new inheritance hierarchy.
+- **Intentional dependencies**: PASS - No new third-party dependencies.
+- **Operational simplicity**: PASS - No migration, worker, external service, or setup change.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/020-version-history-inspection/
++-- spec.md
++-- plan.md
++-- research.md
++-- data-model.md
++-- quickstart.md
++-- checklists/
+|   +-- requirements.md
++-- contracts/
+    +-- version-history-inspection.md
+```
+
+### Source Code (repository root)
+
+```text
+src/
++-- core/Aster.Core/
+|   +-- Abstractions/
+|   |   +-- version history service and activation-state reader contracts
+|   +-- Models/Instances/
+|   |   +-- version history request/result models
+|   +-- Services/
+|       +-- default version history inspection service
+|
++-- persistence/Aster.Persistence.SqliteJson/
+|   +-- activation-state reader implementation over existing activation storage
+|
++-- apps/Aster.Web/
+    +-- no feature-specific host UI
+
+test/
++-- Aster.Tests/
+    +-- Versioning/
+    +-- Tenancy/
+    +-- SqliteJson/
+```
+
+**Structure Decision**: Keep history inspection in `Aster.Core` because version state, tenant boundaries, lifecycle marker visibility, and maintenance hints are SDK semantics. Providers only expose activation-state reads needed to enumerate active channels from existing storage. Do not add a provider registry, scheduler, reporting database, query planner, authorization layer, migration framework, or new dependency.
+
+## Complexity Tracking
+
+No constitution violations.
+
+## Phase 0 Research Summary
+
+Research decisions are captured in [research.md](research.md). Key outcomes:
+
+- Add a dedicated read-only history service rather than expanding policy or query services.
+- Add a narrow activation-state reader because current active-version reads require a known channel.
+- Treat maintenance hints as conservative visibility signals, not policy eligibility.
+- Preserve tenant-scoped missing-resource behavior by returning an empty result.
+- Keep SQLite behavior provider-specific and schema-free.
+
+## Phase 1 Design Summary
+
+Design artifacts:
+
+- [data-model.md](data-model.md)
+- [contracts/version-history-inspection.md](contracts/version-history-inspection.md)
+- [quickstart.md](quickstart.md)
+
+## Post-Design Constitution Check
+
+- **SDK-first/headless**: PASS - Design exposes SDK services and models only.
+- **Immutable versioning**: PASS - No write path is introduced.
+- **Channel activation**: PASS - Active channels are read from activation state and remain decoupled from resource payloads.
+- **Typed/queryable**: PASS - Query AST and typed aspect APIs remain unchanged.
+- **Provider agnostic**: PASS - Core service depends on reader abstractions; SQLite-specific SQL stays in the provider package.
+- **Simplicity first**: PASS - Scope remains one resource history call rather than a reporting framework.
+- **Modern C# idioms**: PASS - Planned models and service follow existing modern C# style.
+- **Readability over cleverness**: PASS - Summaries expose direct booleans and channel lists without hidden inference.
+- **Explicitness over magic**: PASS - Tenant scope and resource ID are explicit request fields.
+- **Abstractions justified**: PASS - The activation reader is required to enumerate channels and is limited to that need.
+- **Optimize for deletion**: PASS - Removing the feature would remove additive contracts/models/service and provider reader methods.
+- **Composition over inheritance**: PASS - The service composes existing stores/readers.
+- **Intentional dependencies**: PASS - No new dependencies.
+- **Operational simplicity**: PASS - Existing build/test workflows remain sufficient.

--- a/specs/020-version-history-inspection/quickstart.md
+++ b/specs/020-version-history-inspection/quickstart.md
@@ -77,7 +77,7 @@ Expected behavior:
 ```csharp
 var tenantHistory = await history.GetHistoryAsync(new ResourceVersionHistoryRequest
 {
-    TenantScope = TenantScope.ForTenant("tenant-a"),
+    TenantScope = TenantScope.FromTenantId("tenant-a"),
     ResourceId = "product-1",
 });
 ```

--- a/specs/020-version-history-inspection/quickstart.md
+++ b/specs/020-version-history-inspection/quickstart.md
@@ -1,0 +1,95 @@
+# Quickstart: Resource Version History Inspection
+
+This quickstart shows the intended host workflow for read-only version history.
+
+## Register Aster
+
+```csharp
+var services = new ServiceCollection()
+    .AddAsterCore();
+
+using var provider = services.BuildServiceProvider();
+```
+
+SQLite JSON hosts use the existing provider registration:
+
+```csharp
+var services = new ServiceCollection()
+    .AddAsterCore()
+    .AddAsterSqliteJson(options =>
+    {
+        options.ConnectionString = "Data Source=aster.db";
+    });
+```
+
+## Create Versions And Activation State
+
+```csharp
+var manager = provider.GetRequiredService<IResourceManager>();
+
+var v1 = await manager.CreateAsync("Product", new CreateResourceRequest
+{
+    ResourceId = "product-1",
+    Owner = "host",
+});
+
+var v2 = await manager.UpdateAsync("product-1", new UpdateResourceRequest
+{
+    BaseVersion = v1.Version,
+    Owner = "host",
+});
+
+var v3 = await manager.UpdateAsync("product-1", new UpdateResourceRequest
+{
+    BaseVersion = v2.Version,
+    Owner = "host",
+});
+
+await manager.ActivateAsync("product-1", v2.Version, "Published");
+```
+
+## Inspect History
+
+```csharp
+var history = provider.GetRequiredService<IResourceVersionHistoryService>();
+
+var result = await history.GetHistoryAsync(new ResourceVersionHistoryRequest
+{
+    ResourceId = "product-1",
+});
+
+foreach (var version in result.Versions)
+{
+    Console.WriteLine(
+        $"{version.Version}: latest={version.IsLatest}, draft={version.IsDraft}, " +
+        $"channels={string.Join(",", version.ActiveChannels)}, maintenance={version.MaintenanceDisposition}");
+}
+```
+
+Expected behavior:
+
+- version 1 is historical, inactive, and a possible maintenance candidate;
+- version 2 is active in `Published` and protected;
+- version 3 is latest and protected.
+
+## Tenant-Scoped Inspection
+
+```csharp
+var tenantHistory = await history.GetHistoryAsync(new ResourceVersionHistoryRequest
+{
+    TenantScope = TenantScope.ForTenant("tenant-a"),
+    ResourceId = "product-1",
+});
+```
+
+Only versions, activation states, and lifecycle marker state from `tenant-a` are considered. Matching identifiers in other tenants do not appear.
+
+## Non-Goals
+
+History inspection does not:
+
+- mutate resources, activation, lifecycle markers, or policies;
+- evaluate pruning policy eligibility;
+- perform restore or pruning;
+- run automatic background maintenance;
+- expose SQL or `IQueryable<Resource>`.

--- a/specs/020-version-history-inspection/research.md
+++ b/specs/020-version-history-inspection/research.md
@@ -1,0 +1,72 @@
+# Research: Resource Version History Inspection
+
+## Dedicated History Service
+
+Decision: Add a dedicated host-facing `IResourceVersionHistoryService` for one-resource history inspection.
+
+Rationale: Existing `IResourceManager` can read versions, but hosts need a single SDK call that combines version snapshots with active channels, lifecycle marker state, tenant scope, and conservative maintenance hints. Keeping this separate from policy services prevents read-only history display from becoming another policy workflow.
+
+Alternatives considered:
+
+- Extend `IResourceManager`: rejected because the manager already owns create/update/activation operations, and history summaries combine state from multiple stores.
+- Use query service projections: rejected because history is not a filter/sort query and must not introduce query planning or public SQL.
+- Add a general reporting framework: rejected as too broad for the current slice.
+
+## Activation State Enumeration
+
+Decision: Add a narrow provider-facing activation-state reader that returns activation states for supplied resource IDs in one tenant.
+
+Rationale: Existing active-version reads require the caller to know a channel name. History inspection needs the inverse: enumerate the channels that contain each version. A small reader over existing activation storage is the simplest explicit contract for this need.
+
+Alternatives considered:
+
+- Add channel enumeration to `IResourceManager`: rejected because it would mix management operations with provider state reads and still need a provider contract underneath.
+- Reuse portability snapshots: rejected because portability reads are broader than one-resource history and carry import/export semantics not needed here.
+- Infer channels from resource payloads: rejected because activation is explicitly decoupled from payloads.
+
+## Maintenance Hints
+
+Decision: Version summaries expose conservative maintenance hints: latest or active versions are protected from destructive pruning; historical inactive non-latest versions are possible maintenance candidates.
+
+Rationale: Hosts benefit from obvious safety signals in version history screens. Policy eligibility still belongs to policy evaluation/application services because policies can include retention counts, lifecycle criteria, and stale-state checks.
+
+Alternatives considered:
+
+- Run policy evaluation from history inspection: rejected because it couples a read-only version timeline to policy workflows and broadens scope.
+- Return no hints: rejected because latest/active protection is already a core invariant and useful to expose.
+- Return definitive prune eligibility: rejected because retained-version and current-policy validation require policy-specific evaluation.
+
+## Missing Resources And Tenant Boundaries
+
+Decision: Missing resources return an empty history result for the effective tenant.
+
+Rationale: Returning an empty result is safe for host screens and avoids leaking whether the same resource identifier exists in another tenant. Invalid request shape still follows existing argument validation patterns.
+
+Alternatives considered:
+
+- Throw not-found exceptions: rejected because existing read paths generally return empty or null for missing resources.
+- Return cross-tenant diagnostics: rejected because tenant boundaries must remain explicit and non-leaky.
+
+## SQLite Provider Behavior
+
+Decision: Implement activation-state reads in the SQLite JSON provider over existing `activation_states` rows without schema changes.
+
+Rationale: Activation states are already stored by tenant, resource, and channel with serialized payloads. Reading those rows for one resource is sufficient for history inspection and avoids migrations or physical indexes.
+
+Alternatives considered:
+
+- Add a new history table or materialized view: rejected because history can be assembled from existing state.
+- Add public raw SQL hooks: rejected by query and provider guardrails.
+- Use JSON query planning for all history fields: rejected because resource versions are already read through `IResourceVersionReader`.
+
+## Out-Of-Scope Boundaries
+
+Decision: The feature adds no mutation behavior, scheduler, automatic policy execution, provider registry, runtime scanning, public SQL, public queryable resource surface, storage migration, or broad workflow/state-machine infrastructure.
+
+Rationale: The current product need is inspection. Keeping the slice read-only preserves operational simplicity and makes it a useful building block for hosts without changing maintenance semantics.
+
+Alternatives considered:
+
+- Add audit log persistence: deferred because it requires separate retention and storage decisions.
+- Add cross-resource history reporting: deferred because this slice is intentionally bounded to one resource.
+- Add policy-aware action recommendations: deferred to a future reporting/audit spec if hosts need it.

--- a/specs/020-version-history-inspection/spec.md
+++ b/specs/020-version-history-inspection/spec.md
@@ -2,7 +2,7 @@
 
 **Feature Branch**: `020-version-history-inspection`
 **Created**: 2026-05-29
-**Status**: Draft
+**Status**: Implemented
 **Input**: User description: "Add a read-only host-facing resource version history inspection workflow. Hosts can request a tenant-scoped history for one resource and receive ordered version summaries that identify latest, draft, active channels, lifecycle marker state, definition version, timestamps, and safe maintenance hints. The feature must reuse existing stores and services, introduce no storage schema changes, no query planner, no public SQL, no IQueryable<Resource>, no provider registry, no background jobs, and no mutation behavior."
 
 ## User Scenarios & Testing *(mandatory)*

--- a/specs/020-version-history-inspection/spec.md
+++ b/specs/020-version-history-inspection/spec.md
@@ -1,0 +1,105 @@
+# Feature Specification: Resource Version History Inspection
+
+**Feature Branch**: `020-version-history-inspection`
+**Created**: 2026-05-29
+**Status**: Draft
+**Input**: User description: "Add a read-only host-facing resource version history inspection workflow. Hosts can request a tenant-scoped history for one resource and receive ordered version summaries that identify latest, draft, active channels, lifecycle marker state, definition version, timestamps, and safe maintenance hints. The feature must reuse existing stores and services, introduce no storage schema changes, no query planner, no public SQL, no IQueryable<Resource>, no provider registry, no background jobs, and no mutation behavior."
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Inspect One Resource History (Priority: P1)
+
+As a host author, I need to request the version history for one resource in one tenant, so that management screens and maintenance workflows can show the current version timeline without assembling state manually.
+
+**Why this priority**: This is the minimum useful behavior and supports existing policy application, restore, and pruning workflows.
+
+**Independent Test**: Can be fully tested by creating several resource versions, activating selected versions, requesting history, and verifying ordered summaries mark latest, draft, and active states correctly.
+
+**Acceptance Scenarios**:
+
+1. **Given** a resource has multiple versions in the default tenant, **When** the host requests its history, **Then** every version is returned in deterministic version order with latest and draft state indicated.
+2. **Given** selected versions are active in one or more channels, **When** the host requests history, **Then** each summary identifies the active channels for that version.
+3. **Given** the resource does not exist in the effective tenant, **When** the host requests history, **Then** the result is empty and no exception or mutation occurs.
+
+---
+
+### User Story 2 - Include Lifecycle and Maintenance Signals (Priority: P2)
+
+As a host author, I need history summaries to include lifecycle marker state and safe maintenance hints, so that users can understand whether versions are visible, restorable, or protected before applying policy actions.
+
+**Why this priority**: Lifecycle and policy workflows landed before this slice; history inspection should make those states visible without creating another write workflow.
+
+**Independent Test**: Can be fully tested by marking a resource archived or soft-deleted, requesting history, and verifying summaries report the lifecycle state and conservative maintenance hints.
+
+**Acceptance Scenarios**:
+
+1. **Given** a resource has an archive or soft-delete marker, **When** the host requests history, **Then** each returned version summary includes the current lifecycle marker state for the resource.
+2. **Given** a version is latest or active, **When** the host requests history, **Then** that version is identified as protected from destructive pruning.
+3. **Given** a version is historical, inactive, and not latest, **When** the host requests history, **Then** that version is identified as a possible maintenance candidate without claiming that policy pruning will definitely apply.
+
+---
+
+### User Story 3 - Preserve Tenant Boundaries and Provider Compatibility (Priority: P3)
+
+As a tenant-aware host author, I need version history inspection to resolve exactly one tenant and work with existing in-memory and SQLite-backed providers, so that history displays cannot leak cross-tenant state.
+
+**Why this priority**: Tenant isolation is a core Phase 5 invariant and SQLite compatibility keeps the feature useful outside tests.
+
+**Independent Test**: Can be fully tested by creating matching resource identifiers in two tenants, requesting history for one tenant, and verifying only that tenant's versions, activation channels, and lifecycle marker appear.
+
+**Acceptance Scenarios**:
+
+1. **Given** matching resource identifiers exist in two tenants, **When** history is requested for tenant A, **Then** no version, activation, or lifecycle state from tenant B appears.
+2. **Given** omitted tenant scope is used, **When** history is requested, **Then** the documented default single-tenant scope is used.
+3. **Given** SQLite JSON persistence is active, **When** history is requested, **Then** the same observable summaries are returned as the in-memory provider for equivalent state.
+
+### Edge Cases
+
+- Resource identifier is null, empty, or whitespace.
+- Resource has versions but no active versions in any channel.
+- Resource is active in multiple channels or multiple active versions exist in one channel.
+- Resource has no lifecycle marker.
+- Resource exists in another tenant but not the effective tenant.
+- Concurrent writes occur while history is being assembled; the result must remain read-only and must not infer stronger consistency than the underlying store provides.
+
+### Constitution Alignment *(mandatory)*
+
+- **Simplicity**: The feature SHOULD add one small read-only service over existing resource, activation, and lifecycle state. It MUST NOT introduce a query planner, registry, scheduler, or workflow engine.
+- **Explicitness**: Hosts MUST request history for an explicit resource identifier and optional tenant scope. No runtime scanning, ambient tenant discovery, or automatic maintenance behavior is introduced.
+- **Dependencies**: None.
+- **Operational Impact**: The feature SHOULD require no schema migration, deployment change, background process, new provider package, or local development setup change.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: System MUST provide a host-facing read-only workflow for inspecting one resource's version history.
+- **FR-002**: History requests MUST resolve exactly one effective tenant.
+- **FR-003**: Omitted tenant scope MUST continue to mean the documented default single-tenant scope.
+- **FR-004**: History inspection MUST NOT create, update, activate, deactivate, restore, prune, mark, or otherwise mutate resource state.
+- **FR-005**: History results MUST include the effective tenant and the requested resource identifier.
+- **FR-006**: History results MUST include one ordered summary for each resource version found in the effective tenant.
+- **FR-007**: Version summaries MUST identify resource version number, resource definition identifier, resource definition version, creation timestamp, latest status, draft status, active channel names, lifecycle marker state, and destructive-pruning protection status.
+- **FR-008**: Version summaries MUST treat latest versions and versions active in any channel as protected from destructive pruning.
+- **FR-009**: Version summaries MAY identify historical inactive non-latest versions as possible maintenance candidates, but MUST NOT guarantee policy eligibility without policy evaluation.
+- **FR-010**: Missing resources in the effective tenant MUST return an empty history result rather than leaking whether the same resource exists in another tenant.
+- **FR-011**: Invalid request shape, including missing or blank resource identity, MUST fail with argument validation consistent with existing core SDK patterns.
+- **FR-012**: History inspection MUST preserve provider-agnostic behavior for the core SDK and MUST work with existing in-memory and SQLite JSON registrations.
+- **FR-013**: History inspection MUST NOT introduce storage schema changes, public raw SQL, public `IQueryable<Resource>`, provider registries, runtime scanning, background jobs, automatic policy execution, or broad workflow/state-machine infrastructure.
+- **FR-014**: Documentation MUST explain read-only behavior, tenant boundaries, lifecycle fields, active-channel interpretation, maintenance hints, and non-goals.
+
+### Key Entities *(include if feature involves data)*
+
+- **Version History Request**: Host-provided request containing a resource identifier and optional tenant scope.
+- **Version History Result**: Ordered read-only response containing the effective tenant, requested resource identifier, and version summaries.
+- **Version Summary**: Read-only description of one resource version, including definition version, timestamps, latest/draft/active/lifecycle state, and conservative maintenance hints.
+- **Maintenance Hint**: Non-authoritative signal describing whether a version is protected from destructive pruning or only a possible candidate for later policy evaluation.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Hosts can inspect a resource with at least five versions and correctly identify latest, draft, active, and historical inactive versions from one call.
+- **SC-002**: Tenant isolation tests demonstrate that matching resource identifiers in two tenants return only the requested tenant's history.
+- **SC-003**: Equivalent in-memory and SQLite JSON test arrangements produce equivalent version summary semantics.
+- **SC-004**: Existing policy, lifecycle restore, pruning, portability, and query tests continue to pass unchanged.

--- a/specs/020-version-history-inspection/tasks.md
+++ b/specs/020-version-history-inspection/tasks.md
@@ -1,0 +1,170 @@
+# Tasks: Resource Version History Inspection
+
+**Input**: Design documents from `/specs/020-version-history-inspection/`
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/
+
+**Tests**: Include focused tests because this is SDK behavior with tenant/provider compatibility requirements.
+
+**Organization**: Tasks are grouped by user story to enable independent implementation and testing.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to
+- Include exact file paths in descriptions
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Confirm current project shape and reusable patterns before editing.
+
+- [X] T001 Review existing resource version, activation, lifecycle marker, and DI patterns in `src/core/Aster.Core/`
+- [X] T002 [P] Review existing tenant and SQLite provider parity test patterns in `test/Aster.Tests/Tenancy/` and `test/Aster.Tests/SqliteJson/`
+- [X] T003 [P] Review docs style in `src/core/Aster.Core/README.md` and `src/persistence/Aster.Persistence.SqliteJson/README.md`
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Add shared contracts/models required by all user stories.
+
+**CRITICAL**: No user story work can begin until this phase is complete.
+
+- [X] T004 Add `IResourceVersionHistoryService` and `IResourceActivationStateReader` contracts in `src/core/Aster.Core/Abstractions/IResourceVersionHistoryService.cs`
+- [X] T005 Add `ResourceVersionHistoryRequest`, `ResourceVersionHistoryResult`, `ResourceVersionSummary`, and `ResourceVersionMaintenanceDisposition` models in `src/core/Aster.Core/Models/Instances/ResourceVersionHistory.cs`
+- [X] T006 Update in-memory resource store to implement activation-state reads in `src/core/Aster.Core/InMemory/InMemoryResourceStore.cs`
+- [X] T007 Register the history service and activation-state reader in `src/core/Aster.Core/Extensions/AsterCoreServiceCollectionExtensions.cs`
+
+**Checkpoint**: Foundation ready - user story implementation can now begin.
+
+---
+
+## Phase 3: User Story 1 - Inspect One Resource History (Priority: P1) MVP
+
+**Goal**: Hosts can read ordered version summaries for one resource and see latest, draft, and active-channel state.
+
+**Independent Test**: Create several versions, activate selected versions, request history, and verify ordered summaries with latest/draft/active-channel flags.
+
+### Tests for User Story 1
+
+- [X] T008 [P] [US1] Add ordered latest/draft/active-channel history tests covering at least five versions in `test/Aster.Tests/Versioning/ResourceVersionHistoryServiceTests.cs`
+- [X] T009 [P] [US1] Add missing-resource and invalid-resource-id tests in `test/Aster.Tests/Versioning/ResourceVersionHistoryServiceTests.cs`
+
+### Implementation for User Story 1
+
+- [X] T010 [US1] Implement `ResourceVersionHistoryService` orchestration over version reads and activation reads in `src/core/Aster.Core/Services/ResourceVersionHistoryService.cs`
+- [X] T011 [US1] Ensure history summaries sort versions and active channels deterministically in `src/core/Aster.Core/Services/ResourceVersionHistoryService.cs`
+- [X] T012 [US1] Ensure missing resources return empty results and invalid request shape follows existing validation patterns in `src/core/Aster.Core/Services/ResourceVersionHistoryService.cs`
+
+**Checkpoint**: User Story 1 is fully functional and independently testable.
+
+---
+
+## Phase 4: User Story 2 - Include Lifecycle and Maintenance Signals (Priority: P2)
+
+**Goal**: History summaries include current lifecycle marker state and conservative maintenance hints.
+
+**Independent Test**: Apply archive or soft-delete markers, request history, and verify lifecycle state plus protected/possible-candidate disposition.
+
+### Tests for User Story 2
+
+- [X] T013 [P] [US2] Add lifecycle marker state tests in `test/Aster.Tests/Versioning/ResourceVersionHistoryLifecycleTests.cs`
+- [X] T014 [P] [US2] Add maintenance disposition tests for latest, active, and historical inactive versions in `test/Aster.Tests/Versioning/ResourceVersionHistoryLifecycleTests.cs`
+
+### Implementation for User Story 2
+
+- [X] T015 [US2] Integrate lifecycle marker reads into `src/core/Aster.Core/Services/ResourceVersionHistoryService.cs`
+- [X] T016 [US2] Implement protected and possible-candidate maintenance disposition mapping in `src/core/Aster.Core/Services/ResourceVersionHistoryService.cs`
+
+**Checkpoint**: User Stories 1 and 2 both work independently.
+
+---
+
+## Phase 5: User Story 3 - Preserve Tenant Boundaries and Provider Compatibility (Priority: P3)
+
+**Goal**: History inspection stays tenant-scoped and returns equivalent semantics for in-memory and SQLite JSON providers.
+
+**Independent Test**: Create matching resource identifiers in two tenants and equivalent SQLite state, then verify only requested-tenant state appears with matching summary semantics.
+
+### Tests for User Story 3
+
+- [X] T017 [P] [US3] Add tenant isolation history tests in `test/Aster.Tests/Tenancy/TenantResourceVersionHistoryTests.cs`
+- [X] T018 [P] [US3] Add SQLite JSON version history parity tests in `test/Aster.Tests/SqliteJson/SqliteJsonResourceVersionHistoryTests.cs`
+
+### Implementation for User Story 3
+
+- [X] T019 [US3] Implement SQLite JSON activation-state reader support in `src/persistence/Aster.Persistence.SqliteJson/SqliteJsonResourceStore.cs`
+- [X] T020 [US3] Register SQLite JSON activation-state reader support in `src/persistence/Aster.Persistence.SqliteJson/SqliteJsonAsterServiceCollectionExtensions.cs`
+- [X] T021 [US3] Verify tenant-scoped version, activation, and lifecycle reads are composed without cross-tenant leakage in `src/core/Aster.Core/Services/ResourceVersionHistoryService.cs`
+
+**Checkpoint**: All user stories are independently functional.
+
+---
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+**Purpose**: Documentation, roadmap, cleanup, and verification.
+
+- [X] T022 [P] Update core SDK documentation for version history inspection in `src/core/Aster.Core/README.md`
+- [X] T023 [P] Update SQLite JSON provider documentation for history support in `src/persistence/Aster.Persistence.SqliteJson/README.md`
+- [X] T024 [P] Update execution roadmap current position and landed/next-slice notes in `docs/ExecutionRoadmap.md`
+- [X] T025 Update `AGENTS.md` recent changes for `020-version-history-inspection`
+- [X] T026 Run `dotnet test Aster.sln`
+- [X] T027 Run `dotnet build Aster.sln /m:1`
+- [X] T028 Run `git diff --check`
+- [X] T029 Re-run constitution check against implemented design and remove any unnecessary abstractions or duplication before final review
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies.
+- **Foundational (Phase 2)**: Depends on Setup completion and blocks all user stories.
+- **US1 (Phase 3)**: Depends on Foundation.
+- **US2 (Phase 4)**: Depends on Foundation and can be tested after service composition exists.
+- **US3 (Phase 5)**: Depends on Foundation and can be validated independently with tenant/provider fixtures.
+- **Polish (Phase 6)**: Depends on desired user stories being complete.
+
+### User Story Dependencies
+
+- **US1**: MVP and should be implemented first.
+- **US2**: Adds lifecycle and maintenance signals over the US1 result shape.
+- **US3**: Adds tenant/provider coverage and SQLite activation-state reader implementation.
+
+### Parallel Opportunities
+
+- T002 and T003 can run in parallel during setup.
+- T008 and T009 can be drafted in parallel.
+- T013 and T014 can be drafted in parallel.
+- T017 and T018 can be drafted in parallel.
+- T022, T023, and T024 can be updated in parallel after implementation stabilizes.
+
+## Parallel Example: User Story 1
+
+```text
+Task: "T008 [P] [US1] Add ordered latest/draft/active-channel history tests in test/Aster.Tests/Versioning/ResourceVersionHistoryServiceTests.cs"
+Task: "T009 [P] [US1] Add missing-resource and invalid-resource-id tests in test/Aster.Tests/Versioning/ResourceVersionHistoryServiceTests.cs"
+```
+
+## Implementation Strategy
+
+### MVP First (User Story 1 Only)
+
+1. Complete setup and foundational contracts/models.
+2. Add failing US1 tests.
+3. Implement `ResourceVersionHistoryService`.
+4. Validate US1 independently.
+
+### Incremental Delivery
+
+1. US1 delivers a usable version timeline.
+2. US2 adds lifecycle and maintenance signals.
+3. US3 adds tenant/provider compatibility.
+4. Polish updates docs and validates the full solution.
+
+## Notes
+
+- Keep the service read-only.
+- Keep maintenance hints conservative; do not call policy evaluation.
+- Do not introduce storage migrations, public SQL, public `IQueryable<Resource>`, provider registries, or background jobs.

--- a/src/core/Aster.Core/Abstractions/IResourceVersionHistoryService.cs
+++ b/src/core/Aster.Core/Abstractions/IResourceVersionHistoryService.cs
@@ -1,0 +1,31 @@
+using Aster.Core.Models.Instances;
+using Aster.Core.Models.Tenancy;
+
+namespace Aster.Core.Abstractions;
+
+/// <summary>
+/// Host-facing service for read-only resource version history inspection.
+/// </summary>
+public interface IResourceVersionHistoryService
+{
+    /// <summary>
+    /// Reads the ordered version history for one resource in one effective tenant.
+    /// </summary>
+    ValueTask<ResourceVersionHistoryResult> GetHistoryAsync(
+        ResourceVersionHistoryRequest request,
+        CancellationToken cancellationToken = default);
+}
+
+/// <summary>
+/// Provider-facing reader for resource activation states.
+/// </summary>
+public interface IResourceActivationStateReader
+{
+    /// <summary>
+    /// Reads activation states for the supplied resource identifiers in one tenant.
+    /// </summary>
+    ValueTask<IReadOnlyList<ActivationState>> ReadActivationStatesAsync(
+        IEnumerable<string> resourceIds,
+        TenantScope tenantScope,
+        CancellationToken cancellationToken = default);
+}

--- a/src/core/Aster.Core/Extensions/AsterCoreServiceCollectionExtensions.cs
+++ b/src/core/Aster.Core/Extensions/AsterCoreServiceCollectionExtensions.cs
@@ -80,6 +80,7 @@ public static class AsterCoreServiceCollectionExtensions
         services.AddSingleton<InMemoryResourceStore>();
         services.AddSingleton<IResourceVersionReader>(sp => sp.GetRequiredService<InMemoryResourceStore>());
         services.AddSingleton<IResourceVersionWriter>(sp => sp.GetRequiredService<InMemoryResourceStore>());
+        services.AddSingleton<IResourceActivationStateReader>(sp => sp.GetRequiredService<InMemoryResourceStore>());
         services.AddSingleton<UnsupportedResourceVersionPruningStore>();
         services.AddSingleton<IResourceVersionPruningStore>(ResolveResourceVersionPruningStore);
         services.AddSingleton<InMemoryPortabilityStore>();
@@ -102,6 +103,7 @@ public static class AsterCoreServiceCollectionExtensions
         services.AddSingleton<IResourcePolicyPruningApplicationService, ResourcePolicyPruningApplicationService>();
         services.AddSingleton<IResourceLifecycleMarkerService, ResourceLifecycleMarkerService>();
         services.AddSingleton<IResourceLifecycleRestoreService, ResourceLifecycleRestoreService>();
+        services.AddSingleton<IResourceVersionHistoryService, ResourceVersionHistoryService>();
 
         // Query service
         services.AddSingleton<InMemoryQueryService>();

--- a/src/core/Aster.Core/Extensions/AsterCoreServiceCollectionExtensions.cs
+++ b/src/core/Aster.Core/Extensions/AsterCoreServiceCollectionExtensions.cs
@@ -80,7 +80,7 @@ public static class AsterCoreServiceCollectionExtensions
         services.AddSingleton<InMemoryResourceStore>();
         services.AddSingleton<IResourceVersionReader>(sp => sp.GetRequiredService<InMemoryResourceStore>());
         services.AddSingleton<IResourceVersionWriter>(sp => sp.GetRequiredService<InMemoryResourceStore>());
-        services.AddSingleton<IResourceActivationStateReader>(sp => sp.GetRequiredService<InMemoryResourceStore>());
+        services.AddSingleton<IResourceActivationStateReader>(ResolveResourceActivationStateReader);
         services.AddSingleton<UnsupportedResourceVersionPruningStore>();
         services.AddSingleton<IResourceVersionPruningStore>(ResolveResourceVersionPruningStore);
         services.AddSingleton<InMemoryPortabilityStore>();
@@ -136,5 +136,13 @@ public static class AsterCoreServiceCollectionExtensions
         var versionReader = serviceProvider.GetRequiredService<IResourceVersionReader>();
         return versionReader as IResourceVersionPruningStore
             ?? serviceProvider.GetRequiredService<UnsupportedResourceVersionPruningStore>();
+    }
+
+    private static IResourceActivationStateReader ResolveResourceActivationStateReader(IServiceProvider serviceProvider)
+    {
+        var versionReader = serviceProvider.GetRequiredService<IResourceVersionReader>();
+        return versionReader as IResourceActivationStateReader
+            ?? throw new InvalidOperationException(
+                $"The active {nameof(IResourceVersionReader)} registration must also implement {nameof(IResourceActivationStateReader)} to use version history inspection.");
     }
 }

--- a/src/core/Aster.Core/InMemory/InMemoryResourceStore.cs
+++ b/src/core/Aster.Core/InMemory/InMemoryResourceStore.cs
@@ -11,7 +11,11 @@ namespace Aster.Core.InMemory;
 /// Thread-safe in-memory store for <see cref="Resource"/> versions and activation state.
 /// Intended for use by <see cref="InMemoryResourceManager"/> only.
 /// </summary>
-public sealed class InMemoryResourceStore : IResourceVersionReader, IResourceVersionWriter, IResourceVersionPruningStore
+public sealed class InMemoryResourceStore :
+    IResourceVersionReader,
+    IResourceVersionWriter,
+    IResourceVersionPruningStore,
+    IResourceActivationStateReader
 {
     /// <summary>
     /// Resource version history keyed by tenant ID and <c>ResourceId</c>.
@@ -222,6 +226,34 @@ public sealed class InMemoryResourceStore : IResourceVersionReader, IResourceVer
         states[channel] = scopedState;
 
         return ValueTask.FromResult(scopedState);
+    }
+
+    /// <inheritdoc />
+    public ValueTask<IReadOnlyList<ActivationState>> ReadActivationStatesAsync(
+        IEnumerable<string> resourceIds,
+        TenantScope tenantScope,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(resourceIds);
+        var tenant = TenantScopeResolver.Resolve(tenantScope);
+        var ids = resourceIds
+            .Where(static id => !string.IsNullOrWhiteSpace(id))
+            .Distinct(StringComparer.Ordinal)
+            .ToHashSet(StringComparer.Ordinal);
+        if (ids.Count == 0)
+            return ValueTask.FromResult<IReadOnlyList<ActivationState>>([]);
+
+        var states = new List<ActivationState>();
+        foreach (var resourceId in ids.Order(StringComparer.Ordinal))
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            if (!ActivationStates.TryGetValue((tenant.TenantId, resourceId), out var channelStates))
+                continue;
+
+            states.AddRange(channelStates.Values.OrderBy(static state => state.Channel, StringComparer.Ordinal));
+        }
+
+        return ValueTask.FromResult<IReadOnlyList<ActivationState>>(states);
     }
 
     /// <inheritdoc />

--- a/src/core/Aster.Core/InMemory/InMemoryResourceStore.cs
+++ b/src/core/Aster.Core/InMemory/InMemoryResourceStore.cs
@@ -238,7 +238,6 @@ public sealed class InMemoryResourceStore :
         var tenant = TenantScopeResolver.Resolve(tenantScope);
         var ids = resourceIds
             .Where(static id => !string.IsNullOrWhiteSpace(id))
-            .Distinct(StringComparer.Ordinal)
             .ToHashSet(StringComparer.Ordinal);
         if (ids.Count == 0)
             return ValueTask.FromResult<IReadOnlyList<ActivationState>>([]);

--- a/src/core/Aster.Core/Models/Instances/ResourceVersionHistory.cs
+++ b/src/core/Aster.Core/Models/Instances/ResourceVersionHistory.cs
@@ -1,0 +1,117 @@
+using Aster.Core.Models.Tenancy;
+
+namespace Aster.Core.Models.Instances;
+
+/// <summary>
+/// Request to inspect one resource's version history.
+/// </summary>
+public sealed class ResourceVersionHistoryRequest
+{
+    /// <summary>
+    /// Tenant scope for the read. When omitted, the default single-tenant scope is used.
+    /// </summary>
+    public TenantScope? TenantScope { get; set; }
+
+    /// <summary>
+    /// Logical resource identifier.
+    /// </summary>
+    public string? ResourceId { get; set; }
+}
+
+/// <summary>
+/// Read-only version history for one resource.
+/// </summary>
+public sealed record ResourceVersionHistoryResult
+{
+    /// <summary>
+    /// Effective tenant used for all reads.
+    /// </summary>
+    public TenantScope TenantScope { get; init; } = TenantScope.Default;
+
+    /// <summary>
+    /// Requested logical resource identifier.
+    /// </summary>
+    public required string ResourceId { get; init; }
+
+    /// <summary>
+    /// Ordered version summaries.
+    /// </summary>
+    public IReadOnlyList<ResourceVersionSummary> Versions { get; init; } = [];
+}
+
+/// <summary>
+/// Read-only summary of one resource version.
+/// </summary>
+public sealed record ResourceVersionSummary
+{
+    /// <summary>
+    /// Version snapshot identifier.
+    /// </summary>
+    public required string ResourceVersionId { get; init; }
+
+    /// <summary>
+    /// Resource version number.
+    /// </summary>
+    public required int Version { get; init; }
+
+    /// <summary>
+    /// Logical resource definition identifier.
+    /// </summary>
+    public required string DefinitionId { get; init; }
+
+    /// <summary>
+    /// Resource definition version captured by this resource version.
+    /// </summary>
+    public int? DefinitionVersion { get; init; }
+
+    /// <summary>
+    /// Version creation timestamp.
+    /// </summary>
+    public required DateTime Created { get; init; }
+
+    /// <summary>
+    /// Whether this is the current latest version.
+    /// </summary>
+    public required bool IsLatest { get; init; }
+
+    /// <summary>
+    /// Whether this version is absent from all active channels.
+    /// </summary>
+    public required bool IsDraft { get; init; }
+
+    /// <summary>
+    /// Active channel names containing this version.
+    /// </summary>
+    public IReadOnlyList<string> ActiveChannels { get; init; } = [];
+
+    /// <summary>
+    /// Current lifecycle marker state for the logical resource.
+    /// </summary>
+    public ResourceLifecycleMarkerState LifecycleState { get; init; } = ResourceLifecycleMarkerState.None;
+
+    /// <summary>
+    /// Whether destructive pruning must protect this version.
+    /// </summary>
+    public required bool IsProtectedFromPruning { get; init; }
+
+    /// <summary>
+    /// Conservative maintenance hint for host displays.
+    /// </summary>
+    public required ResourceVersionMaintenanceDisposition MaintenanceDisposition { get; init; }
+}
+
+/// <summary>
+/// Conservative maintenance signal for a resource version.
+/// </summary>
+public enum ResourceVersionMaintenanceDisposition
+{
+    /// <summary>
+    /// Version is latest or active and must be protected from destructive pruning.
+    /// </summary>
+    Protected,
+
+    /// <summary>
+    /// Version is historical, inactive, and not latest. Policy evaluation is still required before pruning.
+    /// </summary>
+    PossibleCandidate,
+}

--- a/src/core/Aster.Core/README.md
+++ b/src/core/Aster.Core/README.md
@@ -35,7 +35,7 @@ builder.Services.AddAsterCore();
 | Service | Interface |
 |---|---|
 | `InMemoryResourceDefinitionStore` | `IResourceDefinitionStore` |
-| `InMemoryResourceStore` | `IResourceVersionReader`, `IResourceVersionWriter` |
+| `InMemoryResourceStore` | `IResourceVersionReader`, `IResourceVersionWriter`, `IResourceActivationStateReader` |
 | `InMemoryPortabilityStore` | `IResourcePortabilityStore` |
 | `DefaultResourceManager` | `IResourceManager` |
 | `InMemoryQueryService` | `IResourceQueryService` |
@@ -48,6 +48,7 @@ builder.Services.AddAsterCore();
 | `ResourcePolicyEvaluationService` | `IResourcePolicyEvaluationService` |
 | `ResourceLifecycleMarkerService` | `IResourceLifecycleMarkerService` |
 | `ResourceLifecycleRestoreService` | `IResourceLifecycleRestoreService` |
+| `ResourceVersionHistoryService` | `IResourceVersionHistoryService` |
 | `InMemoryResourceLifecycleMarkerStore` | `IResourceLifecycleMarkerStore`, `IResourceLifecycleMarkerClearStore` |
 | `GuidIdentityGenerator` | `IIdentityGenerator` |
 | `SystemTextJsonAspectBinder` | `ITypedAspectBinder` |
@@ -123,7 +124,32 @@ var active = await manager.GetActiveVersionsAsync(resource.ResourceId, "Publishe
 
 ---
 
-### 6. Query resources
+### 6. Inspect version history
+
+`IResourceVersionHistoryService` returns a read-only tenant-scoped timeline for one resource. It combines existing resource versions, activation channels, and lifecycle marker state without evaluating policies or mutating anything.
+
+```csharp
+var history = serviceProvider.GetRequiredService<IResourceVersionHistoryService>();
+
+var result = await history.GetHistoryAsync(new ResourceVersionHistoryRequest
+{
+    ResourceId = resource.ResourceId,
+});
+
+foreach (var version in result.Versions)
+{
+    Console.WriteLine(
+        $"{version.Version}: latest={version.IsLatest}, draft={version.IsDraft}, " +
+        $"channels={string.Join(",", version.ActiveChannels)}, " +
+        $"maintenance={version.MaintenanceDisposition}");
+}
+```
+
+Latest or active versions are reported as protected from destructive pruning. Historical inactive non-latest versions are only reported as possible maintenance candidates; hosts must still use policy preview/application services before pruning.
+
+---
+
+### 7. Query resources
 
 ```csharp
 var queryService = serviceProvider.GetRequiredService<IResourceQueryService>();
@@ -204,7 +230,7 @@ var query = new ResourceQuery
 
 ---
 
-### 7. Inspect and upgrade definition lineage
+### 8. Inspect and upgrade definition lineage
 
 `CreateAsync` records the active definition version on the new resource. Normal `UpdateAsync` calls preserve that `DefinitionVersion`; they do not silently move long-lived resources to newer schemas.
 
@@ -250,7 +276,7 @@ Tenant IDs are opaque exact-match values. `TenantScope.FromTenantId(...)` reject
 
 ---
 
-### 8. Export, preview, and import portable snapshots
+### 9. Export, preview, and import portable snapshots
 
 `IResourcePortabilityService` exports selected definitions, resources, resource versions, and activation state into an SDK-native `PortableSnapshot`. The service also validates snapshots, previews import plans without writing, and performs all-or-nothing imports.
 
@@ -287,7 +313,7 @@ Import is strict by default. Existing identical content is reused, divergent col
 
 ---
 
-### 9. Declare, preview, and mark policy outcomes
+### 10. Declare, preview, and mark policy outcomes
 
 Policy declarations are explicit resource definition metadata. They do not run in the background and they do not mutate resource history when a definition is registered.
 
@@ -410,7 +436,7 @@ Each submitted candidate returns `Pruned`, `AlreadyPruned`, `Skipped`, or `Faile
 
 ---
 
-### 10. Register lifecycle hooks
+### 11. Register lifecycle hooks
 
 Hosts can register explicit lifecycle hooks around resource saves, activation/deactivation, export, preview import, and write import.
 

--- a/src/core/Aster.Core/Services/ResourceVersionHistoryService.cs
+++ b/src/core/Aster.Core/Services/ResourceVersionHistoryService.cs
@@ -1,0 +1,126 @@
+using Aster.Core.Abstractions;
+using Aster.Core.Models.Instances;
+using Aster.Core.Models.Querying;
+using Aster.Core.Models.Tenancy;
+
+namespace Aster.Core.Services;
+
+/// <summary>
+/// Default read-only resource version history inspection service.
+/// </summary>
+public sealed class ResourceVersionHistoryService : IResourceVersionHistoryService
+{
+    private readonly IResourceVersionReader versionReader;
+    private readonly IResourceActivationStateReader activationStateReader;
+    private readonly IResourceLifecycleMarkerStore markerStore;
+
+    /// <summary>
+    /// Initializes a new instance of <see cref="ResourceVersionHistoryService"/>.
+    /// </summary>
+    public ResourceVersionHistoryService(
+        IResourceVersionReader versionReader,
+        IResourceActivationStateReader activationStateReader,
+        IResourceLifecycleMarkerStore markerStore)
+    {
+        ArgumentNullException.ThrowIfNull(versionReader);
+        ArgumentNullException.ThrowIfNull(activationStateReader);
+        ArgumentNullException.ThrowIfNull(markerStore);
+
+        this.versionReader = versionReader;
+        this.activationStateReader = activationStateReader;
+        this.markerStore = markerStore;
+    }
+
+    /// <inheritdoc />
+    public async ValueTask<ResourceVersionHistoryResult> GetHistoryAsync(
+        ResourceVersionHistoryRequest request,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        ArgumentException.ThrowIfNullOrWhiteSpace(request.ResourceId);
+
+        var tenant = TenantScopeResolver.Resolve(request.TenantScope);
+        var resourceId = request.ResourceId;
+
+        var versions = (await versionReader.ReadVersionsAsync(new ResourceVersionReadRequest
+        {
+            TenantScope = tenant,
+            Scope = ResourceVersionScope.AllVersions,
+            ResourceIds = [resourceId],
+        }, cancellationToken)).OrderBy(static resource => resource.Version).ToList();
+
+        if (versions.Count == 0)
+        {
+            return new ResourceVersionHistoryResult
+            {
+                TenantScope = tenant,
+                ResourceId = resourceId,
+            };
+        }
+
+        var activeChannelsByVersion = await ReadActiveChannelsByVersionAsync(resourceId, tenant, cancellationToken);
+        var marker = await markerStore.GetMarkerAsync(resourceId, tenant, cancellationToken);
+        var lifecycleState = marker?.State ?? ResourceLifecycleMarkerState.None;
+        var latestVersion = versions[^1].Version;
+
+        var summaries = versions.Select(resource =>
+        {
+            var activeChannels = activeChannelsByVersion.TryGetValue(resource.Version, out var channels)
+                ? channels
+                : [];
+            var isLatest = resource.Version == latestVersion;
+            var isProtected = isLatest || activeChannels.Count > 0;
+
+            return new ResourceVersionSummary
+            {
+                ResourceVersionId = resource.Id,
+                Version = resource.Version,
+                DefinitionId = resource.DefinitionId,
+                DefinitionVersion = resource.DefinitionVersion,
+                Created = resource.Created,
+                IsLatest = isLatest,
+                IsDraft = activeChannels.Count == 0,
+                ActiveChannels = activeChannels,
+                LifecycleState = lifecycleState,
+                IsProtectedFromPruning = isProtected,
+                MaintenanceDisposition = isProtected
+                    ? ResourceVersionMaintenanceDisposition.Protected
+                    : ResourceVersionMaintenanceDisposition.PossibleCandidate,
+            };
+        }).ToList();
+
+        return new ResourceVersionHistoryResult
+        {
+            TenantScope = tenant,
+            ResourceId = resourceId,
+            Versions = summaries,
+        };
+    }
+
+    private async Task<Dictionary<int, IReadOnlyList<string>>> ReadActiveChannelsByVersionAsync(
+        string resourceId,
+        TenantScope tenant,
+        CancellationToken cancellationToken)
+    {
+        var states = await activationStateReader.ReadActivationStatesAsync([resourceId], tenant, cancellationToken);
+        var channelsByVersion = new Dictionary<int, SortedSet<string>>();
+
+        foreach (var state in states)
+        {
+            foreach (var version in state.ActiveVersions)
+            {
+                if (!channelsByVersion.TryGetValue(version, out var channels))
+                {
+                    channels = new SortedSet<string>(StringComparer.Ordinal);
+                    channelsByVersion[version] = channels;
+                }
+
+                channels.Add(state.Channel);
+            }
+        }
+
+        return channelsByVersion.ToDictionary(
+            static item => item.Key,
+            static item => (IReadOnlyList<string>)item.Value.ToList());
+    }
+}

--- a/src/persistence/Aster.Persistence.SqliteJson/README.md
+++ b/src/persistence/Aster.Persistence.SqliteJson/README.md
@@ -9,6 +9,7 @@ This package currently provides:
 - `IResourceDefinitionStore`
 - `IResourceVersionReader`
 - `IResourceVersionWriter`
+- `IResourceActivationStateReader`
 - `IResourceVersionPruningStore`
 - `IResourcePortabilityStore`
 - `IResourceLifecycleMarkerStore`
@@ -83,3 +84,5 @@ Tenant scope is applied as a provider-owned predicate before user query predicat
 Lifecycle markers are explicit state. `AddAsterSqliteJson(...)` replaces the core in-memory `IResourceLifecycleMarkerStore` and `IResourceLifecycleMarkerClearStore` with the SQLite-backed store so archive and soft-delete markers persist across service provider instances, participate in portability export/import, can be queried through `ResourceQuery.LifecycleState`, and can be explicitly restored through `IResourceLifecycleRestoreService`. Restore deletes only the tenant-scoped marker row for the selected resource; it does not rewrite resource versions, change activation state, mutate policy declarations, or change the portability snapshot format. Omitting `LifecycleState` does not hide archived or soft-deleted resources.
 
 The SQLite store also implements `IResourceVersionPruningStore` for host-controlled policy pruning application. Version pruning deletes only the matching `(tenant_id, resource_id, version)` row after core preflight has protected latest and active versions and revalidated policy criteria. It does not delete activation state, lifecycle markers, definitions, policy declarations, or other tenant rows.
+
+The provider also implements `IResourceActivationStateReader`, which lets the core `IResourceVersionHistoryService` enumerate active channels for a requested resource history without exposing public SQL or changing schema. Version history inspection remains read-only and composes existing resource version, activation, and lifecycle marker rows.

--- a/src/persistence/Aster.Persistence.SqliteJson/SqliteJsonAsterServiceCollectionExtensions.cs
+++ b/src/persistence/Aster.Persistence.SqliteJson/SqliteJsonAsterServiceCollectionExtensions.cs
@@ -32,6 +32,7 @@ public static class SqliteJsonAsterServiceCollectionExtensions
         services.AddSingleton<IResourceDefinitionStore>(sp => sp.GetRequiredService<SqliteJsonResourceStore>());
         services.AddSingleton<IResourceVersionReader>(sp => sp.GetRequiredService<SqliteJsonResourceStore>());
         services.AddSingleton<IResourceVersionWriter>(sp => sp.GetRequiredService<SqliteJsonResourceStore>());
+        services.AddSingleton<IResourceActivationStateReader>(sp => sp.GetRequiredService<SqliteJsonResourceStore>());
         services.AddSingleton<IResourceVersionPruningStore>(sp => sp.GetRequiredService<SqliteJsonResourceStore>());
         services.AddSingleton<IResourcePortabilityStore>(sp => sp.GetRequiredService<SqliteJsonResourceStore>());
         services.AddSingleton<IResourceLifecycleMarkerStore>(sp => sp.GetRequiredService<SqliteJsonResourceStore>());

--- a/src/persistence/Aster.Persistence.SqliteJson/SqliteJsonResourceStore.cs
+++ b/src/persistence/Aster.Persistence.SqliteJson/SqliteJsonResourceStore.cs
@@ -273,7 +273,6 @@ public sealed class SqliteJsonResourceStore :
         var tenant = TenantScopeResolver.Resolve(tenantScope);
         var ids = resourceIds
             .Where(static id => !string.IsNullOrWhiteSpace(id))
-            .Distinct(StringComparer.Ordinal)
             .ToHashSet(StringComparer.Ordinal);
         if (ids.Count == 0)
             return [];

--- a/src/persistence/Aster.Persistence.SqliteJson/SqliteJsonResourceStore.cs
+++ b/src/persistence/Aster.Persistence.SqliteJson/SqliteJsonResourceStore.cs
@@ -17,6 +17,7 @@ public sealed class SqliteJsonResourceStore :
     IResourceDefinitionStore,
     IResourceVersionReader,
     IResourceVersionWriter,
+    IResourceActivationStateReader,
     IResourceVersionPruningStore,
     IResourcePortabilityStore,
     IResourceLifecycleMarkerClearStore
@@ -260,6 +261,30 @@ public sealed class SqliteJsonResourceStore :
 
         await command.ExecuteNonQueryAsync(cancellationToken);
         return scopedState;
+    }
+
+    /// <inheritdoc />
+    public async ValueTask<IReadOnlyList<ActivationState>> ReadActivationStatesAsync(
+        IEnumerable<string> resourceIds,
+        TenantScope tenantScope,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(resourceIds);
+        var tenant = TenantScopeResolver.Resolve(tenantScope);
+        var ids = resourceIds
+            .Where(static id => !string.IsNullOrWhiteSpace(id))
+            .Distinct(StringComparer.Ordinal)
+            .ToHashSet(StringComparer.Ordinal);
+        if (ids.Count == 0)
+            return [];
+
+        return await ReadPayloadsByTextIdsAsync<ActivationState>(
+            tableName: "activation_states",
+            columnName: "resource_id",
+            tenant: tenant,
+            ids: ids,
+            orderBy: "resource_id, channel",
+            cancellationToken);
     }
 
     /// <inheritdoc />

--- a/test/Aster.Tests/SqliteJson/SqliteJsonResourceVersionHistoryTests.cs
+++ b/test/Aster.Tests/SqliteJson/SqliteJsonResourceVersionHistoryTests.cs
@@ -1,0 +1,40 @@
+using Aster.Core.Abstractions;
+using Aster.Core.Models.Instances;
+using Aster.Tests.Policies;
+using Aster.Tests.Versioning;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Aster.Tests.SqliteJson;
+
+public sealed class SqliteJsonResourceVersionHistoryTests : IDisposable
+{
+    private readonly string databasePath = Path.Combine(Path.GetTempPath(), $"aster-history-{Guid.NewGuid():N}.db");
+
+    public void Dispose() => PolicyTestFixtures.DeleteSqliteFiles(databasePath);
+
+    [Fact]
+    public async Task GetHistoryAsync_ReturnsPersistedVersionSummarySemantics()
+    {
+        await using (var provider = PolicyTestFixtures.CreateSqliteProvider(databasePath))
+        {
+            await ResourceVersionHistoryTestFixtures.SaveVersionsAsync(provider, "persisted", versionCount: 5);
+            await ResourceVersionHistoryTestFixtures.ActivateAsync(provider, "persisted", "Published", [2]);
+            await ResourceVersionHistoryTestFixtures.ActivateAsync(provider, "persisted", "Preview", [2, 4]);
+            await ResourceVersionHistoryTestFixtures.MarkAsync(provider, "persisted", ResourceLifecycleMarkerState.SoftDeleted);
+        }
+
+        await using var secondProvider = PolicyTestFixtures.CreateSqliteProvider(databasePath);
+
+        var result = await secondProvider.GetRequiredService<IResourceVersionHistoryService>().GetHistoryAsync(
+            new ResourceVersionHistoryRequest { ResourceId = "persisted" });
+
+        Assert.Equal([1, 2, 3, 4, 5], result.Versions.Select(static version => version.Version));
+        Assert.Equal(ResourceVersionMaintenanceDisposition.PossibleCandidate, result.Versions[0].MaintenanceDisposition);
+        Assert.Equal(["Preview", "Published"], result.Versions[1].ActiveChannels);
+        Assert.Equal(["Preview"], result.Versions[3].ActiveChannels);
+        Assert.True(result.Versions[4].IsLatest);
+        Assert.True(result.Versions[4].IsProtectedFromPruning);
+        Assert.All(result.Versions, version => Assert.Equal(ResourceLifecycleMarkerState.SoftDeleted, version.LifecycleState));
+    }
+
+}

--- a/test/Aster.Tests/Tenancy/TenantResourceVersionHistoryTests.cs
+++ b/test/Aster.Tests/Tenancy/TenantResourceVersionHistoryTests.cs
@@ -1,0 +1,57 @@
+using Aster.Core.Abstractions;
+using Aster.Core.Models.Instances;
+using Aster.Core.Models.Tenancy;
+using Aster.Tests.Versioning;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Aster.Tests.Tenancy;
+
+public sealed class TenantResourceVersionHistoryTests : IDisposable
+{
+    private readonly ServiceProvider provider = ResourceVersionHistoryTestFixtures.CreateCoreProvider();
+
+    public void Dispose() => provider.Dispose();
+
+    [Fact]
+    public async Task GetHistoryAsync_ReturnsOnlyRequestedTenantState()
+    {
+        await RegisterTenantResourceAsync(TenantScopeTestFixtures.TenantA, activeVersions: [1], ResourceLifecycleMarkerState.Archived);
+        await RegisterTenantResourceAsync(TenantScopeTestFixtures.TenantB, activeVersions: [2], ResourceLifecycleMarkerState.SoftDeleted);
+
+        var result = await provider.GetRequiredService<IResourceVersionHistoryService>().GetHistoryAsync(
+            new ResourceVersionHistoryRequest
+            {
+                TenantScope = TenantScopeTestFixtures.TenantA,
+                ResourceId = "shared",
+            });
+
+        Assert.Equal(TenantScopeTestFixtures.TenantA, result.TenantScope);
+        Assert.Equal([1, 2], result.Versions.Select(static version => version.Version));
+        Assert.Equal(["Published"], result.Versions[0].ActiveChannels);
+        Assert.Empty(result.Versions[1].ActiveChannels);
+        Assert.All(result.Versions, version => Assert.Equal(ResourceLifecycleMarkerState.Archived, version.LifecycleState));
+    }
+
+    [Fact]
+    public async Task GetHistoryAsync_OmittedTenantUsesDefaultScope()
+    {
+        await ResourceVersionHistoryTestFixtures.SaveVersionAsync(provider, "default", version: 1);
+
+        var result = await provider.GetRequiredService<IResourceVersionHistoryService>().GetHistoryAsync(
+            new ResourceVersionHistoryRequest { ResourceId = "default" });
+
+        Assert.Equal(TenantScope.Default, result.TenantScope);
+        Assert.Single(result.Versions);
+    }
+
+    private async Task RegisterTenantResourceAsync(
+        TenantScope tenant,
+        IReadOnlyList<int> activeVersions,
+        ResourceLifecycleMarkerState lifecycleState)
+    {
+        await ResourceVersionHistoryTestFixtures.SaveVersionAsync(provider, "shared", version: 1, tenant);
+        await ResourceVersionHistoryTestFixtures.SaveVersionAsync(provider, "shared", version: 2, tenant);
+        await ResourceVersionHistoryTestFixtures.ActivateAsync(provider, "shared", "Published", activeVersions, tenant);
+        await ResourceVersionHistoryTestFixtures.MarkAsync(provider, "shared", lifecycleState, tenant);
+    }
+}

--- a/test/Aster.Tests/Versioning/ResourceVersionHistoryLifecycleTests.cs
+++ b/test/Aster.Tests/Versioning/ResourceVersionHistoryLifecycleTests.cs
@@ -1,0 +1,44 @@
+using Aster.Core.Abstractions;
+using Aster.Core.Models.Instances;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Aster.Tests.Versioning;
+
+public sealed class ResourceVersionHistoryLifecycleTests : IDisposable
+{
+    private readonly ServiceProvider provider = ResourceVersionHistoryTestFixtures.CreateCoreProvider();
+
+    public void Dispose() => provider.Dispose();
+
+    [Fact]
+    public async Task GetHistoryAsync_IncludesCurrentLifecycleMarkerState()
+    {
+        await ResourceVersionHistoryTestFixtures.SaveVersionsAsync(provider, "lifecycle", versionCount: 3);
+        await ResourceVersionHistoryTestFixtures.MarkAsync(provider, "lifecycle", ResourceLifecycleMarkerState.Archived);
+
+        var result = await provider.GetRequiredService<IResourceVersionHistoryService>().GetHistoryAsync(
+            new ResourceVersionHistoryRequest { ResourceId = "lifecycle" });
+
+        Assert.All(result.Versions, version => Assert.Equal(ResourceLifecycleMarkerState.Archived, version.LifecycleState));
+    }
+
+    [Fact]
+    public async Task GetHistoryAsync_MapsMaintenanceDispositionConservatively()
+    {
+        await ResourceVersionHistoryTestFixtures.SaveVersionsAsync(provider, "maintenance", versionCount: 3);
+        await ResourceVersionHistoryTestFixtures.ActivateAsync(provider, "maintenance", "Published", [2]);
+
+        var result = await provider.GetRequiredService<IResourceVersionHistoryService>().GetHistoryAsync(
+            new ResourceVersionHistoryRequest { ResourceId = "maintenance" });
+
+        Assert.Equal(ResourceVersionMaintenanceDisposition.PossibleCandidate, result.Versions[0].MaintenanceDisposition);
+        Assert.False(result.Versions[0].IsProtectedFromPruning);
+
+        Assert.Equal(ResourceVersionMaintenanceDisposition.Protected, result.Versions[1].MaintenanceDisposition);
+        Assert.True(result.Versions[1].IsProtectedFromPruning);
+
+        Assert.Equal(ResourceVersionMaintenanceDisposition.Protected, result.Versions[2].MaintenanceDisposition);
+        Assert.True(result.Versions[2].IsProtectedFromPruning);
+    }
+
+}

--- a/test/Aster.Tests/Versioning/ResourceVersionHistoryServiceTests.cs
+++ b/test/Aster.Tests/Versioning/ResourceVersionHistoryServiceTests.cs
@@ -1,0 +1,79 @@
+using Aster.Core.Abstractions;
+using Aster.Core.Models.Instances;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Aster.Tests.Versioning;
+
+public sealed class ResourceVersionHistoryServiceTests : IDisposable
+{
+    private readonly ServiceProvider provider = ResourceVersionHistoryTestFixtures.CreateCoreProvider();
+
+    public void Dispose() => provider.Dispose();
+
+    [Fact]
+    public async Task GetHistoryAsync_ReturnsOrderedVersionSummariesWithLatestDraftAndActiveChannels()
+    {
+        await ResourceVersionHistoryTestFixtures.SaveVersionsAsync(provider, "history", versionCount: 5);
+        await ResourceVersionHistoryTestFixtures.ActivateAsync(provider, "history", "Published", [2]);
+        await ResourceVersionHistoryTestFixtures.ActivateAsync(provider, "history", "Preview", [2, 4]);
+
+        var result = await provider.GetRequiredService<IResourceVersionHistoryService>().GetHistoryAsync(
+            new ResourceVersionHistoryRequest { ResourceId = "history" });
+
+        Assert.Equal("history", result.ResourceId);
+        Assert.Equal([1, 2, 3, 4, 5], result.Versions.Select(static version => version.Version));
+
+        AssertVersion(result.Versions[0], version: 1, isLatest: false, isDraft: true, [], ResourceVersionMaintenanceDisposition.PossibleCandidate);
+        AssertVersion(result.Versions[1], version: 2, isLatest: false, isDraft: false, ["Preview", "Published"], ResourceVersionMaintenanceDisposition.Protected);
+        AssertVersion(result.Versions[2], version: 3, isLatest: false, isDraft: true, [], ResourceVersionMaintenanceDisposition.PossibleCandidate);
+        AssertVersion(result.Versions[3], version: 4, isLatest: false, isDraft: false, ["Preview"], ResourceVersionMaintenanceDisposition.Protected);
+        AssertVersion(result.Versions[4], version: 5, isLatest: true, isDraft: true, [], ResourceVersionMaintenanceDisposition.Protected);
+    }
+
+    [Fact]
+    public async Task GetHistoryAsync_MissingResourceReturnsEmptyHistory()
+    {
+        var result = await provider.GetRequiredService<IResourceVersionHistoryService>().GetHistoryAsync(
+            new ResourceVersionHistoryRequest { ResourceId = "missing" });
+
+        Assert.Equal("missing", result.ResourceId);
+        Assert.Empty(result.Versions);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public async Task GetHistoryAsync_InvalidResourceIdThrows(string? resourceId)
+    {
+        await Assert.ThrowsAnyAsync<ArgumentException>(async () =>
+            await provider.GetRequiredService<IResourceVersionHistoryService>().GetHistoryAsync(
+                new ResourceVersionHistoryRequest { ResourceId = resourceId }));
+    }
+
+    [Fact]
+    public async Task GetHistoryAsync_NullRequestThrows()
+    {
+        await Assert.ThrowsAsync<ArgumentNullException>(async () =>
+            await provider.GetRequiredService<IResourceVersionHistoryService>().GetHistoryAsync(null!));
+    }
+
+    private static void AssertVersion(
+        ResourceVersionSummary summary,
+        int version,
+        bool isLatest,
+        bool isDraft,
+        IReadOnlyList<string> activeChannels,
+        ResourceVersionMaintenanceDisposition disposition)
+    {
+        Assert.Equal(version, summary.Version);
+        Assert.Equal($"default-history-{version}", summary.ResourceVersionId);
+        Assert.Equal("Product", summary.DefinitionId);
+        Assert.Equal(1, summary.DefinitionVersion);
+        Assert.Equal(isLatest, summary.IsLatest);
+        Assert.Equal(isDraft, summary.IsDraft);
+        Assert.Equal(activeChannels, summary.ActiveChannels);
+        Assert.Equal(disposition, summary.MaintenanceDisposition);
+        Assert.Equal(disposition == ResourceVersionMaintenanceDisposition.Protected, summary.IsProtectedFromPruning);
+    }
+}

--- a/test/Aster.Tests/Versioning/ResourceVersionHistoryServiceTests.cs
+++ b/test/Aster.Tests/Versioning/ResourceVersionHistoryServiceTests.cs
@@ -1,5 +1,7 @@
 using Aster.Core.Abstractions;
+using Aster.Core.Extensions;
 using Aster.Core.Models.Instances;
+using Aster.Core.Models.Tenancy;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Aster.Tests.Versioning;
@@ -58,6 +60,38 @@ public sealed class ResourceVersionHistoryServiceTests : IDisposable
             await provider.GetRequiredService<IResourceVersionHistoryService>().GetHistoryAsync(null!));
     }
 
+    [Fact]
+    public async Task GetHistoryAsync_WhenCustomVersionReaderIsActiveUsesMatchingActivationReader()
+    {
+        var services = new ServiceCollection().AddAsterCore();
+        services.AddSingleton<CustomHistoryProvider>();
+        services.AddSingleton<IResourceVersionReader>(sp => sp.GetRequiredService<CustomHistoryProvider>());
+
+        using var customProvider = services.BuildServiceProvider();
+
+        var result = await customProvider.GetRequiredService<IResourceVersionHistoryService>().GetHistoryAsync(
+            new ResourceVersionHistoryRequest { ResourceId = "custom" });
+
+        var summary = Assert.Single(result.Versions);
+        Assert.False(summary.IsDraft);
+        Assert.True(summary.IsProtectedFromPruning);
+        Assert.Equal(ResourceVersionMaintenanceDisposition.Protected, summary.MaintenanceDisposition);
+        Assert.Equal(["External"], summary.ActiveChannels);
+    }
+
+    [Fact]
+    public void GetHistoryAsync_WhenCustomVersionReaderCannotReadActivationStateFailsFast()
+    {
+        var services = new ServiceCollection().AddAsterCore();
+        services.AddSingleton<IResourceVersionReader, VersionOnlyReader>();
+
+        using var customProvider = services.BuildServiceProvider();
+
+        var exception = Assert.Throws<InvalidOperationException>(
+            () => customProvider.GetRequiredService<IResourceVersionHistoryService>());
+        Assert.Contains(nameof(IResourceActivationStateReader), exception.Message, StringComparison.Ordinal);
+    }
+
     private static void AssertVersion(
         ResourceVersionSummary summary,
         int version,
@@ -75,5 +109,61 @@ public sealed class ResourceVersionHistoryServiceTests : IDisposable
         Assert.Equal(activeChannels, summary.ActiveChannels);
         Assert.Equal(disposition, summary.MaintenanceDisposition);
         Assert.Equal(disposition == ResourceVersionMaintenanceDisposition.Protected, summary.IsProtectedFromPruning);
+    }
+
+    private sealed class CustomHistoryProvider : IResourceVersionReader, IResourceActivationStateReader
+    {
+        private static readonly Resource CustomResource = new()
+        {
+            TenantScope = TenantScope.Default,
+            ResourceId = "custom",
+            Id = "custom-history-1",
+            DefinitionId = "Product",
+            DefinitionVersion = 1,
+            Version = 1,
+            Created = new DateTime(2026, 5, 29, 12, 0, 0, DateTimeKind.Utc),
+        };
+
+        private static readonly ActivationState CustomActivation = new()
+        {
+            TenantScope = TenantScope.Default,
+            ResourceId = "custom",
+            Channel = "External",
+            ActiveVersions = [1],
+            LastUpdated = new DateTime(2026, 5, 29, 12, 5, 0, DateTimeKind.Utc),
+        };
+
+        public ValueTask<IEnumerable<Resource>> ReadVersionsAsync(
+            ResourceVersionReadRequest request,
+            CancellationToken cancellationToken = default)
+        {
+            var selection = request.GetResourceIdSelection();
+            var resources = selection.Matches(CustomResource.ResourceId)
+                ? new[] { CustomResource }
+                : [];
+
+            return ValueTask.FromResult<IEnumerable<Resource>>(resources);
+        }
+
+        public ValueTask<IReadOnlyList<ActivationState>> ReadActivationStatesAsync(
+            IEnumerable<string> resourceIds,
+            TenantScope tenantScope,
+            CancellationToken cancellationToken = default)
+        {
+            var ids = resourceIds.ToHashSet(StringComparer.Ordinal);
+            var states = ids.Contains(CustomActivation.ResourceId)
+                ? new[] { CustomActivation }
+                : [];
+
+            return ValueTask.FromResult<IReadOnlyList<ActivationState>>(states);
+        }
+    }
+
+    private sealed class VersionOnlyReader : IResourceVersionReader
+    {
+        public ValueTask<IEnumerable<Resource>> ReadVersionsAsync(
+            ResourceVersionReadRequest request,
+            CancellationToken cancellationToken = default) =>
+            ValueTask.FromResult<IEnumerable<Resource>>([]);
     }
 }

--- a/test/Aster.Tests/Versioning/ResourceVersionHistoryTestFixtures.cs
+++ b/test/Aster.Tests/Versioning/ResourceVersionHistoryTestFixtures.cs
@@ -1,0 +1,76 @@
+using Aster.Core.Abstractions;
+using Aster.Core.Extensions;
+using Aster.Core.Models.Instances;
+using Aster.Core.Models.Tenancy;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Aster.Tests.Versioning;
+
+internal static class ResourceVersionHistoryTestFixtures
+{
+    public static ServiceProvider CreateCoreProvider() =>
+        new ServiceCollection()
+            .AddAsterCore()
+            .BuildServiceProvider();
+
+    public static async Task SaveVersionsAsync(
+        IServiceProvider provider,
+        string resourceId,
+        int versionCount,
+        TenantScope? tenantScope = null)
+    {
+        for (var version = 1; version <= versionCount; version++)
+            await SaveVersionAsync(provider, resourceId, version, tenantScope);
+    }
+
+    public static async Task SaveVersionAsync(
+        IServiceProvider provider,
+        string resourceId,
+        int version,
+        TenantScope? tenantScope = null)
+    {
+        await provider.GetRequiredService<IResourceVersionWriter>().SaveVersionAsync(new Resource
+        {
+            TenantScope = tenantScope ?? TenantScope.Default,
+            ResourceId = resourceId,
+            Id = $"{(tenantScope ?? TenantScope.Default).TenantId}-{resourceId}-{version}",
+            DefinitionId = "Product",
+            DefinitionVersion = 1,
+            Version = version,
+            Created = new DateTime(2026, 5, 29, 12, 0, 0, DateTimeKind.Utc).AddMinutes(version),
+        });
+    }
+
+    public static async Task ActivateAsync(
+        IServiceProvider provider,
+        string resourceId,
+        string channel,
+        IReadOnlyList<int> versions,
+        TenantScope? tenantScope = null)
+    {
+        var tenant = tenantScope ?? TenantScope.Default;
+        await provider.GetRequiredService<IResourceVersionWriter>().UpdateActivationAsync(resourceId, channel, new ActivationState
+        {
+            TenantScope = tenant,
+            ResourceId = resourceId,
+            Channel = channel,
+            ActiveVersions = versions,
+            LastUpdated = DateTime.UtcNow,
+        });
+    }
+
+    public static async Task MarkAsync(
+        IServiceProvider provider,
+        string resourceId,
+        ResourceLifecycleMarkerState state,
+        TenantScope? tenantScope = null)
+    {
+        await provider.GetRequiredService<IResourceLifecycleMarkerService>().ApplyAsync(new ResourceLifecycleMarkerRequest
+        {
+            TenantScope = tenantScope,
+            ResourceId = resourceId,
+            State = state,
+            MarkedAt = DateTimeOffset.UtcNow,
+        });
+    }
+}


### PR DESCRIPTION
## Summary
- add read-only resource version history inspection service and result models
- expose a narrow activation-state reader for in-memory and SQLite JSON providers
- document version history behavior and update Spec Kit artifacts/roadmap

## Validation
- dotnet test Aster.sln
- dotnet build Aster.sln /m:1
- git diff --check