### PR TITLE
Add portability result summaries

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "featureDir": "specs/027-policy-preview-summaries"
+  "featureDir": "specs/028-portability-result-summaries"
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 <!-- SPECKIT START -->
 For additional context about technologies to be used, project structure,
-shell commands, and other important information, read `specs/027-policy-preview-summaries/plan.md`.
+shell commands, and other important information, read `specs/028-portability-result-summaries/plan.md`.
 <!-- SPECKIT END -->
 
 ## Active Technologies
@@ -40,8 +40,11 @@ shell commands, and other important information, read `specs/027-policy-preview-
 - No storage changes. Summaries are pure in-memory views over existing restore result objects; no schema migration, persistence, provider storage, audit records, or physical index changes. (026-lifecycle-restore-summaries)
 - C# latest, .NET 8.0 / 9.0 / 10.0 multi-targeting + Existing core SDK policy preview models, policy diagnostic models, xUnit test stack; no new dependencies (027-policy-preview-summaries)
 - No storage changes. Summaries are pure in-memory views over existing policy preview result objects; no schema migration, persistence, provider storage, audit records, or physical index changes. (027-policy-preview-summaries)
+- C# latest, .NET 8.0 / 9.0 / 10.0 multi-targeting + Existing core SDK portability result models and xUnit test stack; no new dependencies (028-portability-result-summaries)
+- No storage changes. Summaries are pure in-memory views over existing portability result objects; no schema migration, persistence, provider storage, audit records, or physical index changes. (028-portability-result-summaries)
 
 ## Recent Changes
+- 028-portability-result-summaries: Added pure host-facing portability export/import preview/import summaries with deterministic entity counts, identity mapping reason counts, diagnostic severity counts, diagnostic code counts, status booleans, and no storage, provider, service registration, recipe package, scheduler, audit persistence, public SQL, public IQueryable<Resource>, query planner, or mutation behavior
 - 027-policy-preview-summaries: Added pure host-facing policy preview summaries with deterministic candidate counts, outcome counts, policy kind counts, distinct resource counts, distinct resource-version target counts, diagnostic code counts, diagnostic booleans, and no storage, provider, service registration, scheduler, audit persistence, public SQL, public IQueryable<Resource>, query planner, or mutation behavior
 - 026-lifecycle-restore-summaries: Added pure host-facing lifecycle restore preview and application summaries with deterministic status counts, affected resource counts, diagnostic code counts, completion booleans, and no storage, provider, service registration, scheduler, audit persistence, public SQL, public IQueryable<Resource>, query planner, or mutation behavior
 - 025-operational-hardening: Added bounded operational hardening planning and test context for lifecycle restore retries, same-candidate restore races, policy pruning retries, persisted SQLite pruning retries, and repeated historical activation without new product APIs, storage schema changes, providers, schedulers, benchmark infrastructure, or dependencies

--- a/docs/ExecutionRoadmap.md
+++ b/docs/ExecutionRoadmap.md
@@ -6,9 +6,9 @@ This roadmap tracks the implementation trail we have already cut through the rep
 
 ## Current Position
 
-Aster now has a working Core SDK, in-memory runtime, SQLite JSON persistence/querying, provider capability discovery, provider validation alignment, provider authoring ergonomics, a reusable provider conformance harness, SQLite facet sorting, portable operator expansion, SQLite date-like ranges, explicit provider-declared index projections, explicit definition schema upgrade behavior, deterministic portability primitives, explicit host lifecycle hooks, explicit tenant scoping, policy foundations, host-controlled policy application orchestration, host-controlled lifecycle restore workflows, host-controlled policy pruning application, read-only version history inspection, explicit historical version activation, policy application summaries, batch version history inspection, version history summaries, operational hardening coverage, and lifecycle restore summaries.
+Aster now has a working Core SDK, in-memory runtime, SQLite JSON persistence/querying, provider capability discovery, provider validation alignment, provider authoring ergonomics, a reusable provider conformance harness, SQLite facet sorting, portable operator expansion, SQLite date-like ranges, explicit provider-declared index projections, explicit definition schema upgrade behavior, deterministic portability primitives, explicit host lifecycle hooks, explicit tenant scoping, policy foundations, host-controlled policy application orchestration, host-controlled lifecycle restore workflows, host-controlled policy pruning application, read-only version history inspection, explicit historical version activation, policy application summaries, batch version history inspection, version history summaries, operational hardening coverage, lifecycle restore summaries, and policy preview summaries.
 
-The Phase 4 core workstream is complete enough to defer optional recipes. The active workstream is now **Phase 5: Multi-tenancy, Policies, Advanced Versioning**. Explicit tenant-aware boundaries, policy foundations, policy application orchestration, reversible lifecycle restore, destructive pruning application, version history inspection, historical version activation, policy application summaries, batch version history inspection, version history summaries, operational hardening, and lifecycle restore summaries have landed; policy preview summaries are the current bounded host-reporting slice.
+The Phase 4 core workstream is complete enough to defer optional recipes. The active workstream is now **Phase 5: Multi-tenancy, Policies, Advanced Versioning** with a small cross-cutting portability reporting follow-up. Explicit tenant-aware boundaries, policy foundations, policy application orchestration, reversible lifecycle restore, destructive pruning application, version history inspection, historical version activation, policy application summaries, batch version history inspection, version history summaries, operational hardening, lifecycle restore summaries, and policy preview summaries have landed; portability result summaries are the current bounded host-reporting slice.
 
 ## Landed Slices
 
@@ -40,24 +40,25 @@ The Phase 4 core workstream is complete enough to defer optional recipes. The ac
 | `024-version-history-summaries` | Landed | Pure host-facing summaries for single and batch version history results with deterministic version-state counts, selected/missing resource counts, lifecycle state counts, and no storage, provider, service, query planner, policy evaluation, or reporting infrastructure. |
 | `025-operational-hardening` | Landed | Bounded retry and concurrency-sensitive coverage for lifecycle restore, policy pruning retries, SQLite persisted pruning retries, and repeated historical activation without new product APIs, storage schema changes, schedulers, benchmark infrastructure, or dependencies. |
 | `026-lifecycle-restore-summaries` | Landed | Pure host-facing lifecycle restore preview and application summaries with deterministic status counts, affected resource counts, diagnostic counts, completion booleans, and no storage, provider, service registration, audit persistence, or mutation behavior. |
+| `027-policy-preview-summaries` | Landed | Pure host-facing policy preview summaries with deterministic candidate, outcome, policy-kind, distinct resource, distinct resource-version target, and diagnostic counts without storage, provider, service registration, audit persistence, or mutation behavior. |
 
 ## Near-Term Roadmap
 
-### 027 — Policy Preview Summaries
+### 028 — Portability Result Summaries
 
-**Status:** In progress on `027-policy-preview-summaries`.
+**Status:** In progress on `028-portability-result-summaries`.
 
-**Goal:** Add pure host-facing summaries for policy evaluation preview results.
+**Goal:** Add pure host-facing summaries for portability export, import preview, and import result objects.
 
 Scope:
 
-- Summarize policy preview candidates with deterministic total, outcome, policy-kind, distinct resource, and distinct resource-version target counts.
-- Summarize preview diagnostics with deterministic diagnostic-code counts and diagnostic booleans.
-- Preserve pure transformation behavior over existing result objects with no service registration, provider access, storage changes, audit persistence, schedulers, public SQL, public `IQueryable<Resource>`, or mutation behavior.
+- Summarize export results with deterministic snapshot entity counts, skipped activation counts, diagnostic severity counts, and diagnostic-code counts.
+- Summarize import previews and import results with deterministic planned/actual count totals, identity mapping reason counts, diagnostic counts, and status booleans.
+- Preserve pure transformation behavior over existing result objects with no service registration, provider access, storage changes, recipe package, audit persistence, schedulers, public SQL, public `IQueryable<Resource>`, or mutation behavior.
 
-### 028 — Next Bounded Phase 5 Slice
+### 029 — Next Bounded Slice
 
-**Goal:** Choose one small continuation slice after policy preview summaries land.
+**Goal:** Choose one small continuation slice after portability result summaries land.
 
 Candidate scope:
 

--- a/specs/028-portability-result-summaries/checklists/requirements.md
+++ b/specs/028-portability-result-summaries/checklists/requirements.md
@@ -1,0 +1,34 @@
+# Specification Quality Checklist: Portability Result Summaries
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-05-31
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Specification is ready for planning.

--- a/specs/028-portability-result-summaries/contracts/portability-result-summaries.md
+++ b/specs/028-portability-result-summaries/contracts/portability-result-summaries.md
@@ -1,0 +1,63 @@
+# Contract: Portability Result Summaries
+
+## Public SDK Behavior
+
+The core SDK exposes pure summary helpers for portability result objects.
+
+### Export Summary
+
+`PortableSnapshotExportResult.ToSummary()` returns a `PortableExportSummary`.
+
+Required behavior:
+
+- Throws `ArgumentNullException` when the source result is null.
+- Preserves `SourceTenantScope`.
+- Counts snapshot definitions, resources, activation entries, and lifecycle markers when a snapshot exists.
+- Reports zero snapshot counts when no snapshot exists.
+- Counts skipped activation entries.
+- Aggregates diagnostics by severity and nonblank code.
+
+### Import Preview Summary
+
+`PortableImportPreview.ToSummary()` returns a `PortableImportPreviewSummary`.
+
+Required behavior:
+
+- Throws `ArgumentNullException` when the source preview is null.
+- Preserves `SourceTenantScope`, `TargetTenantScope`, and `CanImport`.
+- Preserves planned count records.
+- Reports total planned item count.
+- Aggregates identity mappings by reason.
+- Aggregates diagnostics by severity and nonblank code.
+
+### Import Summary
+
+`PortableImportResult.ToSummary()` returns a `PortableImportSummary`.
+
+Required behavior:
+
+- Throws `ArgumentNullException` when the source result is null.
+- Preserves `SourceTenantScope`, `TargetTenantScope`, and `Status`.
+- Preserves actual count records.
+- Reports total actual item count.
+- Exposes imported, no-op, and failed status booleans.
+- Aggregates identity mappings by reason.
+- Aggregates diagnostics by severity and nonblank code.
+
+## Non-Goals
+
+This contract does not add:
+
+- New export behavior.
+- New import planning behavior.
+- New import write behavior.
+- Service registration.
+- Storage or provider behavior.
+- Recipe packages.
+- Audit persistence.
+- Reporting infrastructure.
+- Query planning.
+- Public SQL.
+- Public `IQueryable<Resource>`.
+- Runtime scanning or automatic discovery.
+- Background jobs or schedulers.

--- a/specs/028-portability-result-summaries/data-model.md
+++ b/specs/028-portability-result-summaries/data-model.md
@@ -1,0 +1,84 @@
+# Data Model: Portability Result Summaries
+
+## Portable Export Summary
+
+Aggregate view over one `PortableSnapshotExportResult`.
+
+Fields:
+
+- `SourceTenantScope`: Source tenant from the export result.
+- `HasSnapshot`: True when a snapshot is present.
+- `HasErrors`: True when diagnostics include at least one error severity.
+- `DefinitionCount`: Number of definition snapshots exported.
+- `ResourceVersionCount`: Number of resource version snapshots exported.
+- `ActivationEntryCount`: Number of activation entries exported.
+- `LifecycleMarkerCount`: Number of lifecycle markers exported.
+- `SkippedActivationEntryCount`: Number of activation entries skipped during export.
+- `DiagnosticSeverityCounts`: Deterministic counts by diagnostic severity.
+- `DiagnosticCodeCounts`: Deterministic counts by diagnostic code.
+
+## Portable Import Preview Summary
+
+Aggregate view over one `PortableImportPreview`.
+
+Fields:
+
+- `SourceTenantScope`: Source tenant recorded in the snapshot.
+- `TargetTenantScope`: Target tenant planned for import.
+- `CanImport`: Whether the preview allows import.
+- `HasErrors`: True when diagnostics include at least one error severity.
+- `Counts`: Planned import counts from the preview.
+- `TotalPlannedItemCount`: Sum of planned definition, resource, resource version, activation entry, and lifecycle marker counts.
+- `MappingReasonCounts`: Deterministic counts by identity mapping reason.
+- `DiagnosticSeverityCounts`: Deterministic counts by diagnostic severity.
+- `DiagnosticCodeCounts`: Deterministic counts by diagnostic code.
+
+## Portable Import Summary
+
+Aggregate view over one `PortableImportResult`.
+
+Fields:
+
+- `SourceTenantScope`: Source tenant recorded in the snapshot.
+- `TargetTenantScope`: Target tenant used for import.
+- `Status`: Import status.
+- `IsImported`: True when status is imported.
+- `IsNoOp`: True when status is no-op.
+- `IsFailed`: True when status is failed.
+- `HasErrors`: True when diagnostics include at least one error severity.
+- `Counts`: Actual import counts from the result.
+- `TotalActualItemCount`: Sum of actual definition, resource, resource version, activation entry, and lifecycle marker counts.
+- `MappingReasonCounts`: Deterministic counts by identity mapping reason.
+- `DiagnosticSeverityCounts`: Deterministic counts by diagnostic severity.
+- `DiagnosticCodeCounts`: Deterministic counts by diagnostic code.
+
+## Portable Diagnostic Severity Count
+
+Count for one `PortableDiagnosticSeverity`.
+
+Fields:
+
+- `Severity`: Diagnostic severity.
+- `Count`: Number of diagnostics with the severity.
+
+## Portable Diagnostic Code Count
+
+Count for one stable portability diagnostic code.
+
+Fields:
+
+- `Code`: Stable diagnostic code.
+- `Count`: Number of diagnostics with the code.
+
+## Portable Identity Mapping Reason Count
+
+Count for one `PortableIdentityMappingReason`.
+
+Fields:
+
+- `Reason`: Identity mapping reason.
+- `Count`: Number of mappings with the reason.
+
+## State Transitions
+
+None. Summaries are pure transformations over existing result objects and do not change snapshots, imports, exports, storage, providers, lifecycle hooks, or service registrations.

--- a/specs/028-portability-result-summaries/plan.md
+++ b/specs/028-portability-result-summaries/plan.md
@@ -1,0 +1,115 @@
+# Implementation Plan: Portability Result Summaries
+
+**Branch**: `028-portability-result-summaries` | **Date**: 2026-05-31 | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from `/specs/028-portability-result-summaries/spec.md`
+
+## Summary
+
+Add pure host-facing summary records and extension helpers over existing portability export, import preview, and import result objects. The implementation mirrors the existing summary pattern: deterministic entity, mapping, diagnostic, and status counts; no service registration; no provider/storage changes; no recipe package; and no portability behavior changes.
+
+## Technical Context
+
+**Language/Version**: C# latest, .NET 8.0 / 9.0 / 10.0 multi-targeting
+**Primary Dependencies**: Existing core SDK portability models and xUnit test stack; no new dependencies
+**Storage**: No storage changes. Summaries are pure in-memory views over existing portability result objects; no schema migration, persistence, provider storage, audit records, or physical index changes.
+**Testing**: Focused portability summary tests, existing portability regression tests, `dotnet test Aster.sln`, `dotnet build Aster.sln /m:1`, `git diff --check`
+**Target Platform**: .NET SDK/library consumers and local test environment
+**Project Type**: SDK/library with provider packages and tests
+**Performance Goals**: Summary computation is linear over supplied result objects and performs no I/O.
+**Constraints**: Pure transformations only; deterministic counts; null result inputs fail fast; null snapshot/collections are treated as empty for counting; no service, storage, provider, query, public SQL, public `IQueryable<Resource>`, runtime scanning, automatic discovery, import planning changes, export changes, audit persistence, recipe package, reporting framework, or mutation behavior.
+**Scale/Scope**: Core SDK summary records/extensions, focused tests, docs, roadmap, and Spec Kit artifacts.
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+- **SDK-first/headless**: PASS - Adds SDK result helpers only; no UI, CMS, or host authorization behavior.
+- **Immutable versioning**: PASS - Summaries are read-only and do not mutate resource versions.
+- **Channel activation**: PASS - Activation state remains untouched.
+- **Typed/queryable**: PASS - Query AST and typed aspect APIs remain unchanged; no public SQL or `IQueryable` is introduced.
+- **Provider agnostic**: PASS - Summaries operate on existing result objects and do not depend on providers.
+- **Simplicity first**: PASS - Pure records/extensions are the smallest implementation.
+- **Modern C# idioms**: PASS - Records, extension methods, collection expressions, enum ordering, and nullable-safe handling match existing style.
+- **Readability over cleverness**: PASS - Counts are direct and explicit.
+- **Explicitness over magic**: PASS - Hosts explicitly call summary helpers on result objects.
+- **Abstractions justified**: PASS - No service or new interface is introduced.
+- **Optimize for deletion**: PASS - Removing the feature removes one additive model file, tests, and docs.
+- **Composition over inheritance**: PASS - Uses records and extension methods; no inheritance hierarchy.
+- **Intentional dependencies**: PASS - No new third-party dependencies.
+- **Operational simplicity**: PASS - No migration, worker, external service, or setup change.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/028-portability-result-summaries/
++-- spec.md
++-- plan.md
++-- research.md
++-- data-model.md
++-- quickstart.md
++-- checklists/
+|   +-- requirements.md
++-- contracts/
+    +-- portability-result-summaries.md
+```
+
+### Source Code (repository root)
+
+```text
+src/
++-- core/Aster.Core/
+|   +-- Models/Portability/
+|       +-- PortableResultSummaries.cs
+|
++-- persistence/Aster.Persistence.SqliteJson/
+    +-- no changes
+
+test/
++-- Aster.Tests/
+    +-- Portability/
+        +-- PortableResultSummaryTests.cs
+```
+
+**Structure Decision**: Keep portability summaries in `Aster.Core.Models.Portability` beside portability result models. They are pure SDK helpers over existing result objects and need no service registration or provider implementation.
+
+## Complexity Tracking
+
+No constitution violations.
+
+## Phase 0 Research Summary
+
+Research decisions are captured in [research.md](research.md). Key outcomes:
+
+- Use pure extension helpers rather than a service.
+- Preserve source/target tenant identity from source results.
+- Count snapshot/export entities directly from `PortableSnapshot`.
+- Count import planned/actual totals from existing count records.
+- Count diagnostics by severity and code deterministically.
+- Count identity mappings by reason deterministically.
+
+## Phase 1 Design Summary
+
+Design artifacts:
+
+- [data-model.md](data-model.md)
+- [contracts/portability-result-summaries.md](contracts/portability-result-summaries.md)
+- [quickstart.md](quickstart.md)
+
+## Post-Design Constitution Check
+
+- **SDK-first/headless**: PASS - Design exposes records and extension helpers only.
+- **Immutable versioning**: PASS - No write path is introduced.
+- **Channel activation**: PASS - Activation state remains unchanged.
+- **Typed/queryable**: PASS - Query APIs remain unchanged.
+- **Provider agnostic**: PASS - No provider dependency exists.
+- **Simplicity first**: PASS - No service or registry is added.
+- **Modern C# idioms**: PASS - Planned code follows established summary patterns.
+- **Readability over cleverness**: PASS - Count formulas are direct.
+- **Explicitness over magic**: PASS - Callers explicitly invoke `ToSummary`.
+- **Abstractions justified**: PASS - No new abstraction is introduced.
+- **Optimize for deletion**: PASS - Feature is additive and localized.
+- **Composition over inheritance**: PASS - Records/extensions only.
+- **Intentional dependencies**: PASS - No new dependencies.
+- **Operational simplicity**: PASS - Existing validation commands remain sufficient.

--- a/specs/028-portability-result-summaries/quickstart.md
+++ b/specs/028-portability-result-summaries/quickstart.md
@@ -1,0 +1,81 @@
+# Quickstart: Portability Result Summaries
+
+## Minimal Export Summary
+
+```csharp
+using Aster.Core.Models.Portability;
+
+var export = new PortableSnapshotExportResult
+{
+    Snapshot = new PortableSnapshot
+    {
+        FormatVersion = PortableSnapshot.CurrentFormatVersion,
+    },
+};
+
+var summary = export.ToSummary();
+
+Console.WriteLine(summary.HasSnapshot);
+Console.WriteLine(summary.DefinitionCount);
+Console.WriteLine(summary.HasErrors);
+```
+
+## Minimal Import Preview Summary
+
+```csharp
+using Aster.Core.Models.Portability;
+
+var preview = new PortableImportPreview
+{
+    CanImport = true,
+    Counts = new PortablePlannedImportCounts
+    {
+        Definitions = 1,
+        Resources = 1,
+        ResourceVersions = 2,
+    },
+};
+
+var summary = preview.ToSummary();
+
+Console.WriteLine(summary.CanImport);
+Console.WriteLine(summary.TotalPlannedItemCount);
+```
+
+## Minimal Import Summary
+
+```csharp
+using Aster.Core.Models.Portability;
+
+var result = new PortableImportResult
+{
+    Status = PortableImportStatus.Imported,
+    Counts = new PortableActualImportCounts
+    {
+        Definitions = 1,
+        Resources = 1,
+        ResourceVersions = 2,
+    },
+};
+
+var summary = result.ToSummary();
+
+Console.WriteLine(summary.IsImported);
+Console.WriteLine(summary.TotalActualItemCount);
+```
+
+## Validation
+
+Run focused summary tests:
+
+```bash
+dotnet test Aster.sln --filter "FullyQualifiedName~PortableResultSummaryTests"
+```
+
+Run full validation:
+
+```bash
+dotnet test Aster.sln
+dotnet build Aster.sln /m:1
+git diff --check
+```

--- a/specs/028-portability-result-summaries/research.md
+++ b/specs/028-portability-result-summaries/research.md
@@ -1,0 +1,55 @@
+# Research: Portability Result Summaries
+
+## Decision: Use Pure Extension Helpers
+
+Use extension methods over `PortableSnapshotExportResult`, `PortableImportPreview`, and `PortableImportResult`.
+
+**Rationale**: The feature only aggregates data already present on result objects. A service would add registration and lifetime surface without reading external state or coordinating collaborators.
+
+**Alternatives considered**:
+
+- Service-based summarization: rejected because there is no dependency to inject and no provider state to access.
+- Computed properties on result records only: rejected because summaries combine multiple grouped counts and the existing pattern uses explicit `ToSummary` helpers.
+
+## Decision: Keep Export, Preview, and Import Summaries Separate
+
+Expose one summary record per portability operation result shape.
+
+**Rationale**: Export, preview, and import have different source fields and status semantics. Separate records keep behavior explicit and avoid a vague generic operation summary.
+
+**Alternatives considered**:
+
+- One generic portability summary: rejected because export lacks target tenant and import status, while import lacks skipped activation entries.
+- Summarize validation results in this slice too: deferred to keep the slice focused on host operation results.
+
+## Decision: Count Diagnostics by Severity and Code
+
+Summaries expose deterministic severity counts and diagnostic code counts.
+
+**Rationale**: Hosts need to distinguish informational, warning, and error diagnostics and still show stable code-level troubleshooting detail.
+
+**Alternatives considered**:
+
+- Code counts only: rejected because error presence is an operator-critical concept.
+- Severity counts only: rejected because hosts need stable diagnostic detail.
+
+## Decision: Count Identity Mappings by Reason
+
+Import preview and import summaries group identity maps by `PortableIdentityMappingReason`.
+
+**Rationale**: Mapping reason is the compact operator-facing explanation of preserved, reused, remapped, or collided identities.
+
+**Alternatives considered**:
+
+- Count mappings by entity kind: useful later, but reason counts better explain risk and actionability for this slice.
+- Count every mapping only as a total: rejected because it hides remap/collision behavior.
+
+## Decision: Null Collections Are Empty
+
+Summary helpers fail fast for null result objects but treat null snapshots and collections as empty for counting.
+
+**Rationale**: This matches existing summary behavior and keeps manually constructed test/UI DTOs easy to summarize while still catching programming errors for null result inputs.
+
+**Alternatives considered**:
+
+- Throw for null collections: rejected because result records are host-constructible and existing summary helpers already tolerate null collections.

--- a/specs/028-portability-result-summaries/spec.md
+++ b/specs/028-portability-result-summaries/spec.md
@@ -1,0 +1,115 @@
+# Feature Specification: Portability Result Summaries
+
+**Feature Branch**: `028-portability-result-summaries`
+**Created**: 2026-05-31
+**Status**: Draft
+**Input**: Continue with the next bounded slice after policy preview summaries.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Summarize Portable Export Results (Priority: P1)
+
+As a host developer rendering export feedback, I want a deterministic summary of portable export results so that operators can see exported entity counts, skipped activation entries, and diagnostics without recomputing them.
+
+**Why this priority**: Export is the first portability operation. Hosts need a simple rollup before handing snapshots to operators or automation.
+
+**Independent Test**: Construct an export result with a snapshot, skipped activation entries, and diagnostics, then verify entity counts, skipped count, diagnostic severity counts, diagnostic code counts, and success booleans.
+
+**Acceptance Scenarios**:
+
+1. **Given** an export result with a snapshot, **When** it is summarized, **Then** the summary reports definition, resource-version, activation-entry, and lifecycle-marker counts.
+2. **Given** export skipped activation entries, **When** it is summarized, **Then** skipped activation count is reported.
+3. **Given** export diagnostics, **When** it is summarized, **Then** severity and code counts are deterministic.
+
+---
+
+### User Story 2 - Summarize Portable Import Preview Results (Priority: P2)
+
+As a host developer rendering import preview screens, I want a deterministic summary of portable import previews so that operators can see planned counts, identity mapping reasons, and blocking diagnostics before writes.
+
+**Why this priority**: Import preview is the operator decision point before mutation. The summary should make planned scope and blockers easy to present.
+
+**Independent Test**: Construct an import preview with planned counts, identity mappings, and diagnostics, then verify count totals, mapping reason counts, diagnostic counts, and importability booleans.
+
+**Acceptance Scenarios**:
+
+1. **Given** an import preview with planned counts, **When** it is summarized, **Then** the summary reports those counts and a total planned item count.
+2. **Given** an import preview with identity mappings, **When** it is summarized, **Then** mapping reason counts are deterministic.
+3. **Given** an import preview cannot import due to diagnostics, **When** it is summarized, **Then** diagnostic and can-import booleans reflect that state.
+
+---
+
+### User Story 3 - Summarize Portable Import Results (Priority: P3)
+
+As a host developer rendering completed import feedback, I want a deterministic summary of portable import results so that operators can see actual imported counts, reuse/remap counts, status, and diagnostics.
+
+**Why this priority**: Import result reporting should align with preview reporting while preserving existing import semantics.
+
+**Independent Test**: Construct import results for imported, no-op, and failed outcomes, then verify status booleans, actual counts, mapping reason counts, and diagnostics.
+
+**Acceptance Scenarios**:
+
+1. **Given** a successful import result, **When** it is summarized, **Then** imported status and actual count totals are reported.
+2. **Given** a no-op import result, **When** it is summarized, **Then** no-op status is reported without treating the result as failed.
+3. **Given** a failed import result with diagnostics, **When** it is summarized, **Then** failed status and diagnostic counts are reported.
+
+### Edge Cases
+
+- Null result inputs MUST fail fast with argument validation.
+- Null snapshots MUST produce zero exported entity counts.
+- Null diagnostics, identity maps, and skipped activation collections MUST be treated as empty collections.
+- Blank diagnostic codes MUST be ignored for diagnostic code counts.
+- Diagnostic severity counts MUST be ordered deterministically by enum value.
+- Identity mapping reason counts MUST be ordered deterministically by enum value.
+- Summaries MUST NOT perform reads, writes, validation, import planning, export generation, storage access, provider access, background work, or query planning.
+
+### Constitution Alignment *(mandatory)*
+
+- **Simplicity**: Add pure extension helpers and records over existing portability result models only. No service, registry, provider, recipe package, workflow, or audit store is introduced.
+- **Explicitness**: Callers explicitly summarize existing result objects. There is no hidden discovery, scanning, ambient state, or automatic reporting behavior.
+- **Dependencies**: None.
+- **Operational Impact**: No deployment, storage, migration, provider setup, debugging, observability, or runtime behavior changes.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The system MUST provide a pure summary for portable snapshot export results.
+- **FR-002**: Export summaries MUST preserve source tenant scope.
+- **FR-003**: Export summaries MUST report exported definition, resource version, activation entry, lifecycle marker, and skipped activation counts.
+- **FR-004**: Export summaries MUST expose whether a snapshot was produced and whether export diagnostics include errors.
+- **FR-005**: The system MUST provide a pure summary for portable import previews.
+- **FR-006**: Import preview summaries MUST preserve source and target tenant scopes.
+- **FR-007**: Import preview summaries MUST report planned import counts and total planned item count.
+- **FR-008**: Import preview summaries MUST report deterministic identity mapping reason counts.
+- **FR-009**: Import preview summaries MUST expose whether import is allowed and whether diagnostics include errors.
+- **FR-010**: The system MUST provide a pure summary for portable import results.
+- **FR-011**: Import result summaries MUST preserve source and target tenant scopes and import status.
+- **FR-012**: Import result summaries MUST report actual import counts and total actual item count.
+- **FR-013**: Import result summaries MUST expose imported, no-op, and failed status booleans.
+- **FR-014**: Portability summaries MUST report deterministic diagnostic severity and diagnostic code counts.
+- **FR-015**: Portability summary helpers MUST fail fast for null result inputs.
+- **FR-016**: Portability summary helpers MUST treat null snapshots and collections as empty for counting purposes.
+- **FR-017**: Portability summary helpers MUST be usable over manually constructed result objects without services or providers.
+- **FR-018**: The system MUST preserve existing export, validation, preview import, write import, lifecycle hook, tenant, provider, and storage behavior.
+- **FR-019**: The system MUST NOT introduce storage changes, provider changes, service registration, recipe packages, background jobs, audit persistence, public SQL, public `IQueryable<Resource>`, runtime scanning, automatic discovery, query planners, import planning changes, export changes, or mutation behavior.
+- **FR-020**: Roadmap housekeeping MUST mark `027-policy-preview-summaries` as landed and identify `028-portability-result-summaries` as the active bounded slice.
+
+### Key Entities
+
+- **Portable Export Summary**: Aggregate counts and booleans for one export result.
+- **Portable Import Preview Summary**: Aggregate planned counts, mapping counts, diagnostics, and booleans for one import preview.
+- **Portable Import Summary**: Aggregate actual counts, mapping counts, diagnostics, and status booleans for one import result.
+- **Portable Diagnostic Severity Count**: Deterministic count for one diagnostic severity.
+- **Portable Diagnostic Code Count**: Deterministic count for one diagnostic code.
+- **Portable Identity Mapping Reason Count**: Deterministic count for one mapping reason.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: A host can summarize an export result with a snapshot and receive correct exported entity, skipped activation, and diagnostic counts.
+- **SC-002**: A host can summarize an import preview and receive correct planned count totals, mapping reason counts, and diagnostic booleans.
+- **SC-003**: A host can summarize imported, no-op, and failed import results and receive correct status booleans and counts.
+- **SC-004**: Summary helpers can be called on manually constructed portability result objects without service registration or provider setup.
+- **SC-005**: Existing portability, policy summary, lifecycle restore summary, and full test suites continue to pass unchanged.

--- a/specs/028-portability-result-summaries/tasks.md
+++ b/specs/028-portability-result-summaries/tasks.md
@@ -1,0 +1,134 @@
+# Tasks: Portability Result Summaries
+
+**Input**: Design documents from `/specs/028-portability-result-summaries/`
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/
+
+**Tests**: Tests are required by the feature specification because summary behavior is pure and independently testable.
+
+**Organization**: Tasks are grouped by user story to enable independent implementation and testing.
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Confirm the active slice and no dependency or provider setup is needed.
+
+- [ ] T001 Confirm `.specify/feature.json` points to `specs/028-portability-result-summaries`
+- [ ] T002 Confirm `AGENTS.md` points to `specs/028-portability-result-summaries/plan.md`
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Add shared portability summary records and deterministic count helpers.
+
+- [ ] T003 [P] Add portability summary record contracts in `src/core/Aster.Core/Models/Portability/PortableResultSummaries.cs`
+- [ ] T004 Add shared diagnostic and mapping count helpers in `src/core/Aster.Core/Models/Portability/PortableResultSummaries.cs`
+
+**Checkpoint**: Summary models and shared helpers are available for user stories.
+
+---
+
+## Phase 3: User Story 1 - Summarize Portable Export Results (Priority: P1) MVP
+
+**Goal**: Summarize export results with deterministic snapshot, skipped activation, and diagnostic counts.
+
+**Independent Test**: Manually construct an export result with snapshot content, skipped activation entries, and diagnostics and verify all summary fields.
+
+### Tests for User Story 1
+
+- [ ] T005 [P] [US1] Add export summary tests in `test/Aster.Tests/Portability/PortableResultSummaryTests.cs`
+
+### Implementation for User Story 1
+
+- [ ] T006 [US1] Implement `ToSummary(this PortableSnapshotExportResult result)` in `src/core/Aster.Core/Models/Portability/PortableResultSummaries.cs`
+
+**Checkpoint**: User Story 1 is independently testable with focused summary tests.
+
+---
+
+## Phase 4: User Story 2 - Summarize Portable Import Preview Results (Priority: P2)
+
+**Goal**: Summarize import previews with deterministic planned counts, mapping reason counts, and diagnostics.
+
+**Independent Test**: Manually construct an import preview with planned counts, mappings, and diagnostics and verify all summary fields.
+
+### Tests for User Story 2
+
+- [ ] T007 [P] [US2] Add import preview summary tests in `test/Aster.Tests/Portability/PortableResultSummaryTests.cs`
+
+### Implementation for User Story 2
+
+- [ ] T008 [US2] Implement `ToSummary(this PortableImportPreview preview)` in `src/core/Aster.Core/Models/Portability/PortableResultSummaries.cs`
+
+**Checkpoint**: User Story 2 is independently testable with focused summary tests.
+
+---
+
+## Phase 5: User Story 3 - Summarize Portable Import Results (Priority: P3)
+
+**Goal**: Summarize import results with deterministic actual counts, mapping reason counts, status booleans, and diagnostics.
+
+**Independent Test**: Manually construct import results for imported, no-op, and failed statuses and verify all summary fields.
+
+### Tests for User Story 3
+
+- [ ] T009 [P] [US3] Add import result summary tests in `test/Aster.Tests/Portability/PortableResultSummaryTests.cs`
+- [ ] T010 [P] [US3] Add null-input and null-collection tests in `test/Aster.Tests/Portability/PortableResultSummaryTests.cs`
+
+### Implementation for User Story 3
+
+- [ ] T011 [US3] Implement `ToSummary(this PortableImportResult result)` in `src/core/Aster.Core/Models/Portability/PortableResultSummaries.cs`
+- [ ] T012 [US3] Ensure portability summary helpers perform no service/provider/storage access in `src/core/Aster.Core/Models/Portability/PortableResultSummaries.cs`
+
+**Checkpoint**: All user stories are independently covered.
+
+---
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+**Purpose**: Documentation, roadmap, and validation.
+
+- [ ] T013 [P] Update `docs/ExecutionRoadmap.md` to mark 027 landed and make 028 active
+- [ ] T014 [P] Update `AGENTS.md` active technology and recent-change context for 028
+- [ ] T015 Run focused tests: `dotnet test Aster.sln --filter "FullyQualifiedName~PortableResultSummaryTests"`
+- [ ] T016 Run full tests: `dotnet test Aster.sln`
+- [ ] T017 Run build: `dotnet build Aster.sln /m:1`
+- [ ] T018 Run whitespace validation: `git diff --check`
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies.
+- **Foundational (Phase 2)**: Depends on Setup completion and blocks user stories.
+- **User Story 1 (Phase 3)**: Depends on Foundational.
+- **User Story 2 (Phase 4)**: Depends on Foundational.
+- **User Story 3 (Phase 5)**: Depends on Foundational.
+- **Polish (Phase 6)**: Depends on all selected user stories.
+
+### Parallel Opportunities
+
+- T003 and T004 can be developed together in the same file with careful coordination.
+- T005, T007, T009, and T010 are conceptually parallel but edit the same test file, so they should be applied carefully.
+- T013 and T014 can be updated independently once implementation is complete.
+
+## Implementation Strategy
+
+### MVP First
+
+1. Complete Setup and Foundational tasks.
+2. Implement User Story 1 export summary and focused tests.
+3. Run focused tests.
+
+### Incremental Delivery
+
+1. Add User Story 2 import preview summary.
+2. Add User Story 3 import result summary and edge-case coverage.
+3. Run full validation and update roadmap/agent context.
+
+## Notes
+
+- Keep implementation in records/extensions only.
+- Do not add services, interfaces, provider registrations, storage, recipes, or dependencies.
+- Mark each task complete as it is implemented.

--- a/specs/028-portability-result-summaries/tasks.md
+++ b/specs/028-portability-result-summaries/tasks.md
@@ -11,8 +11,8 @@
 
 **Purpose**: Confirm the active slice and no dependency or provider setup is needed.
 
-- [ ] T001 Confirm `.specify/feature.json` points to `specs/028-portability-result-summaries`
-- [ ] T002 Confirm `AGENTS.md` points to `specs/028-portability-result-summaries/plan.md`
+- [X] T001 Confirm `.specify/feature.json` points to `specs/028-portability-result-summaries`
+- [X] T002 Confirm `AGENTS.md` points to `specs/028-portability-result-summaries/plan.md`
 
 ---
 
@@ -20,8 +20,8 @@
 
 **Purpose**: Add shared portability summary records and deterministic count helpers.
 
-- [ ] T003 [P] Add portability summary record contracts in `src/core/Aster.Core/Models/Portability/PortableResultSummaries.cs`
-- [ ] T004 Add shared diagnostic and mapping count helpers in `src/core/Aster.Core/Models/Portability/PortableResultSummaries.cs`
+- [X] T003 [P] Add portability summary record contracts in `src/core/Aster.Core/Models/Portability/PortableResultSummaries.cs`
+- [X] T004 Add shared diagnostic and mapping count helpers in `src/core/Aster.Core/Models/Portability/PortableResultSummaries.cs`
 
 **Checkpoint**: Summary models and shared helpers are available for user stories.
 
@@ -35,11 +35,11 @@
 
 ### Tests for User Story 1
 
-- [ ] T005 [P] [US1] Add export summary tests in `test/Aster.Tests/Portability/PortableResultSummaryTests.cs`
+- [X] T005 [P] [US1] Add export summary tests in `test/Aster.Tests/Portability/PortableResultSummaryTests.cs`
 
 ### Implementation for User Story 1
 
-- [ ] T006 [US1] Implement `ToSummary(this PortableSnapshotExportResult result)` in `src/core/Aster.Core/Models/Portability/PortableResultSummaries.cs`
+- [X] T006 [US1] Implement `ToSummary(this PortableSnapshotExportResult result)` in `src/core/Aster.Core/Models/Portability/PortableResultSummaries.cs`
 
 **Checkpoint**: User Story 1 is independently testable with focused summary tests.
 
@@ -53,11 +53,11 @@
 
 ### Tests for User Story 2
 
-- [ ] T007 [P] [US2] Add import preview summary tests in `test/Aster.Tests/Portability/PortableResultSummaryTests.cs`
+- [X] T007 [P] [US2] Add import preview summary tests in `test/Aster.Tests/Portability/PortableResultSummaryTests.cs`
 
 ### Implementation for User Story 2
 
-- [ ] T008 [US2] Implement `ToSummary(this PortableImportPreview preview)` in `src/core/Aster.Core/Models/Portability/PortableResultSummaries.cs`
+- [X] T008 [US2] Implement `ToSummary(this PortableImportPreview preview)` in `src/core/Aster.Core/Models/Portability/PortableResultSummaries.cs`
 
 **Checkpoint**: User Story 2 is independently testable with focused summary tests.
 
@@ -71,13 +71,13 @@
 
 ### Tests for User Story 3
 
-- [ ] T009 [P] [US3] Add import result summary tests in `test/Aster.Tests/Portability/PortableResultSummaryTests.cs`
-- [ ] T010 [P] [US3] Add null-input and null-collection tests in `test/Aster.Tests/Portability/PortableResultSummaryTests.cs`
+- [X] T009 [P] [US3] Add import result summary tests in `test/Aster.Tests/Portability/PortableResultSummaryTests.cs`
+- [X] T010 [P] [US3] Add null-input and null-collection tests in `test/Aster.Tests/Portability/PortableResultSummaryTests.cs`
 
 ### Implementation for User Story 3
 
-- [ ] T011 [US3] Implement `ToSummary(this PortableImportResult result)` in `src/core/Aster.Core/Models/Portability/PortableResultSummaries.cs`
-- [ ] T012 [US3] Ensure portability summary helpers perform no service/provider/storage access in `src/core/Aster.Core/Models/Portability/PortableResultSummaries.cs`
+- [X] T011 [US3] Implement `ToSummary(this PortableImportResult result)` in `src/core/Aster.Core/Models/Portability/PortableResultSummaries.cs`
+- [X] T012 [US3] Ensure portability summary helpers perform no service/provider/storage access in `src/core/Aster.Core/Models/Portability/PortableResultSummaries.cs`
 
 **Checkpoint**: All user stories are independently covered.
 
@@ -87,12 +87,12 @@
 
 **Purpose**: Documentation, roadmap, and validation.
 
-- [ ] T013 [P] Update `docs/ExecutionRoadmap.md` to mark 027 landed and make 028 active
-- [ ] T014 [P] Update `AGENTS.md` active technology and recent-change context for 028
-- [ ] T015 Run focused tests: `dotnet test Aster.sln --filter "FullyQualifiedName~PortableResultSummaryTests"`
-- [ ] T016 Run full tests: `dotnet test Aster.sln`
-- [ ] T017 Run build: `dotnet build Aster.sln /m:1`
-- [ ] T018 Run whitespace validation: `git diff --check`
+- [X] T013 [P] Update `docs/ExecutionRoadmap.md` to mark 027 landed and make 028 active
+- [X] T014 [P] Update `AGENTS.md` active technology and recent-change context for 028
+- [X] T015 Run focused tests: `dotnet test Aster.sln --filter "FullyQualifiedName~PortableResultSummaryTests"`
+- [X] T016 Run full tests: `dotnet test Aster.sln`
+- [X] T017 Run build: `dotnet build Aster.sln /m:1`
+- [X] T018 Run whitespace validation: `git diff --check`
 
 ---
 

--- a/src/core/Aster.Core/Models/Portability/PortableResultSummaries.cs
+++ b/src/core/Aster.Core/Models/Portability/PortableResultSummaries.cs
@@ -1,0 +1,281 @@
+using Aster.Core.Models.Tenancy;
+
+namespace Aster.Core.Models.Portability;
+
+/// <summary>
+/// Deterministic count for one portability diagnostic severity.
+/// </summary>
+public sealed record PortableDiagnosticSeverityCount
+{
+    /// <summary>Diagnostic severity.</summary>
+    public required PortableDiagnosticSeverity Severity { get; init; }
+
+    /// <summary>Number of diagnostics with the severity.</summary>
+    public required int Count { get; init; }
+}
+
+/// <summary>
+/// Deterministic count for one portability diagnostic code.
+/// </summary>
+public sealed record PortableDiagnosticCodeCount
+{
+    /// <summary>Stable diagnostic code.</summary>
+    public required string Code { get; init; }
+
+    /// <summary>Number of diagnostics with the code.</summary>
+    public required int Count { get; init; }
+}
+
+/// <summary>
+/// Deterministic count for one identity mapping reason.
+/// </summary>
+public sealed record PortableIdentityMappingReasonCount
+{
+    /// <summary>Identity mapping reason.</summary>
+    public required PortableIdentityMappingReason Reason { get; init; }
+
+    /// <summary>Number of mappings with the reason.</summary>
+    public required int Count { get; init; }
+}
+
+/// <summary>
+/// Aggregate view over a portable snapshot export result.
+/// </summary>
+public sealed record PortableExportSummary
+{
+    /// <summary>Source tenant scope used by the export result.</summary>
+    public TenantScope SourceTenantScope { get; init; } = TenantScope.Default;
+
+    /// <summary>Whether the export result includes a snapshot.</summary>
+    public required bool HasSnapshot { get; init; }
+
+    /// <summary>Whether export diagnostics include at least one error.</summary>
+    public bool HasErrors => DiagnosticSeverityCounts.Any(static count => count.Severity == PortableDiagnosticSeverity.Error && count.Count > 0);
+
+    /// <summary>Number of definition snapshots exported.</summary>
+    public required int DefinitionCount { get; init; }
+
+    /// <summary>Number of resource version snapshots exported.</summary>
+    public required int ResourceVersionCount { get; init; }
+
+    /// <summary>Number of activation entries exported.</summary>
+    public required int ActivationEntryCount { get; init; }
+
+    /// <summary>Number of lifecycle markers exported.</summary>
+    public required int LifecycleMarkerCount { get; init; }
+
+    /// <summary>Number of activation entries skipped during export.</summary>
+    public required int SkippedActivationEntryCount { get; init; }
+
+    /// <summary>Deterministic diagnostic severity counts.</summary>
+    public IReadOnlyList<PortableDiagnosticSeverityCount> DiagnosticSeverityCounts { get; init; } = [];
+
+    /// <summary>Deterministic diagnostic code counts.</summary>
+    public IReadOnlyList<PortableDiagnosticCodeCount> DiagnosticCodeCounts { get; init; } = [];
+}
+
+/// <summary>
+/// Aggregate view over a portable import preview result.
+/// </summary>
+public sealed record PortableImportPreviewSummary
+{
+    /// <summary>Source tenant scope recorded in the snapshot.</summary>
+    public TenantScope SourceTenantScope { get; init; } = TenantScope.Default;
+
+    /// <summary>Target tenant scope planned for import.</summary>
+    public TenantScope TargetTenantScope { get; init; } = TenantScope.Default;
+
+    /// <summary>Whether preview allows import.</summary>
+    public required bool CanImport { get; init; }
+
+    /// <summary>Whether preview diagnostics include at least one error.</summary>
+    public bool HasErrors => DiagnosticSeverityCounts.Any(static count => count.Severity == PortableDiagnosticSeverity.Error && count.Count > 0);
+
+    /// <summary>Planned import counts.</summary>
+    public PortablePlannedImportCounts Counts { get; init; } = new();
+
+    /// <summary>Total planned content items, excluding reuse/remap accounting fields.</summary>
+    public required int TotalPlannedItemCount { get; init; }
+
+    /// <summary>Deterministic identity mapping reason counts.</summary>
+    public IReadOnlyList<PortableIdentityMappingReasonCount> MappingReasonCounts { get; init; } = [];
+
+    /// <summary>Deterministic diagnostic severity counts.</summary>
+    public IReadOnlyList<PortableDiagnosticSeverityCount> DiagnosticSeverityCounts { get; init; } = [];
+
+    /// <summary>Deterministic diagnostic code counts.</summary>
+    public IReadOnlyList<PortableDiagnosticCodeCount> DiagnosticCodeCounts { get; init; } = [];
+}
+
+/// <summary>
+/// Aggregate view over a portable import result.
+/// </summary>
+public sealed record PortableImportSummary
+{
+    /// <summary>Source tenant scope recorded in the snapshot.</summary>
+    public TenantScope SourceTenantScope { get; init; } = TenantScope.Default;
+
+    /// <summary>Target tenant scope used for import.</summary>
+    public TenantScope TargetTenantScope { get; init; } = TenantScope.Default;
+
+    /// <summary>Import status.</summary>
+    public required PortableImportStatus Status { get; init; }
+
+    /// <summary>Whether the import wrote content.</summary>
+    public bool IsImported => Status == PortableImportStatus.Imported;
+
+    /// <summary>Whether the import was a no-op.</summary>
+    public bool IsNoOp => Status == PortableImportStatus.NoOp;
+
+    /// <summary>Whether the import failed.</summary>
+    public bool IsFailed => Status == PortableImportStatus.Failed;
+
+    /// <summary>Whether import diagnostics include at least one error.</summary>
+    public bool HasErrors => DiagnosticSeverityCounts.Any(static count => count.Severity == PortableDiagnosticSeverity.Error && count.Count > 0);
+
+    /// <summary>Actual import counts.</summary>
+    public PortableActualImportCounts Counts { get; init; } = new();
+
+    /// <summary>Total actual content items, excluding reuse/remap accounting fields.</summary>
+    public required int TotalActualItemCount { get; init; }
+
+    /// <summary>Deterministic identity mapping reason counts.</summary>
+    public IReadOnlyList<PortableIdentityMappingReasonCount> MappingReasonCounts { get; init; } = [];
+
+    /// <summary>Deterministic diagnostic severity counts.</summary>
+    public IReadOnlyList<PortableDiagnosticSeverityCount> DiagnosticSeverityCounts { get; init; } = [];
+
+    /// <summary>Deterministic diagnostic code counts.</summary>
+    public IReadOnlyList<PortableDiagnosticCodeCount> DiagnosticCodeCounts { get; init; } = [];
+}
+
+/// <summary>
+/// Pure summary helpers for portability result objects.
+/// </summary>
+public static class PortableResultSummaryExtensions
+{
+    /// <summary>
+    /// Creates a deterministic aggregate summary for a portable snapshot export result.
+    /// </summary>
+    /// <param name="result">The export result to summarize.</param>
+    /// <returns>A summary over exported snapshot content and diagnostics.</returns>
+    public static PortableExportSummary ToSummary(this PortableSnapshotExportResult result)
+    {
+        ArgumentNullException.ThrowIfNull(result);
+        var snapshot = result.Snapshot;
+        var diagnostics = result.Diagnostics ?? [];
+
+        return new PortableExportSummary
+        {
+            SourceTenantScope = result.SourceTenantScope,
+            HasSnapshot = snapshot is not null,
+            DefinitionCount = snapshot?.Definitions?.Count ?? 0,
+            ResourceVersionCount = snapshot?.Resources?.Count ?? 0,
+            ActivationEntryCount = snapshot?.ActivationStates?.Count ?? 0,
+            LifecycleMarkerCount = snapshot?.LifecycleMarkers?.Count ?? 0,
+            SkippedActivationEntryCount = (result.SkippedActivationEntries ?? []).Count,
+            DiagnosticSeverityCounts = CountSeverities(diagnostics),
+            DiagnosticCodeCounts = CountCodes(diagnostics),
+        };
+    }
+
+    /// <summary>
+    /// Creates a deterministic aggregate summary for a portable import preview result.
+    /// </summary>
+    /// <param name="preview">The import preview to summarize.</param>
+    /// <returns>A summary over planned import counts, identity mappings, and diagnostics.</returns>
+    public static PortableImportPreviewSummary ToSummary(this PortableImportPreview preview)
+    {
+        ArgumentNullException.ThrowIfNull(preview);
+        var counts = preview.Counts ?? new PortablePlannedImportCounts();
+        var diagnostics = preview.Diagnostics ?? [];
+
+        return new PortableImportPreviewSummary
+        {
+            SourceTenantScope = preview.SourceTenantScope,
+            TargetTenantScope = preview.TargetTenantScope,
+            CanImport = preview.CanImport,
+            Counts = counts,
+            TotalPlannedItemCount = TotalPlannedItems(counts),
+            MappingReasonCounts = CountMappingReasons(preview.IdentityMap ?? []),
+            DiagnosticSeverityCounts = CountSeverities(diagnostics),
+            DiagnosticCodeCounts = CountCodes(diagnostics),
+        };
+    }
+
+    /// <summary>
+    /// Creates a deterministic aggregate summary for a portable import result.
+    /// </summary>
+    /// <param name="result">The import result to summarize.</param>
+    /// <returns>A summary over actual import counts, identity mappings, status, and diagnostics.</returns>
+    public static PortableImportSummary ToSummary(this PortableImportResult result)
+    {
+        ArgumentNullException.ThrowIfNull(result);
+        var counts = result.Counts ?? new PortableActualImportCounts();
+        var diagnostics = result.Diagnostics ?? [];
+
+        return new PortableImportSummary
+        {
+            SourceTenantScope = result.SourceTenantScope,
+            TargetTenantScope = result.TargetTenantScope,
+            Status = result.Status,
+            Counts = counts,
+            TotalActualItemCount = TotalActualItems(counts),
+            MappingReasonCounts = CountMappingReasons(result.IdentityMap ?? []),
+            DiagnosticSeverityCounts = CountSeverities(diagnostics),
+            DiagnosticCodeCounts = CountCodes(diagnostics),
+        };
+    }
+
+    private static int TotalPlannedItems(PortablePlannedImportCounts counts) =>
+        counts.Definitions
+        + counts.Resources
+        + counts.ResourceVersions
+        + counts.ActivationEntries
+        + counts.LifecycleMarkers;
+
+    private static int TotalActualItems(PortableActualImportCounts counts) =>
+        counts.Definitions
+        + counts.Resources
+        + counts.ResourceVersions
+        + counts.ActivationEntries
+        + counts.LifecycleMarkers;
+
+    private static IReadOnlyList<PortableIdentityMappingReasonCount> CountMappingReasons(
+        IEnumerable<PortableIdentityMapping> mappings) =>
+        mappings
+            .GroupBy(static mapping => mapping.Reason)
+            .OrderBy(static group => group.Key)
+            .Select(static group => new PortableIdentityMappingReasonCount
+            {
+                Reason = group.Key,
+                Count = group.Count(),
+            })
+            .ToList();
+
+    private static IReadOnlyList<PortableDiagnosticSeverityCount> CountSeverities(
+        IEnumerable<PortableDiagnostic> diagnostics) =>
+        diagnostics
+            .GroupBy(static diagnostic => diagnostic.Severity)
+            .OrderBy(static group => group.Key)
+            .Select(static group => new PortableDiagnosticSeverityCount
+            {
+                Severity = group.Key,
+                Count = group.Count(),
+            })
+            .ToList();
+
+    private static IReadOnlyList<PortableDiagnosticCodeCount> CountCodes(
+        IEnumerable<PortableDiagnostic> diagnostics) =>
+        diagnostics
+            .Select(static diagnostic => diagnostic.Code)
+            .Where(static code => !string.IsNullOrWhiteSpace(code))
+            .GroupBy(static code => code, StringComparer.Ordinal)
+            .OrderBy(static group => group.Key, StringComparer.Ordinal)
+            .Select(static group => new PortableDiagnosticCodeCount
+            {
+                Code = group.Key,
+                Count = group.Count(),
+            })
+            .ToList();
+}

--- a/test/Aster.Tests/Portability/PortableResultSummaryTests.cs
+++ b/test/Aster.Tests/Portability/PortableResultSummaryTests.cs
@@ -1,0 +1,278 @@
+using Aster.Core.Models.Definitions;
+using Aster.Core.Models.Instances;
+using Aster.Core.Models.Portability;
+using Aster.Core.Models.Tenancy;
+
+namespace Aster.Tests.Portability;
+
+public sealed class PortableResultSummaryTests
+{
+    [Fact]
+    public void ExportSummary_WithSnapshot_AggregatesSnapshotSkippedAndDiagnostics()
+    {
+        var result = new PortableSnapshotExportResult
+        {
+            SourceTenantScope = TenantScope.FromTenantId("tenant-a"),
+            Snapshot = Snapshot(),
+            SkippedActivationEntries = [SkippedActivation()],
+            Diagnostics =
+            [
+                Diagnostic(PortableDiagnosticSeverity.Warning, "z-code"),
+                Diagnostic(PortableDiagnosticSeverity.Error, "a-code"),
+                Diagnostic(PortableDiagnosticSeverity.Warning, "z-code"),
+                Diagnostic(PortableDiagnosticSeverity.Info, ""),
+            ],
+        };
+
+        var summary = result.ToSummary();
+
+        Assert.Equal(result.SourceTenantScope, summary.SourceTenantScope);
+        Assert.True(summary.HasSnapshot);
+        Assert.True(summary.HasErrors);
+        Assert.Equal(1, summary.DefinitionCount);
+        Assert.Equal(2, summary.ResourceVersionCount);
+        Assert.Equal(1, summary.ActivationEntryCount);
+        Assert.Equal(1, summary.LifecycleMarkerCount);
+        Assert.Equal(1, summary.SkippedActivationEntryCount);
+        Assert.Equal(
+            [(PortableDiagnosticSeverity.Info, 1), (PortableDiagnosticSeverity.Warning, 2), (PortableDiagnosticSeverity.Error, 1)],
+            summary.DiagnosticSeverityCounts.Select(static count => (count.Severity, count.Count)).ToList());
+        Assert.Equal(
+            [("a-code", 1), ("z-code", 2)],
+            summary.DiagnosticCodeCounts.Select(static count => (count.Code, count.Count)).ToList());
+    }
+
+    [Fact]
+    public void ExportSummary_NullSnapshotAndCollections_AreTreatedAsEmptyForCounts()
+    {
+        var summary = new PortableSnapshotExportResult
+        {
+            Snapshot = null,
+            Diagnostics = null!,
+            SkippedActivationEntries = null!,
+        }.ToSummary();
+
+        Assert.False(summary.HasSnapshot);
+        Assert.False(summary.HasErrors);
+        Assert.Equal(0, summary.DefinitionCount);
+        Assert.Equal(0, summary.ResourceVersionCount);
+        Assert.Equal(0, summary.ActivationEntryCount);
+        Assert.Equal(0, summary.LifecycleMarkerCount);
+        Assert.Equal(0, summary.SkippedActivationEntryCount);
+        Assert.Empty(summary.DiagnosticSeverityCounts);
+        Assert.Empty(summary.DiagnosticCodeCounts);
+    }
+
+    [Fact]
+    public void ImportPreviewSummary_AggregatesPlannedCountsMappingsAndDiagnostics()
+    {
+        var preview = new PortableImportPreview
+        {
+            SourceTenantScope = TenantScope.FromTenantId("source"),
+            TargetTenantScope = TenantScope.FromTenantId("target"),
+            CanImport = false,
+            Counts = new PortablePlannedImportCounts
+            {
+                Definitions = 1,
+                Resources = 2,
+                ResourceVersions = 3,
+                ActivationEntries = 4,
+                LifecycleMarkers = 5,
+                ReusedIdenticalItems = 6,
+                RemappedItems = 7,
+            },
+            IdentityMap =
+            [
+                Mapping(PortableIdentityMappingReason.Preserved),
+                Mapping(PortableIdentityMappingReason.RemappedDivergent),
+                Mapping(PortableIdentityMappingReason.RemappedDivergent),
+            ],
+            Diagnostics =
+            [
+                Diagnostic(PortableDiagnosticSeverity.Error, PortableDiagnosticCodes.DivergentIdentityCollision),
+            ],
+        };
+
+        var summary = preview.ToSummary();
+
+        Assert.Equal(preview.SourceTenantScope, summary.SourceTenantScope);
+        Assert.Equal(preview.TargetTenantScope, summary.TargetTenantScope);
+        Assert.False(summary.CanImport);
+        Assert.True(summary.HasErrors);
+        Assert.Same(preview.Counts, summary.Counts);
+        Assert.Equal(15, summary.TotalPlannedItemCount);
+        Assert.Equal(
+            [(PortableIdentityMappingReason.Preserved, 1), (PortableIdentityMappingReason.RemappedDivergent, 2)],
+            summary.MappingReasonCounts.Select(static count => (count.Reason, count.Count)).ToList());
+        Assert.Equal(
+            [(PortableDiagnosticSeverity.Error, 1)],
+            summary.DiagnosticSeverityCounts.Select(static count => (count.Severity, count.Count)).ToList());
+    }
+
+    [Fact]
+    public void ImportSummary_AggregatesActualCountsMappingsStatusAndDiagnostics()
+    {
+        var imported = new PortableImportResult
+        {
+            SourceTenantScope = TenantScope.FromTenantId("source"),
+            TargetTenantScope = TenantScope.FromTenantId("target"),
+            Status = PortableImportStatus.Imported,
+            Counts = new PortableActualImportCounts
+            {
+                Definitions = 1,
+                Resources = 1,
+                ResourceVersions = 2,
+                ActivationEntries = 1,
+                LifecycleMarkers = 1,
+                ReusedIdenticalItems = 3,
+                RemappedItems = 2,
+            },
+            IdentityMap =
+            [
+                Mapping(PortableIdentityMappingReason.ReusedIdentical),
+                Mapping(PortableIdentityMappingReason.RemappedDivergent),
+            ],
+        };
+
+        var noOp = imported with { Status = PortableImportStatus.NoOp };
+        var failed = imported with
+        {
+            Status = PortableImportStatus.Failed,
+            Diagnostics = [Diagnostic(PortableDiagnosticSeverity.Error, PortableDiagnosticCodes.ImportApplyFailed)],
+        };
+
+        var importedSummary = imported.ToSummary();
+        var noOpSummary = noOp.ToSummary();
+        var failedSummary = failed.ToSummary();
+
+        Assert.Equal(imported.SourceTenantScope, importedSummary.SourceTenantScope);
+        Assert.Equal(imported.TargetTenantScope, importedSummary.TargetTenantScope);
+        Assert.True(importedSummary.IsImported);
+        Assert.False(importedSummary.IsNoOp);
+        Assert.False(importedSummary.IsFailed);
+        Assert.Equal(6, importedSummary.TotalActualItemCount);
+        Assert.Same(imported.Counts, importedSummary.Counts);
+        Assert.Equal(
+            [(PortableIdentityMappingReason.ReusedIdentical, 1), (PortableIdentityMappingReason.RemappedDivergent, 1)],
+            importedSummary.MappingReasonCounts.Select(static count => (count.Reason, count.Count)).ToList());
+        Assert.True(noOpSummary.IsNoOp);
+        Assert.False(noOpSummary.IsFailed);
+        Assert.True(failedSummary.IsFailed);
+        Assert.True(failedSummary.HasErrors);
+        Assert.Equal(
+            [(PortableDiagnosticSeverity.Error, 1)],
+            failedSummary.DiagnosticSeverityCounts.Select(static count => (count.Severity, count.Count)).ToList());
+    }
+
+    [Fact]
+    public void Summaries_NullInputsThrow()
+    {
+        Assert.Throws<ArgumentNullException>(() => ((PortableSnapshotExportResult)null!).ToSummary());
+        Assert.Throws<ArgumentNullException>(() => ((PortableImportPreview)null!).ToSummary());
+        Assert.Throws<ArgumentNullException>(() => ((PortableImportResult)null!).ToSummary());
+    }
+
+    [Fact]
+    public void ImportSummaries_NullCollectionsAndCounts_AreTreatedAsEmptyForCounts()
+    {
+        var previewSummary = new PortableImportPreview
+        {
+            CanImport = true,
+            Counts = null!,
+            IdentityMap = null!,
+            Diagnostics = null!,
+        }.ToSummary();
+        var importSummary = new PortableImportResult
+        {
+            Status = PortableImportStatus.Imported,
+            Counts = null!,
+            IdentityMap = null!,
+            Diagnostics = null!,
+        }.ToSummary();
+
+        Assert.Equal(0, previewSummary.TotalPlannedItemCount);
+        Assert.Empty(previewSummary.MappingReasonCounts);
+        Assert.Empty(previewSummary.DiagnosticSeverityCounts);
+        Assert.False(previewSummary.HasErrors);
+        Assert.Equal(0, importSummary.TotalActualItemCount);
+        Assert.Empty(importSummary.MappingReasonCounts);
+        Assert.Empty(importSummary.DiagnosticSeverityCounts);
+        Assert.False(importSummary.HasErrors);
+    }
+
+    private static PortableSnapshot Snapshot() =>
+        new()
+        {
+            FormatVersion = PortableSnapshot.CurrentFormatVersion,
+            SourceTenantScope = TenantScope.FromTenantId("tenant-a"),
+            Definitions =
+            [
+                new ResourceDefinition
+                {
+                    DefinitionId = "Product",
+                    Id = "Product:1",
+                    Version = 1,
+                },
+            ],
+            Resources =
+            [
+                Resource("product-1", 1),
+                Resource("product-1", 2),
+            ],
+            ActivationStates =
+            [
+                new ActivationState
+                {
+                    ResourceId = "product-1",
+                    Channel = "Published",
+                    ActiveVersions = [2],
+                    LastUpdated = DateTime.UtcNow,
+                },
+            ],
+            LifecycleMarkers =
+            [
+                new ResourceLifecycleMarker
+                {
+                    ResourceId = "product-1",
+                    State = ResourceLifecycleMarkerState.Archived,
+                    MarkedAt = DateTimeOffset.UtcNow,
+                },
+            ],
+        };
+
+    private static Resource Resource(string resourceId, int version) =>
+        new()
+        {
+            ResourceId = resourceId,
+            Id = $"{resourceId}:{version}",
+            DefinitionId = "Product",
+            Version = version,
+            Created = DateTime.UtcNow,
+        };
+
+    private static SkippedActivationEntry SkippedActivation() =>
+        new()
+        {
+            ResourceId = "product-1",
+            Channel = "Published",
+            Version = 1,
+            Reason = SkippedActivationReason.ExcludedByResourceVersionScope,
+        };
+
+    private static PortableIdentityMapping Mapping(PortableIdentityMappingReason reason) =>
+        new()
+        {
+            EntityKind = PortableEntityKind.Resource,
+            SourceId = $"source-{reason}",
+            TargetId = $"target-{reason}",
+            Reason = reason,
+        };
+
+    private static PortableDiagnostic Diagnostic(PortableDiagnosticSeverity severity, string code) =>
+        new()
+        {
+            Severity = severity,
+            Code = code,
+            Message = code,
+        };
+}

--- a/test/Aster.Tests/Portability/PortableResultSummaryTests.cs
+++ b/test/Aster.Tests/Portability/PortableResultSummaryTests.cs
@@ -107,6 +107,9 @@ public sealed class PortableResultSummaryTests
         Assert.Equal(
             [(PortableDiagnosticSeverity.Error, 1)],
             summary.DiagnosticSeverityCounts.Select(static count => (count.Severity, count.Count)).ToList());
+        Assert.Equal(
+            [(PortableDiagnosticCodes.DivergentIdentityCollision, 1)],
+            summary.DiagnosticCodeCounts.Select(static count => (count.Code, count.Count)).ToList());
     }
 
     [Fact]
@@ -162,6 +165,9 @@ public sealed class PortableResultSummaryTests
         Assert.Equal(
             [(PortableDiagnosticSeverity.Error, 1)],
             failedSummary.DiagnosticSeverityCounts.Select(static count => (count.Severity, count.Count)).ToList());
+        Assert.Equal(
+            [(PortableDiagnosticCodes.ImportApplyFailed, 1)],
+            failedSummary.DiagnosticCodeCounts.Select(static count => (count.Code, count.Count)).ToList());
     }
 
     [Fact]
@@ -193,10 +199,12 @@ public sealed class PortableResultSummaryTests
         Assert.Equal(0, previewSummary.TotalPlannedItemCount);
         Assert.Empty(previewSummary.MappingReasonCounts);
         Assert.Empty(previewSummary.DiagnosticSeverityCounts);
+        Assert.Empty(previewSummary.DiagnosticCodeCounts);
         Assert.False(previewSummary.HasErrors);
         Assert.Equal(0, importSummary.TotalActualItemCount);
         Assert.Empty(importSummary.MappingReasonCounts);
         Assert.Empty(importSummary.DiagnosticSeverityCounts);
+        Assert.Empty(importSummary.DiagnosticCodeCounts);
         Assert.False(importSummary.HasErrors);
     }
 


### PR DESCRIPTION
## Summary
- add pure portability export/import preview/import summary records and ToSummary helpers
- summarize entity counts, mapping reasons, diagnostic severities/codes, skipped activations, and status booleans
- add focused portability summary coverage and update Spec Kit/roadmap context for 028

## Validation
- dotnet test Aster.sln --filter "FullyQualifiedName~PortableResultSummaryTests"
- dotnet test Aster.sln
- dotnet build Aster.sln /m:1
- git diff --check