### PR TITLE
Add historical version activation

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "featureDir": "specs/020-version-history-inspection"
+  "featureDir": "specs/021-historical-version-activation"
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 <!-- SPECKIT START -->
 For additional context about technologies to be used, project structure,
-shell commands, and other important information, read `specs/020-version-history-inspection/plan.md`.
+shell commands, and other important information, read `specs/021-historical-version-activation/plan.md`.
 <!-- SPECKIT END -->
 
 ## Active Technologies
@@ -26,8 +26,11 @@ shell commands, and other important information, read `specs/020-version-history
 - Existing resource version storage only. Pruning removes selected resource version snapshots from in-memory and SQLite JSON stores; no schema migration, policy declaration mutation, lifecycle marker mutation, activation mutation, or portability snapshot format change. (019-policy-pruning-application)
 - C# latest, .NET 8.0 / 9.0 / 10.0 multi-targeting + Existing core SDK, resource version reader, lifecycle marker store, in-memory store, SQLite JSON provider, xUnit test stack; no new dependencies (020-version-history-inspection)
 - Existing resource versions, activation state, and lifecycle marker storage only. No schema migration, data rewrite, portability snapshot format change, or physical index creation. (020-version-history-inspection)
+- C# latest, .NET 8.0 / 9.0 / 10.0 multi-targeting + Existing core SDK, `IResourceManager`, resource version reader/writer, in-memory store, SQLite JSON provider through existing abstractions, lifecycle hook dispatcher, xUnit test stack; no new dependencies (021-historical-version-activation)
+- Existing activation state storage only. Historical activation updates activation rows or in-memory activation state; no resource version rewrite, no latest-version change, no lifecycle marker mutation, no portability format change, and no schema migration. (021-historical-version-activation)
 
 ## Recent Changes
+- 021-historical-version-activation: Added historical resource version activation planning and implementation context for activating any existing version without changing latest, rewriting versions, changing storage schema, adding provider registries, public SQL, public IQueryable<Resource>, schedulers, authorization engines, or workflow infrastructure
 - 020-version-history-inspection: Added read-only host-facing resource version history inspection with latest/draft/active-channel summaries, lifecycle marker state, conservative maintenance hints, tenant scoping, SQLite parity, and no storage migrations, query planner, provider registry, public SQL, public IQueryable<Resource>, background jobs, or mutation behavior
 - 019-policy-pruning-application: Added host-controlled policy pruning application for selected version-pruning preview outcomes with safety preflight, tenant scoping, stable diagnostics, in-memory/SQLite removal support, and no schedulers, authorization engines, provider registries, public SQL, public IQueryable<Resource>, broad workflow/state-machine infrastructure, or schema migrations
 - 018-lifecycle-restore-workflows: Added lifecycle restore workflow planning for host-controlled preview and application over archive/soft-delete markers; no resource version rewrites, activation changes, schedulers, authorization engines, provider registries, public SQL, public IQueryable<Resource>, destructive pruning writes, or schema changes

--- a/docs/ExecutionRoadmap.md
+++ b/docs/ExecutionRoadmap.md
@@ -8,7 +8,7 @@ This roadmap tracks the implementation trail we have already cut through the rep
 
 Aster now has a working Core SDK, in-memory runtime, SQLite JSON persistence/querying, provider capability discovery, provider validation alignment, provider authoring ergonomics, a reusable provider conformance harness, SQLite facet sorting, portable operator expansion, SQLite date-like ranges, explicit provider-declared index projections, explicit definition schema upgrade behavior, deterministic portability primitives, explicit host lifecycle hooks, explicit tenant scoping, policy foundations, host-controlled policy application orchestration, host-controlled lifecycle restore workflows, host-controlled policy pruning application, and read-only version history inspection.
 
-The Phase 4 core workstream is complete enough to defer optional recipes. The active workstream is now **Phase 5: Multi-tenancy, Policies, Advanced Versioning**. Explicit tenant-aware boundaries, policy foundations, policy application orchestration, reversible lifecycle restore, destructive pruning application, and version history inspection have landed; the next slices should stay focused on advanced tenant/versioning behavior or bounded operational hardening, not both at once.
+The Phase 4 core workstream is complete enough to defer optional recipes. The active workstream is now **Phase 5: Multi-tenancy, Policies, Advanced Versioning**. Explicit tenant-aware boundaries, policy foundations, policy application orchestration, reversible lifecycle restore, destructive pruning application, and version history inspection have landed; historical version activation is the current bounded advanced-versioning slice.
 
 ## Landed Slices
 
@@ -37,16 +37,30 @@ The Phase 4 core workstream is complete enough to defer optional recipes. The ac
 
 ## Near-Term Roadmap
 
-### 021 — Next Bounded Phase 5 Slice
+### 021 — Historical Version Activation
 
-**Goal:** Choose one small continuation slice that builds on tenant-aware lifecycle and policy primitives without broadening the architecture.
+**Status:** In progress on `021-historical-version-activation`.
+
+**Goal:** Allow hosts to explicitly activate any existing resource version, including historical non-latest versions, through the existing activation APIs.
+
+Scope:
+
+- Remove the latest-only activation restriction while preserving version existence validation.
+- Keep latest-version identity and immutable resource versions unchanged.
+- Preserve single-active versus multi-active channel behavior.
+- Preserve tenant scoping, lifecycle hooks, and provider-backed activation storage.
+- Keep schema changes, automatic jobs, ambient authorization, provider registries, public SQL, public `IQueryable<Resource>`, and broad workflow/state-machine infrastructure out of scope.
+
+### 022 — Next Bounded Phase 5 Slice
+
+**Goal:** Choose one small continuation slice after historical activation lands.
 
 Candidate scope:
 
-- Advanced versioning behavior that is explicit, append-only, and provider-agnostic.
+- Advanced versioning follow-up only if it stays explicit, append-only, and provider-agnostic.
 - A deliberately bounded policy follow-up, such as reporting or audit-oriented application summaries, only after a separate spec defines exact host value.
 - Tenant extension behavior, such as shared definitions or administrative workflows, only if the boundaries stay explicit.
-- Keep automatic jobs, ambient authorization, provider registries, public SQL, public `IQueryable<Resource>`, and broad workflow/state-machine infrastructure out of scope unless a future spec justifies them directly.
+- Bounded operational hardening such as targeted benchmarks, migration idempotency checks, or concurrency stress tests.
 
 ## Later Roadmap
 

--- a/specs/021-historical-version-activation/checklists/requirements.md
+++ b/specs/021-historical-version-activation/checklists/requirements.md
@@ -1,0 +1,34 @@
+# Specification Quality Checklist: Historical Version Activation
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-05-29
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Specification is ready for planning.

--- a/specs/021-historical-version-activation/contracts/historical-version-activation.md
+++ b/specs/021-historical-version-activation/contracts/historical-version-activation.md
@@ -1,0 +1,62 @@
+# Contract: Historical Version Activation
+
+Historical version activation changes the semantics of existing activation APIs from "latest only" to "any existing version".
+
+## Public SDK Behavior
+
+Existing host-facing methods remain the API:
+
+```csharp
+ValueTask ActivateAsync(
+    string resourceId,
+    int version,
+    string channel,
+    bool allowMultipleActive = false,
+    CancellationToken cancellationToken = default);
+
+ValueTask ActivateAsync(
+    string resourceId,
+    int version,
+    string channel,
+    TenantScope tenantScope,
+    bool allowMultipleActive,
+    CancellationToken cancellationToken);
+```
+
+Rules:
+
+- `resourceId` and `channel` must be non-blank.
+- `version` must exist for the resource in the effective tenant.
+- Non-latest versions are valid activation targets.
+- Activating a historical version does not create a new resource version.
+- Activating a historical version does not change latest.
+- `allowMultipleActive = false` replaces the active version set for the channel with the requested version.
+- `allowMultipleActive = true` appends the requested version to the channel's active version set.
+- Active version sets remain ordered.
+- Existing activation hooks run.
+
+## Provider Behavior
+
+No new provider contract is introduced. Providers continue to persist activation state through `IResourceVersionWriter.UpdateActivationAsync`.
+
+Providers must not:
+
+- rewrite resource versions;
+- change latest;
+- mutate lifecycle marker state;
+- introduce schema changes for this behavior.
+
+## Failure Behavior
+
+Historical activation must fail when:
+
+- resource ID is blank;
+- channel is blank;
+- requested version does not exist in the effective tenant;
+- lifecycle hooks reject or fail activation according to existing hook rules.
+
+Historical activation must not fail merely because:
+
+- requested version is not latest;
+- newer versions exist;
+- another version is already active in the channel.

--- a/specs/021-historical-version-activation/data-model.md
+++ b/specs/021-historical-version-activation/data-model.md
@@ -1,0 +1,41 @@
+# Data Model: Historical Version Activation
+
+## Historical Version Activation
+
+Existing activation operation targeting a non-latest but existing resource version.
+
+Fields:
+
+- Resource ID.
+- Resource version number.
+- Activation channel.
+- Effective tenant scope.
+- `allowMultipleActive` flag.
+
+Rules:
+
+- The resource version must exist in the effective tenant.
+- Latest version identity is not changed.
+- Resource version payload is not changed.
+- Activation state is the only mutated state.
+
+## Active Version Set
+
+Channel-specific ordered list of active version numbers for a logical resource.
+
+Rules:
+
+- When `allowMultipleActive` is false, the resulting set contains only the requested version.
+- When `allowMultipleActive` is true, the requested version is added to existing active versions.
+- Resulting version numbers are ordered deterministically.
+- Tenant scope bounds all reads and writes.
+
+## Lifecycle Hook Context
+
+Existing activation hook context describing the activation attempt.
+
+Rules:
+
+- `Version` is the requested version, even when historical.
+- `ActiveVersions` contains the resulting active version set.
+- Hook invocation order and rejection/failure behavior remain unchanged.

--- a/specs/021-historical-version-activation/plan.md
+++ b/specs/021-historical-version-activation/plan.md
@@ -1,0 +1,116 @@
+# Implementation Plan: Historical Version Activation
+
+**Branch**: `021-historical-version-activation` | **Date**: 2026-05-29 | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from `/specs/021-historical-version-activation/spec.md`
+
+## Summary
+
+Allow hosts to activate any existing resource version, including historical non-latest versions, through the existing activation APIs. The implementation removes the latest-only activation restriction while preserving version existence checks, tenant scoping, lifecycle hooks, single-active/multi-active behavior, deterministic active-version ordering, and append-only resource version storage. No new service, provider contract, schema change, registry, scheduler, authorization engine, public SQL, or public queryable resource surface is introduced.
+
+## Technical Context
+
+**Language/Version**: C# latest, .NET 8.0 / 9.0 / 10.0 multi-targeting
+**Primary Dependencies**: Existing core SDK, `IResourceManager`, resource version reader/writer, in-memory store, SQLite JSON provider through existing abstractions, lifecycle hook dispatcher, xUnit test stack; no new dependencies
+**Storage**: Existing activation state storage only. Historical activation updates activation rows or in-memory activation state; no resource version rewrite, no latest-version change, no lifecycle marker mutation, no portability format change, and no schema migration.
+**Testing**: `dotnet test Aster.sln`, focused activation tests, tenant historical activation tests, lifecycle hook activation tests, SQLite activation persistence tests, `dotnet build Aster.sln /m:1`, `git diff --check`
+**Target Platform**: .NET SDK/library consumers and local test environment
+**Project Type**: SDK/library with provider packages and tests
+**Performance Goals**: Activation remains bounded to one resource ID, one version number, and one channel in one effective tenant.
+**Constraints**: Version must exist in the effective tenant; latest remains unchanged; activation state remains separate from resource payloads; existing hook behavior must remain observable; no scheduler, authorization engine, provider registry, runtime scanning, public SQL, public `IQueryable<Resource>`, broad workflow/state-machine infrastructure, or schema migration.
+**Scale/Scope**: Core activation semantics in provider-backed and direct in-memory managers, docs, Spec Kit artifacts, and focused tests.
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+- **SDK-first/headless**: PASS - Changes SDK activation behavior only; no UI or host framework coupling.
+- **Immutable versioning**: PASS - No resource versions are created or mutated.
+- **Channel activation**: PASS - Activation remains separate state keyed by channel.
+- **Typed/queryable**: PASS - Typed aspects and query AST semantics remain unchanged; no public SQL or `IQueryable` is introduced.
+- **Provider agnostic**: PASS - Uses existing version reader/writer abstractions.
+- **Simplicity first**: PASS - Updating existing activation semantics is simpler than adding a promotion service.
+- **Modern C# idioms**: PASS - Planned edits keep existing async/record/collection style.
+- **Readability over cleverness**: PASS - The behavior is a direct validation change with explicit tests.
+- **Explicitness over magic**: PASS - Hosts explicitly request the version and channel to activate.
+- **Abstractions justified**: PASS - No new abstraction is introduced.
+- **Optimize for deletion**: PASS - The feature is a localized behavior change and tests/docs.
+- **Composition over inheritance**: PASS - No inheritance changes.
+- **Intentional dependencies**: PASS - No new dependencies.
+- **Operational simplicity**: PASS - No schema, migration, worker, or deployment change.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/021-historical-version-activation/
++-- spec.md
++-- plan.md
++-- research.md
++-- data-model.md
++-- quickstart.md
++-- checklists/
+|   +-- requirements.md
++-- contracts/
+    +-- historical-version-activation.md
+```
+
+### Source Code (repository root)
+
+```text
+src/
++-- core/Aster.Core/
+|   +-- Services/DefaultResourceManager.cs
+|   +-- InMemory/InMemoryResourceManager.cs
+|   +-- Abstractions/IResourceManager.cs
+|   +-- README.md
+
+test/
++-- Aster.Tests/
+    +-- InMemory/
+    +-- Integration/
+    +-- Lifecycle/
+    +-- SqliteJson/
+    +-- Tenancy/
+```
+
+**Structure Decision**: Keep this as a behavior change in existing activation APIs. Do not add a new promotion service, provider capability, workflow engine, or storage shape.
+
+## Complexity Tracking
+
+No constitution violations.
+
+## Phase 0 Research Summary
+
+Research decisions are captured in [research.md](research.md). Key outcomes:
+
+- Reuse existing `ActivateAsync` APIs and remove the latest-only check.
+- Preserve version existence validation.
+- Preserve `allowMultipleActive` semantics.
+- Preserve lifecycle hook invocation shape.
+- Keep provider storage unchanged.
+
+## Phase 1 Design Summary
+
+Design artifacts:
+
+- [data-model.md](data-model.md)
+- [contracts/historical-version-activation.md](contracts/historical-version-activation.md)
+- [quickstart.md](quickstart.md)
+
+## Post-Design Constitution Check
+
+- **SDK-first/headless**: PASS - Existing SDK APIs remain the surface.
+- **Immutable versioning**: PASS - Activation writes do not alter resource snapshots.
+- **Channel activation**: PASS - Activation records remain the only mutated state.
+- **Typed/queryable**: PASS - Query and typed aspect behavior is unchanged.
+- **Provider agnostic**: PASS - No provider-specific code path is added.
+- **Simplicity first**: PASS - The design removes an overly narrow validation rule.
+- **Modern C# idioms**: PASS - Existing idioms are retained.
+- **Readability over cleverness**: PASS - Tests document the changed semantics directly.
+- **Explicitness over magic**: PASS - No ambient behavior is added.
+- **Abstractions justified**: PASS - No new abstraction.
+- **Optimize for deletion**: PASS - Localized edits remain easy to revert if needed.
+- **Composition over inheritance**: PASS - No inheritance changes.
+- **Intentional dependencies**: PASS - No new dependencies.
+- **Operational simplicity**: PASS - Existing build/test workflows remain sufficient.

--- a/specs/021-historical-version-activation/quickstart.md
+++ b/specs/021-historical-version-activation/quickstart.md
@@ -1,0 +1,71 @@
+# Quickstart: Historical Version Activation
+
+## Create Multiple Versions
+
+```csharp
+var manager = serviceProvider.GetRequiredService<IResourceManager>();
+
+var v1 = await manager.CreateAsync("Product", new CreateResourceRequest
+{
+    ResourceId = "product-1",
+});
+
+var v2 = await manager.UpdateAsync("product-1", new UpdateResourceRequest
+{
+    BaseVersion = v1.Version,
+});
+```
+
+## Activate A Historical Version
+
+```csharp
+await manager.ActivateAsync("product-1", v1.Version, "Published");
+
+var active = await manager.GetActiveVersionsAsync("product-1", "Published");
+var latest = await manager.GetLatestVersionAsync("product-1");
+```
+
+Expected behavior:
+
+- `active.Single().Version == 1`
+- `latest!.Version == 2`
+
+## Multi-Active Historical Activation
+
+```csharp
+await manager.ActivateAsync("product-1", v2.Version, "Preview", allowMultipleActive: true);
+await manager.ActivateAsync("product-1", v1.Version, "Preview", allowMultipleActive: true);
+
+var preview = await manager.GetActiveVersionsAsync("product-1", "Preview");
+```
+
+Expected behavior:
+
+- `preview.Select(x => x.Version)` contains `[1, 2]` in deterministic order.
+
+## Tenant-Scoped Historical Activation
+
+```csharp
+var tenant = TenantScope.FromTenantId("tenant-a");
+
+await manager.ActivateAsync(
+    "product-1",
+    v1.Version,
+    "Published",
+    tenant,
+    allowMultipleActive: false,
+    CancellationToken.None);
+```
+
+Only the selected tenant's activation state is changed.
+
+## Non-Goals
+
+Historical activation does not:
+
+- create a new resource version;
+- change latest;
+- rewrite resource payloads;
+- evaluate policies;
+- run background jobs;
+- introduce SQL or queryable resource surfaces.

--- a/specs/021-historical-version-activation/research.md
+++ b/specs/021-historical-version-activation/research.md
@@ -1,0 +1,57 @@
+# Research: Historical Version Activation
+
+## Existing API Versus New Promotion Service
+
+Decision: Reuse existing `ActivateAsync` methods and allow the supplied version to be any existing resource version.
+
+Rationale: The existing API already accepts an explicit resource version, channel, tenant scope, and `allowMultipleActive` flag. Adding a separate promotion service would duplicate activation behavior and create unnecessary conceptual surface.
+
+Alternatives considered:
+
+- Add `PromoteAsync`: rejected because it would wrap the same activation state write and require duplicate hooks/docs.
+- Add request models: rejected because the current method arguments are already explicit.
+- Keep latest-only activation: rejected because the roadmap requires historical promotion.
+
+## Version Existence Validation
+
+Decision: Keep the existing version-not-found behavior when the requested version does not exist in the effective tenant.
+
+Rationale: Historical activation should broaden the allowed version set from "latest only" to "any existing version", not relax existence checks.
+
+Alternatives considered:
+
+- Let activation state reference missing versions: rejected because it can create dangling active state.
+- Return no-op for missing versions: rejected because hosts need deterministic failure for invalid selections.
+
+## Single-Active And Multi-Active Behavior
+
+Decision: Preserve the current `allowMultipleActive` behavior for historical versions.
+
+Rationale: The flag already controls whether activation replaces the channel set or appends to it. Historical versions should follow the same channel semantics as latest versions.
+
+Alternatives considered:
+
+- Always replace when activating historical versions: rejected because preview and staging channels may intentionally allow multiple active historical snapshots.
+- Always append historical versions: rejected because published-style channels need single-active rollback semantics.
+
+## Lifecycle Hooks
+
+Decision: Invoke existing activation hooks for historical activation with the requested version and resulting active version list.
+
+Rationale: Hooks are the host-visible way to observe/gate activation. Historical activation is still activation, so hooks should not be bypassed.
+
+Alternatives considered:
+
+- Add new hook points: rejected because this slice does not introduce a new operation type.
+- Skip hooks for historical activation: rejected because it would hide activation writes from host behavior.
+
+## Provider Storage
+
+Decision: Use existing activation state writes through `IResourceVersionWriter`.
+
+Rationale: Historical activation changes only which version number appears in activation state. In-memory and SQLite JSON stores already persist active version lists.
+
+Alternatives considered:
+
+- Add provider migration or activation metadata: rejected because no new data is required.
+- Add provider-specific historical activation capability: rejected because existing writer contract already supports arbitrary active version lists.

--- a/specs/021-historical-version-activation/spec.md
+++ b/specs/021-historical-version-activation/spec.md
@@ -1,0 +1,88 @@
+# Feature Specification: Historical Version Activation
+
+**Feature Branch**: `021-historical-version-activation`
+**Created**: 2026-05-29
+**Status**: Draft
+**Input**: User description: "Allow hosts to explicitly activate historical resource versions in activation channels. Activating an older existing version should no longer be treated as a concurrency conflict; latest remains unchanged, resource versions remain immutable, activation state remains separate, tenant boundaries remain explicit, and single-active versus multi-active channel behavior remains controlled by the existing allowMultipleActive flag. Keep the slice bounded: no schema changes, no new provider registry, no scheduler, no authorization engine, no public SQL, no public IQueryable<Resource>, no broad workflow engine, and no mutation beyond activation state."
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Activate Historical Version (Priority: P1)
+
+As a host author, I need to activate an older existing resource version in a channel, so that hosts can promote or roll back to a known historical snapshot without creating a new resource version.
+
+**Why this priority**: The roadmap names historical promotion as part of the activation model, and version history inspection now makes historical versions visible to hosts.
+
+**Independent Test**: Create a resource with multiple versions, activate version 1 after version 2 exists, and verify version 1 becomes active while version 2 remains latest.
+
+**Acceptance Scenarios**:
+
+1. **Given** a resource has versions 1 and 2, **When** the host activates version 1 in `Published`, **Then** version 1 is active in that channel and version 2 remains latest.
+2. **Given** a historical version is activated with single-active behavior, **When** the channel previously had another active version, **Then** the channel contains only the requested historical version.
+3. **Given** a historical version is activated with multi-active behavior, **When** the channel previously had another active version, **Then** both active versions remain active in deterministic order.
+
+---
+
+### User Story 2 - Preserve Safety and Existing Boundaries (Priority: P2)
+
+As a host author, I need historical activation to preserve existing validation, tenant scoping, lifecycle hooks, and activation storage behavior, so that the feature is a safe extension of current activation semantics.
+
+**Why this priority**: Activation remains a state transition with lifecycle hooks and tenant boundaries; broadening the allowed version set must not bypass existing protections.
+
+**Independent Test**: Attempt to activate a missing version, activate matching identifiers in separate tenants, and verify hook contexts contain the requested historical version and resulting active set.
+
+**Acceptance Scenarios**:
+
+1. **Given** a requested historical version does not exist, **When** activation runs, **Then** activation fails with the existing version-not-found behavior.
+2. **Given** matching resource identifiers exist in two tenants, **When** a historical version is activated in tenant A, **Then** tenant B activation state is unchanged.
+3. **Given** lifecycle hooks are registered, **When** a historical version is activated, **Then** hooks receive the requested version and resulting active version list.
+
+### Edge Cases
+
+- Requested resource identifier is null, empty, or whitespace.
+- Requested channel is null, empty, or whitespace.
+- Requested version exists but is not latest.
+- Requested version is already active in the channel.
+- Activation runs with `allowMultipleActive` set to false.
+- Activation runs with `allowMultipleActive` set to true.
+- Matching resource IDs exist in other tenants.
+
+### Constitution Alignment *(mandatory)*
+
+- **Simplicity**: The feature SHOULD update existing activation semantics directly rather than adding a new promotion service or workflow engine.
+- **Explicitness**: Hosts explicitly pass the resource ID, version, channel, tenant scope, and `allowMultipleActive` flag through existing activation APIs.
+- **Dependencies**: None.
+- **Operational Impact**: No storage schema change, migration, background process, provider registry, or deployment change is introduced.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: System MUST allow activation of any existing resource version, including historical non-latest versions.
+- **FR-002**: Historical activation MUST NOT create a new resource version or mutate any resource version payload.
+- **FR-003**: Historical activation MUST NOT change which version is latest.
+- **FR-004**: Historical activation MUST continue to write only activation state.
+- **FR-005**: Historical activation MUST preserve existing `allowMultipleActive = false` behavior by replacing the channel's active versions with the requested version.
+- **FR-006**: Historical activation MUST preserve existing `allowMultipleActive = true` behavior by adding the requested version alongside existing active versions.
+- **FR-007**: Resulting active version lists MUST remain deterministic and ordered.
+- **FR-008**: Activating a missing version MUST fail with existing version-not-found behavior.
+- **FR-009**: Historical activation MUST resolve exactly one effective tenant per request.
+- **FR-010**: Historical activation MUST NOT read or mutate activation state outside the effective tenant.
+- **FR-011**: Lifecycle activation hooks MUST continue to run for historical activation with the requested version and resulting active version list.
+- **FR-012**: Documentation MUST explain historical activation, latest-version preservation, single-active versus multi-active behavior, tenant boundaries, and non-goals.
+- **FR-013**: The feature MUST NOT introduce schema changes, provider registries, runtime scanning, schedulers, authorization engines, public SQL, public `IQueryable<Resource>`, or broad workflow/state-machine infrastructure.
+
+### Key Entities *(include if feature involves data)*
+
+- **Historical Version Activation**: Existing activation operation targeting a non-latest but existing resource version.
+- **Activation Channel**: Host-defined channel whose active version set is updated.
+- **Active Version Set**: Ordered list of active resource version numbers stored separately from resource payloads.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Hosts can activate version 1 after version 2 exists and observe version 1 active while version 2 remains latest.
+- **SC-002**: Single-active and multi-active historical activation scenarios are both covered by tests.
+- **SC-003**: Tenant isolation tests show historical activation in one tenant does not affect matching identifiers in another tenant.
+- **SC-004**: Existing activation, lifecycle, query, policy, portability, and SQLite tests continue to pass unchanged except for tests updated to reflect the new supported historical activation behavior.

--- a/specs/021-historical-version-activation/tasks.md
+++ b/specs/021-historical-version-activation/tasks.md
@@ -1,0 +1,125 @@
+# Tasks: Historical Version Activation
+
+**Input**: Design documents from `/specs/021-historical-version-activation/`
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/
+
+**Tests**: Required by the feature specification for historical activation, single-active/multi-active behavior, tenant isolation, lifecycle hooks, SQLite parity, and existing compatibility.
+
+**Organization**: Tasks are grouped by user story to keep the P1 historical activation path independently testable before the P2 safety coverage.
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Confirm the feature context and repository guardrails before implementation.
+
+- [X] T001 Verify feature documents and checklist are present in specs/021-historical-version-activation/
+- [X] T002 Confirm no new dependency, schema, provider registry, scheduler, public SQL, or public IQueryable<Resource> work is required by specs/021-historical-version-activation/plan.md
+- [X] T003 Inspect existing activation implementation and tests in src/core/Aster.Core/Services/DefaultResourceManager.cs, src/core/Aster.Core/InMemory/InMemoryResourceManager.cs, and test/Aster.Tests/
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Identify and update stale public contract language before story behavior changes.
+
+- [X] T004 Update activation contract documentation in src/core/Aster.Core/Abstractions/IResourceManager.cs to describe any existing version as a valid activation target
+- [X] T005 Update activation docs in src/core/Aster.Core/README.md to remove latest-only activation wording and describe historical activation behavior
+
+**Checkpoint**: Public docs no longer contradict the intended implementation.
+
+---
+
+## Phase 3: User Story 1 - Activate Historical Version (Priority: P1) MVP
+
+**Goal**: Hosts can activate a historical non-latest version while latest remains unchanged.
+
+**Independent Test**: Create versions 1 and 2, activate version 1 after version 2 exists, and verify version 1 is active while version 2 remains latest.
+
+### Tests for User Story 1
+
+- [X] T006 [P] [US1] Update direct in-memory tests for non-latest activation in test/Aster.Tests/InMemory/InMemoryActivationTests.cs
+- [X] T007 [P] [US1] Add provider-backed historical activation tests for single-active and multi-active behavior in test/Aster.Tests/InMemory/InMemoryActivationTests.cs
+- [X] T008 [P] [US1] Update quickstart integration expectations for historical activation in test/Aster.Tests/Integration/QuickstartIntegrationTest.cs
+
+### Implementation for User Story 1
+
+- [X] T009 [US1] Remove latest-only concurrency rejection from src/core/Aster.Core/Services/DefaultResourceManager.cs while preserving version-not-found validation
+- [X] T010 [US1] Remove latest-only concurrency rejection from src/core/Aster.Core/InMemory/InMemoryResourceManager.cs while preserving version-not-found validation
+- [X] T011 [US1] Run focused historical activation tests for test/Aster.Tests/InMemory/InMemoryActivationTests.cs and test/Aster.Tests/Integration/QuickstartIntegrationTest.cs
+
+**Checkpoint**: Historical activation works for the core manager paths and quickstart behavior.
+
+---
+
+## Phase 4: User Story 2 - Preserve Safety and Existing Boundaries (Priority: P2)
+
+**Goal**: Historical activation keeps existing missing-version failures, tenant scoping, lifecycle hook behavior, SQLite persistence, and compatibility.
+
+**Independent Test**: Attempt a missing historical version, activate matching resource IDs in separate tenants, and verify lifecycle hook contexts contain the requested historical version and resulting active set.
+
+### Tests for User Story 2
+
+- [X] T012 [P] [US2] Add missing-version fail-closed coverage for historical activation in test/Aster.Tests/InMemory/InMemoryActivationTests.cs
+- [X] T013 [P] [US2] Add tenant isolation coverage for historical activation in test/Aster.Tests/Tenancy/TenantActivationTests.cs
+- [X] T014 [P] [US2] Add lifecycle hook context coverage for historical activation in test/Aster.Tests/Lifecycle/LifecycleActivationHookTests.cs
+- [X] T015 [P] [US2] Add SQLite historical activation persistence coverage in test/Aster.Tests/SqliteJson/SqliteJsonResourceStoreTests.cs
+
+### Implementation for User Story 2
+
+- [X] T016 [US2] Adjust any stale compatibility assertions that still expect non-latest activation to throw ConcurrencyException in test/Aster.Tests/
+- [X] T017 [US2] Run focused tenant, lifecycle, and SQLite historical activation tests from test/Aster.Tests/
+
+**Checkpoint**: Safety and provider parity coverage is complete.
+
+---
+
+## Phase 5: Polish & Cross-Cutting Concerns
+
+**Purpose**: Keep roadmap/context current and validate the whole solution.
+
+- [X] T018 [P] Update docs/ExecutionRoadmap.md with the 021 historical activation slice status
+- [X] T019 [P] Ensure AGENTS.md includes 021 technology and recent-change context
+- [X] T020 Validate quickstart behavior against specs/021-historical-version-activation/quickstart.md
+- [X] T021 Run dotnet test Aster.sln
+- [X] T022 Run dotnet build Aster.sln /m:1
+- [X] T023 Run git diff --check
+- [X] T024 Review implementation against specs/021-historical-version-activation/spec.md and mark all completed tasks in specs/021-historical-version-activation/tasks.md
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies.
+- **Foundational (Phase 2)**: Depends on setup and blocks user story work.
+- **User Story 1 (Phase 3)**: Depends on foundational documentation alignment.
+- **User Story 2 (Phase 4)**: Depends on User Story 1 behavior change.
+- **Polish (Phase 5)**: Depends on both user stories.
+
+### User Story Dependencies
+
+- **User Story 1 (P1)**: MVP and required before safety parity can be meaningfully validated.
+- **User Story 2 (P2)**: Extends coverage around the implemented behavior without adding new public APIs.
+
+### Parallel Opportunities
+
+- T006, T007, and T008 can be drafted independently before implementation.
+- T012, T013, T014, and T015 cover different safety dimensions and can be drafted independently.
+- T018 and T019 touch separate documentation files.
+
+---
+
+## Implementation Strategy
+
+### MVP First
+
+1. Complete setup and foundational docs.
+2. Update tests that currently encode latest-only activation.
+3. Remove latest-only concurrency checks from both manager implementations.
+4. Validate historical activation for in-memory and quickstart paths.
+
+### Incremental Delivery
+
+1. Add safety coverage for missing versions, tenant isolation, lifecycle hooks, and SQLite.
+2. Update roadmap and agent context.
+3. Run full test/build/diff validation.

--- a/src/core/Aster.Core/Abstractions/IResourceManager.cs
+++ b/src/core/Aster.Core/Abstractions/IResourceManager.cs
@@ -89,10 +89,10 @@ public interface IResourceManager
     ValueTask<Resource?> GetLatestVersionAsync(string resourceId, TenantScope tenantScope, CancellationToken cancellationToken);
 
     /// <summary>
-    /// Activates the given version in the specified channel.
+    /// Activates any existing version in the specified channel.
     /// </summary>
     /// <param name="resourceId">Logical resource identifier.</param>
-    /// <param name="version">The version number to activate.</param>
+    /// <param name="version">The existing version number to activate, including historical non-latest versions.</param>
     /// <param name="channel">The channel name (e.g., "Published").</param>
     /// <param name="allowMultipleActive">
     /// If <see langword="false"/> (default), activating a version deactivates all others in the same channel.
@@ -100,16 +100,13 @@ public interface IResourceManager
     /// </param>
     /// <param name="cancellationToken">Token to cancel the operation.</param>
     /// <exception cref="VersionNotFoundException">Thrown if the specified version does not exist.</exception>
-    /// <exception cref="ConcurrencyException">
-    /// Thrown if the store's latest version has changed since the caller last read.
-    /// </exception>
     ValueTask ActivateAsync(string resourceId, int version, string channel, bool allowMultipleActive = false, CancellationToken cancellationToken = default);
 
     /// <summary>
-    /// Activates the given tenant-scoped resource version in the specified channel.
+    /// Activates any existing tenant-scoped resource version in the specified channel.
     /// </summary>
     /// <param name="resourceId">Logical resource identifier.</param>
-    /// <param name="version">The version number to activate.</param>
+    /// <param name="version">The existing version number to activate, including historical non-latest versions.</param>
     /// <param name="channel">The channel name.</param>
     /// <param name="tenantScope">Tenant scope for activation.</param>
     /// <param name="allowMultipleActive">Whether to permit multiple active versions in the channel.</param>

--- a/src/core/Aster.Core/InMemory/InMemoryResourceManager.cs
+++ b/src/core/Aster.Core/InMemory/InMemoryResourceManager.cs
@@ -236,19 +236,12 @@ public sealed partial class InMemoryResourceManager : IResourceManager, IResourc
         if (versions is null)
             throw new VersionNotFoundException(resourceId, version);
 
-        Resource latest;
         lock (versions)
         {
             var match = versions.FirstOrDefault(r => r.Version == version);
             if (match is null)
                 throw new VersionNotFoundException(resourceId, version);
-
-            latest = versions[^1];
         }
-
-        // Optimistic concurrency: version must be the current latest
-        if (version != latest.Version)
-            throw new ConcurrencyException(resourceId, version, latest.Version);
 
         var channelActivations = store.GetOrAddActivations(resourceId, tenant);
         var newActiveVersions = new HashSet<int>();
@@ -270,7 +263,7 @@ public sealed partial class InMemoryResourceManager : IResourceManager, IResourc
             TenantScope = tenant,
             ResourceId = resourceId,
             Channel = channel,
-            ActiveVersions = [.. newActiveVersions],
+            ActiveVersions = newActiveVersions.Order().ToList(),
             LastUpdated = DateTime.UtcNow,
         };
 

--- a/src/core/Aster.Core/README.md
+++ b/src/core/Aster.Core/README.md
@@ -502,7 +502,7 @@ Key invariants:
 - `DefinitionVersion` records schema lineage for a resource version. Normal updates preserve it; explicit schema upgrades advance it.
 - Activation channels are independent: a resource can be active in `"Published"` at V2 and in `"Staging"` at V3 simultaneously.
 - Policy declarations are metadata only; policy previews and lifecycle marker writes are explicit host-controlled operations.
-- Optimistic concurrency is enforced on `UpdateAsync` (must supply `BaseVersion == current latest Version`) and `ActivateAsync` (must supply the current latest version number).
+- Optimistic concurrency is enforced on `UpdateAsync` (must supply `BaseVersion == current latest Version`). `ActivateAsync` can target any existing version, including historical non-latest versions; activation changes channel state only and does not change latest.
 
 ---
 

--- a/src/core/Aster.Core/Services/DefaultResourceManager.cs
+++ b/src/core/Aster.Core/Services/DefaultResourceManager.cs
@@ -313,10 +313,6 @@ public sealed partial class DefaultResourceManager : IResourceManager
         if (versions.All(r => r.Version != version))
             throw new VersionNotFoundException(resourceId, version);
 
-        var latest = versions[^1];
-        if (version != latest.Version)
-            throw new ConcurrencyException(resourceId, version, latest.Version);
-
         var activeVersions = allowMultipleActive
             ? (await GetActiveVersionsAsync(resourceId, channel, tenant, cancellationToken))
                 .Select(r => r.Version)

--- a/test/Aster.Tests/InMemory/InMemoryActivationTests.cs
+++ b/test/Aster.Tests/InMemory/InMemoryActivationTests.cs
@@ -125,6 +125,21 @@ public sealed class InMemoryActivationTests
         Assert.Equal(v2.Version, latest.Version);
     }
 
+    [Fact]
+    public async Task DefaultResourceManager_HistoricalVersion_MultiActiveAppendsInDeterministicOrder()
+    {
+        await using var provider = new ServiceCollection().AddAsterCore().BuildServiceProvider();
+        var manager = provider.GetRequiredService<IResourceManager>();
+        var v1 = await manager.CreateAsync("Product", new CreateResourceRequest());
+        var v2 = await manager.UpdateAsync(v1.ResourceId, new UpdateResourceRequest { BaseVersion = 1 });
+        await manager.ActivateAsync(v1.ResourceId, v2.Version, "Preview", allowMultipleActive: true);
+
+        await manager.ActivateAsync(v1.ResourceId, v1.Version, "Preview", allowMultipleActive: true);
+
+        var active = (await manager.GetActiveVersionsAsync(v1.ResourceId, "Preview")).ToList();
+        Assert.Equal([v1.Version, v2.Version], active.Select(r => r.Version).ToList());
+    }
+
     // ──────────────────────────────────────────────────────────────────────────
     // DeactivateAsync
     // ──────────────────────────────────────────────────────────────────────────

--- a/test/Aster.Tests/InMemory/InMemoryActivationTests.cs
+++ b/test/Aster.Tests/InMemory/InMemoryActivationTests.cs
@@ -1,7 +1,9 @@
 using Aster.Core.Abstractions;
 using Aster.Core.Exceptions;
+using Aster.Core.Extensions;
 using Aster.Core.InMemory;
 using Aster.Core.Services;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
 using NSubstitute;
 
@@ -58,61 +60,69 @@ public sealed class InMemoryActivationTests
     }
 
     [Fact]
-    public async Task ActivateAsync_NonLatestVersion_ThrowsConcurrencyException()
+    public async Task ActivateAsync_HistoricalVersion_ActivatesWhileLatestRemainsUnchanged()
     {
-        // Arrange — create V1, update to V2, then try to activate stale V1
         var (manager, _) = CreateManager();
         var v1 = await manager.CreateAsync("Product", new CreateResourceRequest());
-        await manager.UpdateAsync(v1.ResourceId, new UpdateResourceRequest { BaseVersion = 1 });
-
-        // Act & Assert — V2 is latest; activating V1 is a concurrency conflict
-        await Assert.ThrowsAsync<ConcurrencyException>(() =>
-            manager.ActivateAsync(v1.ResourceId, 1, "Published").AsTask());
-    }
-
-    [Fact]
-    public async Task ActivateAsync_SingleActive_DeactivatesPreviousVersion()
-    {
-        // Arrange
-        var (manager, _) = CreateManager();
-        var v1 = await manager.CreateAsync("Product", new CreateResourceRequest());
-        await manager.ActivateAsync(v1.ResourceId, 1, "Published", allowMultipleActive: false);
-
-        // Sanity: V1 is active
-        var beforeUpdate = (await manager.GetActiveVersionsAsync(v1.ResourceId, "Published")).ToList();
-        Assert.Single(beforeUpdate);
-
-        // Update to V2 so V2 is now latest
         var v2 = await manager.UpdateAsync(v1.ResourceId, new UpdateResourceRequest { BaseVersion = 1 });
 
-        // Act — activate V2 with single-active (default)
-        await manager.ActivateAsync(v1.ResourceId, 2, "Published", allowMultipleActive: false);
-        var active = (await manager.GetActiveVersionsAsync(v1.ResourceId, "Published")).ToList();
+        await manager.ActivateAsync(v1.ResourceId, v1.Version, "Published");
 
-        // Assert — only V2 should be active
+        var active = (await manager.GetActiveVersionsAsync(v1.ResourceId, "Published")).ToList();
+        var latest = await manager.GetLatestVersionAsync(v1.ResourceId);
+
         Assert.Single(active);
-        Assert.Equal(2, active[0].Version);
+        Assert.Equal(v1.Version, active[0].Version);
+        Assert.NotNull(latest);
+        Assert.Equal(v2.Version, latest.Version);
     }
 
     [Fact]
-    public async Task ActivateAsync_MultiActive_AppendsBothVersions()
+    public async Task ActivateAsync_SingleActive_HistoricalVersionReplacesPreviousVersion()
     {
-        // Arrange
         var (manager, _) = CreateManager();
         var v1 = await manager.CreateAsync("Product", new CreateResourceRequest());
-        await manager.ActivateAsync(v1.ResourceId, 1, "Preview", allowMultipleActive: true);
+        var v2 = await manager.UpdateAsync(v1.ResourceId, new UpdateResourceRequest { BaseVersion = 1 });
+        await manager.ActivateAsync(v1.ResourceId, v2.Version, "Published", allowMultipleActive: false);
 
-        // Update to V2 and activate too (multi-active)
-        await manager.UpdateAsync(v1.ResourceId, new UpdateResourceRequest { BaseVersion = 1 });
-        await manager.ActivateAsync(v1.ResourceId, 2, "Preview", allowMultipleActive: true);
+        await manager.ActivateAsync(v1.ResourceId, v1.Version, "Published", allowMultipleActive: false);
+        var active = (await manager.GetActiveVersionsAsync(v1.ResourceId, "Published")).ToList();
 
-        // Act
+        Assert.Single(active);
+        Assert.Equal(v1.Version, active[0].Version);
+    }
+
+    [Fact]
+    public async Task ActivateAsync_MultiActive_HistoricalVersionAppendsInDeterministicOrder()
+    {
+        var (manager, _) = CreateManager();
+        var v1 = await manager.CreateAsync("Product", new CreateResourceRequest());
+        var v2 = await manager.UpdateAsync(v1.ResourceId, new UpdateResourceRequest { BaseVersion = 1 });
+        await manager.ActivateAsync(v1.ResourceId, v2.Version, "Preview", allowMultipleActive: true);
+
+        await manager.ActivateAsync(v1.ResourceId, v1.Version, "Preview", allowMultipleActive: true);
         var active = (await manager.GetActiveVersionsAsync(v1.ResourceId, "Preview")).ToList();
 
-        // Assert — both V1 and V2 are active in Preview
-        Assert.Equal(2, active.Count);
-        Assert.Contains(active, r => r.Version == 1);
-        Assert.Contains(active, r => r.Version == 2);
+        Assert.Equal([1, 2], active.Select(r => r.Version).ToList());
+    }
+
+    [Fact]
+    public async Task DefaultResourceManager_HistoricalVersion_ActivatesThroughProviderBackedPath()
+    {
+        await using var provider = new ServiceCollection().AddAsterCore().BuildServiceProvider();
+        var manager = provider.GetRequiredService<IResourceManager>();
+        var v1 = await manager.CreateAsync("Product", new CreateResourceRequest());
+        var v2 = await manager.UpdateAsync(v1.ResourceId, new UpdateResourceRequest { BaseVersion = 1 });
+        await manager.ActivateAsync(v1.ResourceId, v2.Version, "Published");
+
+        await manager.ActivateAsync(v1.ResourceId, v1.Version, "Published");
+
+        var active = (await manager.GetActiveVersionsAsync(v1.ResourceId, "Published")).ToList();
+        var latest = await manager.GetLatestVersionAsync(v1.ResourceId);
+        Assert.Single(active);
+        Assert.Equal(v1.Version, active[0].Version);
+        Assert.NotNull(latest);
+        Assert.Equal(v2.Version, latest.Version);
     }
 
     // ──────────────────────────────────────────────────────────────────────────

--- a/test/Aster.Tests/Integration/QuickstartIntegrationTest.cs
+++ b/test/Aster.Tests/Integration/QuickstartIntegrationTest.cs
@@ -163,4 +163,27 @@ public sealed class QuickstartIntegrationTest
                 AspectUpdates = new Dictionary<string, object> { { "X", "second" } }
             }).AsTask());
     }
+
+    [Fact]
+    public async Task Quickstart_HistoricalActivation_ActivatesOlderVersionWithoutChangingLatest()
+    {
+        var (_, manager) = CreateServices();
+        var v1 = await manager.CreateAsync("Product", new CreateResourceRequest
+        {
+            ResourceId = "product-1",
+        });
+        var v2 = await manager.UpdateAsync("product-1", new UpdateResourceRequest
+        {
+            BaseVersion = v1.Version,
+        });
+
+        await manager.ActivateAsync("product-1", v1.Version, "Published");
+
+        var active = (await manager.GetActiveVersionsAsync("product-1", "Published")).ToList();
+        var latest = await manager.GetLatestVersionAsync("product-1");
+        Assert.Single(active);
+        Assert.Equal(v1.Version, active[0].Version);
+        Assert.NotNull(latest);
+        Assert.Equal(v2.Version, latest.Version);
+    }
 }

--- a/test/Aster.Tests/Lifecycle/LifecycleActivationHookTests.cs
+++ b/test/Aster.Tests/Lifecycle/LifecycleActivationHookTests.cs
@@ -54,6 +54,28 @@ public sealed class LifecycleActivationHookTests : IAsyncDisposable
     }
 
     [Fact]
+    public async Task HistoricalActivateAsync_RunsHooksWithRequestedVersionAndResultingActiveVersions()
+    {
+        await LifecycleHookTestFixtures.SaveDefinitionAsync(provider);
+        var v1 = await manager.CreateAsync(
+            LifecycleHookTestFixtures.DefinitionId,
+            LifecycleHookTestFixtures.CreateRequest());
+        var v2 = await manager.UpdateAsync(v1.ResourceId, LifecycleHookTestFixtures.UpdateRequest(v1.Version));
+        await manager.ActivateAsync(v1.ResourceId, v2.Version, LifecycleHookTestFixtures.Channel);
+        recorder.Events.Clear();
+
+        await manager.ActivateAsync(v1.ResourceId, v1.Version, LifecycleHookTestFixtures.Channel);
+
+        var before = Assert.IsType<ResourceActivationLifecycleContext>(recorder.Events[0].Context);
+        var after = Assert.IsType<ResourceActivationLifecycleContext>(recorder.Events[2].Context);
+        Assert.Equal(v1.Version, before.Version);
+        Assert.Equal(v1.Version, after.Version);
+        Assert.Equal([v1.Version], before.ActiveVersions);
+        Assert.Equal([v1.Version], after.ActiveVersions);
+        Assert.Equal(before.OperationId, after.OperationId);
+    }
+
+    [Fact]
     public async Task BeforeActivationRejection_LeavesChannelStateUnchanged()
     {
         await LifecycleHookTestFixtures.SaveDefinitionAsync(provider);

--- a/test/Aster.Tests/SqliteJson/SqliteJsonResourceStoreTests.cs
+++ b/test/Aster.Tests/SqliteJson/SqliteJsonResourceStoreTests.cs
@@ -108,6 +108,7 @@ public sealed class SqliteJsonResourceStoreTests : IDisposable
             },
         });
         await manager.ActivateAsync(v1.ResourceId, v2.Version, "Published");
+        await manager.ActivateAsync(v1.ResourceId, v1.Version, "Published");
 
         var secondStore = CreateStore();
         var secondManager = CreateManager(secondStore);
@@ -121,7 +122,8 @@ public sealed class SqliteJsonResourceStoreTests : IDisposable
         Assert.Equal(2, latest.Version);
         Assert.Equal("Published", GetTitle(latest));
         Assert.Single(active);
-        Assert.Equal(2, active[0].Version);
+        Assert.Equal(1, active[0].Version);
+        Assert.Equal("Draft", GetTitle(active[0]));
     }
 
     [Fact]

--- a/test/Aster.Tests/Tenancy/TenantActivationTests.cs
+++ b/test/Aster.Tests/Tenancy/TenantActivationTests.cs
@@ -36,6 +36,30 @@ public sealed class TenantActivationTests : IDisposable
     }
 
     [Fact]
+    public async Task HistoricalActivation_IsScopedByTenant()
+    {
+        await TenantScopeTestFixtures.RegisterProductDefinitionAsync(provider, TenantScopeTestFixtures.TenantA);
+        await TenantScopeTestFixtures.RegisterProductDefinitionAsync(provider, TenantScopeTestFixtures.TenantB);
+        await TenantScopeTestFixtures.CreateProductAsync(provider, "shared-product", "Tenant A", TenantScopeTestFixtures.TenantA);
+        await TenantScopeTestFixtures.CreateProductAsync(provider, "shared-product", "Tenant B", TenantScopeTestFixtures.TenantB);
+        await manager.UpdateAsync("shared-product", new UpdateResourceRequest { TenantScope = TenantScopeTestFixtures.TenantA, BaseVersion = 1 });
+        await manager.UpdateAsync("shared-product", new UpdateResourceRequest { TenantScope = TenantScopeTestFixtures.TenantB, BaseVersion = 1 });
+        await manager.ActivateAsync("shared-product", 2, "Published", TenantScopeTestFixtures.TenantB, allowMultipleActive: false, CancellationToken.None);
+
+        await manager.ActivateAsync("shared-product", 1, "Published", TenantScopeTestFixtures.TenantA, allowMultipleActive: false, CancellationToken.None);
+
+        var tenantAActive = (await manager.GetActiveVersionsAsync("shared-product", "Published", TenantScopeTestFixtures.TenantA, CancellationToken.None)).ToList();
+        var tenantBActive = (await manager.GetActiveVersionsAsync("shared-product", "Published", TenantScopeTestFixtures.TenantB, CancellationToken.None)).ToList();
+        var tenantALatest = await manager.GetLatestVersionAsync("shared-product", TenantScopeTestFixtures.TenantA, CancellationToken.None);
+        var tenantBLatest = await manager.GetLatestVersionAsync("shared-product", TenantScopeTestFixtures.TenantB, CancellationToken.None);
+
+        Assert.Equal(1, tenantAActive.Single().Version);
+        Assert.Equal(2, tenantBActive.Single().Version);
+        Assert.Equal(2, tenantALatest!.Version);
+        Assert.Equal(2, tenantBLatest!.Version);
+    }
+
+    [Fact]
     public async Task UpdateActivationAsync_NormalizesPayloadIdentityToMethodArguments()
     {
         var writer = provider.GetRequiredService<IResourceVersionWriter>();


### PR DESCRIPTION
## Summary
- allow activation of any existing resource version, including historical non-latest versions
- preserve latest-version identity, immutable resource versions, tenant scoping, lifecycle hooks, and single-active/multi-active behavior
- add Spec Kit artifacts, roadmap context, docs, and focused in-memory/tenant/lifecycle/SQLite/quickstart coverage

## Validation
- dotnet test test/Aster.Tests/Aster.Tests.csproj --filter "FullyQualifiedName~InMemoryActivationTests|FullyQualifiedName~QuickstartIntegrationTest|FullyQualifiedName~TenantActivationTests|FullyQualifiedName~LifecycleActivationHookTests|FullyQualifiedName~SqliteJsonResourceStoreTests"
- dotnet test Aster.sln
- dotnet build Aster.sln /m:1
- git diff --check