### PR TITLE
Add policy application summaries

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "featureDir": "specs/021-historical-version-activation"
+  "featureDir": "specs/022-policy-application-summaries"
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 <!-- SPECKIT START -->
 For additional context about technologies to be used, project structure,
-shell commands, and other important information, read `specs/021-historical-version-activation/plan.md`.
+shell commands, and other important information, read `specs/022-policy-application-summaries/plan.md`.
 <!-- SPECKIT END -->
 
 ## Active Technologies
@@ -28,8 +28,11 @@ shell commands, and other important information, read `specs/021-historical-vers
 - Existing resource versions, activation state, and lifecycle marker storage only. No schema migration, data rewrite, portability snapshot format change, or physical index creation. (020-version-history-inspection)
 - C# latest, .NET 8.0 / 9.0 / 10.0 multi-targeting + Existing core SDK, `IResourceManager`, resource version reader/writer, in-memory store, SQLite JSON provider through existing abstractions, lifecycle hook dispatcher, xUnit test stack; no new dependencies (021-historical-version-activation)
 - Existing activation state storage only. Historical activation updates activation rows or in-memory activation state; no resource version rewrite, no latest-version change, no lifecycle marker mutation, no portability format change, and no schema migration. (021-historical-version-activation)
+- C# latest, .NET 8.0 / 9.0 / 10.0 multi-targeting + Existing core SDK policy result models and xUnit test stack; no new dependencies (022-policy-application-summaries)
+- No storage changes. Summaries are pure in-memory views over existing result objects; no schema migration, persistence, audit records, or provider storage changes. (022-policy-application-summaries)
 
 ## Recent Changes
+- 022-policy-application-summaries: Added pure host-facing summaries for policy application and pruning application results with deterministic status counts, completion booleans, affected target counts, diagnostic code counts, and no storage, provider, scheduler, authorization, public SQL, public IQueryable<Resource>, audit persistence, or reporting framework
 - 021-historical-version-activation: Added historical resource version activation planning and implementation context for activating any existing version without changing latest, rewriting versions, changing storage schema, adding provider registries, public SQL, public IQueryable<Resource>, schedulers, authorization engines, or workflow infrastructure
 - 020-version-history-inspection: Added read-only host-facing resource version history inspection with latest/draft/active-channel summaries, lifecycle marker state, conservative maintenance hints, tenant scoping, SQLite parity, and no storage migrations, query planner, provider registry, public SQL, public IQueryable<Resource>, background jobs, or mutation behavior
 - 019-policy-pruning-application: Added host-controlled policy pruning application for selected version-pruning preview outcomes with safety preflight, tenant scoping, stable diagnostics, in-memory/SQLite removal support, and no schedulers, authorization engines, provider registries, public SQL, public IQueryable<Resource>, broad workflow/state-machine infrastructure, or schema migrations

--- a/docs/ExecutionRoadmap.md
+++ b/docs/ExecutionRoadmap.md
@@ -6,9 +6,9 @@ This roadmap tracks the implementation trail we have already cut through the rep
 
 ## Current Position
 
-Aster now has a working Core SDK, in-memory runtime, SQLite JSON persistence/querying, provider capability discovery, provider validation alignment, provider authoring ergonomics, a reusable provider conformance harness, SQLite facet sorting, portable operator expansion, SQLite date-like ranges, explicit provider-declared index projections, explicit definition schema upgrade behavior, deterministic portability primitives, explicit host lifecycle hooks, explicit tenant scoping, policy foundations, host-controlled policy application orchestration, host-controlled lifecycle restore workflows, host-controlled policy pruning application, and read-only version history inspection.
+Aster now has a working Core SDK, in-memory runtime, SQLite JSON persistence/querying, provider capability discovery, provider validation alignment, provider authoring ergonomics, a reusable provider conformance harness, SQLite facet sorting, portable operator expansion, SQLite date-like ranges, explicit provider-declared index projections, explicit definition schema upgrade behavior, deterministic portability primitives, explicit host lifecycle hooks, explicit tenant scoping, policy foundations, host-controlled policy application orchestration, host-controlled lifecycle restore workflows, host-controlled policy pruning application, read-only version history inspection, and explicit historical version activation.
 
-The Phase 4 core workstream is complete enough to defer optional recipes. The active workstream is now **Phase 5: Multi-tenancy, Policies, Advanced Versioning**. Explicit tenant-aware boundaries, policy foundations, policy application orchestration, reversible lifecycle restore, destructive pruning application, and version history inspection have landed; historical version activation is the current bounded advanced-versioning slice.
+The Phase 4 core workstream is complete enough to defer optional recipes. The active workstream is now **Phase 5: Multi-tenancy, Policies, Advanced Versioning**. Explicit tenant-aware boundaries, policy foundations, policy application orchestration, reversible lifecycle restore, destructive pruning application, version history inspection, and historical version activation have landed; policy application summaries are the current bounded reporting slice.
 
 ## Landed Slices
 
@@ -34,26 +34,26 @@ The Phase 4 core workstream is complete enough to defer optional recipes. The ac
 | `018-lifecycle-restore-workflows` | Landed | Host-controlled preview and application for restoring archive/soft-delete markers with tenant scoping, idempotent already-restored outcomes, stable diagnostics, and no version or activation mutation. |
 | `019-policy-pruning-application` | Landed | Host-controlled application of selected version-pruning preview outcomes with latest/active protection, policy revalidation, tenant scoping, deterministic retries, provider fallback diagnostics, and no schema or portability format changes. |
 | `020-version-history-inspection` | Landed | Read-only host-facing version history inspection with latest/draft/active-channel summaries, lifecycle marker visibility, conservative maintenance hints, tenant scoping, and in-memory/SQLite parity without schema changes or query-surface expansion. |
+| `021-historical-version-activation` | Landed | Explicit activation of any existing historical or latest resource version while preserving immutable versions, latest identity, activation state separation, tenant scoping, lifecycle hooks, and in-memory/SQLite parity. |
 
 ## Near-Term Roadmap
 
-### 021 — Historical Version Activation
+### 022 — Policy Application Summaries
 
-**Status:** In progress on `021-historical-version-activation`.
+**Status:** In progress on `022-policy-application-summaries`.
 
-**Goal:** Allow hosts to explicitly activate any existing resource version, including historical non-latest versions, through the existing activation APIs.
+**Goal:** Give hosts deterministic summary views over existing policy application and pruning application results for UI/reporting.
 
 Scope:
 
-- Remove the latest-only activation restriction while preserving version existence validation.
-- Keep latest-version identity and immutable resource versions unchanged.
-- Preserve single-active versus multi-active channel behavior.
-- Preserve tenant scoping, lifecycle hooks, and provider-backed activation storage.
-- Keep schema changes, automatic jobs, ambient authorization, provider registries, public SQL, public `IQueryable<Resource>`, and broad workflow/state-machine infrastructure out of scope.
+- Summarize marker-based policy application status counts, completion booleans, affected resource counts, and diagnostic code counts.
+- Summarize pruning application status counts, completion booleans, affected resource-version counts, and diagnostic code counts.
+- Keep summaries as pure SDK helpers over existing result objects.
+- Keep storage changes, audit persistence, automatic jobs, ambient authorization, provider registries, public SQL, public `IQueryable<Resource>`, and broad reporting infrastructure out of scope.
 
-### 022 — Next Bounded Phase 5 Slice
+### 023 — Next Bounded Phase 5 Slice
 
-**Goal:** Choose one small continuation slice after historical activation lands.
+**Goal:** Choose one small continuation slice after policy summaries land.
 
 Candidate scope:
 

--- a/specs/022-policy-application-summaries/checklists/requirements.md
+++ b/specs/022-policy-application-summaries/checklists/requirements.md
@@ -1,0 +1,34 @@
+# Specification Quality Checklist: Policy Application Summaries
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-05-29
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Specification is ready for planning.

--- a/specs/022-policy-application-summaries/contracts/policy-application-summaries.md
+++ b/specs/022-policy-application-summaries/contracts/policy-application-summaries.md
@@ -1,0 +1,57 @@
+# Contract: Policy Application Summaries
+
+Policy application summaries are pure, host-facing aggregate views over existing result objects.
+
+## Public SDK Behavior
+
+The feature adds summary generation for:
+
+```csharp
+ResourcePolicyApplicationResult
+ResourcePolicyPruningApplicationResult
+```
+
+Expected helper shape:
+
+```csharp
+ResourcePolicyApplicationSummary ToSummary();
+ResourcePolicyPruningApplicationSummary ToSummary();
+```
+
+The exact member placement may follow existing SDK style, but summary generation must remain explicit and provider-free.
+
+## Application Summary Rules
+
+For marker-based policy application:
+
+- `TotalCount` equals the number of candidate results.
+- `AppliedCount`, `AlreadySatisfiedCount`, `SkippedCount`, and `FailedCount` reflect candidate statuses.
+- `HasFailures` is true when `FailedCount > 0`.
+- `IsFullySuccessful` is true only when every candidate is applied or already satisfied.
+- `AffectedResourceCount` counts distinct non-blank resource IDs from applied and already satisfied candidates.
+- `DiagnosticCodeCounts` groups non-blank diagnostic codes across all candidate diagnostics in ordinal code order.
+
+## Pruning Summary Rules
+
+For policy pruning application:
+
+- `TotalCount` equals the number of candidate results.
+- `PrunedCount`, `AlreadyPrunedCount`, `SkippedCount`, and `FailedCount` reflect candidate statuses.
+- `HasFailures` is true when `FailedCount > 0`.
+- `IsFullySuccessful` is true only when every candidate is pruned or already pruned.
+- `AffectedTargetCount` counts distinct resource/version pairs from pruned and already pruned candidates.
+- `DiagnosticCodeCounts` groups non-blank diagnostic codes across all candidate diagnostics in ordinal code order.
+
+## Non-Goals
+
+Summary generation does not:
+
+- apply policies;
+- re-evaluate policy criteria;
+- mutate resources, markers, activation state, definitions, or versions;
+- write audit records;
+- query stores or providers;
+- invoke lifecycle hooks;
+- schedule background jobs;
+- introduce public SQL or public `IQueryable<Resource>`;
+- replace existing per-candidate results.

--- a/specs/022-policy-application-summaries/contracts/policy-application-summaries.md
+++ b/specs/022-policy-application-summaries/contracts/policy-application-summaries.md
@@ -24,6 +24,7 @@ The exact member placement may follow existing SDK style, but summary generation
 
 For marker-based policy application:
 
+- `TenantScope` and `AppliedAt` mirror the source result.
 - `TotalCount` equals the number of candidate results.
 - `AppliedCount`, `AlreadySatisfiedCount`, `SkippedCount`, and `FailedCount` reflect candidate statuses.
 - `HasFailures` is true when `FailedCount > 0`.
@@ -35,6 +36,7 @@ For marker-based policy application:
 
 For policy pruning application:
 
+- `TenantScope` and `AppliedAt` mirror the source result.
 - `TotalCount` equals the number of candidate results.
 - `PrunedCount`, `AlreadyPrunedCount`, `SkippedCount`, and `FailedCount` reflect candidate statuses.
 - `HasFailures` is true when `FailedCount > 0`.

--- a/specs/022-policy-application-summaries/data-model.md
+++ b/specs/022-policy-application-summaries/data-model.md
@@ -1,0 +1,66 @@
+# Data Model: Policy Application Summaries
+
+## Policy Application Summary
+
+Aggregate view over a `ResourcePolicyApplicationResult`.
+
+Fields:
+
+- Tenant scope.
+- Applied timestamp.
+- Total candidate count.
+- Applied count.
+- Already satisfied count.
+- Skipped count.
+- Failed count.
+- Has failures flag.
+- Fully successful flag.
+- Distinct affected resource count.
+- Diagnostic code counts.
+
+Rules:
+
+- Applied and already satisfied candidates count as successful.
+- Skipped candidates are not failures, but they prevent the summary from being fully successful.
+- Failed candidates set the failure flag.
+- Affected resource count includes distinct non-blank resource IDs from applied and already satisfied candidates only.
+
+## Policy Pruning Application Summary
+
+Aggregate view over a `ResourcePolicyPruningApplicationResult`.
+
+Fields:
+
+- Tenant scope.
+- Optional applied timestamp.
+- Total candidate count.
+- Pruned count.
+- Already pruned count.
+- Skipped count.
+- Failed count.
+- Has failures flag.
+- Fully successful flag.
+- Distinct affected target count.
+- Diagnostic code counts.
+
+Rules:
+
+- Pruned and already pruned candidates count as successful.
+- Skipped candidates are not failures, but they prevent the summary from being fully successful.
+- Failed candidates set the failure flag.
+- Affected target count includes distinct resource/version pairs from pruned and already pruned candidates only.
+
+## Diagnostic Code Count
+
+Deterministic count of a policy diagnostic code.
+
+Fields:
+
+- Code.
+- Count.
+
+Rules:
+
+- Null, empty, and whitespace-only codes are ignored.
+- Counts are ordered by code using ordinal comparison.
+- Counts include diagnostics from failed and skipped candidates when present.

--- a/specs/022-policy-application-summaries/plan.md
+++ b/specs/022-policy-application-summaries/plan.md
@@ -1,0 +1,113 @@
+# Implementation Plan: Policy Application Summaries
+
+**Branch**: `022-policy-application-summaries` | **Date**: 2026-05-29 | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from `/specs/022-policy-application-summaries/spec.md`
+
+## Summary
+
+Add small host-facing summary records and pure aggregation helpers over existing policy application and policy pruning application result types. The implementation gives hosts deterministic status counts, completion booleans, affected target counts, and diagnostic-code counts for UI/reporting without changing policy execution, storage, providers, or operational behavior.
+
+## Technical Context
+
+**Language/Version**: C# latest, .NET 8.0 / 9.0 / 10.0 multi-targeting
+**Primary Dependencies**: Existing core SDK policy result models and xUnit test stack; no new dependencies
+**Storage**: None. Summaries are pure in-memory views over existing result objects; no schema migration, persistence, audit records, or provider storage changes.
+**Testing**: Focused policy summary tests, `dotnet test Aster.sln`, `dotnet build Aster.sln /m:1`, `git diff --check`
+**Target Platform**: .NET SDK/library consumers
+**Project Type**: SDK/library
+**Performance Goals**: Summary generation is linear in candidate and diagnostic count for one result object.
+**Constraints**: No policy re-evaluation, no writes, no stores, no query providers, no lifecycle hooks, no scheduler, no authorization engine, no provider registry, no runtime scanning, no public SQL, no public `IQueryable<Resource>`, no audit persistence, and no broad reporting framework.
+**Scale/Scope**: Two existing result families: marker-based policy application and version-pruning policy application.
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+- **SDK-first/headless**: PASS - Adds SDK result helpers only; no UI or host framework coupling.
+- **Immutable versioning**: PASS - No resource versions are created, mutated, or removed.
+- **Channel activation**: PASS - Activation state is not touched.
+- **Typed/queryable**: PASS - Query AST and typed aspects are unchanged; no SQL or `IQueryable` surface is introduced.
+- **Provider agnostic**: PASS - Summaries do not depend on providers.
+- **Simplicity first**: PASS - Pure summary records and static/extension helpers are simpler than a reporting service.
+- **Modern C# idioms**: PASS - Use records, collection expressions, and LINQ where they improve clarity.
+- **Readability over cleverness**: PASS - Aggregation rules remain explicit and test-driven.
+- **Explicitness over magic**: PASS - Hosts call summary helpers directly.
+- **Abstractions justified**: PASS - No service abstraction or framework is introduced.
+- **Optimize for deletion**: PASS - Summary types are local to policy result models and easy to remove.
+- **Composition over inheritance**: PASS - Data records and helpers only.
+- **Intentional dependencies**: PASS - No new dependencies.
+- **Operational simplicity**: PASS - No deployment, storage, worker, or provider setup change.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/022-policy-application-summaries/
++-- spec.md
++-- plan.md
++-- research.md
++-- data-model.md
++-- quickstart.md
++-- checklists/
+|   +-- requirements.md
++-- contracts/
+    +-- policy-application-summaries.md
+```
+
+### Source Code (repository root)
+
+```text
+src/
++-- core/Aster.Core/
+|   +-- Models/Policies/
+|   |   +-- ResourcePolicyApplication.cs
+|   |   +-- ResourcePolicyPruningApplication.cs
+|   |   +-- ResourcePolicyApplicationSummaries.cs
+|   +-- README.md
+
+test/
++-- Aster.Tests/
+    +-- Policies/
+        +-- PolicyApplicationSummaryTests.cs
+```
+
+**Structure Decision**: Keep summaries alongside policy result models in core. Do not add services, DI registration, persistence contracts, provider behavior, or reporting infrastructure.
+
+## Complexity Tracking
+
+No constitution violations.
+
+## Phase 0 Research Summary
+
+Research decisions are captured in [research.md](research.md). Key outcomes:
+
+- Use pure result-to-summary helpers instead of a service.
+- Keep one shared diagnostic count model.
+- Treat skipped candidates as not failed but not fully successful.
+- Count affected resources/targets only for successful statuses.
+
+## Phase 1 Design Summary
+
+Design artifacts:
+
+- [data-model.md](data-model.md)
+- [contracts/policy-application-summaries.md](contracts/policy-application-summaries.md)
+- [quickstart.md](quickstart.md)
+
+## Post-Design Constitution Check
+
+- **SDK-first/headless**: PASS - Public SDK models only.
+- **Immutable versioning**: PASS - No version state changes.
+- **Channel activation**: PASS - No activation changes.
+- **Typed/queryable**: PASS - No query surface change.
+- **Provider agnostic**: PASS - Provider-free transformation.
+- **Simplicity first**: PASS - Direct helpers over existing results.
+- **Modern C# idioms**: PASS - Records and simple aggregation.
+- **Readability over cleverness**: PASS - Named properties document semantics.
+- **Explicitness over magic**: PASS - No implicit hooks or scanners.
+- **Abstractions justified**: PASS - No new service abstraction.
+- **Optimize for deletion**: PASS - Local additive result helpers.
+- **Composition over inheritance**: PASS - Records and extension methods only.
+- **Intentional dependencies**: PASS - No new dependencies.
+- **Operational simplicity**: PASS - Existing build/test workflow is sufficient.

--- a/specs/022-policy-application-summaries/quickstart.md
+++ b/specs/022-policy-application-summaries/quickstart.md
@@ -12,6 +12,8 @@ Expected use:
 
 ```csharp
 summary.TotalCount
+summary.TenantScope
+summary.AppliedAt
 summary.AppliedCount
 summary.AlreadySatisfiedCount
 summary.SkippedCount
@@ -36,6 +38,8 @@ Expected use:
 
 ```csharp
 summary.TotalCount
+summary.TenantScope
+summary.AppliedAt
 summary.PrunedCount
 summary.AlreadyPrunedCount
 summary.SkippedCount

--- a/specs/022-policy-application-summaries/quickstart.md
+++ b/specs/022-policy-application-summaries/quickstart.md
@@ -1,0 +1,62 @@
+# Quickstart: Policy Application Summaries
+
+## Summarize Marker-Based Policy Application
+
+```csharp
+ResourcePolicyApplicationResult result = await policyApplication.ApplyAsync(request);
+
+var summary = result.ToSummary();
+```
+
+Expected use:
+
+```csharp
+summary.TotalCount
+summary.AppliedCount
+summary.AlreadySatisfiedCount
+summary.SkippedCount
+summary.FailedCount
+summary.HasFailures
+summary.IsFullySuccessful
+summary.AffectedResourceCount
+summary.DiagnosticCodeCounts
+```
+
+Hosts can use these values for a post-apply UI banner, operation details panel, or log message.
+
+## Summarize Policy Pruning Application
+
+```csharp
+ResourcePolicyPruningApplicationResult result = await pruningApplication.ApplyAsync(request);
+
+var summary = result.ToSummary();
+```
+
+Expected use:
+
+```csharp
+summary.TotalCount
+summary.PrunedCount
+summary.AlreadyPrunedCount
+summary.SkippedCount
+summary.FailedCount
+summary.HasFailures
+summary.IsFullySuccessful
+summary.AffectedTargetCount
+summary.DiagnosticCodeCounts
+```
+
+## Diagnostic Code Counts
+
+```csharp
+foreach (var code in summary.DiagnosticCodeCounts)
+{
+    Console.WriteLine($"{code.Code}: {code.Count}");
+}
+```
+
+Diagnostic code counts are deterministic and ordered by code.
+
+## Non-Goals
+
+Summaries are not audit records. They do not persist, query, re-run policy logic, invoke hooks, schedule work, or provide authorization decisions.

--- a/specs/022-policy-application-summaries/research.md
+++ b/specs/022-policy-application-summaries/research.md
@@ -1,0 +1,56 @@
+# Research: Policy Application Summaries
+
+## Summary Shape
+
+Decision: Add explicit summary records for marker-based policy application results and pruning application results.
+
+Rationale: The two result families have different status vocabularies and affected-target semantics. Explicit records keep host-facing names clear without forcing one generic status enum.
+
+Alternatives considered:
+
+- One generic summary type: rejected because it would hide domain-specific names such as applied versus pruned.
+- Add count properties directly to existing results only: rejected because existing results already have basic counts and need a richer reporting surface with diagnostics and affected target counts.
+
+## Invocation Model
+
+Decision: Generate summaries through pure helpers over existing result objects.
+
+Rationale: Hosts already receive result objects from application services. A pure transformation keeps reporting deterministic and requires no DI registration or provider setup.
+
+Alternatives considered:
+
+- Add `IResourcePolicySummaryService`: rejected because it introduces DI and lifecycle surface without current need.
+- Add summaries to application services automatically: rejected because it changes execution paths and makes summary generation less explicit.
+
+## Diagnostic Code Counts
+
+Decision: Use a shared `ResourcePolicyDiagnosticCodeCount` record ordered by diagnostic code using ordinal comparison, ignoring null/blank codes.
+
+Rationale: Hosts need stable grouping for UI and logs. Ignoring blank codes avoids creating misleading buckets for malformed diagnostics.
+
+Alternatives considered:
+
+- Preserve first-seen diagnostic order: rejected because input ordering can vary by candidate order and is less stable for UI snapshots.
+- Include blank diagnostic codes: rejected because stable policy diagnostics are expected to have meaningful codes.
+
+## Completion Semantics
+
+Decision: `HasFailures` is true only when candidates failed. `IsFullySuccessful` is true only when every candidate completed through a successful terminal status and no candidates were skipped or failed.
+
+Rationale: Skipped candidates are not failures, but a host reporting "fully successful" should not include skipped duplicate/no-write results as full completion.
+
+Alternatives considered:
+
+- Treat skipped as successful: rejected because duplicate/skipped candidates did not perform the requested write.
+- Treat skipped as failure: rejected because existing result semantics distinguish deterministic skips from failures.
+
+## Affected Target Counts
+
+Decision: Count distinct affected resources for marker-based application successes and distinct resource/version pairs for pruning successes.
+
+Rationale: Marker-based application affects a resource lifecycle marker, while pruning affects a specific resource version. Counting only successful statuses avoids overstating impact.
+
+Alternatives considered:
+
+- Count all submitted candidates: rejected because total candidate count already exists.
+- Count failed/skipped targets as affected: rejected because they did not change state.

--- a/specs/022-policy-application-summaries/spec.md
+++ b/specs/022-policy-application-summaries/spec.md
@@ -1,0 +1,107 @@
+# Feature Specification: Policy Application Summaries
+
+**Feature Branch**: `022-policy-application-summaries`
+**Created**: 2026-05-29
+**Status**: Draft
+**Input**: User description: "Add host-facing policy application summary models and helpers over existing policy application and pruning application results. Summaries should provide deterministic status counts, success/failure booleans, diagnostic code counts, and affected resource/version counts for UI/reporting without re-running policy logic or storing audit records. Keep the slice SDK-only and bounded: no storage changes, no scheduler, no authorization engine, no provider registry, no public SQL, no public IQueryable<Resource>, no background jobs, and no broad reporting framework."
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Summarize Policy Application Results (Priority: P1)
+
+As a host author, I need a deterministic summary of policy application results, so that an operations UI can show how many selected policy candidates applied, were already satisfied, skipped, or failed without each host reimplementing result aggregation.
+
+**Why this priority**: Policy application already returns per-candidate results. Hosts need a stable aggregate surface to present those results consistently after applying archive or soft-delete policy outcomes.
+
+**Independent Test**: Build a policy application result containing applied, already satisfied, skipped, and failed candidate results; request a summary; verify total counts, success/failure booleans, affected resource counts, and diagnostic code counts.
+
+**Acceptance Scenarios**:
+
+1. **Given** a policy application result has only applied and already satisfied candidates, **When** a summary is requested, **Then** the summary reports no failures and marks the operation successful.
+2. **Given** a policy application result has failed or skipped candidates, **When** a summary is requested, **Then** the summary reports unsuccessful completion and includes deterministic counts by status.
+3. **Given** failed candidates include diagnostics, **When** a summary is requested, **Then** diagnostic codes are counted deterministically.
+
+---
+
+### User Story 2 - Summarize Policy Pruning Results (Priority: P2)
+
+As a host author, I need the same summary shape for policy pruning application results, so that destructive pruning operations can be reported consistently with marker-based policy applications.
+
+**Why this priority**: Pruning application has a different result type and status vocabulary, but hosts still need aggregate counts and diagnostics for operator review.
+
+**Independent Test**: Build a pruning application result containing pruned, already pruned, skipped, and failed candidate results; request a summary; verify status counts, failure state, affected version counts, and diagnostic code counts.
+
+**Acceptance Scenarios**:
+
+1. **Given** a pruning result has pruned and already-pruned candidates only, **When** a summary is requested, **Then** the summary reports no failures and includes affected version counts.
+2. **Given** a pruning result has skipped duplicate candidates, **When** a summary is requested, **Then** skipped candidates are counted separately from failures.
+3. **Given** a pruning result has failed candidates with diagnostics, **When** a summary is requested, **Then** diagnostic codes are counted deterministically.
+
+---
+
+### User Story 3 - Preserve Bounded SDK Semantics (Priority: P3)
+
+As a host author, I need summaries to be pure views over existing result objects, so that reporting cannot trigger policy re-evaluation, writes, background work, or provider-specific behavior.
+
+**Why this priority**: The feature is a reporting affordance. It must not change policy execution semantics or introduce infrastructure that belongs to a future reporting system.
+
+**Independent Test**: Generate summaries from empty, null-equivalent, and mixed result inputs and verify no store/provider dependencies are required and no policy services are invoked.
+
+**Acceptance Scenarios**:
+
+1. **Given** an empty application result, **When** a summary is requested, **Then** counts are zero and the summary is successful.
+2. **Given** an empty pruning result, **When** a summary is requested, **Then** counts are zero and the summary is successful.
+3. **Given** summaries are generated, **When** tests inspect dependencies, **Then** no storage, query provider, scheduler, authorization, or lifecycle service is required.
+
+### Edge Cases
+
+- Result contains no candidates.
+- Result contains duplicate resource IDs or resource/version pairs.
+- Result contains multiple diagnostics with the same code.
+- Result contains diagnostics without a code or with blank code text.
+- Result contains failed candidates without diagnostics.
+- Result contains skipped candidates that should not count as writes.
+- Result contains null candidate collections only if an existing result shape can represent that state.
+
+### Constitution Alignment *(mandatory)*
+
+- **Simplicity**: The feature SHOULD add small summary records and pure aggregation helpers over existing result objects. It MUST NOT introduce a reporting service, audit log, event stream, or framework-shaped abstraction.
+- **Explicitness**: Hosts explicitly call summary helpers after receiving policy application results. No runtime scanning, implicit execution, or background reporting is introduced.
+- **Dependencies**: None.
+- **Operational Impact**: No storage schema change, data migration, background process, provider configuration, deployment change, or observability pipeline is introduced.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: System MUST expose a host-facing summary for `ResourcePolicyApplicationResult`.
+- **FR-002**: Application summaries MUST include total candidate count and counts for applied, already satisfied, skipped, and failed candidates.
+- **FR-003**: Application summaries MUST expose a boolean indicating whether the result has failures.
+- **FR-004**: Application summaries MUST expose a boolean indicating whether all candidates completed successfully, treating applied and already satisfied candidates as successful and treating skipped or failed candidates as not fully successful.
+- **FR-005**: Application summaries MUST include the count of distinct affected resource identifiers represented by candidates that applied or were already satisfied.
+- **FR-006**: Application summaries MUST include deterministic diagnostic code counts across candidate diagnostics.
+- **FR-007**: System MUST expose a host-facing summary for `ResourcePolicyPruningApplicationResult`.
+- **FR-008**: Pruning summaries MUST include total candidate count and counts for pruned, already pruned, skipped, and failed candidates.
+- **FR-009**: Pruning summaries MUST expose a boolean indicating whether the result has failures.
+- **FR-010**: Pruning summaries MUST expose a boolean indicating whether all candidates completed successfully, treating pruned and already pruned candidates as successful and treating skipped or failed candidates as not fully successful.
+- **FR-011**: Pruning summaries MUST include the count of distinct affected resource/version targets represented by candidates that pruned or were already pruned.
+- **FR-012**: Summary diagnostic code counts MUST ignore null, empty, or whitespace diagnostic codes.
+- **FR-013**: Diagnostic code counts MUST be ordered deterministically by diagnostic code using ordinal comparison.
+- **FR-014**: Summary generation MUST be a pure in-memory transformation over existing result objects and MUST NOT call policy evaluation, application services, stores, query providers, lifecycle hooks, schedulers, authorization engines, or background jobs.
+- **FR-015**: The feature MUST NOT introduce storage changes, provider registries, runtime scanning, public SQL, public `IQueryable<Resource>`, broad reporting infrastructure, or audit persistence.
+- **FR-016**: Documentation MUST explain how hosts can use summaries for UI/reporting and clarify that summaries are not audit records.
+
+### Key Entities *(include if feature involves data)*
+
+- **Policy Application Summary**: Aggregate view over a marker-based policy application result, including status counts, completion booleans, affected resource count, and diagnostic code counts.
+- **Policy Pruning Application Summary**: Aggregate view over a pruning application result, including status counts, completion booleans, affected target count, and diagnostic code counts.
+- **Diagnostic Code Count**: Deterministic pair of diagnostic code and count for repeated policy diagnostics.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Hosts can summarize a mixed marker-based policy application result without inspecting individual candidates manually.
+- **SC-002**: Hosts can summarize a mixed pruning application result without inspecting individual candidates manually.
+- **SC-003**: Diagnostic code counts are stable and ordered deterministically across repeated runs.
+- **SC-004**: Existing policy application, pruning, lifecycle, query, portability, SQLite, and versioning tests continue to pass without new storage or provider setup.

--- a/specs/022-policy-application-summaries/tasks.md
+++ b/specs/022-policy-application-summaries/tasks.md
@@ -1,0 +1,142 @@
+# Tasks: Policy Application Summaries
+
+**Input**: Design documents from `/specs/022-policy-application-summaries/`
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/
+
+**Tests**: Required by the feature specification for application summaries, pruning summaries, deterministic diagnostic counts, and bounded pure helper behavior.
+
+**Organization**: Tasks are grouped by user story so the marker-based application summary can ship as the MVP before pruning summary parity.
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Confirm the feature context and current policy result shapes.
+
+- [X] T001 Verify feature documents and checklist are present in specs/022-policy-application-summaries/
+- [X] T002 Inspect existing policy application result models in src/core/Aster.Core/Models/Policies/ResourcePolicyApplication.cs and src/core/Aster.Core/Models/Policies/ResourcePolicyPruningApplication.cs
+- [X] T003 Inspect current policy result tests in test/Aster.Tests/Policies/PolicyApplicationResultTests.cs and test/Aster.Tests/Policies/PolicyPruningApplicationResultTests.cs
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Add shared summary model surface used by both stories without adding services or dependencies.
+
+- [X] T004 Add shared diagnostic code count and summary helpers in src/core/Aster.Core/Models/Policies/ResourcePolicyApplicationSummaries.cs
+- [X] T005 Add documentation for policy summaries in src/core/Aster.Core/README.md
+
+**Checkpoint**: Shared model surface exists and docs state summaries are pure reporting helpers.
+
+---
+
+## Phase 3: User Story 1 - Summarize Policy Application Results (Priority: P1) MVP
+
+**Goal**: Hosts can summarize marker-based policy application results.
+
+**Independent Test**: Build a result containing applied, already satisfied, skipped, and failed candidates; request a summary; verify counts, booleans, affected resource count, and diagnostic code counts.
+
+### Tests for User Story 1
+
+- [X] T006 [P] [US1] Add mixed marker-based application summary tests in test/Aster.Tests/Policies/PolicyApplicationSummaryTests.cs
+- [X] T007 [P] [US1] Add empty marker-based application summary tests in test/Aster.Tests/Policies/PolicyApplicationSummaryTests.cs
+
+### Implementation for User Story 1
+
+- [X] T008 [US1] Implement ResourcePolicyApplicationResult summary generation in src/core/Aster.Core/Models/Policies/ResourcePolicyApplicationSummaries.cs
+- [X] T009 [US1] Run focused policy application summary tests in test/Aster.Tests/Policies/PolicyApplicationSummaryTests.cs
+
+**Checkpoint**: Marker-based application summaries are independently usable.
+
+---
+
+## Phase 4: User Story 2 - Summarize Policy Pruning Results (Priority: P2)
+
+**Goal**: Hosts can summarize policy pruning application results with the same reporting semantics.
+
+**Independent Test**: Build a pruning result containing pruned, already pruned, skipped, and failed candidates; request a summary; verify counts, booleans, affected target count, and diagnostic code counts.
+
+### Tests for User Story 2
+
+- [X] T010 [P] [US2] Add mixed pruning summary tests in test/Aster.Tests/Policies/PolicyApplicationSummaryTests.cs
+- [X] T011 [P] [US2] Add empty pruning summary tests in test/Aster.Tests/Policies/PolicyApplicationSummaryTests.cs
+
+### Implementation for User Story 2
+
+- [X] T012 [US2] Implement ResourcePolicyPruningApplicationResult summary generation in src/core/Aster.Core/Models/Policies/ResourcePolicyApplicationSummaries.cs
+- [X] T013 [US2] Run focused pruning summary tests in test/Aster.Tests/Policies/PolicyApplicationSummaryTests.cs
+
+**Checkpoint**: Both result families have deterministic summary helpers.
+
+---
+
+## Phase 5: User Story 3 - Preserve Bounded SDK Semantics (Priority: P3)
+
+**Goal**: Summary generation remains a pure transformation and does not imply audit persistence or execution.
+
+**Independent Test**: Verify summaries can be generated from manually constructed result objects with no service provider or storage setup.
+
+### Tests for User Story 3
+
+- [X] T014 [P] [US3] Add tests proving summary generation ignores blank diagnostic codes in test/Aster.Tests/Policies/PolicyApplicationSummaryTests.cs
+- [X] T015 [P] [US3] Add tests proving summaries are generated from manually constructed result objects without service dependencies in test/Aster.Tests/Policies/PolicyApplicationSummaryTests.cs
+
+### Implementation for User Story 3
+
+- [X] T016 [US3] Review summary implementation to ensure it has no service, storage, query, provider, lifecycle, scheduler, authorization, or background dependencies in src/core/Aster.Core/Models/Policies/ResourcePolicyApplicationSummaries.cs
+
+**Checkpoint**: Bounded pure-helper semantics are covered.
+
+---
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+**Purpose**: Keep roadmap/context current and validate the whole solution.
+
+- [X] T017 [P] Update docs/ExecutionRoadmap.md to mark 021 landed and 022 in progress
+- [X] T018 [P] Ensure AGENTS.md includes 022 technology and recent-change context
+- [X] T019 Validate quickstart behavior against specs/022-policy-application-summaries/quickstart.md
+- [X] T020 Run dotnet test Aster.sln
+- [X] T021 Run dotnet build Aster.sln /m:1
+- [X] T022 Run git diff --check
+- [X] T023 Review implementation against specs/022-policy-application-summaries/spec.md and mark all completed tasks in specs/022-policy-application-summaries/tasks.md
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies.
+- **Foundational (Phase 2)**: Depends on setup and blocks user story work.
+- **User Story 1 (Phase 3)**: Depends on foundational summary surface.
+- **User Story 2 (Phase 4)**: Depends on shared summary surface and can reuse US1 helper patterns.
+- **User Story 3 (Phase 5)**: Depends on both summary implementations.
+- **Polish (Phase 6)**: Depends on all stories.
+
+### User Story Dependencies
+
+- **User Story 1 (P1)**: MVP.
+- **User Story 2 (P2)**: Adds pruning parity.
+- **User Story 3 (P3)**: Confirms bounded implementation semantics.
+
+### Parallel Opportunities
+
+- T006 and T007 can be drafted together.
+- T010 and T011 can be drafted together.
+- T014 and T015 cover separate edge-case assertions.
+- T017 and T018 touch separate documentation/context files.
+
+---
+
+## Implementation Strategy
+
+### MVP First
+
+1. Add shared summary records and helpers.
+2. Implement marker-based policy application summary.
+3. Validate marker-based summary tests.
+
+### Incremental Delivery
+
+1. Add pruning summary parity.
+2. Add bounded-semantics edge coverage.
+3. Update docs/context and run full validation.

--- a/src/core/Aster.Core/Models/Policies/ResourcePolicyApplicationSummaries.cs
+++ b/src/core/Aster.Core/Models/Policies/ResourcePolicyApplicationSummaries.cs
@@ -1,0 +1,153 @@
+namespace Aster.Core.Models.Policies;
+
+/// <summary>
+/// Deterministic count for one policy diagnostic code.
+/// </summary>
+public sealed record ResourcePolicyDiagnosticCodeCount
+{
+    /// <summary>Stable diagnostic code.</summary>
+    public required string Code { get; init; }
+
+    /// <summary>Number of diagnostics with the code.</summary>
+    public required int Count { get; init; }
+}
+
+/// <summary>
+/// Aggregate view over a marker-based policy application result.
+/// </summary>
+public sealed record ResourcePolicyApplicationSummary
+{
+    /// <summary>Total number of candidate results.</summary>
+    public required int TotalCount { get; init; }
+
+    /// <summary>Number of candidates that wrote a lifecycle marker.</summary>
+    public required int AppliedCount { get; init; }
+
+    /// <summary>Number of candidates already satisfied by current marker state.</summary>
+    public required int AlreadySatisfiedCount { get; init; }
+
+    /// <summary>Number of candidates skipped deterministically without writes.</summary>
+    public required int SkippedCount { get; init; }
+
+    /// <summary>Number of candidates that failed.</summary>
+    public required int FailedCount { get; init; }
+
+    /// <summary>Whether one or more candidates failed.</summary>
+    public bool HasFailures => FailedCount > 0;
+
+    /// <summary>Whether every candidate completed through a successful terminal status.</summary>
+    public bool IsFullySuccessful => TotalCount == AppliedCount + AlreadySatisfiedCount;
+
+    /// <summary>Number of distinct resource identifiers affected by successful candidates.</summary>
+    public required int AffectedResourceCount { get; init; }
+
+    /// <summary>Deterministic diagnostic code counts across candidate diagnostics.</summary>
+    public IReadOnlyList<ResourcePolicyDiagnosticCodeCount> DiagnosticCodeCounts { get; init; } = [];
+}
+
+/// <summary>
+/// Aggregate view over a policy pruning application result.
+/// </summary>
+public sealed record ResourcePolicyPruningApplicationSummary
+{
+    /// <summary>Total number of candidate results.</summary>
+    public required int TotalCount { get; init; }
+
+    /// <summary>Number of candidates that removed a resource version.</summary>
+    public required int PrunedCount { get; init; }
+
+    /// <summary>Number of candidates whose target version was already absent.</summary>
+    public required int AlreadyPrunedCount { get; init; }
+
+    /// <summary>Number of duplicate candidates skipped deterministically.</summary>
+    public required int SkippedCount { get; init; }
+
+    /// <summary>Number of candidates that failed.</summary>
+    public required int FailedCount { get; init; }
+
+    /// <summary>Whether one or more candidates failed.</summary>
+    public bool HasFailures => FailedCount > 0;
+
+    /// <summary>Whether every candidate completed through a successful terminal status.</summary>
+    public bool IsFullySuccessful => TotalCount == PrunedCount + AlreadyPrunedCount;
+
+    /// <summary>Number of distinct resource/version targets affected by successful candidates.</summary>
+    public required int AffectedTargetCount { get; init; }
+
+    /// <summary>Deterministic diagnostic code counts across candidate diagnostics.</summary>
+    public IReadOnlyList<ResourcePolicyDiagnosticCodeCount> DiagnosticCodeCounts { get; init; } = [];
+}
+
+/// <summary>
+/// Pure summary helpers for policy application result objects.
+/// </summary>
+public static class ResourcePolicyApplicationSummaryExtensions
+{
+    /// <summary>
+    /// Creates a deterministic aggregate summary for a marker-based policy application result.
+    /// </summary>
+    /// <param name="result">The result to summarize.</param>
+    /// <returns>A summary over the result's candidate statuses and diagnostics.</returns>
+    public static ResourcePolicyApplicationSummary ToSummary(this ResourcePolicyApplicationResult result)
+    {
+        ArgumentNullException.ThrowIfNull(result);
+        var candidates = result.Candidates ?? [];
+
+        return new ResourcePolicyApplicationSummary
+        {
+            TotalCount = candidates.Count,
+            AppliedCount = candidates.Count(static candidate => candidate.Status == ResourcePolicyApplicationCandidateStatus.Applied),
+            AlreadySatisfiedCount = candidates.Count(static candidate => candidate.Status == ResourcePolicyApplicationCandidateStatus.AlreadySatisfied),
+            SkippedCount = candidates.Count(static candidate => candidate.Status == ResourcePolicyApplicationCandidateStatus.Skipped),
+            FailedCount = candidates.Count(static candidate => candidate.Status == ResourcePolicyApplicationCandidateStatus.Failed),
+            AffectedResourceCount = candidates
+                .Where(static candidate => candidate.Status is ResourcePolicyApplicationCandidateStatus.Applied or ResourcePolicyApplicationCandidateStatus.AlreadySatisfied)
+                .Select(static candidate => candidate.ResourceId)
+                .Where(static resourceId => !string.IsNullOrWhiteSpace(resourceId))
+                .Distinct(StringComparer.Ordinal)
+                .Count(),
+            DiagnosticCodeCounts = CountDiagnosticCodes(candidates.SelectMany(static candidate => candidate.Diagnostics ?? [])),
+        };
+    }
+
+    /// <summary>
+    /// Creates a deterministic aggregate summary for a policy pruning application result.
+    /// </summary>
+    /// <param name="result">The result to summarize.</param>
+    /// <returns>A summary over the result's candidate statuses and diagnostics.</returns>
+    public static ResourcePolicyPruningApplicationSummary ToSummary(this ResourcePolicyPruningApplicationResult result)
+    {
+        ArgumentNullException.ThrowIfNull(result);
+        var candidates = result.Candidates ?? [];
+
+        return new ResourcePolicyPruningApplicationSummary
+        {
+            TotalCount = candidates.Count,
+            PrunedCount = candidates.Count(static candidate => candidate.Status == ResourcePolicyPruningApplicationCandidateStatus.Pruned),
+            AlreadyPrunedCount = candidates.Count(static candidate => candidate.Status == ResourcePolicyPruningApplicationCandidateStatus.AlreadyPruned),
+            SkippedCount = candidates.Count(static candidate => candidate.Status == ResourcePolicyPruningApplicationCandidateStatus.Skipped),
+            FailedCount = candidates.Count(static candidate => candidate.Status == ResourcePolicyPruningApplicationCandidateStatus.Failed),
+            AffectedTargetCount = candidates
+                .Where(static candidate => candidate.Status is ResourcePolicyPruningApplicationCandidateStatus.Pruned or ResourcePolicyPruningApplicationCandidateStatus.AlreadyPruned)
+                .Where(static candidate => !string.IsNullOrWhiteSpace(candidate.ResourceId) && candidate.ResourceVersion.HasValue)
+                .Select(static candidate => (candidate.ResourceId!, candidate.ResourceVersion!.Value))
+                .Distinct()
+                .Count(),
+            DiagnosticCodeCounts = CountDiagnosticCodes(candidates.SelectMany(static candidate => candidate.Diagnostics ?? [])),
+        };
+    }
+
+    private static IReadOnlyList<ResourcePolicyDiagnosticCodeCount> CountDiagnosticCodes(
+        IEnumerable<ResourcePolicyDiagnostic> diagnostics) =>
+        diagnostics
+            .Select(static diagnostic => diagnostic.Code)
+            .Where(static code => !string.IsNullOrWhiteSpace(code))
+            .GroupBy(static code => code, StringComparer.Ordinal)
+            .OrderBy(static group => group.Key, StringComparer.Ordinal)
+            .Select(static group => new ResourcePolicyDiagnosticCodeCount
+            {
+                Code = group.Key,
+                Count = group.Count(),
+            })
+            .ToList();
+}

--- a/src/core/Aster.Core/Models/Policies/ResourcePolicyApplicationSummaries.cs
+++ b/src/core/Aster.Core/Models/Policies/ResourcePolicyApplicationSummaries.cs
@@ -1,3 +1,5 @@
+using Aster.Core.Models.Tenancy;
+
 namespace Aster.Core.Models.Policies;
 
 /// <summary>
@@ -17,6 +19,12 @@ public sealed record ResourcePolicyDiagnosticCodeCount
 /// </summary>
 public sealed record ResourcePolicyApplicationSummary
 {
+    /// <summary>Effective tenant used by the application result.</summary>
+    public TenantScope TenantScope { get; init; } = TenantScope.Default;
+
+    /// <summary>Timestamp used by the application result.</summary>
+    public required DateTimeOffset AppliedAt { get; init; }
+
     /// <summary>Total number of candidate results.</summary>
     public required int TotalCount { get; init; }
 
@@ -50,6 +58,12 @@ public sealed record ResourcePolicyApplicationSummary
 /// </summary>
 public sealed record ResourcePolicyPruningApplicationSummary
 {
+    /// <summary>Effective tenant used by the pruning result.</summary>
+    public TenantScope TenantScope { get; init; } = TenantScope.Default;
+
+    /// <summary>Optional host timestamp supplied by the pruning result.</summary>
+    public DateTimeOffset? AppliedAt { get; init; }
+
     /// <summary>Total number of candidate results.</summary>
     public required int TotalCount { get; init; }
 
@@ -95,6 +109,8 @@ public static class ResourcePolicyApplicationSummaryExtensions
 
         return new ResourcePolicyApplicationSummary
         {
+            TenantScope = result.TenantScope,
+            AppliedAt = result.AppliedAt,
             TotalCount = candidates.Count,
             AppliedCount = candidates.Count(static candidate => candidate.Status == ResourcePolicyApplicationCandidateStatus.Applied),
             AlreadySatisfiedCount = candidates.Count(static candidate => candidate.Status == ResourcePolicyApplicationCandidateStatus.AlreadySatisfied),
@@ -122,6 +138,8 @@ public static class ResourcePolicyApplicationSummaryExtensions
 
         return new ResourcePolicyPruningApplicationSummary
         {
+            TenantScope = result.TenantScope,
+            AppliedAt = result.AppliedAt,
             TotalCount = candidates.Count,
             PrunedCount = candidates.Count(static candidate => candidate.Status == ResourcePolicyPruningApplicationCandidateStatus.Pruned),
             AlreadyPrunedCount = candidates.Count(static candidate => candidate.Status == ResourcePolicyPruningApplicationCandidateStatus.AlreadyPruned),

--- a/src/core/Aster.Core/README.md
+++ b/src/core/Aster.Core/README.md
@@ -434,6 +434,15 @@ var pruningResult = await pruning.ApplyAsync(new ResourcePolicyPruningApplicatio
 
 Each submitted candidate returns `Pruned`, `AlreadyPruned`, `Skipped`, or `Failed`. Failures include stable policy diagnostics such as `policy-pruning-version-protected-latest`, `policy-pruning-version-protected-active`, `policy-pruning-policy-mismatch`, `policy-pruning-provider-unsupported`, and `policy-pruning-write-failed`. Pruning does not mutate activation state, lifecycle markers, definitions, policy declarations, or remaining versions.
 
+Policy application and pruning application results can be summarized for host UI/reporting without re-running policy logic:
+
+```csharp
+var applicationSummary = applicationResult.ToSummary();
+var pruningSummary = pruningResult.ToSummary();
+```
+
+Summaries report total candidates, status counts, failure/completion booleans, affected resource or resource-version counts, and deterministic diagnostic code counts. They are pure in-memory views over existing result objects; they are not audit records and do not query stores, write state, invoke hooks, schedule work, or authorize operations.
+
 ---
 
 ### 11. Register lifecycle hooks

--- a/src/core/Aster.Core/README.md
+++ b/src/core/Aster.Core/README.md
@@ -441,7 +441,7 @@ var applicationSummary = applicationResult.ToSummary();
 var pruningSummary = pruningResult.ToSummary();
 ```
 
-Summaries report total candidates, status counts, failure/completion booleans, affected resource or resource-version counts, and deterministic diagnostic code counts. They are pure in-memory views over existing result objects; they are not audit records and do not query stores, write state, invoke hooks, schedule work, or authorize operations.
+Summaries report tenant scope, applied timestamp when present, total candidates, status counts, failure/completion booleans, affected resource or resource-version counts, and deterministic diagnostic code counts. They are pure in-memory views over existing result objects; they are not audit records and do not query stores, write state, invoke hooks, schedule work, or authorize operations.
 
 ---
 

--- a/test/Aster.Tests/Policies/PolicyApplicationSummaryTests.cs
+++ b/test/Aster.Tests/Policies/PolicyApplicationSummaryTests.cs
@@ -1,0 +1,194 @@
+using Aster.Core.Models.Policies;
+
+namespace Aster.Tests.Policies;
+
+public sealed class PolicyApplicationSummaryTests
+{
+    [Fact]
+    public void ApplicationSummary_MixedCandidates_AggregatesCountsAndDiagnostics()
+    {
+        var result = new ResourcePolicyApplicationResult
+        {
+            AppliedAt = DateTimeOffset.UtcNow,
+            Candidates =
+            [
+                ApplicationCandidate(ResourcePolicyApplicationCandidateStatus.Applied, "product-1"),
+                ApplicationCandidate(ResourcePolicyApplicationCandidateStatus.AlreadySatisfied, "product-1"),
+                ApplicationCandidate(ResourcePolicyApplicationCandidateStatus.Skipped, "product-2", Diagnostic("duplicate")),
+                ApplicationCandidate(ResourcePolicyApplicationCandidateStatus.Failed, "product-3", Diagnostic("policy-mismatch"), Diagnostic("duplicate")),
+            ],
+        };
+
+        var summary = result.ToSummary();
+
+        Assert.Equal(4, summary.TotalCount);
+        Assert.Equal(1, summary.AppliedCount);
+        Assert.Equal(1, summary.AlreadySatisfiedCount);
+        Assert.Equal(1, summary.SkippedCount);
+        Assert.Equal(1, summary.FailedCount);
+        Assert.True(summary.HasFailures);
+        Assert.False(summary.IsFullySuccessful);
+        Assert.Equal(1, summary.AffectedResourceCount);
+        Assert.Equal(
+            [("duplicate", 2), ("policy-mismatch", 1)],
+            summary.DiagnosticCodeCounts.Select(static count => (count.Code, count.Count)).ToList());
+    }
+
+    [Fact]
+    public void ApplicationSummary_EmptyResult_IsFullySuccessful()
+    {
+        var summary = new ResourcePolicyApplicationResult
+        {
+            AppliedAt = DateTimeOffset.UtcNow,
+        }.ToSummary();
+
+        Assert.Equal(0, summary.TotalCount);
+        Assert.False(summary.HasFailures);
+        Assert.True(summary.IsFullySuccessful);
+        Assert.Equal(0, summary.AffectedResourceCount);
+        Assert.Empty(summary.DiagnosticCodeCounts);
+    }
+
+    [Fact]
+    public void ApplicationSummary_NullCandidateCollection_IsTreatedAsEmpty()
+    {
+        var summary = new ResourcePolicyApplicationResult
+        {
+            AppliedAt = DateTimeOffset.UtcNow,
+            Candidates = null!,
+        }.ToSummary();
+
+        Assert.Equal(0, summary.TotalCount);
+        Assert.True(summary.IsFullySuccessful);
+    }
+
+    [Fact]
+    public void PruningSummary_MixedCandidates_AggregatesCountsTargetsAndDiagnostics()
+    {
+        var result = new ResourcePolicyPruningApplicationResult
+        {
+            Candidates =
+            [
+                PruningCandidate(ResourcePolicyPruningApplicationCandidateStatus.Pruned, "product-1", 1),
+                PruningCandidate(ResourcePolicyPruningApplicationCandidateStatus.AlreadyPruned, "product-1", 1),
+                PruningCandidate(ResourcePolicyPruningApplicationCandidateStatus.Skipped, "product-1", 1, Diagnostic("duplicate")),
+                PruningCandidate(ResourcePolicyPruningApplicationCandidateStatus.Failed, "product-1", 2, Diagnostic("protected"), Diagnostic("duplicate")),
+            ],
+        };
+
+        var summary = result.ToSummary();
+
+        Assert.Equal(4, summary.TotalCount);
+        Assert.Equal(1, summary.PrunedCount);
+        Assert.Equal(1, summary.AlreadyPrunedCount);
+        Assert.Equal(1, summary.SkippedCount);
+        Assert.Equal(1, summary.FailedCount);
+        Assert.True(summary.HasFailures);
+        Assert.False(summary.IsFullySuccessful);
+        Assert.Equal(1, summary.AffectedTargetCount);
+        Assert.Equal(
+            [("duplicate", 2), ("protected", 1)],
+            summary.DiagnosticCodeCounts.Select(static count => (count.Code, count.Count)).ToList());
+    }
+
+    [Fact]
+    public void PruningSummary_EmptyResult_IsFullySuccessful()
+    {
+        var summary = new ResourcePolicyPruningApplicationResult().ToSummary();
+
+        Assert.Equal(0, summary.TotalCount);
+        Assert.False(summary.HasFailures);
+        Assert.True(summary.IsFullySuccessful);
+        Assert.Equal(0, summary.AffectedTargetCount);
+        Assert.Empty(summary.DiagnosticCodeCounts);
+    }
+
+    [Fact]
+    public void PruningSummary_NullCandidateCollection_IsTreatedAsEmpty()
+    {
+        var summary = new ResourcePolicyPruningApplicationResult
+        {
+            Candidates = null!,
+        }.ToSummary();
+
+        Assert.Equal(0, summary.TotalCount);
+        Assert.True(summary.IsFullySuccessful);
+    }
+
+    [Fact]
+    public void SummaryDiagnosticCounts_IgnoreBlankCodesAndUseOrdinalOrdering()
+    {
+        var result = new ResourcePolicyApplicationResult
+        {
+            AppliedAt = DateTimeOffset.UtcNow,
+            Candidates =
+            [
+                ApplicationCandidate(
+                    ResourcePolicyApplicationCandidateStatus.Failed,
+                    "product-1",
+                    Diagnostic("z-code"),
+                    Diagnostic(""),
+                    Diagnostic(" "),
+                    Diagnostic("a-code"),
+                    Diagnostic("z-code")),
+            ],
+        };
+
+        var summary = result.ToSummary();
+
+        Assert.Equal(
+            [("a-code", 1), ("z-code", 2)],
+            summary.DiagnosticCodeCounts.Select(static count => (count.Code, count.Count)).ToList());
+    }
+
+    [Fact]
+    public void Summaries_AreGeneratedFromManuallyConstructedResultsWithoutServices()
+    {
+        var applicationSummary = new ResourcePolicyApplicationResult
+        {
+            AppliedAt = DateTimeOffset.UtcNow,
+            Candidates = [ApplicationCandidate(ResourcePolicyApplicationCandidateStatus.Applied, "product-1")],
+        }.ToSummary();
+
+        var pruningSummary = new ResourcePolicyPruningApplicationResult
+        {
+            Candidates = [PruningCandidate(ResourcePolicyPruningApplicationCandidateStatus.Pruned, "product-1", 1)],
+        }.ToSummary();
+
+        Assert.True(applicationSummary.IsFullySuccessful);
+        Assert.True(pruningSummary.IsFullySuccessful);
+    }
+
+    private static ResourcePolicyApplicationCandidateResult ApplicationCandidate(
+        ResourcePolicyApplicationCandidateStatus status,
+        string resourceId,
+        params ResourcePolicyDiagnostic[] diagnostics) =>
+        new()
+        {
+            Index = 0,
+            Status = status,
+            ResourceId = resourceId,
+            Diagnostics = diagnostics,
+        };
+
+    private static ResourcePolicyPruningApplicationCandidateResult PruningCandidate(
+        ResourcePolicyPruningApplicationCandidateStatus status,
+        string resourceId,
+        int version,
+        params ResourcePolicyDiagnostic[] diagnostics) =>
+        new()
+        {
+            Index = 0,
+            Status = status,
+            ResourceId = resourceId,
+            ResourceVersion = version,
+            Diagnostics = diagnostics,
+        };
+
+    private static ResourcePolicyDiagnostic Diagnostic(string code) =>
+        new()
+        {
+            Code = code,
+            Message = code,
+        };
+}

--- a/test/Aster.Tests/Policies/PolicyApplicationSummaryTests.cs
+++ b/test/Aster.Tests/Policies/PolicyApplicationSummaryTests.cs
@@ -1,4 +1,5 @@
 using Aster.Core.Models.Policies;
+using Aster.Core.Models.Tenancy;
 
 namespace Aster.Tests.Policies;
 
@@ -7,9 +8,11 @@ public sealed class PolicyApplicationSummaryTests
     [Fact]
     public void ApplicationSummary_MixedCandidates_AggregatesCountsAndDiagnostics()
     {
+        var appliedAt = DateTimeOffset.UtcNow;
         var result = new ResourcePolicyApplicationResult
         {
-            AppliedAt = DateTimeOffset.UtcNow,
+            TenantScope = TenantScope.FromTenantId("tenant-a"),
+            AppliedAt = appliedAt,
             Candidates =
             [
                 ApplicationCandidate(ResourcePolicyApplicationCandidateStatus.Applied, "product-1"),
@@ -21,6 +24,8 @@ public sealed class PolicyApplicationSummaryTests
 
         var summary = result.ToSummary();
 
+        Assert.Equal(result.TenantScope, summary.TenantScope);
+        Assert.Equal(appliedAt, summary.AppliedAt);
         Assert.Equal(4, summary.TotalCount);
         Assert.Equal(1, summary.AppliedCount);
         Assert.Equal(1, summary.AlreadySatisfiedCount);
@@ -65,8 +70,11 @@ public sealed class PolicyApplicationSummaryTests
     [Fact]
     public void PruningSummary_MixedCandidates_AggregatesCountsTargetsAndDiagnostics()
     {
+        var appliedAt = DateTimeOffset.UtcNow;
         var result = new ResourcePolicyPruningApplicationResult
         {
+            TenantScope = TenantScope.FromTenantId("tenant-a"),
+            AppliedAt = appliedAt,
             Candidates =
             [
                 PruningCandidate(ResourcePolicyPruningApplicationCandidateStatus.Pruned, "product-1", 1),
@@ -78,6 +86,8 @@ public sealed class PolicyApplicationSummaryTests
 
         var summary = result.ToSummary();
 
+        Assert.Equal(result.TenantScope, summary.TenantScope);
+        Assert.Equal(appliedAt, summary.AppliedAt);
         Assert.Equal(4, summary.TotalCount);
         Assert.Equal(1, summary.PrunedCount);
         Assert.Equal(1, summary.AlreadyPrunedCount);


### PR DESCRIPTION
## Summary
- add pure summary records/helpers for policy application and policy pruning application results
- include deterministic status counts, completion booleans, affected resource/target counts, and diagnostic code counts
- add Spec Kit artifacts, roadmap/context updates, README guidance, and focused summary tests

## Validation
- dotnet test test/Aster.Tests/Aster.Tests.csproj --filter FullyQualifiedName~PolicyApplicationSummaryTests
- dotnet test Aster.sln
- dotnet build Aster.sln /m:1
- git diff --check