### PR TITLE
Add lifecycle restore summaries

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "featureDir": "specs/025-operational-hardening"
+  "featureDir": "specs/026-lifecycle-restore-summaries"
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 <!-- SPECKIT START -->
 For additional context about technologies to be used, project structure,
-shell commands, and other important information, read `specs/025-operational-hardening/plan.md`.
+shell commands, and other important information, read `specs/026-lifecycle-restore-summaries/plan.md`.
 <!-- SPECKIT END -->
 
 ## Active Technologies
@@ -36,8 +36,11 @@ shell commands, and other important information, read `specs/025-operational-har
 - No storage changes. Summaries are pure in-memory views over existing result objects; no schema migration, persistence, provider storage, or physical index changes. (024-version-history-summaries)
 - C# latest, .NET 8.0 / 9.0 / 10.0 multi-targeting + Existing core SDK, in-memory store, SQLite JSON provider, lifecycle restore service, policy pruning application service, historical activation path, xUnit test stack; no new dependencies (025-operational-hardening)
 - Existing resource version, activation state, and lifecycle marker storage only. No schema migration, data rewrite, persisted test artifacts, or physical index changes. (025-operational-hardening)
+- C# latest, .NET 8.0 / 9.0 / 10.0 multi-targeting + Existing core SDK lifecycle restore models, policy diagnostic models, xUnit test stack; no new dependencies (026-lifecycle-restore-summaries)
+- No storage changes. Summaries are pure in-memory views over existing restore result objects; no schema migration, persistence, provider storage, audit records, or physical index changes. (026-lifecycle-restore-summaries)
 
 ## Recent Changes
+- 026-lifecycle-restore-summaries: Added pure host-facing lifecycle restore preview and application summaries with deterministic status counts, affected resource counts, diagnostic code counts, completion booleans, and no storage, provider, service registration, scheduler, audit persistence, public SQL, public IQueryable<Resource>, query planner, or mutation behavior
 - 025-operational-hardening: Added bounded operational hardening planning and test context for lifecycle restore retries, same-candidate restore races, policy pruning retries, persisted SQLite pruning retries, and repeated historical activation without new product APIs, storage schema changes, providers, schedulers, benchmark infrastructure, or dependencies
 - 024-version-history-summaries: Added pure host-facing summaries for single and batch version history results with deterministic version-state counts, selected/missing resource counts, lifecycle state counts, and no storage, provider, service, query planner, public SQL, public IQueryable<Resource>, policy evaluation, reporting infrastructure, or mutation behavior
 - 023-batch-version-history: Added explicit batch version history planning and implementation context for selected resource IDs with first-seen distinct ordering, tenant scoping, missing-resource histories, SQLite parity, and no storage migrations, query planner, provider registry, public SQL, public IQueryable<Resource>, runtime scanning, automatic discovery, or mutation behavior

--- a/docs/ExecutionRoadmap.md
+++ b/docs/ExecutionRoadmap.md
@@ -6,9 +6,9 @@ This roadmap tracks the implementation trail we have already cut through the rep
 
 ## Current Position
 
-Aster now has a working Core SDK, in-memory runtime, SQLite JSON persistence/querying, provider capability discovery, provider validation alignment, provider authoring ergonomics, a reusable provider conformance harness, SQLite facet sorting, portable operator expansion, SQLite date-like ranges, explicit provider-declared index projections, explicit definition schema upgrade behavior, deterministic portability primitives, explicit host lifecycle hooks, explicit tenant scoping, policy foundations, host-controlled policy application orchestration, host-controlled lifecycle restore workflows, host-controlled policy pruning application, read-only version history inspection, explicit historical version activation, policy application summaries, batch version history inspection, and version history summaries.
+Aster now has a working Core SDK, in-memory runtime, SQLite JSON persistence/querying, provider capability discovery, provider validation alignment, provider authoring ergonomics, a reusable provider conformance harness, SQLite facet sorting, portable operator expansion, SQLite date-like ranges, explicit provider-declared index projections, explicit definition schema upgrade behavior, deterministic portability primitives, explicit host lifecycle hooks, explicit tenant scoping, policy foundations, host-controlled policy application orchestration, host-controlled lifecycle restore workflows, host-controlled policy pruning application, read-only version history inspection, explicit historical version activation, policy application summaries, batch version history inspection, version history summaries, and operational hardening coverage.
 
-The Phase 4 core workstream is complete enough to defer optional recipes. The active workstream is now **Phase 5: Multi-tenancy, Policies, Advanced Versioning**. Explicit tenant-aware boundaries, policy foundations, policy application orchestration, reversible lifecycle restore, destructive pruning application, version history inspection, historical version activation, policy application summaries, batch version history inspection, and version history summaries have landed; operational hardening is the current bounded confidence slice.
+The Phase 4 core workstream is complete enough to defer optional recipes. The active workstream is now **Phase 5: Multi-tenancy, Policies, Advanced Versioning**. Explicit tenant-aware boundaries, policy foundations, policy application orchestration, reversible lifecycle restore, destructive pruning application, version history inspection, historical version activation, policy application summaries, batch version history inspection, version history summaries, and operational hardening have landed; lifecycle restore summaries are the current bounded host-reporting slice.
 
 ## Landed Slices
 
@@ -38,31 +38,30 @@ The Phase 4 core workstream is complete enough to defer optional recipes. The ac
 | `022-policy-application-summaries` | Landed | Pure host-facing summaries for policy application and pruning application results with deterministic status counts, completion booleans, affected target counts, diagnostic counts, and no storage or reporting framework. |
 | `023-batch-version-history` | Landed | Explicit batch version history inspection for selected resource IDs with first-seen distinct ordering, tenant scoping, missing-resource histories, SQLite parity, and no storage or query-surface expansion. |
 | `024-version-history-summaries` | Landed | Pure host-facing summaries for single and batch version history results with deterministic version-state counts, selected/missing resource counts, lifecycle state counts, and no storage, provider, service, query planner, policy evaluation, or reporting infrastructure. |
+| `025-operational-hardening` | Landed | Bounded retry and concurrency-sensitive coverage for lifecycle restore, policy pruning retries, SQLite persisted pruning retries, and repeated historical activation without new product APIs, storage schema changes, schedulers, benchmark infrastructure, or dependencies. |
 
 ## Near-Term Roadmap
 
-### 025 — Operational Hardening
+### 026 — Lifecycle Restore Summaries
 
-**Status:** In progress on `025-operational-hardening`.
+**Status:** In progress on `026-lifecycle-restore-summaries`.
 
-**Goal:** Add bounded retry and concurrency-sensitive regression coverage for recent Phase 5 workflows.
+**Goal:** Add pure host-facing summaries for lifecycle restore preview and application results.
 
 Scope:
 
-- Verify lifecycle restore retries and same-candidate concurrent restores leave marker state clear and deterministic.
-- Verify policy pruning retries report already-pruned behavior and do not remove additional versions.
-- Verify SQLite persisted pruning retries remain safe after provider reopen.
-- Verify repeated historical activation keeps active versions unique/ordered and latest version identity unchanged.
-- Keep new product APIs, storage schema changes, providers, schedulers, benchmark infrastructure, public SQL, public `IQueryable<Resource>`, and dependencies out of scope.
+- Summarize restore application results with deterministic restored, already-restored, skipped, failed, affected-resource, and diagnostic-code counts.
+- Summarize restore preview results with deterministic restorable, already-restored, skipped, failed, candidate-resource, and diagnostic-code counts.
+- Preserve pure transformation behavior over existing result objects with no service registration, provider access, storage changes, audit persistence, schedulers, public SQL, public `IQueryable<Resource>`, or mutation behavior.
 
-### 026 — Next Bounded Phase 5 Slice
+### 027 — Next Bounded Phase 5 Slice
 
-**Goal:** Choose one small continuation slice after operational hardening lands.
+**Goal:** Choose one small continuation slice after lifecycle restore summaries land.
 
 Candidate scope:
 
 - Advanced versioning follow-up only if it stays explicit, append-only, and provider-agnostic.
-- A deliberately bounded policy follow-up, such as reporting or audit-oriented application summaries, only after a separate spec defines exact host value.
+- A deliberately bounded policy or lifecycle follow-up, such as reporting or audit-oriented operation views, only after a separate spec defines exact host value.
 - Tenant extension behavior, such as shared definitions or administrative workflows, only if the boundaries stay explicit.
 - Bounded operational hardening such as targeted benchmarks, migration idempotency checks, or concurrency stress tests.
 

--- a/specs/026-lifecycle-restore-summaries/checklists/requirements.md
+++ b/specs/026-lifecycle-restore-summaries/checklists/requirements.md
@@ -1,0 +1,34 @@
+# Specification Quality Checklist: Lifecycle Restore Summaries
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-05-30
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Specification is ready for planning.

--- a/specs/026-lifecycle-restore-summaries/contracts/lifecycle-restore-summaries.md
+++ b/specs/026-lifecycle-restore-summaries/contracts/lifecycle-restore-summaries.md
@@ -1,0 +1,51 @@
+# Contract: Lifecycle Restore Summaries
+
+## Public SDK Behavior
+
+The core SDK exposes pure summary helpers for lifecycle restore result objects.
+
+### Application Summary
+
+`ResourceLifecycleRestoreApplicationResult.ToSummary()` returns a `ResourceLifecycleRestoreApplicationSummary`.
+
+Required behavior:
+
+- Throws `ArgumentNullException` when the source result is null.
+- Preserves `TenantScope`.
+- Preserves `RestoredAt`.
+- Counts all candidate statuses.
+- Sets `HasFailures` when one or more candidates failed.
+- Sets `IsFullySuccessful` only when every candidate is `Restored` or `AlreadyRestored`.
+- Counts distinct nonblank resource identifiers from `Restored` and `AlreadyRestored` candidates.
+- Aggregates nonblank diagnostic codes in ordinal code order.
+- Treats null candidate and diagnostic collections as empty.
+
+### Preview Summary
+
+`ResourceLifecycleRestorePreviewResult.ToSummary()` returns a `ResourceLifecycleRestorePreviewSummary`.
+
+Required behavior:
+
+- Throws `ArgumentNullException` when the source result is null.
+- Preserves `TenantScope`.
+- Counts all candidate statuses.
+- Sets `HasFailures` when one or more candidates failed.
+- Sets `IsFullySuccessful` only when every candidate is `Restorable` or `AlreadyRestored`.
+- Counts distinct nonblank resource identifiers from `Restorable` and `AlreadyRestored` candidates.
+- Aggregates nonblank diagnostic codes in ordinal code order.
+- Treats null candidate and diagnostic collections as empty.
+
+## Non-Goals
+
+This contract does not add:
+
+- New restore preview or application behavior.
+- Service registration.
+- Storage or provider behavior.
+- Audit persistence.
+- Reporting infrastructure.
+- Query planning.
+- Public SQL.
+- Public `IQueryable<Resource>`.
+- Runtime scanning or automatic discovery.
+- Background jobs or schedulers.

--- a/specs/026-lifecycle-restore-summaries/data-model.md
+++ b/specs/026-lifecycle-restore-summaries/data-model.md
@@ -1,0 +1,72 @@
+# Data Model: Lifecycle Restore Summaries
+
+## Lifecycle Restore Application Summary
+
+Aggregate view over one `ResourceLifecycleRestoreApplicationResult`.
+
+Fields:
+
+- `TenantScope`: Effective tenant from the source result.
+- `RestoredAt`: Optional host timestamp from the source application result.
+- `TotalCount`: Number of candidate results.
+- `RestoredCount`: Number of candidates with `Restored` status.
+- `AlreadyRestoredCount`: Number of candidates with `AlreadyRestored` status.
+- `SkippedCount`: Number of candidates with `Skipped` status.
+- `FailedCount`: Number of candidates with `Failed` status.
+- `HasFailures`: True when `FailedCount` is greater than zero.
+- `IsFullySuccessful`: True when every candidate is `Restored` or `AlreadyRestored`.
+- `AffectedResourceCount`: Distinct nonblank resource identifiers from `Restored` and `AlreadyRestored` candidates.
+- `DiagnosticCodeCounts`: Deterministic diagnostic code counts across candidate diagnostics.
+
+Validation and invariants:
+
+- Null source result fails fast.
+- Null candidate collection is treated as empty.
+- Null candidate diagnostic collection is treated as empty.
+- Blank resource identifiers are ignored for `AffectedResourceCount`.
+- Blank diagnostic codes are ignored.
+- Diagnostic code counts are ordered by ordinal code.
+
+## Lifecycle Restore Preview Summary
+
+Aggregate view over one `ResourceLifecycleRestorePreviewResult`.
+
+Fields:
+
+- `TenantScope`: Effective tenant from the source result.
+- `TotalCount`: Number of candidate results.
+- `RestorableCount`: Number of candidates with `Restorable` status.
+- `AlreadyRestoredCount`: Number of candidates with `AlreadyRestored` status.
+- `SkippedCount`: Number of candidates with `Skipped` status.
+- `FailedCount`: Number of candidates with `Failed` status.
+- `HasFailures`: True when `FailedCount` is greater than zero.
+- `IsFullySuccessful`: True when every candidate is `Restorable` or `AlreadyRestored`.
+- `CandidateResourceCount`: Distinct nonblank resource identifiers from `Restorable` and `AlreadyRestored` candidates.
+- `DiagnosticCodeCounts`: Deterministic diagnostic code counts across candidate diagnostics.
+
+Validation and invariants:
+
+- Null source result fails fast.
+- Null candidate collection is treated as empty.
+- Null candidate diagnostic collection is treated as empty.
+- Blank resource identifiers are ignored for `CandidateResourceCount`.
+- Blank diagnostic codes are ignored.
+- Diagnostic code counts are ordered by ordinal code.
+
+## Restore Diagnostic Code Count
+
+Count for one stable diagnostic code observed in candidate diagnostics.
+
+Fields:
+
+- `Code`: Stable diagnostic code.
+- `Count`: Number of diagnostics with the code.
+
+Validation and invariants:
+
+- Counts include only nonblank diagnostic codes.
+- Counts are deterministic and ordered by code.
+
+## State Transitions
+
+None. Summaries are pure transformations over existing result objects and do not change resource versions, activation state, lifecycle marker state, policies, storage, providers, or service registrations.

--- a/specs/026-lifecycle-restore-summaries/plan.md
+++ b/specs/026-lifecycle-restore-summaries/plan.md
@@ -1,0 +1,114 @@
+# Implementation Plan: Lifecycle Restore Summaries
+
+**Branch**: `026-lifecycle-restore-summaries` | **Date**: 2026-05-30 | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from `/specs/026-lifecycle-restore-summaries/spec.md`
+
+## Summary
+
+Add pure host-facing summary records and extension helpers over existing lifecycle restore preview and application result objects. The implementation mirrors the policy application summary pattern: deterministic status counts, distinct resource counts, diagnostic code counts, no service registration, no provider/storage changes, and no restore behavior changes.
+
+## Technical Context
+
+**Language/Version**: C# latest, .NET 8.0 / 9.0 / 10.0 multi-targeting
+**Primary Dependencies**: Existing core SDK lifecycle restore models, policy diagnostic models, xUnit test stack; no new dependencies
+**Storage**: No storage changes. Summaries are pure in-memory views over existing result objects; no schema migration, persistence, provider storage, audit records, or physical index changes.
+**Testing**: Focused lifecycle restore summary tests, existing lifecycle restore and policy summary regression tests, `dotnet test Aster.sln`, `dotnet build Aster.sln /m:1`, `git diff --check`
+**Target Platform**: .NET SDK/library consumers and local test environment
+**Project Type**: SDK/library with provider packages and tests
+**Performance Goals**: Summary computation is linear over supplied candidate results and performs no I/O.
+**Constraints**: Pure transformations only; deterministic counts; null result inputs fail fast; null candidate/diagnostic collections are treated as empty; no service, storage, provider, query, public SQL, public `IQueryable<Resource>`, runtime scanning, automatic discovery, policy evaluation, audit persistence, reporting framework, or mutation behavior.
+**Scale/Scope**: Core SDK summary records/extensions, focused tests, docs, roadmap, and Spec Kit artifacts.
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+- **SDK-first/headless**: PASS - Adds SDK result helpers only; no UI, CMS, or host authorization behavior.
+- **Immutable versioning**: PASS - Summaries are read-only and do not mutate resource versions.
+- **Channel activation**: PASS - Activation state remains untouched.
+- **Typed/queryable**: PASS - Query AST and typed aspect APIs remain unchanged; no public SQL or `IQueryable` is introduced.
+- **Provider agnostic**: PASS - Summaries operate on existing result objects and do not depend on providers.
+- **Simplicity first**: PASS - Pure records/extensions are the smallest implementation.
+- **Modern C# idioms**: PASS - Records, extension methods, collection expressions, and nullable-safe handling match existing style.
+- **Readability over cleverness**: PASS - Counts are direct and explicit.
+- **Explicitness over magic**: PASS - Hosts explicitly call summary helpers on result objects.
+- **Abstractions justified**: PASS - No service or new interface is introduced.
+- **Optimize for deletion**: PASS - Removing the feature removes one additive model file, tests, and docs.
+- **Composition over inheritance**: PASS - Uses records and extension methods; no inheritance hierarchy.
+- **Intentional dependencies**: PASS - No new third-party dependencies.
+- **Operational simplicity**: PASS - No migration, worker, external service, or setup change.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/026-lifecycle-restore-summaries/
++-- spec.md
++-- plan.md
++-- research.md
++-- data-model.md
++-- quickstart.md
++-- checklists/
+|   +-- requirements.md
++-- contracts/
+    +-- lifecycle-restore-summaries.md
+```
+
+### Source Code (repository root)
+
+```text
+src/
++-- core/Aster.Core/
+|   +-- Models/Instances/
+|       +-- ResourceLifecycleRestoreSummaries.cs
+|
++-- persistence/Aster.Persistence.SqliteJson/
+    +-- no changes
+
+test/
++-- Aster.Tests/
+    +-- Lifecycle/
+        +-- ResourceLifecycleRestoreSummaryTests.cs
+```
+
+**Structure Decision**: Keep restore summaries in `Aster.Core.Models.Instances` beside lifecycle restore models. They are pure SDK helpers over existing result objects and need no service registration or provider implementation.
+
+## Complexity Tracking
+
+No constitution violations.
+
+## Phase 0 Research Summary
+
+Research decisions are captured in [research.md](research.md). Key outcomes:
+
+- Use pure extension helpers rather than a service.
+- Mirror the existing policy application summary shape where the restore domain has equivalent concepts.
+- Count successful terminal statuses differently for preview and application.
+- Treat null collections as empty for host-friendly manually constructed results.
+- Keep diagnostic counts deterministic and shared with policy diagnostics.
+
+## Phase 1 Design Summary
+
+Design artifacts:
+
+- [data-model.md](data-model.md)
+- [contracts/lifecycle-restore-summaries.md](contracts/lifecycle-restore-summaries.md)
+- [quickstart.md](quickstart.md)
+
+## Post-Design Constitution Check
+
+- **SDK-first/headless**: PASS - Design exposes records and extension helpers only.
+- **Immutable versioning**: PASS - No write path is introduced.
+- **Channel activation**: PASS - Activation state remains unchanged.
+- **Typed/queryable**: PASS - Query APIs remain unchanged.
+- **Provider agnostic**: PASS - No provider dependency exists.
+- **Simplicity first**: PASS - No service or registry is added.
+- **Modern C# idioms**: PASS - Planned code follows the policy summary pattern.
+- **Readability over cleverness**: PASS - Count formulas are direct.
+- **Explicitness over magic**: PASS - Callers explicitly invoke `ToSummary`.
+- **Abstractions justified**: PASS - No new abstraction is introduced.
+- **Optimize for deletion**: PASS - Feature is additive and localized.
+- **Composition over inheritance**: PASS - Records/extensions only.
+- **Intentional dependencies**: PASS - No new dependencies.
+- **Operational simplicity**: PASS - Existing validation commands remain sufficient.

--- a/specs/026-lifecycle-restore-summaries/quickstart.md
+++ b/specs/026-lifecycle-restore-summaries/quickstart.md
@@ -1,0 +1,92 @@
+# Quickstart: Lifecycle Restore Summaries
+
+## Minimal Application Summary
+
+```csharp
+using Aster.Core.Models.Instances;
+using Aster.Core.Models.Policies;
+
+var result = new ResourceLifecycleRestoreApplicationResult
+{
+    Candidates =
+    [
+        new ResourceLifecycleRestoreCandidateResult
+        {
+            Index = 0,
+            ResourceId = "product-1",
+            ExpectedState = ResourceLifecycleMarkerState.Archived,
+            Status = ResourceLifecycleRestoreCandidateStatus.Restored,
+        },
+        new ResourceLifecycleRestoreCandidateResult
+        {
+            Index = 1,
+            ResourceId = "product-2",
+            ExpectedState = ResourceLifecycleMarkerState.Archived,
+            Status = ResourceLifecycleRestoreCandidateStatus.Failed,
+            Diagnostics =
+            [
+                new ResourcePolicyDiagnostic
+                {
+                    Code = ResourcePolicyDiagnosticCodes.LifecycleRestoreMarkerMismatch,
+                    Message = "Marker state did not match.",
+                },
+            ],
+        },
+    ],
+};
+
+var summary = result.ToSummary();
+
+Console.WriteLine(summary.RestoredCount);
+Console.WriteLine(summary.FailedCount);
+Console.WriteLine(summary.HasFailures);
+```
+
+## Minimal Preview Summary
+
+```csharp
+using Aster.Core.Models.Instances;
+
+var preview = new ResourceLifecycleRestorePreviewResult
+{
+    Candidates =
+    [
+        new ResourceLifecycleRestoreCandidateResult
+        {
+            Index = 0,
+            ResourceId = "product-1",
+            ExpectedState = ResourceLifecycleMarkerState.SoftDeleted,
+            Status = ResourceLifecycleRestoreCandidateStatus.Restorable,
+        },
+        new ResourceLifecycleRestoreCandidateResult
+        {
+            Index = 1,
+            ResourceId = "product-1",
+            ExpectedState = ResourceLifecycleMarkerState.SoftDeleted,
+            Status = ResourceLifecycleRestoreCandidateStatus.AlreadyRestored,
+        },
+    ],
+};
+
+var summary = preview.ToSummary();
+
+Console.WriteLine(summary.RestorableCount);
+Console.WriteLine(summary.CandidateResourceCount);
+Console.WriteLine(summary.IsFullySuccessful);
+```
+
+## Validation
+
+Run focused summary tests:
+
+```bash
+dotnet test Aster.sln --filter "FullyQualifiedName~ResourceLifecycleRestoreSummaryTests"
+```
+
+Run full validation:
+
+```bash
+dotnet test Aster.sln
+dotnet build Aster.sln /m:1
+git diff --check
+```

--- a/specs/026-lifecycle-restore-summaries/research.md
+++ b/specs/026-lifecycle-restore-summaries/research.md
@@ -1,0 +1,66 @@
+# Research: Lifecycle Restore Summaries
+
+## Decision: Use Pure Extension Helpers
+
+Use extension methods over `ResourceLifecycleRestoreApplicationResult` and `ResourceLifecycleRestorePreviewResult`.
+
+**Rationale**: The feature only aggregates data already present on result objects. A service would add registration and lifetime surface without reading external state or coordinating collaborators.
+
+**Alternatives considered**:
+
+- Service-based summarization: rejected because there is no dependency to inject and no provider state to access.
+- Result object computed properties only: rejected because summaries combine multiple counts and diagnostic groupings, and the existing pattern uses explicit `ToSummary` helpers.
+
+## Decision: Mirror Existing Policy Summary Concepts
+
+Use summary records with total/status counts, `HasFailures`, `IsFullySuccessful`, distinct resource counts, and diagnostic code counts.
+
+**Rationale**: Hosts already have a policy application/pruning summary pattern. Restore is another operation result with per-candidate statuses and diagnostics, so using the same conceptual shape reduces learning cost.
+
+**Alternatives considered**:
+
+- One generic operation summary type: rejected because status names and successful terminal statuses differ by operation and a generic type would obscure restore-specific semantics.
+- Only expose count properties on existing results: rejected because affected resource counts and diagnostic code groupings would remain duplicated in hosts.
+
+## Decision: Preview and Application Have Different Successful Terminal Sets
+
+Preview `IsFullySuccessful` counts `Restorable` and `AlreadyRestored`; application `IsFullySuccessful` counts `Restored` and `AlreadyRestored`.
+
+**Rationale**: Preview and application use the same candidate result type but represent different phases. Treating `Restorable` as application success or `Restored` as preview success would hide misuse.
+
+**Alternatives considered**:
+
+- Treat every non-failed status as successful: rejected because skipped duplicate candidates are deterministic but not successful operator outcomes.
+- Use one shared helper for both result types: rejected because it would blur phase-specific semantics.
+
+## Decision: Distinct Resource Counts Use Successful Candidate Resource Identifiers
+
+Application affected resources count nonblank resource IDs from `Restored` and `AlreadyRestored` candidates. Preview candidate resources count nonblank resource IDs from `Restorable` and `AlreadyRestored` candidates.
+
+**Rationale**: These are the resources a host can reasonably present as already satisfied or able to proceed. Failed, skipped, and blank candidates should not inflate success-oriented counts.
+
+**Alternatives considered**:
+
+- Count all candidate resource IDs: rejected because failures and duplicates would inflate operator-facing success counts.
+- Count only write-producing restored candidates: rejected because idempotent already-restored candidates are also successful terminal outcomes for restore workflows.
+
+## Decision: Reuse Policy Diagnostic Model
+
+Diagnostic code counts aggregate existing `ResourcePolicyDiagnostic` values from candidate diagnostics.
+
+**Rationale**: Lifecycle restore already reports stable diagnostics using the policy diagnostic model. Reusing it avoids a second diagnostic shape.
+
+**Alternatives considered**:
+
+- Add restore-specific diagnostic count record: rejected as unnecessary duplication.
+- Emit only failed count: rejected because hosts need stable diagnostic breakdowns for troubleshooting.
+
+## Decision: Null Collections Are Empty
+
+Summary helpers fail fast for null result objects but treat null candidate and diagnostic collections as empty.
+
+**Rationale**: This matches existing summary behavior and keeps manually constructed test/UI DTOs easy to summarize while still catching programming errors for null result inputs.
+
+**Alternatives considered**:
+
+- Throw for null candidate collections: rejected because result records are host-constructible and existing summary helpers already tolerate null collections.

--- a/specs/026-lifecycle-restore-summaries/spec.md
+++ b/specs/026-lifecycle-restore-summaries/spec.md
@@ -1,0 +1,112 @@
+# Feature Specification: Lifecycle Restore Summaries
+
+**Feature Branch**: `026-lifecycle-restore-summaries`
+**Created**: 2026-05-30
+**Status**: Draft
+**Input**: Continue with the next bounded Phase 5 slice after operational hardening.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Summarize Restore Application Results (Priority: P1)
+
+As a host developer rendering restore operation feedback, I want a deterministic summary of lifecycle restore application results so that I can show how many resources were restored, already restored, skipped, or failed without recomputing counts in every host.
+
+**Why this priority**: Restore application is the write-side operator workflow. It needs the same lightweight host-facing reporting convenience that policy application and pruning application already have.
+
+**Independent Test**: Construct a lifecycle restore application result with restored, already-restored, skipped, failed, duplicate resource identifiers, and diagnostics, then verify aggregate counts and distinct affected resources.
+
+**Acceptance Scenarios**:
+
+1. **Given** a restore application result with mixed candidate statuses, **When** it is summarized, **Then** the summary reports total, restored, already-restored, skipped, and failed counts.
+2. **Given** successful restore candidates reference repeated resource identifiers, **When** the application result is summarized, **Then** affected resource count is distinct by ordinal resource identifier.
+3. **Given** failed candidates contain stable diagnostics, **When** the result is summarized, **Then** diagnostic code counts are deterministic and ordered.
+
+---
+
+### User Story 2 - Summarize Restore Preview Results (Priority: P2)
+
+As a host developer rendering a restore preview screen, I want a deterministic summary of lifecycle restore preview results so that I can show how many selected candidates are restorable before any marker state is changed.
+
+**Why this priority**: Preview is the operator review step before writes. A pure summary makes preview screens and tests simpler while preserving non-mutating behavior.
+
+**Independent Test**: Construct a lifecycle restore preview result with restorable, already-restored, skipped, failed, duplicate resource identifiers, and diagnostics, then verify aggregate counts and distinct candidate resources.
+
+**Acceptance Scenarios**:
+
+1. **Given** a restore preview result with mixed candidate statuses, **When** it is summarized, **Then** the summary reports total, restorable, already-restored, skipped, and failed counts.
+2. **Given** preview candidates contain repeated resource identifiers, **When** the preview result is summarized, **Then** candidate resource count is distinct by ordinal resource identifier.
+3. **Given** failed preview candidates contain diagnostics, **When** the result is summarized, **Then** diagnostic code counts are deterministic and ordered.
+
+---
+
+### User Story 3 - Keep Restore Summaries Pure and Predictable (Priority: P3)
+
+As a host developer, I want restore summaries to be pure transformations over existing result objects so that they are safe to use in UI adapters, tests, logs, and reports without service resolution or provider state.
+
+**Why this priority**: The feature should not change restore execution. Its value is a deletable, explicit convenience over already-returned result objects.
+
+**Independent Test**: Construct restore result objects manually and summarize them without any registered services or storage provider.
+
+**Acceptance Scenarios**:
+
+1. **Given** manually constructed restore result objects, **When** summary helpers are called, **Then** summaries are produced without services, stores, providers, or mutations.
+2. **Given** null restore result input, **When** summary helpers are called, **Then** they fail fast with argument validation.
+3. **Given** null candidate collections on result objects, **When** summary helpers are called, **Then** they are treated as empty collections.
+
+### Edge Cases
+
+- Null restore result inputs MUST fail fast with argument validation.
+- Null candidate collections MUST be treated as empty collections.
+- Blank resource identifiers MUST be ignored for distinct resource counts.
+- Blank diagnostic codes MUST be ignored for diagnostic code counts.
+- Diagnostic code counts MUST be ordered deterministically by ordinal code.
+- Application success MUST count restored and already-restored candidates as successful terminal statuses.
+- Preview success MUST count restorable and already-restored candidates as successful terminal statuses.
+- Summaries MUST NOT perform reads, writes, validation, policy evaluation, lifecycle marker changes, storage access, provider access, background work, or query planning.
+
+### Constitution Alignment *(mandatory)*
+
+- **Simplicity**: Add pure extension helpers and records over existing restore result models only. No service, registry, provider, workflow, or audit store is introduced.
+- **Explicitness**: Callers explicitly summarize existing result objects. There is no hidden discovery, scanning, ambient state, or automatic reporting behavior.
+- **Dependencies**: None.
+- **Operational Impact**: No deployment, storage, migration, provider setup, debugging, observability, or runtime behavior changes.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The system MUST provide a pure summary for lifecycle restore application results.
+- **FR-002**: A restore application summary MUST preserve the effective tenant and optional restored timestamp from the source result.
+- **FR-003**: A restore application summary MUST report total, restored, already-restored, skipped, and failed candidate counts.
+- **FR-004**: A restore application summary MUST expose whether any candidates failed.
+- **FR-005**: A restore application summary MUST expose whether every candidate completed through a successful terminal application status.
+- **FR-006**: A restore application summary MUST report the number of distinct nonblank resource identifiers affected by restored or already-restored candidates.
+- **FR-007**: The system MUST provide a pure summary for lifecycle restore preview results.
+- **FR-008**: A restore preview summary MUST preserve the effective tenant from the source result.
+- **FR-009**: A restore preview summary MUST report total, restorable, already-restored, skipped, and failed candidate counts.
+- **FR-010**: A restore preview summary MUST expose whether any candidates failed.
+- **FR-011**: A restore preview summary MUST expose whether every candidate completed through a successful terminal preview status.
+- **FR-012**: A restore preview summary MUST report the number of distinct nonblank resource identifiers represented by restorable or already-restored candidates.
+- **FR-013**: Restore summary helpers MUST provide deterministic diagnostic code counts across candidate diagnostics.
+- **FR-014**: Restore summary helpers MUST fail fast for null result inputs.
+- **FR-015**: Restore summary helpers MUST treat null candidate and diagnostic collections as empty collections.
+- **FR-016**: Restore summary helpers MUST be usable over manually constructed result objects without services or providers.
+- **FR-017**: The system MUST preserve existing lifecycle restore preview and application behavior.
+- **FR-018**: The system MUST NOT introduce storage changes, provider changes, service registration, background jobs, audit persistence, public SQL, public `IQueryable<Resource>`, runtime scanning, automatic discovery, query planners, policy evaluation, or mutation behavior.
+- **FR-019**: Roadmap housekeeping MUST mark `025-operational-hardening` as landed and identify `026-lifecycle-restore-summaries` as the active bounded slice.
+
+### Key Entities
+
+- **Lifecycle Restore Application Summary**: Aggregate counts and status booleans for one restore application result.
+- **Lifecycle Restore Preview Summary**: Aggregate counts and status booleans for one restore preview result.
+- **Restore Diagnostic Code Count**: Deterministic count for one stable diagnostic code observed in candidate diagnostics.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: A host can summarize a restore application result containing at least four mixed candidate statuses and receive correct counts.
+- **SC-002**: A host can summarize a restore preview result containing at least four mixed candidate statuses and receive correct counts.
+- **SC-003**: Restore summaries produce deterministic distinct resource counts and diagnostic code counts for repeated resources and repeated diagnostics.
+- **SC-004**: Summary helpers can be called on manually constructed result objects without service registration or provider setup.
+- **SC-005**: Existing lifecycle restore, policy summary, and full test suites continue to pass unchanged.

--- a/specs/026-lifecycle-restore-summaries/tasks.md
+++ b/specs/026-lifecycle-restore-summaries/tasks.md
@@ -11,8 +11,8 @@
 
 **Purpose**: Confirm the active slice and no dependency or provider setup is needed.
 
-- [ ] T001 Confirm `.specify/feature.json` points to `specs/026-lifecycle-restore-summaries`
-- [ ] T002 Confirm `AGENTS.md` points to `specs/026-lifecycle-restore-summaries/plan.md`
+- [X] T001 Confirm `.specify/feature.json` points to `specs/026-lifecycle-restore-summaries`
+- [X] T002 Confirm `AGENTS.md` points to `specs/026-lifecycle-restore-summaries/plan.md`
 
 ---
 
@@ -20,8 +20,8 @@
 
 **Purpose**: Add the shared summary model file used by both preview and application stories.
 
-- [ ] T003 [P] Add restore summary record contracts in `src/core/Aster.Core/Models/Instances/ResourceLifecycleRestoreSummaries.cs`
-- [ ] T004 Add shared deterministic diagnostic-count helper in `src/core/Aster.Core/Models/Instances/ResourceLifecycleRestoreSummaries.cs`
+- [X] T003 [P] Add restore summary record contracts in `src/core/Aster.Core/Models/Instances/ResourceLifecycleRestoreSummaries.cs`
+- [X] T004 Add shared deterministic diagnostic-count helper in `src/core/Aster.Core/Models/Policies/ResourcePolicyApplicationSummaries.cs`
 
 **Checkpoint**: Summary models and shared helpers are available for user stories.
 
@@ -35,12 +35,12 @@
 
 ### Tests for User Story 1
 
-- [ ] T005 [P] [US1] Add mixed-status application summary test in `test/Aster.Tests/Lifecycle/ResourceLifecycleRestoreSummaryTests.cs`
-- [ ] T006 [P] [US1] Add application null/empty collection tests in `test/Aster.Tests/Lifecycle/ResourceLifecycleRestoreSummaryTests.cs`
+- [X] T005 [P] [US1] Add mixed-status application summary test in `test/Aster.Tests/Lifecycle/ResourceLifecycleRestoreSummaryTests.cs`
+- [X] T006 [P] [US1] Add application null/empty collection tests in `test/Aster.Tests/Lifecycle/ResourceLifecycleRestoreSummaryTests.cs`
 
 ### Implementation for User Story 1
 
-- [ ] T007 [US1] Implement `ToSummary(this ResourceLifecycleRestoreApplicationResult result)` in `src/core/Aster.Core/Models/Instances/ResourceLifecycleRestoreSummaries.cs`
+- [X] T007 [US1] Implement `ToSummary(this ResourceLifecycleRestoreApplicationResult result)` in `src/core/Aster.Core/Models/Instances/ResourceLifecycleRestoreSummaries.cs`
 
 **Checkpoint**: User Story 1 is independently testable with focused summary tests.
 
@@ -54,12 +54,12 @@
 
 ### Tests for User Story 2
 
-- [ ] T008 [P] [US2] Add mixed-status preview summary test in `test/Aster.Tests/Lifecycle/ResourceLifecycleRestoreSummaryTests.cs`
-- [ ] T009 [P] [US2] Add preview null/empty collection tests in `test/Aster.Tests/Lifecycle/ResourceLifecycleRestoreSummaryTests.cs`
+- [X] T008 [P] [US2] Add mixed-status preview summary test in `test/Aster.Tests/Lifecycle/ResourceLifecycleRestoreSummaryTests.cs`
+- [X] T009 [P] [US2] Add preview null/empty collection tests in `test/Aster.Tests/Lifecycle/ResourceLifecycleRestoreSummaryTests.cs`
 
 ### Implementation for User Story 2
 
-- [ ] T010 [US2] Implement `ToSummary(this ResourceLifecycleRestorePreviewResult result)` in `src/core/Aster.Core/Models/Instances/ResourceLifecycleRestoreSummaries.cs`
+- [X] T010 [US2] Implement `ToSummary(this ResourceLifecycleRestorePreviewResult result)` in `src/core/Aster.Core/Models/Instances/ResourceLifecycleRestoreSummaries.cs`
 
 **Checkpoint**: User Story 2 is independently testable with focused summary tests.
 
@@ -73,12 +73,12 @@
 
 ### Tests for User Story 3
 
-- [ ] T011 [P] [US3] Add manual-construction purity coverage in `test/Aster.Tests/Lifecycle/ResourceLifecycleRestoreSummaryTests.cs`
-- [ ] T012 [P] [US3] Add diagnostic ordering and blank-code filtering coverage in `test/Aster.Tests/Lifecycle/ResourceLifecycleRestoreSummaryTests.cs`
+- [X] T011 [P] [US3] Add manual-construction purity coverage in `test/Aster.Tests/Lifecycle/ResourceLifecycleRestoreSummaryTests.cs`
+- [X] T012 [P] [US3] Add diagnostic ordering and blank-code filtering coverage in `test/Aster.Tests/Lifecycle/ResourceLifecycleRestoreSummaryTests.cs`
 
 ### Implementation for User Story 3
 
-- [ ] T013 [US3] Ensure restore summary helpers perform no service/provider/storage access in `src/core/Aster.Core/Models/Instances/ResourceLifecycleRestoreSummaries.cs`
+- [X] T013 [US3] Ensure restore summary helpers perform no service/provider/storage access in `src/core/Aster.Core/Models/Instances/ResourceLifecycleRestoreSummaries.cs`
 
 **Checkpoint**: All user stories are independently covered.
 
@@ -88,12 +88,12 @@
 
 **Purpose**: Documentation, roadmap, and validation.
 
-- [ ] T014 [P] Update `docs/ExecutionRoadmap.md` to mark 025 landed and make 026 active
-- [ ] T015 [P] Update `AGENTS.md` active technology and recent-change context for 026
-- [ ] T016 Run focused tests: `dotnet test Aster.sln --filter "FullyQualifiedName~ResourceLifecycleRestoreSummaryTests"`
-- [ ] T017 Run full tests: `dotnet test Aster.sln`
-- [ ] T018 Run build: `dotnet build Aster.sln /m:1`
-- [ ] T019 Run whitespace validation: `git diff --check`
+- [X] T014 [P] Update `docs/ExecutionRoadmap.md` to mark 025 landed and make 026 active
+- [X] T015 [P] Update `AGENTS.md` active technology and recent-change context for 026
+- [X] T016 Run focused tests: `dotnet test Aster.sln --filter "FullyQualifiedName~ResourceLifecycleRestoreSummaryTests"`
+- [X] T017 Run full tests: `dotnet test Aster.sln`
+- [X] T018 Run build: `dotnet build Aster.sln /m:1`
+- [X] T019 Run whitespace validation: `git diff --check`
 
 ---
 

--- a/specs/026-lifecycle-restore-summaries/tasks.md
+++ b/specs/026-lifecycle-restore-summaries/tasks.md
@@ -1,0 +1,141 @@
+# Tasks: Lifecycle Restore Summaries
+
+**Input**: Design documents from `/specs/026-lifecycle-restore-summaries/`
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/
+
+**Tests**: Tests are required by the feature specification because summary behavior is pure and independently testable.
+
+**Organization**: Tasks are grouped by user story to enable independent implementation and testing.
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Confirm the active slice and no dependency or provider setup is needed.
+
+- [ ] T001 Confirm `.specify/feature.json` points to `specs/026-lifecycle-restore-summaries`
+- [ ] T002 Confirm `AGENTS.md` points to `specs/026-lifecycle-restore-summaries/plan.md`
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Add the shared summary model file used by both preview and application stories.
+
+- [ ] T003 [P] Add restore summary record contracts in `src/core/Aster.Core/Models/Instances/ResourceLifecycleRestoreSummaries.cs`
+- [ ] T004 Add shared deterministic diagnostic-count helper in `src/core/Aster.Core/Models/Instances/ResourceLifecycleRestoreSummaries.cs`
+
+**Checkpoint**: Summary models and shared helpers are available for user stories.
+
+---
+
+## Phase 3: User Story 1 - Summarize Restore Application Results (Priority: P1) MVP
+
+**Goal**: Summarize write-side restore application results with deterministic counts.
+
+**Independent Test**: Manually construct an application result with mixed statuses and diagnostics and verify all summary fields.
+
+### Tests for User Story 1
+
+- [ ] T005 [P] [US1] Add mixed-status application summary test in `test/Aster.Tests/Lifecycle/ResourceLifecycleRestoreSummaryTests.cs`
+- [ ] T006 [P] [US1] Add application null/empty collection tests in `test/Aster.Tests/Lifecycle/ResourceLifecycleRestoreSummaryTests.cs`
+
+### Implementation for User Story 1
+
+- [ ] T007 [US1] Implement `ToSummary(this ResourceLifecycleRestoreApplicationResult result)` in `src/core/Aster.Core/Models/Instances/ResourceLifecycleRestoreSummaries.cs`
+
+**Checkpoint**: User Story 1 is independently testable with focused summary tests.
+
+---
+
+## Phase 4: User Story 2 - Summarize Restore Preview Results (Priority: P2)
+
+**Goal**: Summarize non-mutating restore preview results with deterministic counts.
+
+**Independent Test**: Manually construct a preview result with mixed statuses and diagnostics and verify all summary fields.
+
+### Tests for User Story 2
+
+- [ ] T008 [P] [US2] Add mixed-status preview summary test in `test/Aster.Tests/Lifecycle/ResourceLifecycleRestoreSummaryTests.cs`
+- [ ] T009 [P] [US2] Add preview null/empty collection tests in `test/Aster.Tests/Lifecycle/ResourceLifecycleRestoreSummaryTests.cs`
+
+### Implementation for User Story 2
+
+- [ ] T010 [US2] Implement `ToSummary(this ResourceLifecycleRestorePreviewResult result)` in `src/core/Aster.Core/Models/Instances/ResourceLifecycleRestoreSummaries.cs`
+
+**Checkpoint**: User Story 2 is independently testable with focused summary tests.
+
+---
+
+## Phase 5: User Story 3 - Keep Restore Summaries Pure and Predictable (Priority: P3)
+
+**Goal**: Verify summaries do not require services, providers, storage, or restore execution.
+
+**Independent Test**: Construct result objects directly and summarize them without building a service provider.
+
+### Tests for User Story 3
+
+- [ ] T011 [P] [US3] Add manual-construction purity coverage in `test/Aster.Tests/Lifecycle/ResourceLifecycleRestoreSummaryTests.cs`
+- [ ] T012 [P] [US3] Add diagnostic ordering and blank-code filtering coverage in `test/Aster.Tests/Lifecycle/ResourceLifecycleRestoreSummaryTests.cs`
+
+### Implementation for User Story 3
+
+- [ ] T013 [US3] Ensure restore summary helpers perform no service/provider/storage access in `src/core/Aster.Core/Models/Instances/ResourceLifecycleRestoreSummaries.cs`
+
+**Checkpoint**: All user stories are independently covered.
+
+---
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+**Purpose**: Documentation, roadmap, and validation.
+
+- [ ] T014 [P] Update `docs/ExecutionRoadmap.md` to mark 025 landed and make 026 active
+- [ ] T015 [P] Update `AGENTS.md` active technology and recent-change context for 026
+- [ ] T016 Run focused tests: `dotnet test Aster.sln --filter "FullyQualifiedName~ResourceLifecycleRestoreSummaryTests"`
+- [ ] T017 Run full tests: `dotnet test Aster.sln`
+- [ ] T018 Run build: `dotnet build Aster.sln /m:1`
+- [ ] T019 Run whitespace validation: `git diff --check`
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies.
+- **Foundational (Phase 2)**: Depends on Setup completion and blocks user stories.
+- **User Story 1 (Phase 3)**: Depends on Foundational.
+- **User Story 2 (Phase 4)**: Depends on Foundational.
+- **User Story 3 (Phase 5)**: Depends on User Story 1 and User Story 2 helper shape.
+- **Polish (Phase 6)**: Depends on all selected user stories.
+
+### User Story Dependencies
+
+- **User Story 1 (P1)**: MVP and independently testable after foundational records exist.
+- **User Story 2 (P2)**: Independently testable after foundational records exist.
+- **User Story 3 (P3)**: Verifies purity and deterministic helper behavior across both summaries.
+
+### Parallel Opportunities
+
+- T003 can be prepared independently from T004 but lands in the same file.
+- T005/T006 and T008/T009 are conceptually parallel but edit the same test file, so they should be applied carefully.
+- T014 and T015 can be updated independently once implementation is complete.
+
+## Implementation Strategy
+
+### MVP First
+
+1. Complete Setup and Foundational tasks.
+2. Implement User Story 1 application summary and focused tests.
+3. Run focused tests.
+
+### Incremental Delivery
+
+1. Add User Story 2 preview summary.
+2. Add User Story 3 purity and deterministic edge-case coverage.
+3. Run full validation and update roadmap/agent context.
+
+## Notes
+
+- Keep implementation in records/extensions only.
+- Do not add services, interfaces, provider registrations, storage, or dependencies.
+- Mark each task complete as it is implemented.

--- a/src/core/Aster.Core/Models/Instances/ResourceLifecycleRestoreSummaries.cs
+++ b/src/core/Aster.Core/Models/Instances/ResourceLifecycleRestoreSummaries.cs
@@ -1,0 +1,148 @@
+using Aster.Core.Models.Policies;
+using Aster.Core.Models.Tenancy;
+
+namespace Aster.Core.Models.Instances;
+
+/// <summary>
+/// Aggregate view over a lifecycle restore application result.
+/// </summary>
+public sealed record ResourceLifecycleRestoreApplicationSummary
+{
+    /// <summary>Effective tenant used by the application result.</summary>
+    public TenantScope TenantScope { get; init; } = TenantScope.Default;
+
+    /// <summary>Optional host timestamp supplied by the application result.</summary>
+    public DateTimeOffset? RestoredAt { get; init; }
+
+    /// <summary>Total number of candidate results.</summary>
+    public required int TotalCount { get; init; }
+
+    /// <summary>Number of candidates that cleared a matching lifecycle marker.</summary>
+    public required int RestoredCount { get; init; }
+
+    /// <summary>Number of candidates already in the restored state.</summary>
+    public required int AlreadyRestoredCount { get; init; }
+
+    /// <summary>Number of duplicate candidates skipped deterministically.</summary>
+    public required int SkippedCount { get; init; }
+
+    /// <summary>Number of candidates that failed.</summary>
+    public required int FailedCount { get; init; }
+
+    /// <summary>Whether one or more candidates failed.</summary>
+    public bool HasFailures => FailedCount > 0;
+
+    /// <summary>Whether every candidate completed through a successful terminal application status.</summary>
+    public bool IsFullySuccessful => TotalCount == RestoredCount + AlreadyRestoredCount;
+
+    /// <summary>Number of distinct resource identifiers affected by successful candidates.</summary>
+    public required int AffectedResourceCount { get; init; }
+
+    /// <summary>Deterministic diagnostic code counts across candidate diagnostics.</summary>
+    public IReadOnlyList<ResourcePolicyDiagnosticCodeCount> DiagnosticCodeCounts { get; init; } = [];
+}
+
+/// <summary>
+/// Aggregate view over a lifecycle restore preview result.
+/// </summary>
+public sealed record ResourceLifecycleRestorePreviewSummary
+{
+    /// <summary>Effective tenant used by the preview result.</summary>
+    public TenantScope TenantScope { get; init; } = TenantScope.Default;
+
+    /// <summary>Total number of candidate results.</summary>
+    public required int TotalCount { get; init; }
+
+    /// <summary>Number of candidates that can be restored.</summary>
+    public required int RestorableCount { get; init; }
+
+    /// <summary>Number of candidates already in the restored state.</summary>
+    public required int AlreadyRestoredCount { get; init; }
+
+    /// <summary>Number of duplicate candidates skipped deterministically.</summary>
+    public required int SkippedCount { get; init; }
+
+    /// <summary>Number of candidates that failed.</summary>
+    public required int FailedCount { get; init; }
+
+    /// <summary>Whether one or more candidates failed.</summary>
+    public bool HasFailures => FailedCount > 0;
+
+    /// <summary>Whether every candidate completed through a successful terminal preview status.</summary>
+    public bool IsFullySuccessful => TotalCount == RestorableCount + AlreadyRestoredCount;
+
+    /// <summary>Number of distinct resource identifiers represented by successful preview candidates.</summary>
+    public required int CandidateResourceCount { get; init; }
+
+    /// <summary>Deterministic diagnostic code counts across candidate diagnostics.</summary>
+    public IReadOnlyList<ResourcePolicyDiagnosticCodeCount> DiagnosticCodeCounts { get; init; } = [];
+}
+
+/// <summary>
+/// Pure summary helpers for lifecycle restore result objects.
+/// </summary>
+public static class ResourceLifecycleRestoreSummaryExtensions
+{
+    /// <summary>
+    /// Creates a deterministic aggregate summary for a lifecycle restore application result.
+    /// </summary>
+    /// <param name="result">The result to summarize.</param>
+    /// <returns>A summary over the result's candidate statuses and diagnostics.</returns>
+    public static ResourceLifecycleRestoreApplicationSummary ToSummary(this ResourceLifecycleRestoreApplicationResult result)
+    {
+        ArgumentNullException.ThrowIfNull(result);
+        var candidates = result.Candidates ?? [];
+
+        return new ResourceLifecycleRestoreApplicationSummary
+        {
+            TenantScope = result.TenantScope,
+            RestoredAt = result.RestoredAt,
+            TotalCount = candidates.Count,
+            RestoredCount = candidates.Count(static candidate => candidate.Status == ResourceLifecycleRestoreCandidateStatus.Restored),
+            AlreadyRestoredCount = candidates.Count(static candidate => candidate.Status == ResourceLifecycleRestoreCandidateStatus.AlreadyRestored),
+            SkippedCount = candidates.Count(static candidate => candidate.Status == ResourceLifecycleRestoreCandidateStatus.Skipped),
+            FailedCount = candidates.Count(static candidate => candidate.Status == ResourceLifecycleRestoreCandidateStatus.Failed),
+            AffectedResourceCount = CountDistinctResources(
+                candidates,
+                ResourceLifecycleRestoreCandidateStatus.Restored,
+                ResourceLifecycleRestoreCandidateStatus.AlreadyRestored),
+            DiagnosticCodeCounts = ResourcePolicyDiagnosticCodeCounter.Count(candidates.SelectMany(static candidate => candidate.Diagnostics ?? [])),
+        };
+    }
+
+    /// <summary>
+    /// Creates a deterministic aggregate summary for a lifecycle restore preview result.
+    /// </summary>
+    /// <param name="result">The result to summarize.</param>
+    /// <returns>A summary over the result's candidate statuses and diagnostics.</returns>
+    public static ResourceLifecycleRestorePreviewSummary ToSummary(this ResourceLifecycleRestorePreviewResult result)
+    {
+        ArgumentNullException.ThrowIfNull(result);
+        var candidates = result.Candidates ?? [];
+
+        return new ResourceLifecycleRestorePreviewSummary
+        {
+            TenantScope = result.TenantScope,
+            TotalCount = candidates.Count,
+            RestorableCount = candidates.Count(static candidate => candidate.Status == ResourceLifecycleRestoreCandidateStatus.Restorable),
+            AlreadyRestoredCount = candidates.Count(static candidate => candidate.Status == ResourceLifecycleRestoreCandidateStatus.AlreadyRestored),
+            SkippedCount = candidates.Count(static candidate => candidate.Status == ResourceLifecycleRestoreCandidateStatus.Skipped),
+            FailedCount = candidates.Count(static candidate => candidate.Status == ResourceLifecycleRestoreCandidateStatus.Failed),
+            CandidateResourceCount = CountDistinctResources(
+                candidates,
+                ResourceLifecycleRestoreCandidateStatus.Restorable,
+                ResourceLifecycleRestoreCandidateStatus.AlreadyRestored),
+            DiagnosticCodeCounts = ResourcePolicyDiagnosticCodeCounter.Count(candidates.SelectMany(static candidate => candidate.Diagnostics ?? [])),
+        };
+    }
+
+    private static int CountDistinctResources(
+        IEnumerable<ResourceLifecycleRestoreCandidateResult> candidates,
+        params ResourceLifecycleRestoreCandidateStatus[] statuses) =>
+        candidates
+            .Where(candidate => statuses.Contains(candidate.Status))
+            .Select(static candidate => candidate.ResourceId)
+            .Where(static resourceId => !string.IsNullOrWhiteSpace(resourceId))
+            .Distinct(StringComparer.Ordinal)
+            .Count();
+}

--- a/src/core/Aster.Core/Models/Policies/ResourcePolicyApplicationSummaries.cs
+++ b/src/core/Aster.Core/Models/Policies/ResourcePolicyApplicationSummaries.cs
@@ -122,7 +122,7 @@ public static class ResourcePolicyApplicationSummaryExtensions
                 .Where(static resourceId => !string.IsNullOrWhiteSpace(resourceId))
                 .Distinct(StringComparer.Ordinal)
                 .Count(),
-            DiagnosticCodeCounts = CountDiagnosticCodes(candidates.SelectMany(static candidate => candidate.Diagnostics ?? [])),
+            DiagnosticCodeCounts = ResourcePolicyDiagnosticCodeCounter.Count(candidates.SelectMany(static candidate => candidate.Diagnostics ?? [])),
         };
     }
 
@@ -151,11 +151,14 @@ public static class ResourcePolicyApplicationSummaryExtensions
                 .Select(static candidate => (candidate.ResourceId!, candidate.ResourceVersion!.Value))
                 .Distinct()
                 .Count(),
-            DiagnosticCodeCounts = CountDiagnosticCodes(candidates.SelectMany(static candidate => candidate.Diagnostics ?? [])),
+            DiagnosticCodeCounts = ResourcePolicyDiagnosticCodeCounter.Count(candidates.SelectMany(static candidate => candidate.Diagnostics ?? [])),
         };
     }
+}
 
-    private static IReadOnlyList<ResourcePolicyDiagnosticCodeCount> CountDiagnosticCodes(
+internal static class ResourcePolicyDiagnosticCodeCounter
+{
+    public static IReadOnlyList<ResourcePolicyDiagnosticCodeCount> Count(
         IEnumerable<ResourcePolicyDiagnostic> diagnostics) =>
         diagnostics
             .Select(static diagnostic => diagnostic.Code)

--- a/test/Aster.Tests/Lifecycle/ResourceLifecycleRestoreSummaryTests.cs
+++ b/test/Aster.Tests/Lifecycle/ResourceLifecycleRestoreSummaryTests.cs
@@ -1,0 +1,189 @@
+using Aster.Core.Models.Instances;
+using Aster.Core.Models.Policies;
+using Aster.Core.Models.Tenancy;
+
+namespace Aster.Tests.Lifecycle;
+
+public sealed class ResourceLifecycleRestoreSummaryTests
+{
+    [Fact]
+    public void ApplicationSummary_MixedCandidates_AggregatesCountsResourcesAndDiagnostics()
+    {
+        var restoredAt = DateTimeOffset.UtcNow;
+        var result = new ResourceLifecycleRestoreApplicationResult
+        {
+            TenantScope = TenantScope.FromTenantId("tenant-a"),
+            RestoredAt = restoredAt,
+            Candidates =
+            [
+                Candidate(ResourceLifecycleRestoreCandidateStatus.Restored, "product-1"),
+                Candidate(ResourceLifecycleRestoreCandidateStatus.AlreadyRestored, "product-1"),
+                Candidate(ResourceLifecycleRestoreCandidateStatus.Skipped, "product-2", Diagnostic("duplicate")),
+                Candidate(ResourceLifecycleRestoreCandidateStatus.Failed, "product-3", Diagnostic("marker-mismatch"), Diagnostic("duplicate")),
+            ],
+        };
+
+        var summary = result.ToSummary();
+
+        Assert.Equal(result.TenantScope, summary.TenantScope);
+        Assert.Equal(restoredAt, summary.RestoredAt);
+        Assert.Equal(4, summary.TotalCount);
+        Assert.Equal(1, summary.RestoredCount);
+        Assert.Equal(1, summary.AlreadyRestoredCount);
+        Assert.Equal(1, summary.SkippedCount);
+        Assert.Equal(1, summary.FailedCount);
+        Assert.True(summary.HasFailures);
+        Assert.False(summary.IsFullySuccessful);
+        Assert.Equal(1, summary.AffectedResourceCount);
+        Assert.Equal(
+            [("duplicate", 2), ("marker-mismatch", 1)],
+            summary.DiagnosticCodeCounts.Select(static count => (count.Code, count.Count)).ToList());
+    }
+
+    [Fact]
+    public void ApplicationSummary_EmptyResult_IsFullySuccessful()
+    {
+        var summary = new ResourceLifecycleRestoreApplicationResult().ToSummary();
+
+        Assert.Equal(0, summary.TotalCount);
+        Assert.False(summary.HasFailures);
+        Assert.True(summary.IsFullySuccessful);
+        Assert.Equal(0, summary.AffectedResourceCount);
+        Assert.Empty(summary.DiagnosticCodeCounts);
+    }
+
+    [Fact]
+    public void ApplicationSummary_NullCandidateCollection_IsTreatedAsEmpty()
+    {
+        var summary = new ResourceLifecycleRestoreApplicationResult
+        {
+            Candidates = null!,
+        }.ToSummary();
+
+        Assert.Equal(0, summary.TotalCount);
+        Assert.True(summary.IsFullySuccessful);
+    }
+
+    [Fact]
+    public void PreviewSummary_MixedCandidates_AggregatesCountsResourcesAndDiagnostics()
+    {
+        var result = new ResourceLifecycleRestorePreviewResult
+        {
+            TenantScope = TenantScope.FromTenantId("tenant-a"),
+            Candidates =
+            [
+                Candidate(ResourceLifecycleRestoreCandidateStatus.Restorable, "product-1"),
+                Candidate(ResourceLifecycleRestoreCandidateStatus.AlreadyRestored, "product-1"),
+                Candidate(ResourceLifecycleRestoreCandidateStatus.Skipped, "product-2", Diagnostic("duplicate")),
+                Candidate(ResourceLifecycleRestoreCandidateStatus.Failed, "product-3", Diagnostic("marker-mismatch"), Diagnostic("duplicate")),
+            ],
+        };
+
+        var summary = result.ToSummary();
+
+        Assert.Equal(result.TenantScope, summary.TenantScope);
+        Assert.Equal(4, summary.TotalCount);
+        Assert.Equal(1, summary.RestorableCount);
+        Assert.Equal(1, summary.AlreadyRestoredCount);
+        Assert.Equal(1, summary.SkippedCount);
+        Assert.Equal(1, summary.FailedCount);
+        Assert.True(summary.HasFailures);
+        Assert.False(summary.IsFullySuccessful);
+        Assert.Equal(1, summary.CandidateResourceCount);
+        Assert.Equal(
+            [("duplicate", 2), ("marker-mismatch", 1)],
+            summary.DiagnosticCodeCounts.Select(static count => (count.Code, count.Count)).ToList());
+    }
+
+    [Fact]
+    public void PreviewSummary_EmptyResult_IsFullySuccessful()
+    {
+        var summary = new ResourceLifecycleRestorePreviewResult().ToSummary();
+
+        Assert.Equal(0, summary.TotalCount);
+        Assert.False(summary.HasFailures);
+        Assert.True(summary.IsFullySuccessful);
+        Assert.Equal(0, summary.CandidateResourceCount);
+        Assert.Empty(summary.DiagnosticCodeCounts);
+    }
+
+    [Fact]
+    public void PreviewSummary_NullCandidateCollection_IsTreatedAsEmpty()
+    {
+        var summary = new ResourceLifecycleRestorePreviewResult
+        {
+            Candidates = null!,
+        }.ToSummary();
+
+        Assert.Equal(0, summary.TotalCount);
+        Assert.True(summary.IsFullySuccessful);
+    }
+
+    [Fact]
+    public void Summaries_NullInputsThrow()
+    {
+        Assert.Throws<ArgumentNullException>(() => ((ResourceLifecycleRestoreApplicationResult)null!).ToSummary());
+        Assert.Throws<ArgumentNullException>(() => ((ResourceLifecycleRestorePreviewResult)null!).ToSummary());
+    }
+
+    [Fact]
+    public void SummaryDiagnosticCounts_IgnoreBlankCodesAndUseOrdinalOrdering()
+    {
+        var result = new ResourceLifecycleRestoreApplicationResult
+        {
+            Candidates =
+            [
+                Candidate(
+                    ResourceLifecycleRestoreCandidateStatus.Failed,
+                    "product-1",
+                    Diagnostic("z-code"),
+                    Diagnostic(""),
+                    Diagnostic(" "),
+                    Diagnostic("a-code"),
+                    Diagnostic("z-code")),
+            ],
+        };
+
+        var summary = result.ToSummary();
+
+        Assert.Equal(
+            [("a-code", 1), ("z-code", 2)],
+            summary.DiagnosticCodeCounts.Select(static count => (count.Code, count.Count)).ToList());
+    }
+
+    [Fact]
+    public void Summaries_AreGeneratedFromManuallyConstructedResultsWithoutServices()
+    {
+        var applicationSummary = new ResourceLifecycleRestoreApplicationResult
+        {
+            Candidates = [Candidate(ResourceLifecycleRestoreCandidateStatus.Restored, "product-1")],
+        }.ToSummary();
+        var previewSummary = new ResourceLifecycleRestorePreviewResult
+        {
+            Candidates = [Candidate(ResourceLifecycleRestoreCandidateStatus.Restorable, "product-1")],
+        }.ToSummary();
+
+        Assert.True(applicationSummary.IsFullySuccessful);
+        Assert.True(previewSummary.IsFullySuccessful);
+    }
+
+    private static ResourceLifecycleRestoreCandidateResult Candidate(
+        ResourceLifecycleRestoreCandidateStatus status,
+        string resourceId,
+        params ResourcePolicyDiagnostic[] diagnostics) =>
+        new()
+        {
+            Index = 0,
+            Status = status,
+            ResourceId = resourceId,
+            ExpectedState = ResourceLifecycleMarkerState.Archived,
+            Diagnostics = diagnostics,
+        };
+
+    private static ResourcePolicyDiagnostic Diagnostic(string code) =>
+        new()
+        {
+            Code = code,
+            Message = code,
+        };
+}


### PR DESCRIPTION
## Summary
- add pure lifecycle restore preview/application summary records and ToSummary helpers
- share deterministic diagnostic code counting with policy summaries
- add focused restore summary coverage and update Spec Kit/roadmap context for 026

## Validation
- dotnet test Aster.sln --filter "FullyQualifiedName~ResourceLifecycleRestoreSummaryTests"
- dotnet test Aster.sln
- dotnet build Aster.sln /m:1
- git diff --check