### PR TITLE
Add version history summaries

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "featureDir": "specs/023-batch-version-history"
+  "featureDir": "specs/024-version-history-summaries"
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 <!-- SPECKIT START -->
 For additional context about technologies to be used, project structure,
-shell commands, and other important information, read `specs/023-batch-version-history/plan.md`.
+shell commands, and other important information, read `specs/024-version-history-summaries/plan.md`.
 <!-- SPECKIT END -->
 
 ## Active Technologies
@@ -32,8 +32,11 @@ shell commands, and other important information, read `specs/023-batch-version-h
 - No storage changes. Summaries are pure in-memory views over existing result objects; no schema migration, persistence, audit records, or provider storage changes. (022-policy-application-summaries)
 - C# latest, .NET 8.0 / 9.0 / 10.0 multi-targeting + Existing core SDK, resource version history service, resource version reader, activation-state reader, lifecycle marker store, in-memory store, SQLite JSON provider, xUnit test stack; no new dependencies (023-batch-version-history)
 - Existing resource versions, activation state, and lifecycle marker storage only. No schema migration, data rewrite, portability snapshot format change, or physical index creation. (023-batch-version-history)
+- C# latest, .NET 8.0 / 9.0 / 10.0 multi-targeting + Existing core SDK version history models and xUnit test stack; no new dependencies (024-version-history-summaries)
+- No storage changes. Summaries are pure in-memory views over existing result objects; no schema migration, persistence, provider storage, or physical index changes. (024-version-history-summaries)
 
 ## Recent Changes
+- 024-version-history-summaries: Added pure host-facing summaries for single and batch version history results with deterministic version-state counts, selected/missing resource counts, lifecycle state counts, and no storage, provider, service, query planner, public SQL, public IQueryable<Resource>, policy evaluation, reporting infrastructure, or mutation behavior
 - 023-batch-version-history: Added explicit batch version history planning and implementation context for selected resource IDs with first-seen distinct ordering, tenant scoping, missing-resource histories, SQLite parity, and no storage migrations, query planner, provider registry, public SQL, public IQueryable<Resource>, runtime scanning, automatic discovery, or mutation behavior
 - 022-policy-application-summaries: Added pure host-facing summaries for policy application and pruning application results with deterministic status counts, completion booleans, affected target counts, diagnostic code counts, and no storage, provider, scheduler, authorization, public SQL, public IQueryable<Resource>, audit persistence, or reporting framework
 - 021-historical-version-activation: Added historical resource version activation planning and implementation context for activating any existing version without changing latest, rewriting versions, changing storage schema, adding provider registries, public SQL, public IQueryable<Resource>, schedulers, authorization engines, or workflow infrastructure

--- a/docs/ExecutionRoadmap.md
+++ b/docs/ExecutionRoadmap.md
@@ -6,9 +6,9 @@ This roadmap tracks the implementation trail we have already cut through the rep
 
 ## Current Position
 
-Aster now has a working Core SDK, in-memory runtime, SQLite JSON persistence/querying, provider capability discovery, provider validation alignment, provider authoring ergonomics, a reusable provider conformance harness, SQLite facet sorting, portable operator expansion, SQLite date-like ranges, explicit provider-declared index projections, explicit definition schema upgrade behavior, deterministic portability primitives, explicit host lifecycle hooks, explicit tenant scoping, policy foundations, host-controlled policy application orchestration, host-controlled lifecycle restore workflows, host-controlled policy pruning application, read-only version history inspection, explicit historical version activation, and policy application summaries.
+Aster now has a working Core SDK, in-memory runtime, SQLite JSON persistence/querying, provider capability discovery, provider validation alignment, provider authoring ergonomics, a reusable provider conformance harness, SQLite facet sorting, portable operator expansion, SQLite date-like ranges, explicit provider-declared index projections, explicit definition schema upgrade behavior, deterministic portability primitives, explicit host lifecycle hooks, explicit tenant scoping, policy foundations, host-controlled policy application orchestration, host-controlled lifecycle restore workflows, host-controlled policy pruning application, read-only version history inspection, explicit historical version activation, policy application summaries, and batch version history inspection.
 
-The Phase 4 core workstream is complete enough to defer optional recipes. The active workstream is now **Phase 5: Multi-tenancy, Policies, Advanced Versioning**. Explicit tenant-aware boundaries, policy foundations, policy application orchestration, reversible lifecycle restore, destructive pruning application, version history inspection, historical version activation, and policy application summaries have landed; batch version history inspection is the current bounded advanced-versioning slice.
+The Phase 4 core workstream is complete enough to defer optional recipes. The active workstream is now **Phase 5: Multi-tenancy, Policies, Advanced Versioning**. Explicit tenant-aware boundaries, policy foundations, policy application orchestration, reversible lifecycle restore, destructive pruning application, version history inspection, historical version activation, policy application summaries, and batch version history inspection have landed; version history summaries are the current bounded reporting slice.
 
 ## Landed Slices
 
@@ -36,26 +36,26 @@ The Phase 4 core workstream is complete enough to defer optional recipes. The ac
 | `020-version-history-inspection` | Landed | Read-only host-facing version history inspection with latest/draft/active-channel summaries, lifecycle marker visibility, conservative maintenance hints, tenant scoping, and in-memory/SQLite parity without schema changes or query-surface expansion. |
 | `021-historical-version-activation` | Landed | Explicit activation of any existing historical or latest resource version while preserving immutable versions, latest identity, activation state separation, tenant scoping, lifecycle hooks, and in-memory/SQLite parity. |
 | `022-policy-application-summaries` | Landed | Pure host-facing summaries for policy application and pruning application results with deterministic status counts, completion booleans, affected target counts, diagnostic counts, and no storage or reporting framework. |
+| `023-batch-version-history` | Landed | Explicit batch version history inspection for selected resource IDs with first-seen distinct ordering, tenant scoping, missing-resource histories, SQLite parity, and no storage or query-surface expansion. |
 
 ## Near-Term Roadmap
 
-### 023 — Batch Version History Inspection
+### 024 — Version History Summaries
 
-**Status:** In progress on `023-batch-version-history`.
+**Status:** In progress on `024-version-history-summaries`.
 
-**Goal:** Let hosts inspect version histories for an explicit bounded set of resource IDs in one tenant-scoped service call.
+**Goal:** Give hosts deterministic summary views over single and batch version history result objects.
 
 Scope:
 
-- Add batch request/result models over existing per-resource history results.
-- Preserve first-seen distinct resource ID ordering with ordinal duplicate collapse.
-- Preserve existing latest/draft/active-channel/lifecycle/maintenance semantics per resource.
-- Keep empty selection, missing resources, invalid IDs, tenant boundaries, and SQLite parity deterministic.
-- Keep storage changes, provider registries, public SQL, public `IQueryable<Resource>`, runtime scanning, automatic discovery, query planners, and reporting infrastructure out of scope.
+- Summarize one resource history with total/latest/draft/active/protected/candidate counts and lifecycle state counts.
+- Summarize batch history results with selected-resource, resources-with-versions, missing-resource, total-version, and version-state counts.
+- Keep summaries as pure SDK helpers over existing result objects.
+- Keep storage, providers, services, audit persistence, automatic jobs, public SQL, public `IQueryable<Resource>`, query planners, policy evaluation, and reporting infrastructure out of scope.
 
-### 024 — Next Bounded Phase 5 Slice
+### 025 — Next Bounded Phase 5 Slice
 
-**Goal:** Choose one small continuation slice after batch version history inspection lands.
+**Goal:** Choose one small continuation slice after version history summaries land.
 
 Candidate scope:
 

--- a/specs/024-version-history-summaries/checklists/requirements.md
+++ b/specs/024-version-history-summaries/checklists/requirements.md
@@ -1,0 +1,34 @@
+# Specification Quality Checklist: Version History Summaries
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-05-30
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Validation complete. The feature is ready for planning.

--- a/specs/024-version-history-summaries/contracts/version-history-summaries.md
+++ b/specs/024-version-history-summaries/contracts/version-history-summaries.md
@@ -1,0 +1,82 @@
+# Contract: Version History Summaries
+
+Version history summaries provide pure aggregate views over existing history result objects.
+
+## Host-Facing Behavior
+
+Hosts can:
+
+- summarize one `ResourceVersionHistoryResult`;
+- summarize one `ResourceVersionHistoryBatchResult`;
+- use summaries over service-produced or manually constructed result objects;
+- display deterministic version-state and lifecycle-state counts without recomputing them.
+
+The SDK must:
+
+- fail fast for null result inputs;
+- treat null result collections as empty;
+- preserve source tenant and resource identity;
+- count only values already present on `ResourceVersionSummary`;
+- order lifecycle state counts deterministically.
+
+The SDK must not:
+
+- read from providers or stores;
+- evaluate policy eligibility;
+- mutate versions, activation state, or lifecycle markers;
+- introduce storage, service registration, public SQL, public `IQueryable<Resource>`, query planning, runtime scanning, automatic discovery, background jobs, or reporting infrastructure.
+
+## Proposed Public SDK Contract
+
+```csharp
+public sealed record ResourceVersionLifecycleStateCount
+{
+    public required ResourceLifecycleMarkerState State { get; init; }
+    public required int Count { get; init; }
+}
+
+public sealed record ResourceVersionHistorySummary
+{
+    public TenantScope TenantScope { get; init; } = TenantScope.Default;
+    public required string ResourceId { get; init; }
+    public required int TotalVersionCount { get; init; }
+    public required int LatestVersionCount { get; init; }
+    public required int DraftVersionCount { get; init; }
+    public required int ActiveVersionCount { get; init; }
+    public required int ProtectedVersionCount { get; init; }
+    public required int PossibleCandidateCount { get; init; }
+    public IReadOnlyList<ResourceVersionLifecycleStateCount> LifecycleStateCounts { get; init; } = [];
+}
+
+public sealed record ResourceVersionHistoryBatchSummary
+{
+    public TenantScope TenantScope { get; init; } = TenantScope.Default;
+    public required int SelectedResourceCount { get; init; }
+    public required int ResourcesWithVersionsCount { get; init; }
+    public required int MissingResourceCount { get; init; }
+    public required int TotalVersionCount { get; init; }
+    public required int ActiveVersionCount { get; init; }
+    public required int ProtectedVersionCount { get; init; }
+    public required int PossibleCandidateCount { get; init; }
+    public IReadOnlyList<ResourceVersionLifecycleStateCount> LifecycleStateCounts { get; init; } = [];
+}
+
+public static class ResourceVersionHistorySummaryExtensions
+{
+    public static ResourceVersionHistorySummary ToSummary(this ResourceVersionHistoryResult result);
+
+    public static ResourceVersionHistoryBatchSummary ToSummary(this ResourceVersionHistoryBatchResult result);
+}
+```
+
+## Counting Rules
+
+- `TotalVersionCount`: count of version summaries.
+- `LatestVersionCount`: summaries where `IsLatest` is true.
+- `DraftVersionCount`: summaries where `IsDraft` is true.
+- `ActiveVersionCount`: summaries with at least one active channel.
+- `ProtectedVersionCount`: summaries where `IsProtectedFromPruning` is true.
+- `PossibleCandidateCount`: summaries where `MaintenanceDisposition` is `PossibleCandidate`.
+- `ResourcesWithVersionsCount`: histories with at least one version.
+- `MissingResourceCount`: histories with zero versions.
+- `LifecycleStateCounts`: grouped by `LifecycleState`, ordered by enum value.

--- a/specs/024-version-history-summaries/data-model.md
+++ b/specs/024-version-history-summaries/data-model.md
@@ -1,0 +1,61 @@
+# Data Model: Version History Summaries
+
+## Resource Version History Summary
+
+Aggregate view over one `ResourceVersionHistoryResult`.
+
+Fields:
+
+- `TenantScope`: Effective tenant from the source result.
+- `ResourceId`: Source logical resource identifier.
+- `TotalVersionCount`: Number of version summaries.
+- `LatestVersionCount`: Number of summaries marked latest.
+- `DraftVersionCount`: Number of summaries marked draft.
+- `ActiveVersionCount`: Number of summaries with one or more active channels.
+- `ProtectedVersionCount`: Number of summaries protected from pruning.
+- `PossibleCandidateCount`: Number of summaries with possible-candidate maintenance disposition.
+- `LifecycleStateCounts`: Deterministic counts by lifecycle marker state.
+
+Validation:
+
+- Source result must not be null.
+- Null `Versions` collection is treated as empty.
+
+## Resource Version History Batch Summary
+
+Aggregate view over one `ResourceVersionHistoryBatchResult`.
+
+Fields:
+
+- `TenantScope`: Effective tenant from the source result.
+- `SelectedResourceCount`: Number of histories in the batch result.
+- `ResourcesWithVersionsCount`: Number of histories containing one or more versions.
+- `MissingResourceCount`: Number of histories containing no versions.
+- `TotalVersionCount`: Total number of version summaries across histories.
+- `ActiveVersionCount`: Number of version summaries with one or more active channels.
+- `ProtectedVersionCount`: Number of protected version summaries.
+- `PossibleCandidateCount`: Number of possible-candidate version summaries.
+- `LifecycleStateCounts`: Deterministic counts by lifecycle marker state across all version summaries.
+
+Validation:
+
+- Source batch result must not be null.
+- Null `Histories` collection is treated as empty.
+- Null per-history `Versions` collection is treated as empty.
+
+## Lifecycle State Count
+
+Deterministic count for one lifecycle state.
+
+Fields:
+
+- `State`: Lifecycle marker state.
+- `Count`: Number of version summaries with the state.
+
+Ordering:
+
+- Counts are ordered by lifecycle state enum value.
+
+## State Transitions
+
+None. Summaries are pure projections and must not mutate resources, versions, activation state, lifecycle markers, policies, or storage.

--- a/specs/024-version-history-summaries/plan.md
+++ b/specs/024-version-history-summaries/plan.md
@@ -1,0 +1,113 @@
+# Implementation Plan: Version History Summaries
+
+**Branch**: `024-version-history-summaries` | **Date**: 2026-05-30 | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from `/specs/024-version-history-summaries/spec.md`
+
+## Summary
+
+Add pure host-facing summary records and extension helpers over existing `ResourceVersionHistoryResult` and `ResourceVersionHistoryBatchResult` objects. The implementation mirrors the policy summary pattern: deterministic counts, no service registration, no provider/storage changes, no policy evaluation, and no mutation behavior.
+
+## Technical Context
+
+**Language/Version**: C# latest, .NET 8.0 / 9.0 / 10.0 multi-targeting
+**Primary Dependencies**: Existing core SDK version history models and xUnit test stack; no new dependencies
+**Storage**: No storage changes. Summaries are pure in-memory views over existing result objects; no schema migration, persistence, provider storage, or physical index changes.
+**Testing**: `dotnet test Aster.sln`, focused version history summary tests, existing version history and policy summary regression tests, `dotnet build Aster.sln /m:1`, `git diff --check`
+**Target Platform**: .NET SDK/library consumers and local test environment
+**Project Type**: SDK/library with provider packages and tests
+**Performance Goals**: Summary computation is linear over supplied result objects and performs no I/O.
+**Constraints**: Pure transformations only; deterministic counts; null result inputs fail fast; null collections are treated as empty; no service, storage, provider, query, public SQL, public `IQueryable<Resource>`, runtime scanning, automatic discovery, policy evaluation, reporting framework, or mutation behavior.
+**Scale/Scope**: Core SDK summary records/extensions, focused tests, docs, roadmap, and Spec Kit artifacts.
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+- **SDK-first/headless**: PASS - Adds SDK result helpers only; no UI, CMS, or host authorization behavior.
+- **Immutable versioning**: PASS - Summaries are read-only and do not mutate versions.
+- **Channel activation**: PASS - Summaries aggregate existing active-channel flags without changing activation state.
+- **Typed/queryable**: PASS - Query AST and typed aspect APIs remain unchanged; no public SQL or `IQueryable` is introduced.
+- **Provider agnostic**: PASS - Summaries operate on existing result objects and do not depend on providers.
+- **Simplicity first**: PASS - Pure records/extensions are the smallest implementation.
+- **Modern C# idioms**: PASS - Records, extension methods, collection expressions, and nullable-safe handling match existing style.
+- **Readability over cleverness**: PASS - Counts are direct and explicit.
+- **Explicitness over magic**: PASS - Hosts explicitly call summary helpers on result objects.
+- **Abstractions justified**: PASS - No service or new abstraction is introduced.
+- **Optimize for deletion**: PASS - Removing the feature removes one additive model file, tests, and docs.
+- **Composition over inheritance**: PASS - Uses records and extension methods; no inheritance hierarchy.
+- **Intentional dependencies**: PASS - No new third-party dependencies.
+- **Operational simplicity**: PASS - No migration, worker, external service, or setup change.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/024-version-history-summaries/
++-- spec.md
++-- plan.md
++-- research.md
++-- data-model.md
++-- quickstart.md
++-- checklists/
+|   +-- requirements.md
++-- contracts/
+    +-- version-history-summaries.md
+```
+
+### Source Code (repository root)
+
+```text
+src/
++-- core/Aster.Core/
+|   +-- Models/Instances/
+|       +-- ResourceVersionHistorySummaries.cs
+|
++-- persistence/Aster.Persistence.SqliteJson/
+    +-- no changes
+
+test/
++-- Aster.Tests/
+    +-- Versioning/
+```
+
+**Structure Decision**: Keep summaries in `Aster.Core.Models.Instances` beside version history models. They are pure SDK helpers over existing result objects and need no service registration or provider implementation.
+
+## Complexity Tracking
+
+No constitution violations.
+
+## Phase 0 Research Summary
+
+Research decisions are captured in [research.md](research.md). Key outcomes:
+
+- Use pure extension helpers rather than a service.
+- Keep counts descriptive and derived only from existing summary fields.
+- Treat null collections as empty for host-friendly manually constructed results.
+- Keep lifecycle counts deterministic.
+- Do not evaluate policy or add reporting infrastructure.
+
+## Phase 1 Design Summary
+
+Design artifacts:
+
+- [data-model.md](data-model.md)
+- [contracts/version-history-summaries.md](contracts/version-history-summaries.md)
+- [quickstart.md](quickstart.md)
+
+## Post-Design Constitution Check
+
+- **SDK-first/headless**: PASS - Design exposes records and extension helpers only.
+- **Immutable versioning**: PASS - No write path is introduced.
+- **Channel activation**: PASS - Active state is summarized from existing result fields only.
+- **Typed/queryable**: PASS - Query APIs remain unchanged.
+- **Provider agnostic**: PASS - No provider dependency exists.
+- **Simplicity first**: PASS - No service or registry is added.
+- **Modern C# idioms**: PASS - Planned code follows the policy summary pattern.
+- **Readability over cleverness**: PASS - Count formulas are direct.
+- **Explicitness over magic**: PASS - Callers explicitly invoke `ToSummary`.
+- **Abstractions justified**: PASS - No new abstraction is introduced.
+- **Optimize for deletion**: PASS - Feature is additive and localized.
+- **Composition over inheritance**: PASS - Records/extensions only.
+- **Intentional dependencies**: PASS - No new dependencies.
+- **Operational simplicity**: PASS - Existing validation commands remain sufficient.

--- a/specs/024-version-history-summaries/quickstart.md
+++ b/specs/024-version-history-summaries/quickstart.md
@@ -1,0 +1,47 @@
+# Quickstart: Version History Summaries
+
+## Summarize One Resource History
+
+```csharp
+var historyService = provider.GetRequiredService<IResourceVersionHistoryService>();
+
+var history = await historyService.GetHistoryAsync(new ResourceVersionHistoryRequest
+{
+    ResourceId = "product-1",
+});
+
+var summary = history.ToSummary();
+
+Console.WriteLine($"Versions: {summary.TotalVersionCount}");
+Console.WriteLine($"Protected: {summary.ProtectedVersionCount}");
+Console.WriteLine($"Candidates: {summary.PossibleCandidateCount}");
+```
+
+## Summarize A Batch Result
+
+```csharp
+var batch = await historyService.GetHistoriesAsync(new ResourceVersionHistoryBatchRequest
+{
+    ResourceIds = ["product-1", "product-2", "missing-product"],
+});
+
+var summary = batch.ToSummary();
+
+Console.WriteLine($"Selected resources: {summary.SelectedResourceCount}");
+Console.WriteLine($"Resources with versions: {summary.ResourcesWithVersionsCount}");
+Console.WriteLine($"Missing resources: {summary.MissingResourceCount}");
+```
+
+## Manual Results
+
+Summary helpers are pure transformations and do not require service registration:
+
+```csharp
+var summary = new ResourceVersionHistoryResult
+{
+    ResourceId = "manual",
+    Versions = [],
+}.ToSummary();
+```
+
+No provider, storage, policy evaluation, or mutation behavior is involved.

--- a/specs/024-version-history-summaries/research.md
+++ b/specs/024-version-history-summaries/research.md
@@ -1,0 +1,53 @@
+# Research: Version History Summaries
+
+## Pure Extension Helpers
+
+Decision: Add `ToSummary` extension helpers over `ResourceVersionHistoryResult` and `ResourceVersionHistoryBatchResult`.
+
+Rationale: Hosts already receive result objects from history services or can construct them in tests. Pure helpers avoid a service abstraction, DI registration, provider dependency, or hidden reads.
+
+Alternatives considered:
+
+- Add an `IResourceVersionHistorySummaryService`: rejected because no external collaborator or lifecycle is needed.
+- Add summary calculation inside history services only: rejected because manually constructed results should be summarizable without services.
+- Add provider-side summary queries: rejected because summaries are derived from already materialized results.
+
+## Count Semantics
+
+Decision: Summaries count existing `ResourceVersionSummary` fields: total, latest, draft, active, protected, possible candidate, and lifecycle states.
+
+Rationale: These are stable values already computed by history inspection. Summaries should not introduce new product semantics or imply policy eligibility.
+
+Alternatives considered:
+
+- Add definitive prune eligibility counts: rejected because policy evaluation owns eligibility.
+- Add time-window or age buckets: deferred because they require product decisions about retention windows.
+- Add channel-specific aggregate maps: deferred until hosts demonstrate the need.
+
+## Batch Aggregation
+
+Decision: Batch summaries aggregate across histories and report selected resources, resources with versions, missing resources, and version-state totals.
+
+Rationale: This gives host dashboards useful top-level numbers while preserving the explicit selected-resource shape from batch history.
+
+Alternatives considered:
+
+- Return one nested single summary per resource: rejected for this slice because callers can already call `ToSummary` per history; the batch summary should be aggregate.
+- Exclude missing resources from selected counts: rejected because selected-resource count should reflect caller selection.
+
+## Null Collection Handling
+
+Decision: Null `Versions` and `Histories` collections are treated as empty; null result inputs fail fast.
+
+Rationale: Result object collections normally default to empty, but manually constructed objects can set them to null. Treating collections as empty matches policy summary precedent and keeps helpers host-friendly.
+
+Alternatives considered:
+
+- Throw for null collections: rejected as unnecessary strictness for derived summaries.
+- Silently accept null result input: rejected because extension helpers need a real source identity.
+
+## Out-Of-Scope Boundaries
+
+Decision: Do not add storage, services, providers, policy evaluation, audit persistence, public SQL, public `IQueryable<Resource>`, query planning, runtime scanning, automatic discovery, background jobs, or mutation behavior.
+
+Rationale: The feature is a pure view over result objects. Broader reporting or audit features need separate product and storage decisions.

--- a/specs/024-version-history-summaries/spec.md
+++ b/specs/024-version-history-summaries/spec.md
@@ -1,0 +1,103 @@
+# Feature Specification: Version History Summaries
+
+**Feature Branch**: `024-version-history-summaries`
+**Created**: 2026-05-30
+**Status**: Draft
+**Input**: Continue with the next bounded Phase 5 slice after batch version history inspection.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Summarize One Resource History (Priority: P1)
+
+As a host developer rendering resource maintenance screens, I want a deterministic summary of one resource history so that I can display counts and simple status indicators without recomputing them in every host.
+
+**Why this priority**: Single-resource history is the existing baseline and the summary should be useful without requiring batch history.
+
+**Independent Test**: Build a resource history with latest, active, draft, protected, possible-candidate, and lifecycle-marked versions, then verify the summary counts.
+
+**Acceptance Scenarios**:
+
+1. **Given** a history with multiple version states, **When** the history is summarized, **Then** the summary reports total versions, latest versions, draft versions, active versions, protected versions, and possible maintenance candidates.
+2. **Given** a missing resource history with no versions, **When** the history is summarized, **Then** the summary reports zero counts and preserves the requested resource identity.
+3. **Given** a history with lifecycle marker states, **When** the history is summarized, **Then** lifecycle state counts are deterministic and ordered.
+
+---
+
+### User Story 2 - Summarize Batch History Results (Priority: P2)
+
+As a host developer rendering selected-resource dashboards, I want a summary of a batch history result so that I can show aggregate counts across the selected resource set.
+
+**Why this priority**: Batch history landed in the prior slice and needs lightweight host-facing aggregation for dashboards.
+
+**Independent Test**: Build a batch result with populated histories, duplicate lifecycle states, and missing resources, then verify aggregate resource/version counts.
+
+**Acceptance Scenarios**:
+
+1. **Given** a batch result containing populated and empty histories, **When** the batch is summarized, **Then** the summary reports selected resource count, resources with versions, missing resource count, and total version count.
+2. **Given** a batch result with protected and possible-candidate versions across resources, **When** the batch is summarized, **Then** protected and candidate counts are aggregated across all histories.
+3. **Given** an empty batch result, **When** it is summarized, **Then** all counts are zero and the effective tenant is preserved.
+
+---
+
+### User Story 3 - Keep Summaries Pure and Predictable (Priority: P3)
+
+As a host developer, I want summaries to be pure transformations over result objects so that they are safe to use in tests, UI adapters, and reports without service resolution or provider state.
+
+**Why this priority**: The feature should not change runtime behavior or add infrastructure.
+
+**Independent Test**: Construct result objects manually and summarize them without any registered services or storage provider.
+
+**Acceptance Scenarios**:
+
+1. **Given** manually constructed history result objects, **When** summary helpers are called, **Then** summaries are produced without services, stores, or providers.
+2. **Given** null result input, **When** summary helpers are called, **Then** they fail fast with argument validation.
+3. **Given** null version or history collections on result objects, **When** summary helpers are called, **Then** they are treated as empty collections.
+
+### Edge Cases
+
+- Null result inputs MUST fail fast with argument validation.
+- Null `Versions` or `Histories` collections MUST be treated as empty collections.
+- Lifecycle state counts MUST be ordered deterministically.
+- Batch missing-resource count MUST be based on histories with zero versions.
+- Summaries MUST NOT evaluate policy eligibility or claim definitive prune safety beyond existing maintenance disposition.
+- Summaries MUST NOT introduce storage, providers, services, background work, public SQL, public `IQueryable<Resource>`, runtime scanning, automatic discovery, query planning, or mutation behavior.
+
+### Constitution Alignment *(mandatory)*
+
+- **Simplicity**: Add pure extension helpers and records over existing result models only.
+- **Explicitness**: Callers explicitly summarize existing result objects; no hidden reads or discovery.
+- **Dependencies**: None.
+- **Operational Impact**: No deployment, storage, migration, provider, debugging, or observability changes.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The system MUST provide a pure summary for a single resource version history result.
+- **FR-002**: A single-history summary MUST preserve tenant scope and resource identifier from the source history.
+- **FR-003**: A single-history summary MUST report total version count, latest version count, draft version count, active version count, protected version count, and possible maintenance candidate count.
+- **FR-004**: A single-history summary MUST report deterministic lifecycle state counts.
+- **FR-005**: The system MUST provide a pure summary for a batch resource version history result.
+- **FR-006**: A batch summary MUST preserve the effective tenant from the source batch result.
+- **FR-007**: A batch summary MUST report selected resource count, resources with versions, missing resource count, total version count, active version count, protected version count, and possible maintenance candidate count.
+- **FR-008**: A batch summary MUST report deterministic lifecycle state counts aggregated across all version summaries.
+- **FR-009**: Summary helpers MUST fail fast for null result inputs.
+- **FR-010**: Summary helpers MUST treat null result collections as empty collections.
+- **FR-011**: Summary helpers MUST be usable over manually constructed result objects without services or providers.
+- **FR-012**: The system MUST NOT introduce storage changes, provider changes, services, background jobs, public SQL, public `IQueryable<Resource>`, runtime scanning, automatic discovery, query planners, policy evaluation, or mutation behavior.
+
+### Key Entities
+
+- **Version History Summary**: Aggregate counts for one resource history.
+- **Batch Version History Summary**: Aggregate counts for a selected resource history batch.
+- **Lifecycle State Count**: Deterministic count for one lifecycle marker state.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: A host can summarize a single history result with at least five mixed version states and receive correct counts.
+- **SC-002**: A host can summarize a batch result containing at least three resource histories and receive correct aggregate resource and version counts.
+- **SC-003**: Summary helpers can be called on manually constructed result objects without service registration.
+- **SC-004**: Empty and null collection edge cases produce deterministic zero-count summaries.
+- **SC-005**: Existing version history and policy summary tests continue to pass unchanged.

--- a/specs/024-version-history-summaries/tasks.md
+++ b/specs/024-version-history-summaries/tasks.md
@@ -1,0 +1,121 @@
+# Tasks: Version History Summaries
+
+**Input**: Design documents from `/specs/024-version-history-summaries/`
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/
+
+**Tests**: Include focused tests because this is public SDK behavior and mirrors policy summary helpers.
+
+**Organization**: Tasks are grouped by user story to enable independent implementation and testing.
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Confirm current summary and version history patterns before editing.
+
+- [X] T001 Review policy summary records/extensions in `src/core/Aster.Core/Models/Policies/ResourcePolicyApplicationSummaries.cs`
+- [X] T002 [P] Review policy summary tests in `test/Aster.Tests/Policies/PolicyApplicationSummaryTests.cs`
+- [X] T003 [P] Review version history result models in `src/core/Aster.Core/Models/Instances/ResourceVersionHistory.cs`
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Add shared summary model and helper surface.
+
+- [X] T004 Add version history summary records and extension class in `src/core/Aster.Core/Models/Instances/ResourceVersionHistorySummaries.cs`
+- [X] T005 Implement deterministic lifecycle-state count helper in `src/core/Aster.Core/Models/Instances/ResourceVersionHistorySummaries.cs`
+
+---
+
+## Phase 3: User Story 1 - Summarize One Resource History (Priority: P1) MVP
+
+**Goal**: Hosts can summarize one resource history with deterministic version-state counts.
+
+**Independent Test**: Construct one history with mixed version states and verify all counts.
+
+### Tests for User Story 1
+
+- [X] T006 [P] [US1] Add single-history mixed count tests in `test/Aster.Tests/Versioning/ResourceVersionHistorySummaryTests.cs`
+- [X] T007 [P] [US1] Add empty single-history tests in `test/Aster.Tests/Versioning/ResourceVersionHistorySummaryTests.cs`
+
+### Implementation for User Story 1
+
+- [X] T008 [US1] Implement `ToSummary(this ResourceVersionHistoryResult)` in `src/core/Aster.Core/Models/Instances/ResourceVersionHistorySummaries.cs`
+
+---
+
+## Phase 4: User Story 2 - Summarize Batch History Results (Priority: P2)
+
+**Goal**: Hosts can summarize selected-resource batch history results.
+
+**Independent Test**: Construct a batch result with populated and missing histories and verify aggregate counts.
+
+### Tests for User Story 2
+
+- [X] T009 [P] [US2] Add batch aggregate count tests in `test/Aster.Tests/Versioning/ResourceVersionHistorySummaryTests.cs`
+- [X] T010 [P] [US2] Add empty batch summary tests in `test/Aster.Tests/Versioning/ResourceVersionHistorySummaryTests.cs`
+
+### Implementation for User Story 2
+
+- [X] T011 [US2] Implement `ToSummary(this ResourceVersionHistoryBatchResult)` in `src/core/Aster.Core/Models/Instances/ResourceVersionHistorySummaries.cs`
+
+---
+
+## Phase 5: User Story 3 - Keep Summaries Pure and Predictable (Priority: P3)
+
+**Goal**: Summary helpers work over manually constructed results without services and handle invalid/null shapes predictably.
+
+**Independent Test**: Call summary helpers over manually constructed result objects with null collections and null inputs.
+
+### Tests for User Story 3
+
+- [X] T012 [P] [US3] Add null input and null collection tests in `test/Aster.Tests/Versioning/ResourceVersionHistorySummaryTests.cs`
+- [X] T013 [P] [US3] Add no-service manual result test in `test/Aster.Tests/Versioning/ResourceVersionHistorySummaryTests.cs`
+
+### Implementation for User Story 3
+
+- [X] T014 [US3] Ensure summary helpers fail fast for null result inputs and treat null collections as empty in `src/core/Aster.Core/Models/Instances/ResourceVersionHistorySummaries.cs`
+
+---
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+**Purpose**: Documentation, roadmap, cleanup, and validation.
+
+- [X] T015 [P] Update core SDK documentation for version history summaries in `src/core/Aster.Core/README.md`
+- [X] T016 [P] Update execution roadmap to mark 023 landed and 024 in progress in `docs/ExecutionRoadmap.md`
+- [X] T017 Update `AGENTS.md` recent changes for `024-version-history-summaries`
+- [X] T018 Run `dotnet test Aster.sln`
+- [X] T019 Run `dotnet build Aster.sln /m:1`
+- [X] T020 Run `git diff --check`
+- [X] T021 Re-run constitution check against implemented design and remove unnecessary abstractions or duplication before final review
+
+## Dependencies & Execution Order
+
+- Setup precedes all implementation.
+- Foundational records/extensions precede user stories.
+- US1 is the MVP and should land before batch aggregation.
+- US2 builds on shared helper logic.
+- US3 verifies purity and null-shape behavior.
+- Polish follows implementation.
+
+## Parallel Opportunities
+
+- T002 and T003 can run in parallel.
+- T006 and T007 can be drafted in parallel.
+- T009 and T010 can be drafted in parallel.
+- T012 and T013 can be drafted in parallel.
+- T015 and T016 can be updated in parallel.
+
+## Implementation Strategy
+
+1. Add the pure model/extension file.
+2. Add tests for single-history summaries.
+3. Add tests for batch summaries.
+4. Add null/manual result tests.
+5. Update docs and roadmap.
+6. Run full validation.
+
+## Notes
+
+- Keep summaries pure; do not add service registration.
+- Do not add storage, provider, policy, query, public SQL, public `IQueryable<Resource>`, runtime scanning, automatic discovery, or mutation behavior.

--- a/src/core/Aster.Core/Models/Instances/ResourceVersionHistorySummaries.cs
+++ b/src/core/Aster.Core/Models/Instances/ResourceVersionHistorySummaries.cs
@@ -1,0 +1,149 @@
+using Aster.Core.Models.Tenancy;
+
+namespace Aster.Core.Models.Instances;
+
+/// <summary>
+/// Deterministic count for one resource lifecycle marker state in version history summaries.
+/// </summary>
+public sealed record ResourceVersionLifecycleStateCount
+{
+    /// <summary>Lifecycle marker state.</summary>
+    public required ResourceLifecycleMarkerState State { get; init; }
+
+    /// <summary>Number of version summaries with the state.</summary>
+    public required int Count { get; init; }
+}
+
+/// <summary>
+/// Aggregate view over one resource version history result.
+/// </summary>
+public sealed record ResourceVersionHistorySummary
+{
+    /// <summary>Effective tenant used by the source history.</summary>
+    public TenantScope TenantScope { get; init; } = TenantScope.Default;
+
+    /// <summary>Logical resource identifier from the source history.</summary>
+    public required string ResourceId { get; init; }
+
+    /// <summary>Total number of version summaries.</summary>
+    public required int TotalVersionCount { get; init; }
+
+    /// <summary>Number of summaries marked as latest.</summary>
+    public required int LatestVersionCount { get; init; }
+
+    /// <summary>Number of summaries marked as draft.</summary>
+    public required int DraftVersionCount { get; init; }
+
+    /// <summary>Number of summaries active in at least one channel.</summary>
+    public required int ActiveVersionCount { get; init; }
+
+    /// <summary>Number of summaries protected from destructive pruning.</summary>
+    public required int ProtectedVersionCount { get; init; }
+
+    /// <summary>Number of summaries with possible-candidate maintenance disposition.</summary>
+    public required int PossibleCandidateCount { get; init; }
+
+    /// <summary>Deterministic lifecycle marker state counts across version summaries.</summary>
+    public IReadOnlyList<ResourceVersionLifecycleStateCount> LifecycleStateCounts { get; init; } = [];
+}
+
+/// <summary>
+/// Aggregate view over a batch resource version history result.
+/// </summary>
+public sealed record ResourceVersionHistoryBatchSummary
+{
+    /// <summary>Effective tenant used by the source batch result.</summary>
+    public TenantScope TenantScope { get; init; } = TenantScope.Default;
+
+    /// <summary>Number of resource histories in the batch result.</summary>
+    public required int SelectedResourceCount { get; init; }
+
+    /// <summary>Number of resource histories containing one or more versions.</summary>
+    public required int ResourcesWithVersionsCount { get; init; }
+
+    /// <summary>Number of resource histories containing no versions.</summary>
+    public required int MissingResourceCount { get; init; }
+
+    /// <summary>Total number of version summaries across all histories.</summary>
+    public required int TotalVersionCount { get; init; }
+
+    /// <summary>Number of version summaries active in at least one channel.</summary>
+    public required int ActiveVersionCount { get; init; }
+
+    /// <summary>Number of version summaries protected from destructive pruning.</summary>
+    public required int ProtectedVersionCount { get; init; }
+
+    /// <summary>Number of version summaries with possible-candidate maintenance disposition.</summary>
+    public required int PossibleCandidateCount { get; init; }
+
+    /// <summary>Deterministic lifecycle marker state counts across all version summaries.</summary>
+    public IReadOnlyList<ResourceVersionLifecycleStateCount> LifecycleStateCounts { get; init; } = [];
+}
+
+/// <summary>
+/// Pure summary helpers for resource version history result objects.
+/// </summary>
+public static class ResourceVersionHistorySummaryExtensions
+{
+    /// <summary>
+    /// Creates a deterministic aggregate summary for one resource version history result.
+    /// </summary>
+    /// <param name="result">The history result to summarize.</param>
+    /// <returns>A summary over the history's version states.</returns>
+    public static ResourceVersionHistorySummary ToSummary(this ResourceVersionHistoryResult result)
+    {
+        ArgumentNullException.ThrowIfNull(result);
+        var versions = result.Versions ?? [];
+
+        return new ResourceVersionHistorySummary
+        {
+            TenantScope = result.TenantScope,
+            ResourceId = result.ResourceId,
+            TotalVersionCount = versions.Count,
+            LatestVersionCount = versions.Count(static version => version.IsLatest),
+            DraftVersionCount = versions.Count(static version => version.IsDraft),
+            ActiveVersionCount = versions.Count(static version => version.ActiveChannels is { Count: > 0 }),
+            ProtectedVersionCount = versions.Count(static version => version.IsProtectedFromPruning),
+            PossibleCandidateCount = versions.Count(static version => version.MaintenanceDisposition == ResourceVersionMaintenanceDisposition.PossibleCandidate),
+            LifecycleStateCounts = CountLifecycleStates(versions),
+        };
+    }
+
+    /// <summary>
+    /// Creates a deterministic aggregate summary for a batch resource version history result.
+    /// </summary>
+    /// <param name="result">The batch history result to summarize.</param>
+    /// <returns>A summary over the batch's resource and version states.</returns>
+    public static ResourceVersionHistoryBatchSummary ToSummary(this ResourceVersionHistoryBatchResult result)
+    {
+        ArgumentNullException.ThrowIfNull(result);
+        var histories = result.Histories ?? [];
+        var versionSets = histories.Select(static history => history.Versions ?? []).ToList();
+        var versions = versionSets.SelectMany(static historyVersions => historyVersions).ToList();
+
+        return new ResourceVersionHistoryBatchSummary
+        {
+            TenantScope = result.TenantScope,
+            SelectedResourceCount = histories.Count,
+            ResourcesWithVersionsCount = versionSets.Count(static historyVersions => historyVersions.Count > 0),
+            MissingResourceCount = versionSets.Count(static historyVersions => historyVersions.Count == 0),
+            TotalVersionCount = versions.Count,
+            ActiveVersionCount = versions.Count(static version => version.ActiveChannels is { Count: > 0 }),
+            ProtectedVersionCount = versions.Count(static version => version.IsProtectedFromPruning),
+            PossibleCandidateCount = versions.Count(static version => version.MaintenanceDisposition == ResourceVersionMaintenanceDisposition.PossibleCandidate),
+            LifecycleStateCounts = CountLifecycleStates(versions),
+        };
+    }
+
+    private static IReadOnlyList<ResourceVersionLifecycleStateCount> CountLifecycleStates(
+        IEnumerable<ResourceVersionSummary> versions) =>
+        versions
+            .GroupBy(static version => version.LifecycleState)
+            .OrderBy(static group => group.Key)
+            .Select(static group => new ResourceVersionLifecycleStateCount
+            {
+                State = group.Key,
+                Count = group.Count(),
+            })
+            .ToList();
+}

--- a/src/core/Aster.Core/README.md
+++ b/src/core/Aster.Core/README.md
@@ -157,6 +157,16 @@ var batch = await history.GetHistoriesAsync(new ResourceVersionHistoryBatchReque
 // Duplicate IDs are collapsed; missing resources return empty histories.
 ```
 
+Use `ToSummary()` when a host needs deterministic counts for a single history or selected batch:
+
+```csharp
+var singleSummary = result.ToSummary();
+var batchSummary = batch.ToSummary();
+
+Console.WriteLine($"Protected versions: {singleSummary.ProtectedVersionCount}");
+Console.WriteLine($"Missing resources: {batchSummary.MissingResourceCount}");
+```
+
 Latest or active versions are reported as protected from destructive pruning. Historical inactive non-latest versions are only reported as possible maintenance candidates; hosts must still use policy preview/application services before pruning.
 
 ---

--- a/test/Aster.Tests/Versioning/ResourceVersionHistorySummaryTests.cs
+++ b/test/Aster.Tests/Versioning/ResourceVersionHistorySummaryTests.cs
@@ -1,0 +1,204 @@
+using Aster.Core.Models.Instances;
+using Aster.Core.Models.Tenancy;
+
+namespace Aster.Tests.Versioning;
+
+public sealed class ResourceVersionHistorySummaryTests
+{
+    [Fact]
+    public void HistorySummary_MixedVersions_AggregatesCounts()
+    {
+        var result = new ResourceVersionHistoryResult
+        {
+            TenantScope = TenantScope.FromTenantId("tenant-a"),
+            ResourceId = "product-1",
+            Versions =
+            [
+                Version(1, isLatest: false, isDraft: true, activeChannels: [], ResourceLifecycleMarkerState.Archived, ResourceVersionMaintenanceDisposition.PossibleCandidate),
+                Version(2, isLatest: false, isDraft: false, activeChannels: ["Published"], ResourceLifecycleMarkerState.Archived, ResourceVersionMaintenanceDisposition.Protected),
+                Version(3, isLatest: true, isDraft: true, activeChannels: [], ResourceLifecycleMarkerState.None, ResourceVersionMaintenanceDisposition.Protected),
+            ],
+        };
+
+        var summary = result.ToSummary();
+
+        Assert.Equal(result.TenantScope, summary.TenantScope);
+        Assert.Equal("product-1", summary.ResourceId);
+        Assert.Equal(3, summary.TotalVersionCount);
+        Assert.Equal(1, summary.LatestVersionCount);
+        Assert.Equal(2, summary.DraftVersionCount);
+        Assert.Equal(1, summary.ActiveVersionCount);
+        Assert.Equal(2, summary.ProtectedVersionCount);
+        Assert.Equal(1, summary.PossibleCandidateCount);
+        Assert.Equal(
+            [(ResourceLifecycleMarkerState.None, 1), (ResourceLifecycleMarkerState.Archived, 2)],
+            summary.LifecycleStateCounts.Select(static count => (count.State, count.Count)).ToList());
+    }
+
+    [Fact]
+    public void HistorySummary_EmptyHistory_PreservesIdentityWithZeroCounts()
+    {
+        var summary = new ResourceVersionHistoryResult
+        {
+            TenantScope = TenantScope.FromTenantId("tenant-a"),
+            ResourceId = "missing",
+        }.ToSummary();
+
+        Assert.Equal(TenantScope.FromTenantId("tenant-a"), summary.TenantScope);
+        Assert.Equal("missing", summary.ResourceId);
+        Assert.Equal(0, summary.TotalVersionCount);
+        Assert.Equal(0, summary.LatestVersionCount);
+        Assert.Equal(0, summary.DraftVersionCount);
+        Assert.Equal(0, summary.ActiveVersionCount);
+        Assert.Equal(0, summary.ProtectedVersionCount);
+        Assert.Equal(0, summary.PossibleCandidateCount);
+        Assert.Empty(summary.LifecycleStateCounts);
+    }
+
+    [Fact]
+    public void BatchSummary_MixedHistories_AggregatesResourceAndVersionCounts()
+    {
+        var result = new ResourceVersionHistoryBatchResult
+        {
+            TenantScope = TenantScope.FromTenantId("tenant-a"),
+            Histories =
+            [
+                new ResourceVersionHistoryResult
+                {
+                    TenantScope = TenantScope.FromTenantId("tenant-a"),
+                    ResourceId = "product-1",
+                    Versions =
+                    [
+                        Version(1, isLatest: false, isDraft: false, activeChannels: ["Published"], ResourceLifecycleMarkerState.Archived, ResourceVersionMaintenanceDisposition.Protected),
+                        Version(2, isLatest: true, isDraft: true, activeChannels: [], ResourceLifecycleMarkerState.Archived, ResourceVersionMaintenanceDisposition.Protected),
+                    ],
+                },
+                new ResourceVersionHistoryResult
+                {
+                    TenantScope = TenantScope.FromTenantId("tenant-a"),
+                    ResourceId = "product-2",
+                    Versions =
+                    [
+                        Version(1, isLatest: true, isDraft: true, activeChannels: [], ResourceLifecycleMarkerState.None, ResourceVersionMaintenanceDisposition.PossibleCandidate),
+                    ],
+                },
+                new ResourceVersionHistoryResult
+                {
+                    TenantScope = TenantScope.FromTenantId("tenant-a"),
+                    ResourceId = "missing",
+                },
+            ],
+        };
+
+        var summary = result.ToSummary();
+
+        Assert.Equal(result.TenantScope, summary.TenantScope);
+        Assert.Equal(3, summary.SelectedResourceCount);
+        Assert.Equal(2, summary.ResourcesWithVersionsCount);
+        Assert.Equal(1, summary.MissingResourceCount);
+        Assert.Equal(3, summary.TotalVersionCount);
+        Assert.Equal(1, summary.ActiveVersionCount);
+        Assert.Equal(2, summary.ProtectedVersionCount);
+        Assert.Equal(1, summary.PossibleCandidateCount);
+        Assert.Equal(
+            [(ResourceLifecycleMarkerState.None, 1), (ResourceLifecycleMarkerState.Archived, 2)],
+            summary.LifecycleStateCounts.Select(static count => (count.State, count.Count)).ToList());
+    }
+
+    [Fact]
+    public void BatchSummary_EmptyBatch_PreservesTenantWithZeroCounts()
+    {
+        var summary = new ResourceVersionHistoryBatchResult
+        {
+            TenantScope = TenantScope.FromTenantId("tenant-a"),
+        }.ToSummary();
+
+        Assert.Equal(TenantScope.FromTenantId("tenant-a"), summary.TenantScope);
+        Assert.Equal(0, summary.SelectedResourceCount);
+        Assert.Equal(0, summary.ResourcesWithVersionsCount);
+        Assert.Equal(0, summary.MissingResourceCount);
+        Assert.Equal(0, summary.TotalVersionCount);
+        Assert.Empty(summary.LifecycleStateCounts);
+    }
+
+    [Fact]
+    public void Summaries_NullInputsThrow()
+    {
+        Assert.Throws<ArgumentNullException>(() => ((ResourceVersionHistoryResult)null!).ToSummary());
+        Assert.Throws<ArgumentNullException>(() => ((ResourceVersionHistoryBatchResult)null!).ToSummary());
+    }
+
+    [Fact]
+    public void Summaries_NullCollectionsAreTreatedAsEmpty()
+    {
+        var historySummary = new ResourceVersionHistoryResult
+        {
+            ResourceId = "manual",
+            Versions = null!,
+        }.ToSummary();
+
+        var batchSummary = new ResourceVersionHistoryBatchResult
+        {
+            Histories =
+            [
+                new ResourceVersionHistoryResult
+                {
+                    ResourceId = "manual",
+                    Versions = null!,
+                },
+            ],
+        }.ToSummary();
+
+        Assert.Equal(0, historySummary.TotalVersionCount);
+        Assert.Equal(1, batchSummary.SelectedResourceCount);
+        Assert.Equal(0, batchSummary.ResourcesWithVersionsCount);
+        Assert.Equal(1, batchSummary.MissingResourceCount);
+    }
+
+    [Fact]
+    public void Summaries_AreGeneratedFromManuallyConstructedResultsWithoutServices()
+    {
+        var historySummary = new ResourceVersionHistoryResult
+        {
+            ResourceId = "manual",
+            Versions = [Version(1, isLatest: true, isDraft: true, activeChannels: [], ResourceLifecycleMarkerState.None, ResourceVersionMaintenanceDisposition.Protected)],
+        }.ToSummary();
+
+        var batchSummary = new ResourceVersionHistoryBatchResult
+        {
+            Histories =
+            [
+                new ResourceVersionHistoryResult
+                {
+                    ResourceId = "manual",
+                    Versions = [Version(1, isLatest: true, isDraft: true, activeChannels: [], ResourceLifecycleMarkerState.None, ResourceVersionMaintenanceDisposition.Protected)],
+                },
+            ],
+        }.ToSummary();
+
+        Assert.Equal(1, historySummary.TotalVersionCount);
+        Assert.Equal(1, batchSummary.TotalVersionCount);
+    }
+
+    private static ResourceVersionSummary Version(
+        int version,
+        bool isLatest,
+        bool isDraft,
+        IReadOnlyList<string> activeChannels,
+        ResourceLifecycleMarkerState lifecycleState,
+        ResourceVersionMaintenanceDisposition disposition) =>
+        new()
+        {
+            ResourceVersionId = $"version-{version}",
+            Version = version,
+            DefinitionId = "Product",
+            DefinitionVersion = 1,
+            Created = new DateTime(2026, 5, 30, 12, 0, 0, DateTimeKind.Utc).AddMinutes(version),
+            IsLatest = isLatest,
+            IsDraft = isDraft,
+            ActiveChannels = activeChannels,
+            LifecycleState = lifecycleState,
+            IsProtectedFromPruning = disposition == ResourceVersionMaintenanceDisposition.Protected,
+            MaintenanceDisposition = disposition,
+        };
+}


### PR DESCRIPTION
## Summary
- add pure summary records and ToSummary helpers for single and batch version history results
- aggregate deterministic version-state, selected/missing resource, and lifecycle-state counts without services or providers
- add Spec Kit artifacts, docs, roadmap updates, and focused tests

## Validation
- dotnet test Aster.sln
- dotnet build Aster.sln /m:1
- git diff --check