### PR TITLE
Route policy application through lifecycle transitions

### DIFF
--- a/src/core/Aster.Core/Extensions/AsterCoreServiceCollectionExtensions.cs
+++ b/src/core/Aster.Core/Extensions/AsterCoreServiceCollectionExtensions.cs
@@ -99,10 +99,15 @@ public static class AsterCoreServiceCollectionExtensions
         services.AddSingleton<IResourcePortabilityService, ResourcePortabilityService>();
         services.AddSingleton<IResourcePolicyValidator, ResourcePolicyValidator>();
         services.AddSingleton<IResourcePolicyEvaluationService, ResourcePolicyEvaluationService>();
-        services.AddSingleton<IResourcePolicyApplicationService, ResourcePolicyApplicationService>();
-        services.AddSingleton<IResourcePolicyPruningApplicationService, ResourcePolicyPruningApplicationService>();
         services.AddSingleton<ResourceLifecycleMarkerTransitionService>();
         services.AddSingleton<IResourceLifecycleMarkerTransitionService>(sp => sp.GetRequiredService<ResourceLifecycleMarkerTransitionService>());
+        services.AddSingleton<IResourcePolicyApplicationService>(sp =>
+            new ResourcePolicyApplicationService(
+                sp.GetRequiredService<IResourceDefinitionStore>(),
+                sp.GetRequiredService<IResourceVersionReader>(),
+                sp.GetRequiredService<IResourceLifecycleMarkerStore>(),
+                sp.GetRequiredService<IResourceLifecycleMarkerTransitionService>()));
+        services.AddSingleton<IResourcePolicyPruningApplicationService, ResourcePolicyPruningApplicationService>();
         services.AddSingleton<IResourceLifecycleMarkerService>(sp =>
             new ResourceLifecycleMarkerService(sp.GetRequiredService<IResourceLifecycleMarkerTransitionService>()));
         services.AddSingleton<IResourceLifecycleRestoreService, ResourceLifecycleRestoreService>();

--- a/src/core/Aster.Core/Services/ResourcePolicyApplicationService.cs
+++ b/src/core/Aster.Core/Services/ResourcePolicyApplicationService.cs
@@ -15,6 +15,7 @@ public sealed class ResourcePolicyApplicationService : IResourcePolicyApplicatio
     private readonly IResourceDefinitionStore definitionStore;
     private readonly IResourceVersionReader versionReader;
     private readonly IResourceLifecycleMarkerStore markerStore;
+    private readonly IResourceLifecycleMarkerTransitionService transitions;
 
     /// <summary>
     /// Initializes a new instance of <see cref="ResourcePolicyApplicationService"/>.
@@ -26,13 +27,28 @@ public sealed class ResourcePolicyApplicationService : IResourcePolicyApplicatio
         IResourceDefinitionStore definitionStore,
         IResourceVersionReader versionReader,
         IResourceLifecycleMarkerStore markerStore)
+        : this(
+            definitionStore,
+            versionReader,
+            markerStore,
+            new ResourceLifecycleMarkerTransitionService(versionReader, markerStore))
+    {
+    }
+
+    internal ResourcePolicyApplicationService(
+        IResourceDefinitionStore definitionStore,
+        IResourceVersionReader versionReader,
+        IResourceLifecycleMarkerStore markerStore,
+        IResourceLifecycleMarkerTransitionService transitions)
     {
         ArgumentNullException.ThrowIfNull(definitionStore);
         ArgumentNullException.ThrowIfNull(versionReader);
         ArgumentNullException.ThrowIfNull(markerStore);
+        ArgumentNullException.ThrowIfNull(transitions);
         this.definitionStore = definitionStore;
         this.versionReader = versionReader;
         this.markerStore = markerStore;
+        this.transitions = transitions;
     }
 
     /// <inheritdoc />
@@ -124,18 +140,8 @@ public sealed class ResourcePolicyApplicationService : IResourcePolicyApplicatio
                 continue;
             }
 
-            if (!latestResources.TryGetValue(candidate.ResourceId!, out var latest))
-            {
-                results[index] = Failure(
-                    index,
-                    candidate,
-                    ResourcePolicyDiagnosticCodes.LifecycleMarkerTargetNotFound,
-                    $"Resource '{candidate.ResourceId}' was not found in tenant '{tenant.TenantId}'.",
-                    "resourceId");
-                continue;
-            }
-
-            if (candidate.ResourceVersion is { } resourceVersion && latest.Version != resourceVersion)
+            latestResources.TryGetValue(candidate.ResourceId!, out var latest);
+            if (latest is not null && candidate.ResourceVersion is { } resourceVersion && latest.Version != resourceVersion)
             {
                 results[index] = Failure(
                     index,
@@ -146,11 +152,14 @@ public sealed class ResourcePolicyApplicationService : IResourcePolicyApplicatio
                 continue;
             }
 
-            var policyFailure = await ValidatePolicyAsync(index, candidate, latest, tenant, definitions, cancellationToken);
-            if (policyFailure is not null)
+            if (latest is not null)
             {
-                results[index] = policyFailure;
-                continue;
+                var policyFailure = await ValidatePolicyAsync(index, candidate, latest, tenant, definitions, cancellationToken);
+                if (policyFailure is not null)
+                {
+                    results[index] = policyFailure;
+                    continue;
+                }
             }
 
             var key = new LifecycleCandidateKey(candidate.ResourceId!, markerState);
@@ -224,35 +233,28 @@ public sealed class ResourcePolicyApplicationService : IResourcePolicyApplicatio
         IDictionary<string, ResourceLifecycleMarker> markers,
         CancellationToken cancellationToken)
     {
-        if (existing is not null)
-        {
-            return existing.State == markerState
-                ? CandidateResult(index, candidate, ResourcePolicyApplicationCandidateStatus.AlreadySatisfied, existing)
-                : CandidateResult(
-                    index,
-                    candidate,
-                    ResourcePolicyApplicationCandidateStatus.Failed,
-                    existing,
-                    [
-                        ResourcePolicyValidator.Diagnostic(
-                            ResourcePolicyDiagnosticCodes.LifecycleMarkerConflict,
-                            $"Resource '{candidate.ResourceId}' is already marked as {existing.State}.",
-                            "state",
-                            resourceId: candidate.ResourceId),
-                    ]);
-        }
-
-        var marker = await markerStore.SaveMarkerAsync(new ResourceLifecycleMarker
+        var transition = await transitions.ApplyAsync(new ResourceLifecycleMarkerTransitionApplyRequest
         {
             TenantScope = tenant,
             ResourceId = candidate.ResourceId!,
             State = markerState,
             MarkedAt = request.AppliedAt,
             Reason = candidate.Reason ?? request.Reason,
+            HasCurrentMarker = true,
+            CurrentMarker = existing,
         }, cancellationToken);
-        markers[candidate.ResourceId!] = marker;
 
-        return CandidateResult(index, candidate, ResourcePolicyApplicationCandidateStatus.Applied, marker);
+        if (transition.Status == ResourceLifecycleMarkerTransitionStatus.Applied && transition.Marker is not null)
+            markers[candidate.ResourceId!] = transition.Marker;
+
+        var status = transition.Status switch
+        {
+            ResourceLifecycleMarkerTransitionStatus.Applied => ResourcePolicyApplicationCandidateStatus.Applied,
+            ResourceLifecycleMarkerTransitionStatus.AlreadySatisfied => ResourcePolicyApplicationCandidateStatus.AlreadySatisfied,
+            _ => ResourcePolicyApplicationCandidateStatus.Failed,
+        };
+
+        return CandidateResult(index, candidate, status, transition.Marker, transition.Diagnostics);
     }
 
     private static ResourcePolicyApplicationCandidateResult DuplicateResult(


### PR DESCRIPTION
## Summary

- Routes policy application archive and soft-delete marker writes through the internal Lifecycle Marker Transition module.
- Keeps policy identity, stale candidate, and duplicate candidate handling in the policy workflow.
- Preserves preloaded batch marker state when delegating transition behavior.

## Verification

- `dotnet test test/Aster.Tests/Aster.Tests.csproj --filter "FullyQualifiedName~PolicyApplication"`
- `dotnet test test/Aster.Tests/Aster.Tests.csproj --filter "FullyQualifiedName~LifecycleMarker|FullyQualifiedName~PolicyApplication"`
- `dotnet test Aster.sln`

Refs #46
Closes #48
