### PR TITLE
Add policy preview summaries

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "featureDir": "specs/026-lifecycle-restore-summaries"
+  "featureDir": "specs/027-policy-preview-summaries"
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 <!-- SPECKIT START -->
 For additional context about technologies to be used, project structure,
-shell commands, and other important information, read `specs/026-lifecycle-restore-summaries/plan.md`.
+shell commands, and other important information, read `specs/027-policy-preview-summaries/plan.md`.
 <!-- SPECKIT END -->
 
 ## Active Technologies
@@ -38,8 +38,11 @@ shell commands, and other important information, read `specs/026-lifecycle-resto
 - Existing resource version, activation state, and lifecycle marker storage only. No schema migration, data rewrite, persisted test artifacts, or physical index changes. (025-operational-hardening)
 - C# latest, .NET 8.0 / 9.0 / 10.0 multi-targeting + Existing core SDK lifecycle restore models, policy diagnostic models, xUnit test stack; no new dependencies (026-lifecycle-restore-summaries)
 - No storage changes. Summaries are pure in-memory views over existing restore result objects; no schema migration, persistence, provider storage, audit records, or physical index changes. (026-lifecycle-restore-summaries)
+- C# latest, .NET 8.0 / 9.0 / 10.0 multi-targeting + Existing core SDK policy preview models, policy diagnostic models, xUnit test stack; no new dependencies (027-policy-preview-summaries)
+- No storage changes. Summaries are pure in-memory views over existing policy preview result objects; no schema migration, persistence, provider storage, audit records, or physical index changes. (027-policy-preview-summaries)
 
 ## Recent Changes
+- 027-policy-preview-summaries: Added pure host-facing policy preview summaries with deterministic candidate counts, outcome counts, policy kind counts, distinct resource counts, distinct resource-version target counts, diagnostic code counts, diagnostic booleans, and no storage, provider, service registration, scheduler, audit persistence, public SQL, public IQueryable<Resource>, query planner, or mutation behavior
 - 026-lifecycle-restore-summaries: Added pure host-facing lifecycle restore preview and application summaries with deterministic status counts, affected resource counts, diagnostic code counts, completion booleans, and no storage, provider, service registration, scheduler, audit persistence, public SQL, public IQueryable<Resource>, query planner, or mutation behavior
 - 025-operational-hardening: Added bounded operational hardening planning and test context for lifecycle restore retries, same-candidate restore races, policy pruning retries, persisted SQLite pruning retries, and repeated historical activation without new product APIs, storage schema changes, providers, schedulers, benchmark infrastructure, or dependencies
 - 024-version-history-summaries: Added pure host-facing summaries for single and batch version history results with deterministic version-state counts, selected/missing resource counts, lifecycle state counts, and no storage, provider, service, query planner, public SQL, public IQueryable<Resource>, policy evaluation, reporting infrastructure, or mutation behavior

--- a/docs/ExecutionRoadmap.md
+++ b/docs/ExecutionRoadmap.md
@@ -1,14 +1,14 @@
 # Aster Execution Roadmap
 
-Last updated: 2026-05-30
+Last updated: 2026-05-31
 
 This roadmap tracks the implementation trail we have already cut through the repo and the next product slices that should stay small enough for Spec Kit-driven PRs. It is intentionally execution-oriented; the broader architecture narrative remains in `docs/Roadmap.md` and the wiki.
 
 ## Current Position
 
-Aster now has a working Core SDK, in-memory runtime, SQLite JSON persistence/querying, provider capability discovery, provider validation alignment, provider authoring ergonomics, a reusable provider conformance harness, SQLite facet sorting, portable operator expansion, SQLite date-like ranges, explicit provider-declared index projections, explicit definition schema upgrade behavior, deterministic portability primitives, explicit host lifecycle hooks, explicit tenant scoping, policy foundations, host-controlled policy application orchestration, host-controlled lifecycle restore workflows, host-controlled policy pruning application, read-only version history inspection, explicit historical version activation, policy application summaries, batch version history inspection, version history summaries, and operational hardening coverage.
+Aster now has a working Core SDK, in-memory runtime, SQLite JSON persistence/querying, provider capability discovery, provider validation alignment, provider authoring ergonomics, a reusable provider conformance harness, SQLite facet sorting, portable operator expansion, SQLite date-like ranges, explicit provider-declared index projections, explicit definition schema upgrade behavior, deterministic portability primitives, explicit host lifecycle hooks, explicit tenant scoping, policy foundations, host-controlled policy application orchestration, host-controlled lifecycle restore workflows, host-controlled policy pruning application, read-only version history inspection, explicit historical version activation, policy application summaries, batch version history inspection, version history summaries, operational hardening coverage, and lifecycle restore summaries.
 
-The Phase 4 core workstream is complete enough to defer optional recipes. The active workstream is now **Phase 5: Multi-tenancy, Policies, Advanced Versioning**. Explicit tenant-aware boundaries, policy foundations, policy application orchestration, reversible lifecycle restore, destructive pruning application, version history inspection, historical version activation, policy application summaries, batch version history inspection, version history summaries, and operational hardening have landed; lifecycle restore summaries are the current bounded host-reporting slice.
+The Phase 4 core workstream is complete enough to defer optional recipes. The active workstream is now **Phase 5: Multi-tenancy, Policies, Advanced Versioning**. Explicit tenant-aware boundaries, policy foundations, policy application orchestration, reversible lifecycle restore, destructive pruning application, version history inspection, historical version activation, policy application summaries, batch version history inspection, version history summaries, operational hardening, and lifecycle restore summaries have landed; policy preview summaries are the current bounded host-reporting slice.
 
 ## Landed Slices
 
@@ -39,24 +39,25 @@ The Phase 4 core workstream is complete enough to defer optional recipes. The ac
 | `023-batch-version-history` | Landed | Explicit batch version history inspection for selected resource IDs with first-seen distinct ordering, tenant scoping, missing-resource histories, SQLite parity, and no storage or query-surface expansion. |
 | `024-version-history-summaries` | Landed | Pure host-facing summaries for single and batch version history results with deterministic version-state counts, selected/missing resource counts, lifecycle state counts, and no storage, provider, service, query planner, policy evaluation, or reporting infrastructure. |
 | `025-operational-hardening` | Landed | Bounded retry and concurrency-sensitive coverage for lifecycle restore, policy pruning retries, SQLite persisted pruning retries, and repeated historical activation without new product APIs, storage schema changes, schedulers, benchmark infrastructure, or dependencies. |
+| `026-lifecycle-restore-summaries` | Landed | Pure host-facing lifecycle restore preview and application summaries with deterministic status counts, affected resource counts, diagnostic counts, completion booleans, and no storage, provider, service registration, audit persistence, or mutation behavior. |
 
 ## Near-Term Roadmap
 
-### 026 — Lifecycle Restore Summaries
+### 027 — Policy Preview Summaries
 
-**Status:** In progress on `026-lifecycle-restore-summaries`.
+**Status:** In progress on `027-policy-preview-summaries`.
 
-**Goal:** Add pure host-facing summaries for lifecycle restore preview and application results.
+**Goal:** Add pure host-facing summaries for policy evaluation preview results.
 
 Scope:
 
-- Summarize restore application results with deterministic restored, already-restored, skipped, failed, affected-resource, and diagnostic-code counts.
-- Summarize restore preview results with deterministic restorable, already-restored, skipped, failed, candidate-resource, and diagnostic-code counts.
+- Summarize policy preview candidates with deterministic total, outcome, policy-kind, distinct resource, and distinct resource-version target counts.
+- Summarize preview diagnostics with deterministic diagnostic-code counts and diagnostic booleans.
 - Preserve pure transformation behavior over existing result objects with no service registration, provider access, storage changes, audit persistence, schedulers, public SQL, public `IQueryable<Resource>`, or mutation behavior.
 
-### 027 — Next Bounded Phase 5 Slice
+### 028 — Next Bounded Phase 5 Slice
 
-**Goal:** Choose one small continuation slice after lifecycle restore summaries land.
+**Goal:** Choose one small continuation slice after policy preview summaries land.
 
 Candidate scope:
 

--- a/specs/027-policy-preview-summaries/checklists/requirements.md
+++ b/specs/027-policy-preview-summaries/checklists/requirements.md
@@ -1,0 +1,34 @@
+# Specification Quality Checklist: Policy Preview Summaries
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-05-31
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Specification is ready for planning.

--- a/specs/027-policy-preview-summaries/contracts/policy-preview-summaries.md
+++ b/specs/027-policy-preview-summaries/contracts/policy-preview-summaries.md
@@ -1,0 +1,37 @@
+# Contract: Policy Preview Summaries
+
+## Public SDK Behavior
+
+The core SDK exposes a pure summary helper for policy preview result objects.
+
+`ResourcePolicyEvaluationPreview.ToSummary()` returns a `ResourcePolicyPreviewSummary`.
+
+Required behavior:
+
+- Throws `ArgumentNullException` when the source preview is null.
+- Preserves `TenantScope`.
+- Preserves `EvaluationTimestamp`.
+- Counts all preview candidates.
+- Counts distinct nonblank resource identifiers across candidates.
+- Counts distinct `(resourceId, resourceVersion)` targets where both values are present.
+- Aggregates candidates by `ResourcePolicyOutcome` in deterministic enum order.
+- Aggregates candidates by `ResourcePolicyKind` in deterministic enum order.
+- Aggregates nonblank diagnostic codes in ordinal code order.
+- Treats null candidate and diagnostic collections as empty.
+- Performs no service resolution, provider access, storage access, policy evaluation, validation, or mutation.
+
+## Non-Goals
+
+This contract does not add:
+
+- New policy preview behavior.
+- New policy application behavior.
+- Service registration.
+- Storage or provider behavior.
+- Audit persistence.
+- Reporting infrastructure.
+- Query planning.
+- Public SQL.
+- Public `IQueryable<Resource>`.
+- Runtime scanning or automatic discovery.
+- Background jobs or schedulers.

--- a/specs/027-policy-preview-summaries/data-model.md
+++ b/specs/027-policy-preview-summaries/data-model.md
@@ -1,0 +1,50 @@
+# Data Model: Policy Preview Summaries
+
+## Policy Preview Summary
+
+Aggregate view over one `ResourcePolicyEvaluationPreview`.
+
+Fields:
+
+- `TenantScope`: Effective tenant from the source preview.
+- `EvaluationTimestamp`: Optional timestamp used by the source preview.
+- `TotalCandidateCount`: Number of candidate outcomes.
+- `DistinctResourceCount`: Distinct nonblank resource identifiers represented by candidates.
+- `DistinctResourceVersionTargetCount`: Distinct `(resourceId, resourceVersion)` targets represented by candidates with a nonblank resource identifier and resource version.
+- `HasDiagnostics`: True when at least one nonblank diagnostic code is present.
+- `IsDiagnosticFree`: True when no nonblank diagnostic code is present.
+- `OutcomeCounts`: Deterministic counts by `ResourcePolicyOutcome`.
+- `KindCounts`: Deterministic counts by `ResourcePolicyKind`.
+- `DiagnosticCodeCounts`: Deterministic diagnostic code counts across preview diagnostics.
+
+Validation and invariants:
+
+- Null source preview fails fast.
+- Null candidate collection is treated as empty.
+- Null diagnostic collection is treated as empty.
+- Blank resource identifiers are ignored for distinct resource counts.
+- Blank diagnostic codes are ignored.
+- Outcome and kind counts are ordered by enum value.
+- Diagnostic code counts are ordered by ordinal code.
+
+## Policy Outcome Count
+
+Count for one previewed `ResourcePolicyOutcome`.
+
+Fields:
+
+- `Outcome`: Previewed policy outcome.
+- `Count`: Number of candidates with the outcome.
+
+## Policy Kind Count
+
+Count for one previewed `ResourcePolicyKind`.
+
+Fields:
+
+- `Kind`: Policy kind.
+- `Count`: Number of candidates with the kind.
+
+## State Transitions
+
+None. Summaries are pure transformations over existing preview result objects and do not change resource versions, activation state, lifecycle marker state, policies, storage, providers, or service registrations.

--- a/specs/027-policy-preview-summaries/plan.md
+++ b/specs/027-policy-preview-summaries/plan.md
@@ -1,0 +1,114 @@
+# Implementation Plan: Policy Preview Summaries
+
+**Branch**: `027-policy-preview-summaries` | **Date**: 2026-05-31 | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from `/specs/027-policy-preview-summaries/spec.md`
+
+## Summary
+
+Add pure host-facing summary records and extension helpers over existing `ResourcePolicyEvaluationPreview` objects. The implementation follows the existing policy and restore summary pattern: deterministic candidate, outcome, kind, target, and diagnostic counts; no service registration; no provider/storage changes; and no policy evaluation behavior changes.
+
+## Technical Context
+
+**Language/Version**: C# latest, .NET 8.0 / 9.0 / 10.0 multi-targeting
+**Primary Dependencies**: Existing core SDK policy preview models, policy diagnostic models, xUnit test stack; no new dependencies
+**Storage**: No storage changes. Summaries are pure in-memory views over existing preview result objects; no schema migration, persistence, provider storage, audit records, or physical index changes.
+**Testing**: Focused policy preview summary tests, existing policy preview and summary regression tests, `dotnet test Aster.sln`, `dotnet build Aster.sln /m:1`, `git diff --check`
+**Target Platform**: .NET SDK/library consumers and local test environment
+**Project Type**: SDK/library with provider packages and tests
+**Performance Goals**: Summary computation is linear over supplied preview candidates and diagnostics and performs no I/O.
+**Constraints**: Pure transformations only; deterministic counts; null result inputs fail fast; null candidate/diagnostic collections are treated as empty; no service, storage, provider, query, public SQL, public `IQueryable<Resource>`, runtime scanning, automatic discovery, policy evaluation changes, audit persistence, reporting framework, or mutation behavior.
+**Scale/Scope**: Core SDK summary records/extensions, focused tests, docs, roadmap, and Spec Kit artifacts.
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+- **SDK-first/headless**: PASS - Adds SDK result helpers only; no UI, CMS, or host authorization behavior.
+- **Immutable versioning**: PASS - Summaries are read-only and do not mutate resource versions.
+- **Channel activation**: PASS - Activation state remains untouched.
+- **Typed/queryable**: PASS - Query AST and typed aspect APIs remain unchanged; no public SQL or `IQueryable` is introduced.
+- **Provider agnostic**: PASS - Summaries operate on existing result objects and do not depend on providers.
+- **Simplicity first**: PASS - Pure records/extensions are the smallest implementation.
+- **Modern C# idioms**: PASS - Records, extension methods, collection expressions, enum ordering, and nullable-safe handling match existing style.
+- **Readability over cleverness**: PASS - Counts are direct and explicit.
+- **Explicitness over magic**: PASS - Hosts explicitly call summary helpers on result objects.
+- **Abstractions justified**: PASS - No service or new interface is introduced.
+- **Optimize for deletion**: PASS - Removing the feature removes one additive model file, tests, and docs.
+- **Composition over inheritance**: PASS - Uses records and extension methods; no inheritance hierarchy.
+- **Intentional dependencies**: PASS - No new third-party dependencies.
+- **Operational simplicity**: PASS - No migration, worker, external service, or setup change.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/027-policy-preview-summaries/
++-- spec.md
++-- plan.md
++-- research.md
++-- data-model.md
++-- quickstart.md
++-- checklists/
+|   +-- requirements.md
++-- contracts/
+    +-- policy-preview-summaries.md
+```
+
+### Source Code (repository root)
+
+```text
+src/
++-- core/Aster.Core/
+|   +-- Models/Policies/
+|       +-- ResourcePolicyPreviewSummaries.cs
+|
++-- persistence/Aster.Persistence.SqliteJson/
+    +-- no changes
+
+test/
++-- Aster.Tests/
+    +-- Policies/
+        +-- PolicyPreviewSummaryTests.cs
+```
+
+**Structure Decision**: Keep preview summaries in `Aster.Core.Models.Policies` beside policy preview and application summary models. They are pure SDK helpers over existing result objects and need no service registration or provider implementation.
+
+## Complexity Tracking
+
+No constitution violations.
+
+## Phase 0 Research Summary
+
+Research decisions are captured in [research.md](research.md). Key outcomes:
+
+- Use pure extension helpers rather than a service.
+- Count policy outcomes and policy kinds using deterministic enum ordering.
+- Count resource-version targets only when both resource identity and version are present.
+- Reuse the existing diagnostic-code count model and helper.
+- Treat null collections as empty for host-friendly manually constructed previews.
+
+## Phase 1 Design Summary
+
+Design artifacts:
+
+- [data-model.md](data-model.md)
+- [contracts/policy-preview-summaries.md](contracts/policy-preview-summaries.md)
+- [quickstart.md](quickstart.md)
+
+## Post-Design Constitution Check
+
+- **SDK-first/headless**: PASS - Design exposes records and extension helpers only.
+- **Immutable versioning**: PASS - No write path is introduced.
+- **Channel activation**: PASS - Activation state remains unchanged.
+- **Typed/queryable**: PASS - Query APIs remain unchanged.
+- **Provider agnostic**: PASS - No provider dependency exists.
+- **Simplicity first**: PASS - No service or registry is added.
+- **Modern C# idioms**: PASS - Planned code follows established summary patterns.
+- **Readability over cleverness**: PASS - Count formulas are direct.
+- **Explicitness over magic**: PASS - Callers explicitly invoke `ToSummary`.
+- **Abstractions justified**: PASS - No new abstraction is introduced.
+- **Optimize for deletion**: PASS - Feature is additive and localized.
+- **Composition over inheritance**: PASS - Records/extensions only.
+- **Intentional dependencies**: PASS - No new dependencies.
+- **Operational simplicity**: PASS - Existing validation commands remain sufficient.

--- a/specs/027-policy-preview-summaries/quickstart.md
+++ b/specs/027-policy-preview-summaries/quickstart.md
@@ -1,0 +1,53 @@
+# Quickstart: Policy Preview Summaries
+
+## Minimal Preview Summary
+
+```csharp
+using Aster.Core.Models.Policies;
+
+var preview = new ResourcePolicyEvaluationPreview
+{
+    Candidates =
+    [
+        new ResourcePolicyCandidateOutcome
+        {
+            PolicyId = "archive-old",
+            PolicyKind = ResourcePolicyKind.Archival,
+            Outcome = ResourcePolicyOutcome.Archive,
+            ResourceId = "product-1",
+            Reason = "Older than threshold.",
+        },
+        new ResourcePolicyCandidateOutcome
+        {
+            PolicyId = "prune-old-versions",
+            PolicyKind = ResourcePolicyKind.VersionPruning,
+            Outcome = ResourcePolicyOutcome.PrunePreview,
+            ResourceId = "product-1",
+            ResourceVersion = 1,
+            Reason = "Outside retained version window.",
+        },
+    ],
+};
+
+var summary = preview.ToSummary();
+
+Console.WriteLine(summary.TotalCandidateCount);
+Console.WriteLine(summary.DistinctResourceCount);
+Console.WriteLine(summary.DistinctResourceVersionTargetCount);
+```
+
+## Validation
+
+Run focused summary tests:
+
+```bash
+dotnet test Aster.sln --filter "FullyQualifiedName~PolicyPreviewSummaryTests"
+```
+
+Run full validation:
+
+```bash
+dotnet test Aster.sln
+dotnet build Aster.sln /m:1
+git diff --check
+```

--- a/specs/027-policy-preview-summaries/research.md
+++ b/specs/027-policy-preview-summaries/research.md
@@ -1,0 +1,55 @@
+# Research: Policy Preview Summaries
+
+## Decision: Use Pure Extension Helpers
+
+Use an extension method over `ResourcePolicyEvaluationPreview`.
+
+**Rationale**: The feature only aggregates data already present on preview result objects. A service would add registration and lifetime surface without reading external state or coordinating collaborators.
+
+**Alternatives considered**:
+
+- Service-based summarization: rejected because there is no dependency to inject and no provider state to access.
+- Computed properties on preview results only: rejected because summaries combine multiple grouped counts and the existing pattern uses explicit `ToSummary` helpers.
+
+## Decision: Count Outcomes and Kinds by Enum Ordering
+
+Group candidates by `ResourcePolicyOutcome` and `ResourcePolicyKind`, then order by enum value.
+
+**Rationale**: Enum ordering is deterministic, stable for tests, and avoids host-specific sort rules.
+
+**Alternatives considered**:
+
+- Alphabetical display-name ordering: rejected because display names are not part of the model and would add presentation assumptions.
+- Preserve first-seen order: rejected because summaries should be deterministic independent of candidate order for grouped count display.
+
+## Decision: Count Distinct Resources and Version Targets Separately
+
+Resource count uses nonblank `ResourceId`. Resource-version target count uses `(ResourceId, ResourceVersion)` when both are present.
+
+**Rationale**: Policy previews can target logical resources or specific versions. Hosts need both counts without inferring version targeting from outcome names.
+
+**Alternatives considered**:
+
+- Count only resource IDs: rejected because version-pruning previews need a version-target count.
+- Count every candidate as a target: rejected because repeated candidates would inflate operator-facing counts.
+
+## Decision: Reuse Policy Diagnostic Count Model and Helper
+
+Diagnostic code counts use the existing `ResourcePolicyDiagnosticCodeCount` model and `ResourcePolicyDiagnosticCodeCounter`.
+
+**Rationale**: Preview diagnostics already use `ResourcePolicyDiagnostic`. Reusing the count model avoids duplicated concepts across policy operation summaries.
+
+**Alternatives considered**:
+
+- Add a preview-specific diagnostic count record: rejected as unnecessary duplication.
+- Emit only a boolean: rejected because hosts need stable diagnostic breakdowns for troubleshooting.
+
+## Decision: Null Collections Are Empty
+
+Summary helpers fail fast for null preview result objects but treat null candidate and diagnostic collections as empty.
+
+**Rationale**: This matches existing summary behavior and keeps manually constructed test/UI DTOs easy to summarize while still catching programming errors for null result inputs.
+
+**Alternatives considered**:
+
+- Throw for null candidate or diagnostic collections: rejected because result records are host-constructible and existing summary helpers already tolerate null collections.

--- a/specs/027-policy-preview-summaries/spec.md
+++ b/specs/027-policy-preview-summaries/spec.md
@@ -1,0 +1,110 @@
+# Feature Specification: Policy Preview Summaries
+
+**Feature Branch**: `027-policy-preview-summaries`
+**Created**: 2026-05-31
+**Status**: Draft
+**Input**: Continue with the next bounded Phase 5 slice after lifecycle restore summaries.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Summarize Policy Preview Candidates (Priority: P1)
+
+As a host developer rendering policy preview screens, I want a deterministic summary of policy preview candidates so that operators can see how many resources and versions are affected before selecting application actions.
+
+**Why this priority**: Policy preview is the first operator decision point. Hosts already have application summaries; preview summaries complete the pre-write reporting story without adding execution behavior.
+
+**Independent Test**: Construct a policy preview with archive, soft-delete, prune-preview, and retain candidates, then verify total candidate, distinct resource, distinct resource-version target, outcome, and policy-kind counts.
+
+**Acceptance Scenarios**:
+
+1. **Given** a policy preview with mixed outcomes, **When** it is summarized, **Then** outcome counts are deterministic.
+2. **Given** a policy preview with mixed policy kinds, **When** it is summarized, **Then** policy-kind counts are deterministic.
+3. **Given** candidates repeat resource identifiers and resource-version targets, **When** the preview is summarized, **Then** distinct resource and version-target counts use ordinal identity.
+
+---
+
+### User Story 2 - Summarize Preview Diagnostics (Priority: P2)
+
+As a host developer troubleshooting policy previews, I want stable diagnostic counts in the preview summary so that UI and logs can show why preview evaluation is incomplete or partially blocked.
+
+**Why this priority**: Policy validation and preview diagnostics already exist. A deterministic diagnostic rollup avoids duplicated host code.
+
+**Independent Test**: Construct a preview with repeated diagnostics, blank diagnostic codes, and no candidates, then verify diagnostic code counts, diagnostic booleans, and empty-preview behavior.
+
+**Acceptance Scenarios**:
+
+1. **Given** preview diagnostics contain repeated codes, **When** the preview is summarized, **Then** diagnostic code counts are grouped and ordered deterministically.
+2. **Given** diagnostics contain blank codes, **When** the preview is summarized, **Then** blank diagnostic codes are ignored.
+3. **Given** a preview has diagnostics but no candidates, **When** the preview is summarized, **Then** diagnostic counts are still reported.
+
+---
+
+### User Story 3 - Keep Policy Preview Summaries Pure (Priority: P3)
+
+As a host developer, I want policy preview summaries to be pure transformations over existing result objects so that they are safe in tests, UI adapters, logs, and reports without service resolution or provider state.
+
+**Why this priority**: The feature should not change policy evaluation or application semantics. It should remain a deletable convenience over already-returned data.
+
+**Independent Test**: Construct preview result objects manually and summarize them without any registered services or storage provider.
+
+**Acceptance Scenarios**:
+
+1. **Given** a manually constructed preview result, **When** summary helpers are called, **Then** summaries are produced without services, stores, providers, or mutations.
+2. **Given** null preview result input, **When** summary helpers are called, **Then** they fail fast with argument validation.
+3. **Given** null candidate and diagnostic collections on the preview result, **When** summary helpers are called, **Then** they are treated as empty collections.
+
+### Edge Cases
+
+- Null preview result input MUST fail fast with argument validation.
+- Null candidate and diagnostic collections MUST be treated as empty collections.
+- Blank resource identifiers MUST be ignored for distinct resource counts.
+- Resource-version target counts MUST include only candidates with nonblank resource identifiers and resource versions.
+- Blank diagnostic codes MUST be ignored for diagnostic code counts.
+- Outcome and policy-kind counts MUST be ordered deterministically by enum value.
+- Diagnostic code counts MUST be ordered deterministically by ordinal code.
+- Summaries MUST NOT perform reads, writes, validation, policy evaluation, lifecycle marker changes, storage access, provider access, background work, or query planning.
+
+### Constitution Alignment *(mandatory)*
+
+- **Simplicity**: Add pure extension helpers and records over existing policy preview result models only. No service, registry, provider, workflow, or audit store is introduced.
+- **Explicitness**: Callers explicitly summarize existing result objects. There is no hidden discovery, scanning, ambient state, or automatic reporting behavior.
+- **Dependencies**: None.
+- **Operational Impact**: No deployment, storage, migration, provider setup, debugging, observability, or runtime behavior changes.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The system MUST provide a pure summary for policy evaluation preview results.
+- **FR-002**: A policy preview summary MUST preserve the effective tenant and optional evaluation timestamp from the source preview.
+- **FR-003**: A policy preview summary MUST report total candidate count.
+- **FR-004**: A policy preview summary MUST report the number of distinct nonblank resource identifiers represented by preview candidates.
+- **FR-005**: A policy preview summary MUST report the number of distinct resource-version targets represented by preview candidates.
+- **FR-006**: A policy preview summary MUST report deterministic counts by policy outcome.
+- **FR-007**: A policy preview summary MUST report deterministic counts by policy kind.
+- **FR-008**: A policy preview summary MUST report deterministic diagnostic code counts across preview diagnostics.
+- **FR-009**: A policy preview summary MUST expose whether any preview diagnostics are present.
+- **FR-010**: A policy preview summary MUST expose whether the preview has no diagnostics.
+- **FR-011**: Policy preview summary helpers MUST fail fast for null result inputs.
+- **FR-012**: Policy preview summary helpers MUST treat null candidate and diagnostic collections as empty collections.
+- **FR-013**: Policy preview summary helpers MUST be usable over manually constructed preview result objects without services or providers.
+- **FR-014**: The system MUST preserve existing policy validation, preview, application, pruning, restore, query, portability, and lifecycle hook behavior.
+- **FR-015**: The system MUST NOT introduce storage changes, provider changes, service registration, background jobs, audit persistence, public SQL, public `IQueryable<Resource>`, runtime scanning, automatic discovery, query planners, policy evaluation changes, or mutation behavior.
+- **FR-016**: Roadmap housekeeping MUST mark `026-lifecycle-restore-summaries` as landed and identify `027-policy-preview-summaries` as the active bounded slice.
+
+### Key Entities
+
+- **Policy Preview Summary**: Aggregate counts and status booleans for one policy evaluation preview.
+- **Policy Outcome Count**: Deterministic count for one previewed policy outcome.
+- **Policy Kind Count**: Deterministic count for one previewed policy kind.
+- **Policy Diagnostic Code Count**: Existing deterministic count for one stable diagnostic code observed in preview diagnostics.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: A host can summarize a policy preview containing at least four mixed policy outcomes and receive correct outcome counts.
+- **SC-002**: A host can summarize a policy preview containing at least three policy kinds and receive correct kind counts.
+- **SC-003**: Policy preview summaries produce deterministic distinct resource, distinct version-target, and diagnostic code counts for repeated values.
+- **SC-004**: Summary helpers can be called on manually constructed preview objects without service registration or provider setup.
+- **SC-005**: Existing policy preview, policy summary, lifecycle restore summary, and full test suites continue to pass unchanged.

--- a/specs/027-policy-preview-summaries/tasks.md
+++ b/specs/027-policy-preview-summaries/tasks.md
@@ -11,8 +11,8 @@
 
 **Purpose**: Confirm the active slice and no dependency or provider setup is needed.
 
-- [ ] T001 Confirm `.specify/feature.json` points to `specs/027-policy-preview-summaries`
-- [ ] T002 Confirm `AGENTS.md` points to `specs/027-policy-preview-summaries/plan.md`
+- [X] T001 Confirm `.specify/feature.json` points to `specs/027-policy-preview-summaries`
+- [X] T002 Confirm `AGENTS.md` points to `specs/027-policy-preview-summaries/plan.md`
 
 ---
 
@@ -20,8 +20,8 @@
 
 **Purpose**: Add the shared preview summary model file used by all stories.
 
-- [ ] T003 [P] Add preview summary record contracts in `src/core/Aster.Core/Models/Policies/ResourcePolicyPreviewSummaries.cs`
-- [ ] T004 Confirm the existing diagnostic-code helper is reused from `src/core/Aster.Core/Models/Policies/ResourcePolicyApplicationSummaries.cs`
+- [X] T003 [P] Add preview summary record contracts in `src/core/Aster.Core/Models/Policies/ResourcePolicyPreviewSummaries.cs`
+- [X] T004 Confirm the existing diagnostic-code helper is reused from `src/core/Aster.Core/Models/Policies/ResourcePolicyApplicationSummaries.cs`
 
 **Checkpoint**: Summary models and shared helpers are available for user stories.
 
@@ -35,11 +35,11 @@
 
 ### Tests for User Story 1
 
-- [ ] T005 [P] [US1] Add mixed-candidate preview summary test in `test/Aster.Tests/Policies/PolicyPreviewSummaryTests.cs`
+- [X] T005 [P] [US1] Add mixed-candidate preview summary test in `test/Aster.Tests/Policies/PolicyPreviewSummaryTests.cs`
 
 ### Implementation for User Story 1
 
-- [ ] T006 [US1] Implement candidate, resource, target, outcome, and kind counts in `src/core/Aster.Core/Models/Policies/ResourcePolicyPreviewSummaries.cs`
+- [X] T006 [US1] Implement candidate, resource, target, outcome, and kind counts in `src/core/Aster.Core/Models/Policies/ResourcePolicyPreviewSummaries.cs`
 
 **Checkpoint**: User Story 1 is independently testable with focused summary tests.
 
@@ -53,11 +53,11 @@
 
 ### Tests for User Story 2
 
-- [ ] T007 [P] [US2] Add diagnostic summary test in `test/Aster.Tests/Policies/PolicyPreviewSummaryTests.cs`
+- [X] T007 [P] [US2] Add diagnostic summary test in `test/Aster.Tests/Policies/PolicyPreviewSummaryTests.cs`
 
 ### Implementation for User Story 2
 
-- [ ] T008 [US2] Implement diagnostic count and diagnostic boolean fields in `src/core/Aster.Core/Models/Policies/ResourcePolicyPreviewSummaries.cs`
+- [X] T008 [US2] Implement diagnostic count and diagnostic boolean fields in `src/core/Aster.Core/Models/Policies/ResourcePolicyPreviewSummaries.cs`
 
 **Checkpoint**: User Story 2 is independently testable with focused summary tests.
 
@@ -71,12 +71,12 @@
 
 ### Tests for User Story 3
 
-- [ ] T009 [P] [US3] Add null-input and null-collection tests in `test/Aster.Tests/Policies/PolicyPreviewSummaryTests.cs`
-- [ ] T010 [P] [US3] Add manual-construction purity coverage in `test/Aster.Tests/Policies/PolicyPreviewSummaryTests.cs`
+- [X] T009 [P] [US3] Add null-input and null-collection tests in `test/Aster.Tests/Policies/PolicyPreviewSummaryTests.cs`
+- [X] T010 [P] [US3] Add manual-construction purity coverage in `test/Aster.Tests/Policies/PolicyPreviewSummaryTests.cs`
 
 ### Implementation for User Story 3
 
-- [ ] T011 [US3] Ensure preview summary helpers perform no service/provider/storage access in `src/core/Aster.Core/Models/Policies/ResourcePolicyPreviewSummaries.cs`
+- [X] T011 [US3] Ensure preview summary helpers perform no service/provider/storage access in `src/core/Aster.Core/Models/Policies/ResourcePolicyPreviewSummaries.cs`
 
 **Checkpoint**: All user stories are independently covered.
 
@@ -86,12 +86,12 @@
 
 **Purpose**: Documentation, roadmap, and validation.
 
-- [ ] T012 [P] Update `docs/ExecutionRoadmap.md` to mark 026 landed and make 027 active
-- [ ] T013 [P] Update `AGENTS.md` active technology and recent-change context for 027
-- [ ] T014 Run focused tests: `dotnet test Aster.sln --filter "FullyQualifiedName~PolicyPreviewSummaryTests"`
-- [ ] T015 Run full tests: `dotnet test Aster.sln`
-- [ ] T016 Run build: `dotnet build Aster.sln /m:1`
-- [ ] T017 Run whitespace validation: `git diff --check`
+- [X] T012 [P] Update `docs/ExecutionRoadmap.md` to mark 026 landed and make 027 active
+- [X] T013 [P] Update `AGENTS.md` active technology and recent-change context for 027
+- [X] T014 Run focused tests: `dotnet test Aster.sln --filter "FullyQualifiedName~PolicyPreviewSummaryTests"`
+- [X] T015 Run full tests: `dotnet test Aster.sln`
+- [X] T016 Run build: `dotnet build Aster.sln /m:1`
+- [X] T017 Run whitespace validation: `git diff --check`
 
 ---
 

--- a/specs/027-policy-preview-summaries/tasks.md
+++ b/specs/027-policy-preview-summaries/tasks.md
@@ -1,0 +1,139 @@
+# Tasks: Policy Preview Summaries
+
+**Input**: Design documents from `/specs/027-policy-preview-summaries/`
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/
+
+**Tests**: Tests are required by the feature specification because summary behavior is pure and independently testable.
+
+**Organization**: Tasks are grouped by user story to enable independent implementation and testing.
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Confirm the active slice and no dependency or provider setup is needed.
+
+- [ ] T001 Confirm `.specify/feature.json` points to `specs/027-policy-preview-summaries`
+- [ ] T002 Confirm `AGENTS.md` points to `specs/027-policy-preview-summaries/plan.md`
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Add the shared preview summary model file used by all stories.
+
+- [ ] T003 [P] Add preview summary record contracts in `src/core/Aster.Core/Models/Policies/ResourcePolicyPreviewSummaries.cs`
+- [ ] T004 Confirm the existing diagnostic-code helper is reused from `src/core/Aster.Core/Models/Policies/ResourcePolicyApplicationSummaries.cs`
+
+**Checkpoint**: Summary models and shared helpers are available for user stories.
+
+---
+
+## Phase 3: User Story 1 - Summarize Policy Preview Candidates (Priority: P1) MVP
+
+**Goal**: Summarize preview candidates with deterministic candidate, resource, target, outcome, and kind counts.
+
+**Independent Test**: Manually construct a preview with mixed outcomes/kinds and verify all candidate summary fields.
+
+### Tests for User Story 1
+
+- [ ] T005 [P] [US1] Add mixed-candidate preview summary test in `test/Aster.Tests/Policies/PolicyPreviewSummaryTests.cs`
+
+### Implementation for User Story 1
+
+- [ ] T006 [US1] Implement candidate, resource, target, outcome, and kind counts in `src/core/Aster.Core/Models/Policies/ResourcePolicyPreviewSummaries.cs`
+
+**Checkpoint**: User Story 1 is independently testable with focused summary tests.
+
+---
+
+## Phase 4: User Story 2 - Summarize Preview Diagnostics (Priority: P2)
+
+**Goal**: Summarize preview diagnostics deterministically.
+
+**Independent Test**: Manually construct a preview with repeated diagnostics, blank codes, and no candidates and verify diagnostic fields.
+
+### Tests for User Story 2
+
+- [ ] T007 [P] [US2] Add diagnostic summary test in `test/Aster.Tests/Policies/PolicyPreviewSummaryTests.cs`
+
+### Implementation for User Story 2
+
+- [ ] T008 [US2] Implement diagnostic count and diagnostic boolean fields in `src/core/Aster.Core/Models/Policies/ResourcePolicyPreviewSummaries.cs`
+
+**Checkpoint**: User Story 2 is independently testable with focused summary tests.
+
+---
+
+## Phase 5: User Story 3 - Keep Policy Preview Summaries Pure (Priority: P3)
+
+**Goal**: Verify summaries do not require services, providers, storage, or policy evaluation.
+
+**Independent Test**: Construct preview objects directly and summarize them without building a service provider.
+
+### Tests for User Story 3
+
+- [ ] T009 [P] [US3] Add null-input and null-collection tests in `test/Aster.Tests/Policies/PolicyPreviewSummaryTests.cs`
+- [ ] T010 [P] [US3] Add manual-construction purity coverage in `test/Aster.Tests/Policies/PolicyPreviewSummaryTests.cs`
+
+### Implementation for User Story 3
+
+- [ ] T011 [US3] Ensure preview summary helpers perform no service/provider/storage access in `src/core/Aster.Core/Models/Policies/ResourcePolicyPreviewSummaries.cs`
+
+**Checkpoint**: All user stories are independently covered.
+
+---
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+**Purpose**: Documentation, roadmap, and validation.
+
+- [ ] T012 [P] Update `docs/ExecutionRoadmap.md` to mark 026 landed and make 027 active
+- [ ] T013 [P] Update `AGENTS.md` active technology and recent-change context for 027
+- [ ] T014 Run focused tests: `dotnet test Aster.sln --filter "FullyQualifiedName~PolicyPreviewSummaryTests"`
+- [ ] T015 Run full tests: `dotnet test Aster.sln`
+- [ ] T016 Run build: `dotnet build Aster.sln /m:1`
+- [ ] T017 Run whitespace validation: `git diff --check`
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies.
+- **Foundational (Phase 2)**: Depends on Setup completion and blocks user stories.
+- **User Story 1 (Phase 3)**: Depends on Foundational.
+- **User Story 2 (Phase 4)**: Depends on Foundational.
+- **User Story 3 (Phase 5)**: Depends on User Story 1 and User Story 2 helper shape.
+- **Polish (Phase 6)**: Depends on all selected user stories.
+
+### User Story Dependencies
+
+- **User Story 1 (P1)**: MVP and independently testable after foundational records exist.
+- **User Story 2 (P2)**: Independently testable after foundational records exist.
+- **User Story 3 (P3)**: Verifies purity and deterministic edge-case behavior across preview summaries.
+
+### Parallel Opportunities
+
+- T003 and T004 can be assessed independently.
+- T005, T007, T009, and T010 are conceptually parallel but edit the same test file, so they should be applied carefully.
+- T012 and T013 can be updated independently once implementation is complete.
+
+## Implementation Strategy
+
+### MVP First
+
+1. Complete Setup and Foundational tasks.
+2. Implement User Story 1 candidate summary and focused tests.
+3. Run focused tests.
+
+### Incremental Delivery
+
+1. Add User Story 2 diagnostic summary.
+2. Add User Story 3 purity and deterministic edge-case coverage.
+3. Run full validation and update roadmap/agent context.
+
+## Notes
+
+- Keep implementation in records/extensions only.
+- Do not add services, interfaces, provider registrations, storage, or dependencies.
+- Mark each task complete as it is implemented.

--- a/src/core/Aster.Core/Models/Policies/ResourcePolicyPreviewSummaries.cs
+++ b/src/core/Aster.Core/Models/Policies/ResourcePolicyPreviewSummaries.cs
@@ -1,0 +1,117 @@
+using Aster.Core.Models.Tenancy;
+
+namespace Aster.Core.Models.Policies;
+
+/// <summary>
+/// Deterministic count for one policy preview outcome.
+/// </summary>
+public sealed record ResourcePolicyOutcomeCount
+{
+    /// <summary>Previewed policy outcome.</summary>
+    public required ResourcePolicyOutcome Outcome { get; init; }
+
+    /// <summary>Number of candidates with the outcome.</summary>
+    public required int Count { get; init; }
+}
+
+/// <summary>
+/// Deterministic count for one policy kind.
+/// </summary>
+public sealed record ResourcePolicyKindCount
+{
+    /// <summary>Policy kind.</summary>
+    public required ResourcePolicyKind Kind { get; init; }
+
+    /// <summary>Number of candidates with the kind.</summary>
+    public required int Count { get; init; }
+}
+
+/// <summary>
+/// Aggregate view over a policy evaluation preview result.
+/// </summary>
+public sealed record ResourcePolicyPreviewSummary
+{
+    /// <summary>Effective tenant used by the preview result.</summary>
+    public TenantScope TenantScope { get; init; } = TenantScope.Default;
+
+    /// <summary>Timestamp used by the preview result when supplied.</summary>
+    public DateTimeOffset? EvaluationTimestamp { get; init; }
+
+    /// <summary>Total number of preview candidate outcomes.</summary>
+    public required int TotalCandidateCount { get; init; }
+
+    /// <summary>Number of distinct nonblank logical resources represented by preview candidates.</summary>
+    public required int DistinctResourceCount { get; init; }
+
+    /// <summary>Number of distinct resource/version targets represented by preview candidates.</summary>
+    public required int DistinctResourceVersionTargetCount { get; init; }
+
+    /// <summary>Whether one or more nonblank diagnostic codes are present.</summary>
+    public bool HasDiagnostics => DiagnosticCodeCounts.Count > 0;
+
+    /// <summary>Whether no nonblank diagnostic codes are present.</summary>
+    public bool IsDiagnosticFree => !HasDiagnostics;
+
+    /// <summary>Deterministic policy outcome counts across preview candidates.</summary>
+    public IReadOnlyList<ResourcePolicyOutcomeCount> OutcomeCounts { get; init; } = [];
+
+    /// <summary>Deterministic policy kind counts across preview candidates.</summary>
+    public IReadOnlyList<ResourcePolicyKindCount> KindCounts { get; init; } = [];
+
+    /// <summary>Deterministic diagnostic code counts across preview diagnostics.</summary>
+    public IReadOnlyList<ResourcePolicyDiagnosticCodeCount> DiagnosticCodeCounts { get; init; } = [];
+}
+
+/// <summary>
+/// Pure summary helpers for policy evaluation preview result objects.
+/// </summary>
+public static class ResourcePolicyPreviewSummaryExtensions
+{
+    /// <summary>
+    /// Creates a deterministic aggregate summary for a policy evaluation preview result.
+    /// </summary>
+    /// <param name="preview">The preview result to summarize.</param>
+    /// <returns>A summary over the preview's candidates and diagnostics.</returns>
+    public static ResourcePolicyPreviewSummary ToSummary(this ResourcePolicyEvaluationPreview preview)
+    {
+        ArgumentNullException.ThrowIfNull(preview);
+        var candidates = preview.Candidates ?? [];
+        var diagnosticCodeCounts = ResourcePolicyDiagnosticCodeCounter.Count(preview.Diagnostics ?? []);
+
+        return new ResourcePolicyPreviewSummary
+        {
+            TenantScope = preview.TenantScope,
+            EvaluationTimestamp = preview.EvaluationTimestamp,
+            TotalCandidateCount = candidates.Count,
+            DistinctResourceCount = candidates
+                .Select(static candidate => candidate.ResourceId)
+                .Where(static resourceId => !string.IsNullOrWhiteSpace(resourceId))
+                .Distinct(StringComparer.Ordinal)
+                .Count(),
+            DistinctResourceVersionTargetCount = candidates
+                .Where(static candidate => !string.IsNullOrWhiteSpace(candidate.ResourceId) && candidate.ResourceVersion.HasValue)
+                .Select(static candidate => (candidate.ResourceId, candidate.ResourceVersion!.Value))
+                .Distinct()
+                .Count(),
+            OutcomeCounts = candidates
+                .GroupBy(static candidate => candidate.Outcome)
+                .OrderBy(static group => group.Key)
+                .Select(static group => new ResourcePolicyOutcomeCount
+                {
+                    Outcome = group.Key,
+                    Count = group.Count(),
+                })
+                .ToList(),
+            KindCounts = candidates
+                .GroupBy(static candidate => candidate.PolicyKind)
+                .OrderBy(static group => group.Key)
+                .Select(static group => new ResourcePolicyKindCount
+                {
+                    Kind = group.Key,
+                    Count = group.Count(),
+                })
+                .ToList(),
+            DiagnosticCodeCounts = diagnosticCodeCounts,
+        };
+    }
+}

--- a/test/Aster.Tests/Policies/PolicyPreviewSummaryTests.cs
+++ b/test/Aster.Tests/Policies/PolicyPreviewSummaryTests.cs
@@ -1,0 +1,140 @@
+using Aster.Core.Models.Policies;
+using Aster.Core.Models.Tenancy;
+
+namespace Aster.Tests.Policies;
+
+public sealed class PolicyPreviewSummaryTests
+{
+    [Fact]
+    public void PreviewSummary_MixedCandidates_AggregatesCandidatesOutcomesKindsAndTargets()
+    {
+        var evaluatedAt = DateTimeOffset.UtcNow;
+        var preview = new ResourcePolicyEvaluationPreview
+        {
+            TenantScope = TenantScope.FromTenantId("tenant-a"),
+            EvaluationTimestamp = evaluatedAt,
+            Candidates =
+            [
+                Candidate(ResourcePolicyKind.Archival, ResourcePolicyOutcome.Archive, "product-1"),
+                Candidate(ResourcePolicyKind.SoftDelete, ResourcePolicyOutcome.SoftDelete, "product-1"),
+                Candidate(ResourcePolicyKind.VersionPruning, ResourcePolicyOutcome.PrunePreview, "product-1", 1),
+                Candidate(ResourcePolicyKind.VersionPruning, ResourcePolicyOutcome.PrunePreview, "product-1", 1),
+                Candidate(ResourcePolicyKind.Retention, ResourcePolicyOutcome.Retain, "product-2", 2),
+                Candidate(ResourcePolicyKind.Archival, ResourcePolicyOutcome.Archive, ""),
+            ],
+        };
+
+        var summary = preview.ToSummary();
+
+        Assert.Equal(preview.TenantScope, summary.TenantScope);
+        Assert.Equal(evaluatedAt, summary.EvaluationTimestamp);
+        Assert.Equal(6, summary.TotalCandidateCount);
+        Assert.Equal(2, summary.DistinctResourceCount);
+        Assert.Equal(2, summary.DistinctResourceVersionTargetCount);
+        Assert.Equal(
+            [
+                (ResourcePolicyOutcome.Retain, 1),
+                (ResourcePolicyOutcome.Archive, 2),
+                (ResourcePolicyOutcome.SoftDelete, 1),
+                (ResourcePolicyOutcome.PrunePreview, 2),
+            ],
+            summary.OutcomeCounts.Select(static count => (count.Outcome, count.Count)).ToList());
+        Assert.Equal(
+            [
+                (ResourcePolicyKind.Retention, 1),
+                (ResourcePolicyKind.Archival, 2),
+                (ResourcePolicyKind.SoftDelete, 1),
+                (ResourcePolicyKind.VersionPruning, 2),
+            ],
+            summary.KindCounts.Select(static count => (count.Kind, count.Count)).ToList());
+        Assert.False(summary.HasDiagnostics);
+        Assert.True(summary.IsDiagnosticFree);
+    }
+
+    [Fact]
+    public void PreviewSummary_Diagnostics_AggregatesCodesAndIgnoresBlankCodes()
+    {
+        var preview = new ResourcePolicyEvaluationPreview
+        {
+            Diagnostics =
+            [
+                Diagnostic("z-code"),
+                Diagnostic(""),
+                Diagnostic(" "),
+                Diagnostic("a-code"),
+                Diagnostic("z-code"),
+            ],
+        };
+
+        var summary = preview.ToSummary();
+
+        Assert.Equal(0, summary.TotalCandidateCount);
+        Assert.True(summary.HasDiagnostics);
+        Assert.False(summary.IsDiagnosticFree);
+        Assert.Equal(
+            [("a-code", 1), ("z-code", 2)],
+            summary.DiagnosticCodeCounts.Select(static count => (count.Code, count.Count)).ToList());
+    }
+
+    [Fact]
+    public void PreviewSummary_NullInputThrows()
+    {
+        Assert.Throws<ArgumentNullException>(() => ((ResourcePolicyEvaluationPreview)null!).ToSummary());
+    }
+
+    [Fact]
+    public void PreviewSummary_NullCollectionsAreTreatedAsEmpty()
+    {
+        var summary = new ResourcePolicyEvaluationPreview
+        {
+            Candidates = null!,
+            Diagnostics = null!,
+        }.ToSummary();
+
+        Assert.Equal(0, summary.TotalCandidateCount);
+        Assert.Equal(0, summary.DistinctResourceCount);
+        Assert.Equal(0, summary.DistinctResourceVersionTargetCount);
+        Assert.Empty(summary.OutcomeCounts);
+        Assert.Empty(summary.KindCounts);
+        Assert.Empty(summary.DiagnosticCodeCounts);
+        Assert.True(summary.IsDiagnosticFree);
+    }
+
+    [Fact]
+    public void PreviewSummary_IsGeneratedFromManuallyConstructedResultWithoutServices()
+    {
+        var summary = new ResourcePolicyEvaluationPreview
+        {
+            Candidates =
+            [
+                Candidate(ResourcePolicyKind.Archival, ResourcePolicyOutcome.Archive, "manual"),
+            ],
+        }.ToSummary();
+
+        Assert.Equal(1, summary.TotalCandidateCount);
+        Assert.Equal(1, summary.DistinctResourceCount);
+        Assert.True(summary.IsDiagnosticFree);
+    }
+
+    private static ResourcePolicyCandidateOutcome Candidate(
+        ResourcePolicyKind kind,
+        ResourcePolicyOutcome outcome,
+        string resourceId,
+        int? resourceVersion = null) =>
+        new()
+        {
+            PolicyId = $"{kind}-{outcome}",
+            PolicyKind = kind,
+            Outcome = outcome,
+            ResourceId = resourceId,
+            ResourceVersion = resourceVersion,
+            Reason = "Matched test policy.",
+        };
+
+    private static ResourcePolicyDiagnostic Diagnostic(string code) =>
+        new()
+        {
+            Code = code,
+            Message = code,
+        };
+}


### PR DESCRIPTION
## Summary
- add pure policy preview summary records and ToSummary helper
- summarize preview candidates by outcome, policy kind, distinct resources, version targets, and diagnostics
- add focused policy preview summary coverage and update Spec Kit/roadmap context for 027

## Validation
- dotnet test Aster.sln --filter "FullyQualifiedName~PolicyPreviewSummaryTests"
- dotnet test Aster.sln
- dotnet build Aster.sln /m:1
- git diff --check