### PR TITLE
Introduce lifecycle marker transition module

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,17 @@
+# Aster
+
+Aster is a headless SDK for resource definitions, versioned resources, activation state, lifecycle markers, policy workflows, portability, and provider-backed querying.
+
+## Language
+
+**Resource**:
+A versioned domain record stored under a resource definition. A resource can have operational state beside its immutable versions.
+_Avoid_: Entity, item, record
+
+**Lifecycle Marker**:
+Operational state that marks a resource as archived or soft-deleted without rewriting the resource version.
+_Avoid_: Resource status, lifecycle flag, deletion flag
+
+**Lifecycle Marker Transition**:
+A requested change to a resource's lifecycle marker, such as applying an archive or soft-delete marker, or clearing an expected marker during restore.
+_Avoid_: Marker update, status change, delete operation

--- a/src/core/Aster.Core/Extensions/AsterCoreServiceCollectionExtensions.cs
+++ b/src/core/Aster.Core/Extensions/AsterCoreServiceCollectionExtensions.cs
@@ -101,7 +101,10 @@ public static class AsterCoreServiceCollectionExtensions
         services.AddSingleton<IResourcePolicyEvaluationService, ResourcePolicyEvaluationService>();
         services.AddSingleton<IResourcePolicyApplicationService, ResourcePolicyApplicationService>();
         services.AddSingleton<IResourcePolicyPruningApplicationService, ResourcePolicyPruningApplicationService>();
-        services.AddSingleton<IResourceLifecycleMarkerService, ResourceLifecycleMarkerService>();
+        services.AddSingleton<ResourceLifecycleMarkerTransitionService>();
+        services.AddSingleton<IResourceLifecycleMarkerTransitionService>(sp => sp.GetRequiredService<ResourceLifecycleMarkerTransitionService>());
+        services.AddSingleton<IResourceLifecycleMarkerService>(sp =>
+            new ResourceLifecycleMarkerService(sp.GetRequiredService<IResourceLifecycleMarkerTransitionService>()));
         services.AddSingleton<IResourceLifecycleRestoreService, ResourceLifecycleRestoreService>();
         services.AddSingleton<IResourceVersionHistoryService, ResourceVersionHistoryService>();
 

--- a/src/core/Aster.Core/Properties/AssemblyInfo.cs
+++ b/src/core/Aster.Core/Properties/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("Aster.Tests")]

--- a/src/core/Aster.Core/Services/ResourceLifecycleMarkerService.cs
+++ b/src/core/Aster.Core/Services/ResourceLifecycleMarkerService.cs
@@ -1,7 +1,5 @@
 using Aster.Core.Abstractions;
 using Aster.Core.Models.Instances;
-using Aster.Core.Models.Policies;
-using Aster.Core.Models.Querying;
 
 namespace Aster.Core.Services;
 
@@ -10,8 +8,7 @@ namespace Aster.Core.Services;
 /// </summary>
 public sealed class ResourceLifecycleMarkerService : IResourceLifecycleMarkerService
 {
-    private readonly IResourceVersionReader versionReader;
-    private readonly IResourceLifecycleMarkerStore markerStore;
+    private readonly IResourceLifecycleMarkerTransitionService transitions;
 
     /// <summary>
     /// Initializes a new instance of <see cref="ResourceLifecycleMarkerService"/>.
@@ -19,11 +16,14 @@ public sealed class ResourceLifecycleMarkerService : IResourceLifecycleMarkerSer
     public ResourceLifecycleMarkerService(
         IResourceVersionReader versionReader,
         IResourceLifecycleMarkerStore markerStore)
+        : this(new ResourceLifecycleMarkerTransitionService(versionReader, markerStore))
     {
-        ArgumentNullException.ThrowIfNull(versionReader);
-        ArgumentNullException.ThrowIfNull(markerStore);
-        this.versionReader = versionReader;
-        this.markerStore = markerStore;
+    }
+
+    internal ResourceLifecycleMarkerService(IResourceLifecycleMarkerTransitionService transitions)
+    {
+        ArgumentNullException.ThrowIfNull(transitions);
+        this.transitions = transitions;
     }
 
     /// <inheritdoc />
@@ -35,50 +35,7 @@ public sealed class ResourceLifecycleMarkerService : IResourceLifecycleMarkerSer
         ArgumentException.ThrowIfNullOrWhiteSpace(request.ResourceId);
         var tenant = TenantScopeResolver.Resolve(request.TenantScope);
 
-        if (request.State == ResourceLifecycleMarkerState.None || !Enum.IsDefined(request.State))
-        {
-            return Failure(
-                ResourcePolicyDiagnosticCodes.PolicyInvalid,
-                "Lifecycle marker writes must apply Archived or SoftDeleted state.",
-                request.ResourceId);
-        }
-
-        var resources = await versionReader.ReadVersionsAsync(new ResourceVersionReadRequest
-        {
-            TenantScope = tenant,
-            Scope = ResourceVersionScope.Latest,
-            ResourceIds = [request.ResourceId],
-        }, cancellationToken);
-
-        if (!resources.Any(resource => string.Equals(resource.ResourceId, request.ResourceId, StringComparison.Ordinal)))
-        {
-            return Failure(
-                ResourcePolicyDiagnosticCodes.LifecycleMarkerTargetNotFound,
-                $"Resource '{request.ResourceId}' was not found in tenant '{tenant.TenantId}'.",
-                request.ResourceId);
-        }
-
-        var existing = await markerStore.GetMarkerAsync(request.ResourceId, tenant, cancellationToken);
-        if (existing is not null)
-        {
-            if (existing.State == request.State)
-                return new ResourceLifecycleMarkerResult { Marker = existing };
-
-            return new ResourceLifecycleMarkerResult
-            {
-                Marker = existing,
-                Diagnostics =
-                [
-                    ResourcePolicyValidator.Diagnostic(
-                        ResourcePolicyDiagnosticCodes.LifecycleMarkerConflict,
-                        $"Resource '{request.ResourceId}' is already marked as {existing.State}.",
-                        "state",
-                        resourceId: request.ResourceId),
-                ],
-            };
-        }
-
-        var marker = await markerStore.SaveMarkerAsync(new ResourceLifecycleMarker
+        var transition = await transitions.ApplyAsync(new ResourceLifecycleMarkerTransitionApplyRequest
         {
             TenantScope = tenant,
             ResourceId = request.ResourceId,
@@ -87,18 +44,10 @@ public sealed class ResourceLifecycleMarkerService : IResourceLifecycleMarkerSer
             Reason = request.Reason,
         }, cancellationToken);
 
-        return new ResourceLifecycleMarkerResult { Marker = marker };
-    }
-
-    private static ResourceLifecycleMarkerResult Failure(string code, string message, string resourceId) =>
-        new()
+        return new ResourceLifecycleMarkerResult
         {
-            Diagnostics =
-            [
-                ResourcePolicyValidator.Diagnostic(
-                    code,
-                    message,
-                    resourceId: resourceId),
-            ],
+            Marker = transition.Marker,
+            Diagnostics = transition.Diagnostics,
         };
+    }
 }

--- a/src/core/Aster.Core/Services/ResourceLifecycleMarkerTransitionService.cs
+++ b/src/core/Aster.Core/Services/ResourceLifecycleMarkerTransitionService.cs
@@ -1,0 +1,172 @@
+using Aster.Core.Abstractions;
+using Aster.Core.Models.Instances;
+using Aster.Core.Models.Policies;
+using Aster.Core.Models.Querying;
+using Aster.Core.Models.Tenancy;
+
+namespace Aster.Core.Services;
+
+internal interface IResourceLifecycleMarkerTransitionService
+{
+    ValueTask<ResourceLifecycleMarkerTransitionResult> ApplyAsync(
+        ResourceLifecycleMarkerTransitionApplyRequest request,
+        CancellationToken cancellationToken = default);
+}
+
+internal sealed class ResourceLifecycleMarkerTransitionService : IResourceLifecycleMarkerTransitionService
+{
+    private readonly IResourceVersionReader versionReader;
+    private readonly IResourceLifecycleMarkerStore markerStore;
+
+    public ResourceLifecycleMarkerTransitionService(
+        IResourceVersionReader versionReader,
+        IResourceLifecycleMarkerStore markerStore)
+    {
+        ArgumentNullException.ThrowIfNull(versionReader);
+        ArgumentNullException.ThrowIfNull(markerStore);
+        this.versionReader = versionReader;
+        this.markerStore = markerStore;
+    }
+
+    public async ValueTask<ResourceLifecycleMarkerTransitionResult> ApplyAsync(
+        ResourceLifecycleMarkerTransitionApplyRequest request,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        ArgumentException.ThrowIfNullOrWhiteSpace(request.ResourceId);
+
+        if (request.State == ResourceLifecycleMarkerState.None || !Enum.IsDefined(request.State))
+        {
+            return Failure(
+                ResourceLifecycleMarkerTransitionStatus.Failed,
+                ResourcePolicyDiagnosticCodes.PolicyInvalid,
+                "Lifecycle marker writes must apply Archived or SoftDeleted state.",
+                request.ResourceId);
+        }
+
+        if (!await TargetExistsAsync(request, cancellationToken))
+        {
+            return Failure(
+                ResourceLifecycleMarkerTransitionStatus.Failed,
+                ResourcePolicyDiagnosticCodes.LifecycleMarkerTargetNotFound,
+                $"Resource '{request.ResourceId}' was not found in tenant '{request.TenantScope.TenantId}'.",
+                request.ResourceId);
+        }
+
+        var existing = await ResolveCurrentMarkerAsync(request, cancellationToken);
+        if (existing is not null)
+        {
+            if (existing.State == request.State)
+            {
+                return new ResourceLifecycleMarkerTransitionResult
+                {
+                    Status = ResourceLifecycleMarkerTransitionStatus.AlreadySatisfied,
+                    Marker = existing,
+                };
+            }
+
+            return new ResourceLifecycleMarkerTransitionResult
+            {
+                Status = ResourceLifecycleMarkerTransitionStatus.Failed,
+                Marker = existing,
+                Diagnostics =
+                [
+                    ResourcePolicyValidator.Diagnostic(
+                        ResourcePolicyDiagnosticCodes.LifecycleMarkerConflict,
+                        $"Resource '{request.ResourceId}' is already marked as {existing.State}.",
+                        "state",
+                        resourceId: request.ResourceId),
+                ],
+            };
+        }
+
+        var marker = await markerStore.SaveMarkerAsync(new ResourceLifecycleMarker
+        {
+            TenantScope = request.TenantScope,
+            ResourceId = request.ResourceId,
+            State = request.State,
+            MarkedAt = request.MarkedAt,
+            Reason = request.Reason,
+        }, cancellationToken);
+
+        return new ResourceLifecycleMarkerTransitionResult
+        {
+            Status = ResourceLifecycleMarkerTransitionStatus.Applied,
+            Marker = marker,
+        };
+    }
+
+    private async ValueTask<bool> TargetExistsAsync(
+        ResourceLifecycleMarkerTransitionApplyRequest request,
+        CancellationToken cancellationToken)
+    {
+        var resources = await versionReader.ReadVersionsAsync(new ResourceVersionReadRequest
+        {
+            TenantScope = request.TenantScope,
+            Scope = ResourceVersionScope.Latest,
+            ResourceIds = [request.ResourceId],
+        }, cancellationToken);
+
+        return resources.Any(resource => string.Equals(resource.ResourceId, request.ResourceId, StringComparison.Ordinal));
+    }
+
+    private async ValueTask<ResourceLifecycleMarker?> ResolveCurrentMarkerAsync(
+        ResourceLifecycleMarkerTransitionApplyRequest request,
+        CancellationToken cancellationToken)
+    {
+        if (request.HasCurrentMarker)
+            return request.CurrentMarker;
+
+        return await markerStore.GetMarkerAsync(request.ResourceId, request.TenantScope, cancellationToken);
+    }
+
+    private static ResourceLifecycleMarkerTransitionResult Failure(
+        ResourceLifecycleMarkerTransitionStatus status,
+        string code,
+        string message,
+        string resourceId) =>
+        new()
+        {
+            Status = status,
+            Diagnostics =
+            [
+                ResourcePolicyValidator.Diagnostic(
+                    code,
+                    message,
+                    resourceId: resourceId),
+            ],
+        };
+}
+
+internal sealed class ResourceLifecycleMarkerTransitionApplyRequest
+{
+    public required TenantScope TenantScope { get; init; }
+
+    public required string ResourceId { get; init; }
+
+    public required ResourceLifecycleMarkerState State { get; init; }
+
+    public required DateTimeOffset MarkedAt { get; init; }
+
+    public string? Reason { get; init; }
+
+    public ResourceLifecycleMarker? CurrentMarker { get; init; }
+
+    public bool HasCurrentMarker { get; init; }
+}
+
+internal sealed record ResourceLifecycleMarkerTransitionResult
+{
+    public required ResourceLifecycleMarkerTransitionStatus Status { get; init; }
+
+    public ResourceLifecycleMarker? Marker { get; init; }
+
+    public IReadOnlyList<ResourcePolicyDiagnostic> Diagnostics { get; init; } = [];
+}
+
+internal enum ResourceLifecycleMarkerTransitionStatus
+{
+    Applied,
+    AlreadySatisfied,
+    Failed,
+}

--- a/test/Aster.Tests/Policies/LifecycleMarkerTransitionTests.cs
+++ b/test/Aster.Tests/Policies/LifecycleMarkerTransitionTests.cs
@@ -1,0 +1,126 @@
+using Aster.Core.Abstractions;
+using Aster.Core.Models.Instances;
+using Aster.Core.Models.Policies;
+using Aster.Core.Models.Tenancy;
+using Aster.Core.Services;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Aster.Tests.Policies;
+
+public sealed class LifecycleMarkerTransitionTests : IDisposable
+{
+    private static readonly DateTimeOffset MarkedAt = new(2026, 6, 26, 9, 0, 0, TimeSpan.Zero);
+    private readonly ServiceProvider provider = PolicyTestFixtures.CreateCoreProvider();
+
+    public void Dispose() => provider.Dispose();
+
+    [Fact]
+    public async Task ApplyAsync_AppliesMarkerWhenTargetExists()
+    {
+        await PolicyTestFixtures.SaveResourceAsync(provider, "product-1");
+        var transition = provider.GetRequiredService<IResourceLifecycleMarkerTransitionService>();
+
+        var result = await transition.ApplyAsync(ApplyRequest("product-1", ResourceLifecycleMarkerState.Archived));
+
+        Assert.Equal(ResourceLifecycleMarkerTransitionStatus.Applied, result.Status);
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(ResourceLifecycleMarkerState.Archived, result.Marker!.State);
+        Assert.Equal("product-1", result.Marker.ResourceId);
+    }
+
+    [Fact]
+    public async Task ApplyAsync_ReapplyingSameStateIsAlreadySatisfied()
+    {
+        await PolicyTestFixtures.SaveResourceAsync(provider, "product-1");
+        var transition = provider.GetRequiredService<IResourceLifecycleMarkerTransitionService>();
+
+        var first = await transition.ApplyAsync(ApplyRequest("product-1", ResourceLifecycleMarkerState.Archived));
+        var second = await transition.ApplyAsync(ApplyRequest("product-1", ResourceLifecycleMarkerState.Archived));
+
+        Assert.Equal(ResourceLifecycleMarkerTransitionStatus.Applied, first.Status);
+        Assert.Equal(ResourceLifecycleMarkerTransitionStatus.AlreadySatisfied, second.Status);
+        Assert.Empty(second.Diagnostics);
+        Assert.Equal(first.Marker, second.Marker);
+    }
+
+    [Fact]
+    public async Task ApplyAsync_RejectsUnsupportedState()
+    {
+        await PolicyTestFixtures.SaveResourceAsync(provider, "product-1");
+        var transition = provider.GetRequiredService<IResourceLifecycleMarkerTransitionService>();
+
+        var result = await transition.ApplyAsync(ApplyRequest("product-1", ResourceLifecycleMarkerState.None));
+
+        Assert.Equal(ResourceLifecycleMarkerTransitionStatus.Failed, result.Status);
+        var diagnostic = Assert.Single(result.Diagnostics);
+        Assert.Equal(ResourcePolicyDiagnosticCodes.PolicyInvalid, diagnostic.Code);
+        Assert.Null(result.Marker);
+    }
+
+    [Fact]
+    public async Task ApplyAsync_RejectsMissingTarget()
+    {
+        var transition = provider.GetRequiredService<IResourceLifecycleMarkerTransitionService>();
+
+        var result = await transition.ApplyAsync(ApplyRequest("missing", ResourceLifecycleMarkerState.Archived));
+
+        Assert.Equal(ResourceLifecycleMarkerTransitionStatus.Failed, result.Status);
+        var diagnostic = Assert.Single(result.Diagnostics);
+        Assert.Equal(ResourcePolicyDiagnosticCodes.LifecycleMarkerTargetNotFound, diagnostic.Code);
+        Assert.Null(result.Marker);
+    }
+
+    [Fact]
+    public async Task ApplyAsync_RejectsConflictingExistingMarker()
+    {
+        await PolicyTestFixtures.SaveResourceAsync(provider, "product-1");
+        var transition = provider.GetRequiredService<IResourceLifecycleMarkerTransitionService>();
+        var archived = await transition.ApplyAsync(ApplyRequest("product-1", ResourceLifecycleMarkerState.Archived));
+
+        var result = await transition.ApplyAsync(ApplyRequest("product-1", ResourceLifecycleMarkerState.SoftDeleted));
+
+        Assert.Equal(ResourceLifecycleMarkerTransitionStatus.Failed, result.Status);
+        Assert.Equal(archived.Marker, result.Marker);
+        var diagnostic = Assert.Single(result.Diagnostics);
+        Assert.Equal(ResourcePolicyDiagnosticCodes.LifecycleMarkerConflict, diagnostic.Code);
+    }
+
+    [Fact]
+    public async Task ApplyAsync_UsesPreloadedCurrentMarker()
+    {
+        await PolicyTestFixtures.SaveResourceAsync(provider, "product-1");
+        var transition = provider.GetRequiredService<IResourceLifecycleMarkerTransitionService>();
+        var existing = new ResourceLifecycleMarker
+        {
+            TenantScope = TenantScope.Default,
+            ResourceId = "product-1",
+            State = ResourceLifecycleMarkerState.Archived,
+            MarkedAt = MarkedAt,
+        };
+
+        var result = await transition.ApplyAsync(ApplyRequest(
+            "product-1",
+            ResourceLifecycleMarkerState.Archived,
+            currentMarker: existing));
+
+        Assert.Equal(ResourceLifecycleMarkerTransitionStatus.AlreadySatisfied, result.Status);
+        Assert.Equal(existing, result.Marker);
+        var persisted = await provider.GetRequiredService<IResourceLifecycleMarkerStore>()
+            .GetMarkerAsync("product-1", TenantScope.Default);
+        Assert.Null(persisted);
+    }
+
+    private static ResourceLifecycleMarkerTransitionApplyRequest ApplyRequest(
+        string resourceId,
+        ResourceLifecycleMarkerState state,
+        ResourceLifecycleMarker? currentMarker = null) =>
+        new()
+        {
+            TenantScope = TenantScope.Default,
+            ResourceId = resourceId,
+            State = state,
+            MarkedAt = MarkedAt,
+            HasCurrentMarker = currentMarker is not null,
+            CurrentMarker = currentMarker,
+        };
+}

--- a/test/Aster.Tests/Portability/PortabilityImportTests.cs
+++ b/test/Aster.Tests/Portability/PortabilityImportTests.cs
@@ -403,7 +403,7 @@ public sealed class PortabilityImportTests : IDisposable
     {
         var service = new ResourcePortabilityService(
             new ThrowingApplyPortabilityStore(),
-            new NoopResourceLifecycleHookDispatcher());
+            new Lifecycle.NoopResourceLifecycleHookDispatcher());
 
         var result = await service.ImportAsync(CreateSnapshot());
 

--- a/test/Aster.Tests/SqliteJson/SqliteJsonResourceStoreTests.cs
+++ b/test/Aster.Tests/SqliteJson/SqliteJsonResourceStoreTests.cs
@@ -297,7 +297,7 @@ public sealed class SqliteJsonResourceStoreTests : IDisposable
             store,
             store,
             new GuidIdentityGenerator(),
-            new NoopResourceLifecycleHookDispatcher(),
+            new Lifecycle.NoopResourceLifecycleHookDispatcher(),
             NullLogger<DefaultResourceManager>.Instance);
 
     private static string GetTitle(Resource resource)


### PR DESCRIPTION
## Summary

- Adds an internal Lifecycle Marker Transition module for apply-marker semantics.
- Routes manual lifecycle marker writes through the transition module while preserving the existing public result shape.
- Adds focused transition tests and keeps existing lifecycle marker behavior green.

## Verification

- `dotnet test test/Aster.Tests/Aster.Tests.csproj --filter "FullyQualifiedName~LifecycleMarker"`
- `dotnet test Aster.sln`

Refs #46
Closes #47
