### PR TITLE
Add operational hardening coverage

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "featureDir": "specs/024-version-history-summaries"
+  "featureDir": "specs/025-operational-hardening"
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 <!-- SPECKIT START -->
 For additional context about technologies to be used, project structure,
-shell commands, and other important information, read `specs/024-version-history-summaries/plan.md`.
+shell commands, and other important information, read `specs/025-operational-hardening/plan.md`.
 <!-- SPECKIT END -->
 
 ## Active Technologies
@@ -34,8 +34,11 @@ shell commands, and other important information, read `specs/024-version-history
 - Existing resource versions, activation state, and lifecycle marker storage only. No schema migration, data rewrite, portability snapshot format change, or physical index creation. (023-batch-version-history)
 - C# latest, .NET 8.0 / 9.0 / 10.0 multi-targeting + Existing core SDK version history models and xUnit test stack; no new dependencies (024-version-history-summaries)
 - No storage changes. Summaries are pure in-memory views over existing result objects; no schema migration, persistence, provider storage, or physical index changes. (024-version-history-summaries)
+- C# latest, .NET 8.0 / 9.0 / 10.0 multi-targeting + Existing core SDK, in-memory store, SQLite JSON provider, lifecycle restore service, policy pruning application service, historical activation path, xUnit test stack; no new dependencies (025-operational-hardening)
+- Existing resource version, activation state, and lifecycle marker storage only. No schema migration, data rewrite, persisted test artifacts, or physical index changes. (025-operational-hardening)
 
 ## Recent Changes
+- 025-operational-hardening: Added bounded operational hardening planning and test context for lifecycle restore retries, same-candidate restore races, policy pruning retries, persisted SQLite pruning retries, and repeated historical activation without new product APIs, storage schema changes, providers, schedulers, benchmark infrastructure, or dependencies
 - 024-version-history-summaries: Added pure host-facing summaries for single and batch version history results with deterministic version-state counts, selected/missing resource counts, lifecycle state counts, and no storage, provider, service, query planner, public SQL, public IQueryable<Resource>, policy evaluation, reporting infrastructure, or mutation behavior
 - 023-batch-version-history: Added explicit batch version history planning and implementation context for selected resource IDs with first-seen distinct ordering, tenant scoping, missing-resource histories, SQLite parity, and no storage migrations, query planner, provider registry, public SQL, public IQueryable<Resource>, runtime scanning, automatic discovery, or mutation behavior
 - 022-policy-application-summaries: Added pure host-facing summaries for policy application and pruning application results with deterministic status counts, completion booleans, affected target counts, diagnostic code counts, and no storage, provider, scheduler, authorization, public SQL, public IQueryable<Resource>, audit persistence, or reporting framework

--- a/docs/ExecutionRoadmap.md
+++ b/docs/ExecutionRoadmap.md
@@ -6,9 +6,9 @@ This roadmap tracks the implementation trail we have already cut through the rep
 
 ## Current Position
 
-Aster now has a working Core SDK, in-memory runtime, SQLite JSON persistence/querying, provider capability discovery, provider validation alignment, provider authoring ergonomics, a reusable provider conformance harness, SQLite facet sorting, portable operator expansion, SQLite date-like ranges, explicit provider-declared index projections, explicit definition schema upgrade behavior, deterministic portability primitives, explicit host lifecycle hooks, explicit tenant scoping, policy foundations, host-controlled policy application orchestration, host-controlled lifecycle restore workflows, host-controlled policy pruning application, read-only version history inspection, explicit historical version activation, policy application summaries, and batch version history inspection.
+Aster now has a working Core SDK, in-memory runtime, SQLite JSON persistence/querying, provider capability discovery, provider validation alignment, provider authoring ergonomics, a reusable provider conformance harness, SQLite facet sorting, portable operator expansion, SQLite date-like ranges, explicit provider-declared index projections, explicit definition schema upgrade behavior, deterministic portability primitives, explicit host lifecycle hooks, explicit tenant scoping, policy foundations, host-controlled policy application orchestration, host-controlled lifecycle restore workflows, host-controlled policy pruning application, read-only version history inspection, explicit historical version activation, policy application summaries, batch version history inspection, and version history summaries.
 
-The Phase 4 core workstream is complete enough to defer optional recipes. The active workstream is now **Phase 5: Multi-tenancy, Policies, Advanced Versioning**. Explicit tenant-aware boundaries, policy foundations, policy application orchestration, reversible lifecycle restore, destructive pruning application, version history inspection, historical version activation, policy application summaries, and batch version history inspection have landed; version history summaries are the current bounded reporting slice.
+The Phase 4 core workstream is complete enough to defer optional recipes. The active workstream is now **Phase 5: Multi-tenancy, Policies, Advanced Versioning**. Explicit tenant-aware boundaries, policy foundations, policy application orchestration, reversible lifecycle restore, destructive pruning application, version history inspection, historical version activation, policy application summaries, batch version history inspection, and version history summaries have landed; operational hardening is the current bounded confidence slice.
 
 ## Landed Slices
 
@@ -37,25 +37,27 @@ The Phase 4 core workstream is complete enough to defer optional recipes. The ac
 | `021-historical-version-activation` | Landed | Explicit activation of any existing historical or latest resource version while preserving immutable versions, latest identity, activation state separation, tenant scoping, lifecycle hooks, and in-memory/SQLite parity. |
 | `022-policy-application-summaries` | Landed | Pure host-facing summaries for policy application and pruning application results with deterministic status counts, completion booleans, affected target counts, diagnostic counts, and no storage or reporting framework. |
 | `023-batch-version-history` | Landed | Explicit batch version history inspection for selected resource IDs with first-seen distinct ordering, tenant scoping, missing-resource histories, SQLite parity, and no storage or query-surface expansion. |
+| `024-version-history-summaries` | Landed | Pure host-facing summaries for single and batch version history results with deterministic version-state counts, selected/missing resource counts, lifecycle state counts, and no storage, provider, service, query planner, policy evaluation, or reporting infrastructure. |
 
 ## Near-Term Roadmap
 
-### 024 — Version History Summaries
+### 025 — Operational Hardening
 
-**Status:** In progress on `024-version-history-summaries`.
+**Status:** In progress on `025-operational-hardening`.
 
-**Goal:** Give hosts deterministic summary views over single and batch version history result objects.
+**Goal:** Add bounded retry and concurrency-sensitive regression coverage for recent Phase 5 workflows.
 
 Scope:
 
-- Summarize one resource history with total/latest/draft/active/protected/candidate counts and lifecycle state counts.
-- Summarize batch history results with selected-resource, resources-with-versions, missing-resource, total-version, and version-state counts.
-- Keep summaries as pure SDK helpers over existing result objects.
-- Keep storage, providers, services, audit persistence, automatic jobs, public SQL, public `IQueryable<Resource>`, query planners, policy evaluation, and reporting infrastructure out of scope.
+- Verify lifecycle restore retries and same-candidate concurrent restores leave marker state clear and deterministic.
+- Verify policy pruning retries report already-pruned behavior and do not remove additional versions.
+- Verify SQLite persisted pruning retries remain safe after provider reopen.
+- Verify repeated historical activation keeps active versions unique/ordered and latest version identity unchanged.
+- Keep new product APIs, storage schema changes, providers, schedulers, benchmark infrastructure, public SQL, public `IQueryable<Resource>`, and dependencies out of scope.
 
-### 025 — Next Bounded Phase 5 Slice
+### 026 — Next Bounded Phase 5 Slice
 
-**Goal:** Choose one small continuation slice after version history summaries land.
+**Goal:** Choose one small continuation slice after operational hardening lands.
 
 Candidate scope:
 

--- a/specs/025-operational-hardening/checklists/requirements.md
+++ b/specs/025-operational-hardening/checklists/requirements.md
@@ -1,0 +1,34 @@
+# Specification Quality Checklist: Operational Hardening
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-05-30
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Validation complete. The feature is ready for planning.

--- a/specs/025-operational-hardening/contracts/operational-hardening.md
+++ b/specs/025-operational-hardening/contracts/operational-hardening.md
@@ -1,0 +1,43 @@
+# Contract: Operational Hardening
+
+Operational hardening is delivered as regression coverage over existing public SDK behavior.
+
+## Expected Behavior
+
+Lifecycle restore:
+
+- Applying the same valid restore candidate after the marker is cleared reports already-restored behavior.
+- Concurrent same-candidate restore attempts leave the lifecycle marker cleared.
+
+Policy pruning application:
+
+- Retrying the same pruned target reports already-pruned behavior.
+- Retry does not remove latest, active, or unrelated versions.
+- SQLite persisted state preserves retry behavior after provider reopen.
+
+Historical activation:
+
+- Repeating single-active historical activation leaves exactly one active version for the channel.
+- Repeating multi-active historical activation leaves active versions unique and ordered.
+- Latest version remains separate from activation state.
+
+## Non-Goals
+
+This slice does not add:
+
+- new public APIs;
+- storage schema changes;
+- provider registries or provider extensions;
+- public SQL or public `IQueryable<Resource>`;
+- runtime scanning or automatic discovery;
+- schedulers, background jobs, benchmark infrastructure, audit persistence, or new dependencies.
+
+## Validation Contract
+
+The slice is complete when:
+
+- focused operational hardening tests pass;
+- full solution tests pass;
+- build passes;
+- whitespace check passes;
+- roadmap marks `024-version-history-summaries` landed and `025-operational-hardening` active.

--- a/specs/025-operational-hardening/data-model.md
+++ b/specs/025-operational-hardening/data-model.md
@@ -1,0 +1,60 @@
+# Data Model: Operational Hardening
+
+## Restore Retry Scenario
+
+Represents applying the same restore candidate more than once.
+
+Fields:
+
+- Resource identifier.
+- Expected lifecycle marker state.
+- Effective tenant.
+- Application result statuses.
+- Final lifecycle marker state.
+
+Rules:
+
+- First successful restore clears the marker.
+- Retry observes already-restored behavior.
+- Concurrent same-candidate calls leave the marker cleared and do not recreate marker state.
+
+## Pruning Retry Scenario
+
+Represents applying the same version-pruning candidate more than once.
+
+Fields:
+
+- Resource identifier.
+- Target resource version.
+- Effective tenant.
+- Application result statuses.
+- Remaining version list.
+
+Rules:
+
+- First successful pruning removes only the target version.
+- Retry observes already-pruned behavior.
+- Remaining versions are unchanged by retry.
+
+## Historical Activation Retry Scenario
+
+Represents activating the same existing resource version more than once.
+
+Fields:
+
+- Resource identifier.
+- Target version.
+- Channel.
+- Multi-active setting.
+- Active version list.
+- Latest version.
+
+Rules:
+
+- Single-active retry leaves one active version.
+- Multi-active retry leaves a unique ordered active version list.
+- Latest version remains the highest saved version and is not rewritten by activation.
+
+## State Transitions
+
+No new state transitions are introduced. Tests exercise existing restore, pruning, and activation transitions.

--- a/specs/025-operational-hardening/plan.md
+++ b/specs/025-operational-hardening/plan.md
@@ -1,0 +1,112 @@
+# Implementation Plan: Operational Hardening
+
+**Branch**: `025-operational-hardening` | **Date**: 2026-05-30 | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from `/specs/025-operational-hardening/spec.md`
+
+## Summary
+
+Add targeted operational hardening coverage around retry and concurrency-sensitive Phase 5 workflows: lifecycle restore, policy pruning application, and repeated historical activation. The slice is test-first and does not add product APIs, storage schema changes, provider registries, background jobs, schedulers, benchmark infrastructure, or dependencies. If tests expose a bug, fixes must be narrowly scoped to existing behavior.
+
+## Technical Context
+
+**Language/Version**: C# latest, .NET 8.0 / 9.0 / 10.0 multi-targeting
+**Primary Dependencies**: Existing core SDK, in-memory store, SQLite JSON provider, lifecycle restore service, policy pruning application service, historical activation path, xUnit test stack; no new dependencies
+**Storage**: Existing resource version, activation state, and lifecycle marker storage only. No schema migration, data rewrite, persisted test artifacts, or physical index changes.
+**Testing**: `dotnet test Aster.sln`, focused operational hardening tests, existing lifecycle/policy/versioning/SQLite regression tests, `dotnet build Aster.sln /m:1`, `git diff --check`
+**Target Platform**: .NET SDK/library consumers and local test environment
+**Project Type**: SDK/library with provider packages and tests
+**Performance Goals**: Hardening tests remain bounded to small explicit fixtures and do not introduce benchmark infrastructure.
+**Constraints**: Test-focused slice; deterministic explicit resources/tenants/channels; final state assertions required; no new product APIs, storage schema changes, provider registries, public SQL, public `IQueryable<Resource>`, runtime scanning, automatic discovery, schedulers, background jobs, benchmark infrastructure, or dependencies.
+**Scale/Scope**: One focused operational test file, possible narrow bug fix if needed, roadmap/agent housekeeping, and Spec Kit artifacts.
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+- **SDK-first/headless**: PASS - Adds tests and docs only unless a narrow SDK bug is exposed.
+- **Immutable versioning**: PASS - Hardening asserts version pruning and activation invariants without rewriting versions.
+- **Channel activation**: PASS - Activation state remains separate; tests verify repeat activation behavior.
+- **Typed/queryable**: PASS - Query APIs remain unchanged; no public SQL or `IQueryable` is introduced.
+- **Provider agnostic**: PASS - Core behavior remains provider-agnostic; SQLite tests validate provider parity through existing abstractions.
+- **Simplicity first**: PASS - Focused regression tests are simpler than infrastructure or framework changes.
+- **Modern C# idioms**: PASS - Tests use existing xUnit async patterns and collection expressions.
+- **Readability over cleverness**: PASS - Scenarios are explicit and state-based.
+- **Explicitness over magic**: PASS - Fixtures name resource IDs, candidates, tenants, and channels explicitly.
+- **Abstractions justified**: PASS - No new abstraction is planned.
+- **Optimize for deletion**: PASS - Tests and docs can be removed without runtime cleanup.
+- **Composition over inheritance**: PASS - No inheritance changes.
+- **Intentional dependencies**: PASS - No new dependencies.
+- **Operational simplicity**: PASS - No runtime setup, storage, worker, or deployment change.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/025-operational-hardening/
++-- spec.md
++-- plan.md
++-- research.md
++-- data-model.md
++-- quickstart.md
++-- checklists/
+|   +-- requirements.md
++-- contracts/
+    +-- operational-hardening.md
+```
+
+### Source Code (repository root)
+
+```text
+test/
++-- Aster.Tests/
+    +-- Operational/
+        +-- OperationalHardeningTests.cs
+
+src/
++-- core/Aster.Core/
+|   +-- no planned product changes
++-- persistence/Aster.Persistence.SqliteJson/
+    +-- no planned provider changes
+```
+
+**Structure Decision**: Place hardening coverage under `test/Aster.Tests/Operational/` because these scenarios cross lifecycle, policy, versioning, and provider boundaries. Keep production code untouched unless a test exposes a real existing-behavior bug.
+
+## Complexity Tracking
+
+No constitution violations.
+
+## Phase 0 Research Summary
+
+Research decisions are captured in [research.md](research.md). Key outcomes:
+
+- Use focused xUnit regression tests, not benchmark or stress infrastructure.
+- Cover both retry and one bounded concurrent restore scenario.
+- Cover pruning retry in memory and persisted SQLite state.
+- Cover repeated historical activation for single-active and multi-active modes.
+- Keep roadmap housekeeping in the same feature PR.
+
+## Phase 1 Design Summary
+
+Design artifacts:
+
+- [data-model.md](data-model.md)
+- [contracts/operational-hardening.md](contracts/operational-hardening.md)
+- [quickstart.md](quickstart.md)
+
+## Post-Design Constitution Check
+
+- **SDK-first/headless**: PASS - No UI or host-specific runtime is introduced.
+- **Immutable versioning**: PASS - Tests assert immutable/latest invariants.
+- **Channel activation**: PASS - Tests assert activation state behavior through existing manager APIs.
+- **Typed/queryable**: PASS - Query surface remains unchanged.
+- **Provider agnostic**: PASS - Provider parity is validated through existing abstractions.
+- **Simplicity first**: PASS - No new infrastructure or framework is introduced.
+- **Modern C# idioms**: PASS - Uses direct async xUnit tests.
+- **Readability over cleverness**: PASS - Tests are explicit and state-based.
+- **Explicitness over magic**: PASS - No discovery or ambient state.
+- **Abstractions justified**: PASS - No new abstraction.
+- **Optimize for deletion**: PASS - Additive tests and docs only.
+- **Composition over inheritance**: PASS - No inheritance.
+- **Intentional dependencies**: PASS - No new dependencies.
+- **Operational simplicity**: PASS - Existing commands validate the slice.

--- a/specs/025-operational-hardening/quickstart.md
+++ b/specs/025-operational-hardening/quickstart.md
@@ -1,0 +1,22 @@
+# Quickstart: Operational Hardening
+
+Run the focused hardening tests:
+
+```bash
+dotnet test Aster.sln --filter "FullyQualifiedName~OperationalHardeningTests"
+```
+
+Run the full validation suite:
+
+```bash
+dotnet test Aster.sln
+dotnet build Aster.sln /m:1
+git diff --check
+```
+
+Expected outcome:
+
+- Restore retries leave markers cleared.
+- Pruning retries leave only the selected version removed.
+- Repeated historical activation leaves active channels unique and latest versions unchanged.
+- No new storage, provider, scheduler, query, or dependency behavior is introduced.

--- a/specs/025-operational-hardening/research.md
+++ b/specs/025-operational-hardening/research.md
@@ -1,0 +1,52 @@
+# Research: Operational Hardening
+
+## Focused Regression Tests Over Stress Infrastructure
+
+Decision: Add bounded xUnit regression tests instead of benchmark, load, or stress-test infrastructure.
+
+Rationale: The current need is confidence in recently added Phase 5 workflows. Focused tests are deterministic, cheap to run locally, and consistent with operational simplicity.
+
+Alternatives considered:
+
+- Add benchmark suite: rejected because it adds infrastructure and timing concerns without a measured performance requirement.
+- Add randomized concurrency tests: rejected because nondeterminism would reduce reliability.
+- Add background job simulation: rejected because schedulers and jobs are out of scope.
+
+## Restore Retry And Concurrent Same-Candidate Coverage
+
+Decision: Cover lifecycle restore retry plus one bounded concurrent same-candidate restore scenario.
+
+Rationale: Restore is recovery-oriented and safe retry semantics matter operationally. The concurrent scenario verifies the existing clear-if-state-matches behavior remains safe when two callers race the same marker.
+
+Alternatives considered:
+
+- Cover every marker state and provider combination: rejected as too broad; existing tests cover marker state/provider basics.
+- Add locking to the service preemptively: rejected unless tests expose a bug.
+
+## Pruning Retry Coverage
+
+Decision: Cover in-memory retry and SQLite persisted retry for the same pruning candidate.
+
+Rationale: Pruning is destructive. Retrying the same target should report already-pruned behavior and must not delete additional versions after the original target is gone.
+
+Alternatives considered:
+
+- Add concurrent pruning tests: deferred because destructive concurrent writes can be provider timing-sensitive and need a separate design if broadened.
+- Add audit records for pruning retries: rejected because persistence/audit is out of scope.
+
+## Repeated Historical Activation Coverage
+
+Decision: Cover repeated activation for single-active and multi-active channels.
+
+Rationale: Hosts may retry activation calls after transient failures. Active version lists should remain unique and ordered, while latest version identity remains separate from activation state.
+
+Alternatives considered:
+
+- Add new idempotency result models: rejected because existing activation APIs are command-style and no product behavior change is requested.
+- Add activation concurrency tests: deferred to a deeper concurrency slice if needed.
+
+## Out-Of-Scope Boundaries
+
+Decision: Do not add new APIs, storage schema changes, provider registries, public SQL, public `IQueryable<Resource>`, runtime scanning, automatic discovery, schedulers, background jobs, benchmark infrastructure, or dependencies.
+
+Rationale: This is a hardening slice. Any runtime change should be justified by a failing deterministic regression test.

--- a/specs/025-operational-hardening/spec.md
+++ b/specs/025-operational-hardening/spec.md
@@ -1,0 +1,95 @@
+# Feature Specification: Operational Hardening
+
+**Feature Branch**: `025-operational-hardening`
+**Created**: 2026-05-30
+**Status**: Draft
+**Input**: Proceed with housekeeping, then the next recommended bounded candidate: operational hardening.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Retry Restore Safely (Priority: P1)
+
+As a host developer, I want lifecycle restore application to remain deterministic when the same selected restore candidate is retried or raced so that operational retries do not recreate markers or produce ambiguous state.
+
+**Why this priority**: Restore is a host-controlled recovery workflow and should remain safe under common retry behavior.
+
+**Independent Test**: Apply a marker, restore it, retry the same restore, and run two same-candidate restores concurrently; verify terminal statuses and final marker state.
+
+**Acceptance Scenarios**:
+
+1. **Given** an archived resource marker, **When** restore is applied twice with the same candidate, **Then** the first result reports restored, the retry reports already restored, and the marker remains cleared.
+2. **Given** an archived resource marker, **When** two identical restore applications run concurrently, **Then** exactly one result restores, the other observes already-restored or equivalent safe terminal state, and the marker remains cleared.
+
+---
+
+### User Story 2 - Retry Pruning Safely (Priority: P2)
+
+As a host developer, I want version pruning application to be retry-safe so that destructive maintenance jobs can retry the same selected target without deleting additional versions.
+
+**Why this priority**: Pruning is destructive and already has safety preflight; retry behavior should be pinned down.
+
+**Independent Test**: Prune one eligible historical draft version, retry the same candidate, and verify only the selected version is removed.
+
+**Acceptance Scenarios**:
+
+1. **Given** a resource with an eligible historical draft version, **When** pruning is applied then retried for the same target, **Then** the first result reports pruned, the retry reports already pruned, and remaining versions are unchanged by the retry.
+2. **Given** SQLite-backed resources, **When** pruning is retried after reopening the provider, **Then** persisted state reports already pruned and does not remove additional rows.
+
+---
+
+### User Story 3 - Repeat Historical Activation Predictably (Priority: P3)
+
+As a host developer, I want repeated historical activation requests to be deterministic so that retrying activation does not duplicate active versions or change latest version state.
+
+**Why this priority**: Historical activation is a core advanced-versioning operation and should remain stable under host retries.
+
+**Independent Test**: Activate the same historical version repeatedly in single-active and multi-active modes and verify active channels contain deterministic unique versions while latest remains unchanged.
+
+**Acceptance Scenarios**:
+
+1. **Given** a resource with two versions, **When** the same historical version is activated twice in single-active mode, **Then** the active channel contains that version once and latest remains the highest saved version.
+2. **Given** a resource with multiple versions, **When** the same historical version is activated twice with multi-active enabled, **Then** the active channel contains unique ordered versions and latest remains unchanged.
+
+### Edge Cases
+
+- Hardening MUST focus on targeted regression coverage before product changes.
+- Tests MUST be deterministic and bounded to explicit resources and tenants.
+- Retry and concurrency-sensitive tests MUST assert final persisted state, not only result statuses.
+- If a hardening test exposes a bug, the fix MUST remain narrowly scoped to existing behavior.
+- The slice MUST NOT introduce new public product behavior, storage schema changes, provider registries, public SQL, public `IQueryable<Resource>`, runtime scanning, automatic discovery, schedulers, background jobs, benchmark infrastructure, or new dependencies.
+
+### Constitution Alignment *(mandatory)*
+
+- **Simplicity**: Add focused regression coverage and only fix bugs exposed by that coverage.
+- **Explicitness**: Tests use explicit resources, tenants, candidates, and channels.
+- **Dependencies**: None.
+- **Operational Impact**: No runtime setup, storage, deployment, or observability changes.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The system MUST include retry coverage for lifecycle restore application over existing in-memory behavior.
+- **FR-002**: The system MUST include concurrency-sensitive same-candidate restore coverage that verifies safe terminal statuses and final marker state.
+- **FR-003**: The system MUST include retry coverage for policy pruning application over existing in-memory behavior.
+- **FR-004**: The system MUST include persisted SQLite retry coverage for policy pruning application.
+- **FR-005**: The system MUST include repeated historical activation coverage for single-active channels.
+- **FR-006**: The system MUST include repeated historical activation coverage for multi-active channels.
+- **FR-007**: The system MUST verify final resource, marker, activation, or version state after each hardening scenario.
+- **FR-008**: The system MUST update roadmap housekeeping so `024-version-history-summaries` is listed as landed and `025-operational-hardening` is the active slice.
+- **FR-009**: The system MUST NOT introduce new product APIs, storage schema changes, provider registries, public SQL, public `IQueryable<Resource>`, runtime scanning, automatic discovery, schedulers, benchmark infrastructure, or dependencies.
+
+### Key Entities
+
+- **Restore Retry Scenario**: Existing restore candidate applied more than once or concurrently.
+- **Pruning Retry Scenario**: Existing pruning candidate applied more than once.
+- **Historical Activation Retry Scenario**: Existing version activation repeated for the same channel.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Restore retry tests prove final lifecycle marker state is cleared after repeated and concurrent same-candidate restore attempts.
+- **SC-002**: Pruning retry tests prove only the originally selected resource version is removed and retries report already-pruned behavior.
+- **SC-003**: Historical activation retry tests prove active version lists remain unique and ordered while latest version identity is unchanged.
+- **SC-004**: The full test suite passes without introducing new dependencies, storage migrations, or product APIs.

--- a/specs/025-operational-hardening/tasks.md
+++ b/specs/025-operational-hardening/tasks.md
@@ -1,0 +1,56 @@
+# Tasks: Operational Hardening
+
+**Input**: Design documents from `/specs/025-operational-hardening/`
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/
+
+**Tests**: This slice is test-focused. Add production fixes only if deterministic tests expose a bug.
+
+## Phase 1: Setup
+
+- [X] T001 Review lifecycle restore fixtures and tests in `test/Aster.Tests/Lifecycle/`
+- [X] T002 [P] Review policy pruning fixtures and SQLite tests in `test/Aster.Tests/Policies/` and `test/Aster.Tests/SqliteJson/`
+- [X] T003 [P] Review historical activation tests in `test/Aster.Tests/InMemory/` and `test/Aster.Tests/Tenancy/`
+
+## Phase 2: Foundational
+
+- [X] T004 Create operational hardening test file in `test/Aster.Tests/Operational/OperationalHardeningTests.cs`
+- [X] T005 Add shared fixture helpers for in-memory and SQLite scenarios in `test/Aster.Tests/Operational/OperationalHardeningTests.cs`
+
+## Phase 3: User Story 1 - Retry Restore Safely (P1)
+
+- [X] T006 [US1] Add repeated restore retry test in `test/Aster.Tests/Operational/OperationalHardeningTests.cs`
+- [X] T007 [US1] Add concurrent same-candidate restore test in `test/Aster.Tests/Operational/OperationalHardeningTests.cs`
+
+## Phase 4: User Story 2 - Retry Pruning Safely (P2)
+
+- [X] T008 [US2] Add in-memory pruning retry test in `test/Aster.Tests/Operational/OperationalHardeningTests.cs`
+- [X] T009 [US2] Add SQLite persisted pruning retry test in `test/Aster.Tests/Operational/OperationalHardeningTests.cs`
+
+## Phase 5: User Story 3 - Repeat Historical Activation Predictably (P3)
+
+- [X] T010 [US3] Add repeated single-active historical activation test in `test/Aster.Tests/Operational/OperationalHardeningTests.cs`
+- [X] T011 [US3] Add repeated multi-active historical activation test in `test/Aster.Tests/Operational/OperationalHardeningTests.cs`
+
+## Phase 6: Polish
+
+- [X] T012 Update roadmap housekeeping in `docs/ExecutionRoadmap.md`
+- [X] T013 Update `AGENTS.md` recent changes for `025-operational-hardening`
+- [X] T014 Run focused hardening tests with `dotnet test Aster.sln --filter "FullyQualifiedName~OperationalHardeningTests"`
+- [X] T015 Run `dotnet test Aster.sln`
+- [X] T016 Run `dotnet build Aster.sln /m:1`
+- [X] T017 Run `git diff --check`
+- [X] T018 Re-check constitution constraints and keep production changes absent unless tests require a bug fix
+
+## Dependencies & Execution Order
+
+- Setup tasks precede test implementation.
+- Restore hardening can run independently.
+- Pruning hardening can run independently after shared fixtures.
+- Activation hardening can run independently after shared fixtures.
+- Polish follows focused tests.
+
+## Notes
+
+- Keep tests bounded and deterministic.
+- Assert final state, not only result statuses.
+- Do not introduce new APIs, storage schema changes, providers, schedulers, benchmark infrastructure, or dependencies.

--- a/test/Aster.Tests/Operational/OperationalHardeningTests.cs
+++ b/test/Aster.Tests/Operational/OperationalHardeningTests.cs
@@ -1,0 +1,164 @@
+using Aster.Core.Abstractions;
+using Aster.Core.Extensions;
+using Aster.Core.Models.Instances;
+using Aster.Core.Models.Policies;
+using Aster.Tests.Lifecycle;
+using Aster.Tests.Policies;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Aster.Tests.Operational;
+
+public sealed class OperationalHardeningTests : IDisposable
+{
+    private readonly List<string> sqliteDatabasePaths = [];
+
+    public void Dispose()
+    {
+        foreach (var databasePath in sqliteDatabasePaths)
+            PolicyTestFixtures.DeleteSqliteFiles(databasePath);
+    }
+
+    [Fact]
+    public async Task RestoreAsync_RetryReportsAlreadyRestoredAndLeavesMarkerCleared()
+    {
+        using var provider = LifecycleRestoreTestFixtures.CreateCoreProvider();
+        await LifecycleRestoreTestFixtures.SaveProductAsync(provider, "retry-restore");
+        await LifecycleRestoreTestFixtures.MarkAsync(provider, "retry-restore", ResourceLifecycleMarkerState.Archived);
+        var restore = provider.GetRequiredService<IResourceLifecycleRestoreService>();
+
+        var first = await restore.RestoreAsync(RestoreRequest("retry-restore", ResourceLifecycleMarkerState.Archived));
+        var retry = await restore.RestoreAsync(RestoreRequest("retry-restore", ResourceLifecycleMarkerState.Archived));
+
+        Assert.Equal(1, first.RestoredCount);
+        Assert.Equal(1, retry.AlreadyRestoredCount);
+        Assert.Null(await LifecycleRestoreTestFixtures.ReadMarkerAsync(provider, "retry-restore"));
+    }
+
+    [Fact]
+    public async Task RestoreAsync_ConcurrentSameCandidateLeavesMarkerCleared()
+    {
+        using var provider = LifecycleRestoreTestFixtures.CreateCoreProvider();
+        await LifecycleRestoreTestFixtures.SaveProductAsync(provider, "concurrent-restore");
+        await LifecycleRestoreTestFixtures.MarkAsync(provider, "concurrent-restore", ResourceLifecycleMarkerState.Archived);
+        var restore = provider.GetRequiredService<IResourceLifecycleRestoreService>();
+
+        var results = await Task.WhenAll(
+            restore.RestoreAsync(RestoreRequest("concurrent-restore", ResourceLifecycleMarkerState.Archived)).AsTask(),
+            restore.RestoreAsync(RestoreRequest("concurrent-restore", ResourceLifecycleMarkerState.Archived)).AsTask());
+
+        Assert.Equal(1, results.Sum(static result => result.RestoredCount));
+        Assert.Equal(1, results.Sum(static result => result.AlreadyRestoredCount));
+        Assert.Null(await LifecycleRestoreTestFixtures.ReadMarkerAsync(provider, "concurrent-restore"));
+    }
+
+    [Fact]
+    public async Task PruningApplication_RetryReportsAlreadyPrunedAndDoesNotRemoveAdditionalVersions()
+    {
+        using var provider = PolicyTestFixtures.CreateCoreProvider();
+        await RegisterPrunableResourceAsync(provider, "retry-prune");
+        var pruning = provider.GetRequiredService<IResourcePolicyPruningApplicationService>();
+
+        var first = await pruning.ApplyAsync(PruningRequest("retry-prune", resourceVersion: 1));
+        var retry = await pruning.ApplyAsync(PruningRequest("retry-prune", resourceVersion: 1));
+
+        Assert.Equal(1, first.PrunedCount);
+        Assert.Equal(1, retry.AlreadyPrunedCount);
+        Assert.Equal([2, 3], (await PolicyTestFixtures.ReadVersionsAsync(provider, "retry-prune")).Select(static version => version.Version).ToList());
+    }
+
+    [Fact]
+    public async Task PruningApplication_SqliteRetryAfterReopenReportsAlreadyPruned()
+    {
+        var databasePath = NewSqliteDatabasePath("aster-hardening-prune");
+        await using (var provider = PolicyTestFixtures.CreateSqliteProvider(databasePath))
+        {
+            await RegisterPrunableResourceAsync(provider, "persisted-prune");
+
+            var first = await provider.GetRequiredService<IResourcePolicyPruningApplicationService>().ApplyAsync(
+                PruningRequest("persisted-prune", resourceVersion: 1));
+
+            Assert.Equal(1, first.PrunedCount);
+        }
+
+        await using var secondProvider = PolicyTestFixtures.CreateSqliteProvider(databasePath);
+
+        var retry = await secondProvider.GetRequiredService<IResourcePolicyPruningApplicationService>().ApplyAsync(
+            PruningRequest("persisted-prune", resourceVersion: 1));
+
+        Assert.Equal(1, retry.AlreadyPrunedCount);
+        Assert.Equal([2, 3], (await PolicyTestFixtures.ReadVersionsAsync(secondProvider, "persisted-prune")).Select(static version => version.Version).ToList());
+    }
+
+    [Fact]
+    public async Task HistoricalActivation_SingleActiveRetryLeavesOneActiveVersionAndLatestUnchanged()
+    {
+        using var provider = new ServiceCollection().AddAsterCore().BuildServiceProvider();
+        var manager = provider.GetRequiredService<IResourceManager>();
+        var v1 = await manager.CreateAsync("Product", new CreateResourceRequest());
+        var v2 = await manager.UpdateAsync(v1.ResourceId, new UpdateResourceRequest { BaseVersion = v1.Version });
+
+        await manager.ActivateAsync(v1.ResourceId, v1.Version, "Published");
+        await manager.ActivateAsync(v1.ResourceId, v1.Version, "Published");
+
+        var active = (await manager.GetActiveVersionsAsync(v1.ResourceId, "Published")).ToList();
+        var latest = await manager.GetLatestVersionAsync(v1.ResourceId);
+
+        Assert.Equal([v1.Version], active.Select(static version => version.Version).ToList());
+        Assert.NotNull(latest);
+        Assert.Equal(v2.Version, latest.Version);
+    }
+
+    [Fact]
+    public async Task HistoricalActivation_MultiActiveRetryLeavesUniqueOrderedActiveVersionsAndLatestUnchanged()
+    {
+        using var provider = new ServiceCollection().AddAsterCore().BuildServiceProvider();
+        var manager = provider.GetRequiredService<IResourceManager>();
+        var v1 = await manager.CreateAsync("Product", new CreateResourceRequest());
+        var v2 = await manager.UpdateAsync(v1.ResourceId, new UpdateResourceRequest { BaseVersion = v1.Version });
+        var v3 = await manager.UpdateAsync(v1.ResourceId, new UpdateResourceRequest { BaseVersion = v2.Version });
+
+        await manager.ActivateAsync(v1.ResourceId, v2.Version, "Preview", allowMultipleActive: true);
+        await manager.ActivateAsync(v1.ResourceId, v1.Version, "Preview", allowMultipleActive: true);
+        await manager.ActivateAsync(v1.ResourceId, v1.Version, "Preview", allowMultipleActive: true);
+
+        var active = (await manager.GetActiveVersionsAsync(v1.ResourceId, "Preview")).ToList();
+        var latest = await manager.GetLatestVersionAsync(v1.ResourceId);
+
+        Assert.Equal([v1.Version, v2.Version], active.Select(static version => version.Version).ToList());
+        Assert.NotNull(latest);
+        Assert.Equal(v3.Version, latest.Version);
+    }
+
+    private static ResourceLifecycleRestoreRequest RestoreRequest(
+        string resourceId,
+        ResourceLifecycleMarkerState expectedState) =>
+        new()
+        {
+            Candidates = [LifecycleRestoreTestFixtures.Candidate(resourceId, expectedState)],
+        };
+
+    private static ResourcePolicyPruningApplicationRequest PruningRequest(
+        string resourceId,
+        int resourceVersion) =>
+        new()
+        {
+            Candidates = [PolicyTestFixtures.PruningCandidate(resourceId, resourceVersion)],
+        };
+
+    private static async Task RegisterPrunableResourceAsync(
+        IServiceProvider provider,
+        string resourceId)
+    {
+        await PolicyTestFixtures.RegisterProductDefinitionAsync(provider, policies: [PolicyTestFixtures.PruningPolicy(retainedVersions: 2)]);
+        await PolicyTestFixtures.SaveResourceAsync(provider, resourceId, version: 1);
+        await PolicyTestFixtures.SaveResourceAsync(provider, resourceId, version: 2);
+        await PolicyTestFixtures.SaveResourceAsync(provider, resourceId, version: 3);
+    }
+
+    private string NewSqliteDatabasePath(string prefix)
+    {
+        var databasePath = Path.Combine(Path.GetTempPath(), $"{prefix}-{Guid.NewGuid():N}.db");
+        sqliteDatabasePaths.Add(databasePath);
+        return databasePath;
+    }
+}

--- a/test/Aster.Tests/Operational/OperationalHardeningTests.cs
+++ b/test/Aster.Tests/Operational/OperationalHardeningTests.cs
@@ -2,6 +2,8 @@ using Aster.Core.Abstractions;
 using Aster.Core.Extensions;
 using Aster.Core.Models.Instances;
 using Aster.Core.Models.Policies;
+using Aster.Core.Models.Tenancy;
+using Aster.Core.Services;
 using Aster.Tests.Lifecycle;
 using Aster.Tests.Policies;
 using Microsoft.Extensions.DependencyInjection;
@@ -40,7 +42,10 @@ public sealed class OperationalHardeningTests : IDisposable
         using var provider = LifecycleRestoreTestFixtures.CreateCoreProvider();
         await LifecycleRestoreTestFixtures.SaveProductAsync(provider, "concurrent-restore");
         await LifecycleRestoreTestFixtures.MarkAsync(provider, "concurrent-restore", ResourceLifecycleMarkerState.Archived);
-        var restore = provider.GetRequiredService<IResourceLifecycleRestoreService>();
+        var markerStore = new CoordinatedMarkerClearStore(provider.GetRequiredService<IResourceLifecycleMarkerClearStore>());
+        var restore = new ResourceLifecycleRestoreService(
+            provider.GetRequiredService<IResourceVersionReader>(),
+            markerStore);
 
         var results = await Task.WhenAll(
             restore.RestoreAsync(RestoreRequest("concurrent-restore", ResourceLifecycleMarkerState.Archived)).AsTask(),
@@ -48,6 +53,7 @@ public sealed class OperationalHardeningTests : IDisposable
 
         Assert.Equal(1, results.Sum(static result => result.RestoredCount));
         Assert.Equal(1, results.Sum(static result => result.AlreadyRestoredCount));
+        Assert.Equal(2, markerStore.ClearAttempts);
         Assert.Null(await LifecycleRestoreTestFixtures.ReadMarkerAsync(provider, "concurrent-restore"));
     }
 
@@ -160,5 +166,50 @@ public sealed class OperationalHardeningTests : IDisposable
         var databasePath = Path.Combine(Path.GetTempPath(), $"{prefix}-{Guid.NewGuid():N}.db");
         sqliteDatabasePaths.Add(databasePath);
         return databasePath;
+    }
+
+    private sealed class CoordinatedMarkerClearStore : IResourceLifecycleMarkerClearStore
+    {
+        private readonly IResourceLifecycleMarkerClearStore inner;
+        private readonly TaskCompletionSource bothClearAttemptsArrived = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        private int clearAttempts;
+
+        public CoordinatedMarkerClearStore(IResourceLifecycleMarkerClearStore inner)
+        {
+            ArgumentNullException.ThrowIfNull(inner);
+            this.inner = inner;
+        }
+
+        public int ClearAttempts => Volatile.Read(ref clearAttempts);
+
+        public ValueTask<ResourceLifecycleMarker?> GetMarkerAsync(
+            string resourceId,
+            TenantScope tenantScope,
+            CancellationToken cancellationToken = default) =>
+            inner.GetMarkerAsync(resourceId, tenantScope, cancellationToken);
+
+        public ValueTask<IReadOnlyDictionary<string, ResourceLifecycleMarker>> GetMarkersAsync(
+            IEnumerable<string> resourceIds,
+            TenantScope tenantScope,
+            CancellationToken cancellationToken = default) =>
+            inner.GetMarkersAsync(resourceIds, tenantScope, cancellationToken);
+
+        public ValueTask<ResourceLifecycleMarker> SaveMarkerAsync(
+            ResourceLifecycleMarker marker,
+            CancellationToken cancellationToken = default) =>
+            inner.SaveMarkerAsync(marker, cancellationToken);
+
+        public async ValueTask<bool> ClearMarkerAsync(
+            string resourceId,
+            TenantScope tenantScope,
+            ResourceLifecycleMarkerState expectedState,
+            CancellationToken cancellationToken = default)
+        {
+            if (Interlocked.Increment(ref clearAttempts) == 2)
+                bothClearAttemptsArrived.TrySetResult();
+
+            await bothClearAttemptsArrived.Task.WaitAsync(TimeSpan.FromSeconds(5), cancellationToken);
+            return await inner.ClearMarkerAsync(resourceId, tenantScope, expectedState, cancellationToken);
+        }
     }
 }


### PR DESCRIPTION
## Summary
- mark 024 as landed and move roadmap/agent context to 025 operational hardening
- add bounded retry/concurrency-sensitive regression coverage for lifecycle restore, policy pruning, SQLite persisted pruning retry, and repeated historical activation
- keep slice test-focused with no production code, storage schema, provider, scheduler, or dependency changes

## Validation
- dotnet test Aster.sln --filter "FullyQualifiedName~OperationalHardeningTests"
- dotnet test Aster.sln
- dotnet build Aster.sln /m:1
- git diff --check