### PR TITLE
Route lifecycle restore through marker transitions

### DIFF
--- a/src/core/Aster.Core/Extensions/AsterCoreServiceCollectionExtensions.cs
+++ b/src/core/Aster.Core/Extensions/AsterCoreServiceCollectionExtensions.cs
@@ -110,7 +110,11 @@ public static class AsterCoreServiceCollectionExtensions
         services.AddSingleton<IResourcePolicyPruningApplicationService, ResourcePolicyPruningApplicationService>();
         services.AddSingleton<IResourceLifecycleMarkerService>(sp =>
             new ResourceLifecycleMarkerService(sp.GetRequiredService<IResourceLifecycleMarkerTransitionService>()));
-        services.AddSingleton<IResourceLifecycleRestoreService, ResourceLifecycleRestoreService>();
+        services.AddSingleton<IResourceLifecycleRestoreService>(sp =>
+            new ResourceLifecycleRestoreService(
+                sp.GetRequiredService<IResourceVersionReader>(),
+                sp.GetRequiredService<IResourceLifecycleMarkerClearStore>(),
+                sp.GetRequiredService<IResourceLifecycleMarkerTransitionService>()));
         services.AddSingleton<IResourceVersionHistoryService, ResourceVersionHistoryService>();
 
         // Query service

--- a/src/core/Aster.Core/Services/ResourceLifecycleMarkerTransitionService.cs
+++ b/src/core/Aster.Core/Services/ResourceLifecycleMarkerTransitionService.cs
@@ -11,12 +11,17 @@ internal interface IResourceLifecycleMarkerTransitionService
     ValueTask<ResourceLifecycleMarkerTransitionResult> ApplyAsync(
         ResourceLifecycleMarkerTransitionApplyRequest request,
         CancellationToken cancellationToken = default);
+
+    ValueTask<ResourceLifecycleMarkerTransitionResult> ClearAsync(
+        ResourceLifecycleMarkerTransitionClearRequest request,
+        CancellationToken cancellationToken = default);
 }
 
 internal sealed class ResourceLifecycleMarkerTransitionService : IResourceLifecycleMarkerTransitionService
 {
     private readonly IResourceVersionReader versionReader;
     private readonly IResourceLifecycleMarkerStore markerStore;
+    private readonly IResourceLifecycleMarkerClearStore? markerClearStore;
 
     public ResourceLifecycleMarkerTransitionService(
         IResourceVersionReader versionReader,
@@ -26,6 +31,7 @@ internal sealed class ResourceLifecycleMarkerTransitionService : IResourceLifecy
         ArgumentNullException.ThrowIfNull(markerStore);
         this.versionReader = versionReader;
         this.markerStore = markerStore;
+        markerClearStore = markerStore as IResourceLifecycleMarkerClearStore;
     }
 
     public async ValueTask<ResourceLifecycleMarkerTransitionResult> ApplyAsync(
@@ -96,10 +102,88 @@ internal sealed class ResourceLifecycleMarkerTransitionService : IResourceLifecy
         };
     }
 
+    public async ValueTask<ResourceLifecycleMarkerTransitionResult> ClearAsync(
+        ResourceLifecycleMarkerTransitionClearRequest request,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        ArgumentException.ThrowIfNullOrWhiteSpace(request.ResourceId);
+
+        if (request.ExpectedState == ResourceLifecycleMarkerState.None || !Enum.IsDefined(request.ExpectedState))
+        {
+            return Failure(
+                ResourceLifecycleMarkerTransitionStatus.Failed,
+                ResourcePolicyDiagnosticCodes.LifecycleRestoreStateUnsupported,
+                $"Lifecycle restore expected state '{request.ExpectedState}' is not supported.",
+                request.ResourceId);
+        }
+
+        if (!await TargetExistsAsync(request, cancellationToken))
+        {
+            return Failure(
+                ResourceLifecycleMarkerTransitionStatus.Failed,
+                ResourcePolicyDiagnosticCodes.LifecycleMarkerTargetNotFound,
+                $"Resource '{request.ResourceId}' was not found in tenant '{request.TenantScope.TenantId}'.",
+                request.ResourceId);
+        }
+
+        var existing = await ResolveCurrentMarkerAsync(request, cancellationToken);
+        if (existing is null)
+        {
+            return new ResourceLifecycleMarkerTransitionResult
+            {
+                Status = ResourceLifecycleMarkerTransitionStatus.AlreadyCleared,
+            };
+        }
+
+        if (existing.State != request.ExpectedState)
+            return MarkerMismatch(request, existing);
+
+        if (!request.Apply)
+        {
+            return new ResourceLifecycleMarkerTransitionResult
+            {
+                Status = ResourceLifecycleMarkerTransitionStatus.ReadyToClear,
+                Marker = existing,
+            };
+        }
+
+        var clearStore = markerClearStore
+            ?? throw new InvalidOperationException(
+                $"The active {nameof(IResourceLifecycleMarkerStore)} registration must also implement {nameof(IResourceLifecycleMarkerClearStore)} to clear lifecycle markers.");
+        var removed = await clearStore.ClearMarkerAsync(
+            request.ResourceId,
+            request.TenantScope,
+            request.ExpectedState,
+            cancellationToken);
+        if (removed)
+        {
+            return new ResourceLifecycleMarkerTransitionResult
+            {
+                Status = ResourceLifecycleMarkerTransitionStatus.Cleared,
+                Marker = existing,
+            };
+        }
+
+        var current = await markerStore.GetMarkerAsync(request.ResourceId, request.TenantScope, cancellationToken);
+        if (current is null)
+        {
+            return new ResourceLifecycleMarkerTransitionResult
+            {
+                Status = ResourceLifecycleMarkerTransitionStatus.AlreadyCleared,
+            };
+        }
+
+        return MarkerMismatch(request, current);
+    }
+
     private async ValueTask<bool> TargetExistsAsync(
-        ResourceLifecycleMarkerTransitionApplyRequest request,
+        ResourceLifecycleMarkerTransitionRequest request,
         CancellationToken cancellationToken)
     {
+        if (request.HasTargetExistence)
+            return request.TargetExists;
+
         var resources = await versionReader.ReadVersionsAsync(new ResourceVersionReadRequest
         {
             TenantScope = request.TenantScope,
@@ -111,7 +195,7 @@ internal sealed class ResourceLifecycleMarkerTransitionService : IResourceLifecy
     }
 
     private async ValueTask<ResourceLifecycleMarker?> ResolveCurrentMarkerAsync(
-        ResourceLifecycleMarkerTransitionApplyRequest request,
+        ResourceLifecycleMarkerTransitionRequest request,
         CancellationToken cancellationToken)
     {
         if (request.HasCurrentMarker)
@@ -119,6 +203,23 @@ internal sealed class ResourceLifecycleMarkerTransitionService : IResourceLifecy
 
         return await markerStore.GetMarkerAsync(request.ResourceId, request.TenantScope, cancellationToken);
     }
+
+    private static ResourceLifecycleMarkerTransitionResult MarkerMismatch(
+        ResourceLifecycleMarkerTransitionClearRequest request,
+        ResourceLifecycleMarker marker) =>
+        new()
+        {
+            Status = ResourceLifecycleMarkerTransitionStatus.MarkerMismatch,
+            Marker = marker,
+            Diagnostics =
+            [
+                ResourcePolicyValidator.Diagnostic(
+                    ResourcePolicyDiagnosticCodes.LifecycleRestoreMarkerMismatch,
+                    $"Resource '{request.ResourceId}' is marked as {marker.State}; expected {request.ExpectedState}.",
+                    "expectedState",
+                    resourceId: request.ResourceId),
+            ],
+        };
 
     private static ResourceLifecycleMarkerTransitionResult Failure(
         ResourceLifecycleMarkerTransitionStatus status,
@@ -138,21 +239,35 @@ internal sealed class ResourceLifecycleMarkerTransitionService : IResourceLifecy
         };
 }
 
-internal sealed class ResourceLifecycleMarkerTransitionApplyRequest
+internal abstract class ResourceLifecycleMarkerTransitionRequest
 {
     public required TenantScope TenantScope { get; init; }
 
     public required string ResourceId { get; init; }
 
+    public bool TargetExists { get; init; }
+
+    public bool HasTargetExistence { get; init; }
+
+    public ResourceLifecycleMarker? CurrentMarker { get; init; }
+
+    public bool HasCurrentMarker { get; init; }
+}
+
+internal sealed class ResourceLifecycleMarkerTransitionApplyRequest : ResourceLifecycleMarkerTransitionRequest
+{
     public required ResourceLifecycleMarkerState State { get; init; }
 
     public required DateTimeOffset MarkedAt { get; init; }
 
     public string? Reason { get; init; }
+}
 
-    public ResourceLifecycleMarker? CurrentMarker { get; init; }
+internal sealed class ResourceLifecycleMarkerTransitionClearRequest : ResourceLifecycleMarkerTransitionRequest
+{
+    public required ResourceLifecycleMarkerState ExpectedState { get; init; }
 
-    public bool HasCurrentMarker { get; init; }
+    public bool Apply { get; init; }
 }
 
 internal sealed record ResourceLifecycleMarkerTransitionResult
@@ -168,5 +283,9 @@ internal enum ResourceLifecycleMarkerTransitionStatus
 {
     Applied,
     AlreadySatisfied,
+    ReadyToClear,
+    Cleared,
+    AlreadyCleared,
+    MarkerMismatch,
     Failed,
 }

--- a/src/core/Aster.Core/Services/ResourceLifecycleRestoreService.cs
+++ b/src/core/Aster.Core/Services/ResourceLifecycleRestoreService.cs
@@ -13,6 +13,7 @@ public sealed class ResourceLifecycleRestoreService : IResourceLifecycleRestoreS
 {
     private readonly IResourceVersionReader versionReader;
     private readonly IResourceLifecycleMarkerClearStore markerStore;
+    private readonly IResourceLifecycleMarkerTransitionService transitions;
 
     /// <summary>
     /// Initializes a new instance of <see cref="ResourceLifecycleRestoreService"/>.
@@ -20,11 +21,24 @@ public sealed class ResourceLifecycleRestoreService : IResourceLifecycleRestoreS
     public ResourceLifecycleRestoreService(
         IResourceVersionReader versionReader,
         IResourceLifecycleMarkerClearStore markerStore)
+        : this(
+            versionReader,
+            markerStore,
+            new ResourceLifecycleMarkerTransitionService(versionReader, markerStore))
+    {
+    }
+
+    internal ResourceLifecycleRestoreService(
+        IResourceVersionReader versionReader,
+        IResourceLifecycleMarkerClearStore markerStore,
+        IResourceLifecycleMarkerTransitionService transitions)
     {
         ArgumentNullException.ThrowIfNull(versionReader);
         ArgumentNullException.ThrowIfNull(markerStore);
+        ArgumentNullException.ThrowIfNull(transitions);
         this.versionReader = versionReader;
         this.markerStore = markerStore;
+        this.transitions = transitions;
     }
 
     /// <inheritdoc />
@@ -126,67 +140,62 @@ public sealed class ResourceLifecycleRestoreService : IResourceLifecycleRestoreS
                 continue;
             }
 
-            results[index] = apply
-                ? await ApplyCandidateAsync(index, candidate, expectedState, tenant, markers, latestResources, cancellationToken)
-                : PreviewCandidate(index, candidate, expectedState, tenant, markers, latestResources);
+            results[index] = await EvaluateCandidateAsync(
+                index,
+                candidate,
+                expectedState,
+                tenant,
+                apply,
+                markers,
+                latestResources.ContainsKey(candidate.ResourceId!),
+                cancellationToken);
         }
 
         return results.Select(static result => result!).ToList();
     }
 
-    private async ValueTask<ResourceLifecycleRestoreCandidateResult> ApplyCandidateAsync(
+    private async ValueTask<ResourceLifecycleRestoreCandidateResult> EvaluateCandidateAsync(
         int index,
         ResourceLifecycleRestoreCandidate candidate,
         ResourceLifecycleMarkerState expectedState,
         TenantScope tenant,
+        bool apply,
         IDictionary<string, ResourceLifecycleMarker> markers,
-        IReadOnlyDictionary<string, Resource> latestResources,
+        bool targetExists,
         CancellationToken cancellationToken)
     {
-        if (!latestResources.ContainsKey(candidate.ResourceId!))
-            return TargetNotFound(index, candidate, tenant);
+        markers.TryGetValue(candidate.ResourceId!, out var marker);
+        var transition = await transitions.ClearAsync(new ResourceLifecycleMarkerTransitionClearRequest
+        {
+            TenantScope = tenant,
+            ResourceId = candidate.ResourceId!,
+            ExpectedState = expectedState,
+            Apply = apply,
+            TargetExists = targetExists,
+            HasTargetExistence = true,
+            CurrentMarker = marker,
+            HasCurrentMarker = true,
+        }, cancellationToken);
 
-        if (!markers.TryGetValue(candidate.ResourceId!, out var marker))
-            return CandidateResult(index, candidate, ResourceLifecycleRestoreCandidateStatus.AlreadyRestored);
-
-        if (marker.State != expectedState)
-            return MarkerMismatch(index, candidate, expectedState, marker);
-
-        var removed = await markerStore.ClearMarkerAsync(candidate.ResourceId!, tenant, expectedState, cancellationToken);
-        if (removed)
+        if (transition.Status is ResourceLifecycleMarkerTransitionStatus.Cleared
+            or ResourceLifecycleMarkerTransitionStatus.AlreadyCleared)
         {
             markers.Remove(candidate.ResourceId!);
-            return CandidateResult(index, candidate, ResourceLifecycleRestoreCandidateStatus.Restored, marker);
         }
-
-        var current = await markerStore.GetMarkerAsync(candidate.ResourceId!, tenant, cancellationToken);
-        if (current is null)
+        else if (transition.Status == ResourceLifecycleMarkerTransitionStatus.MarkerMismatch && transition.Marker is not null)
         {
-            markers.Remove(candidate.ResourceId!);
-            return CandidateResult(index, candidate, ResourceLifecycleRestoreCandidateStatus.AlreadyRestored);
+            markers[candidate.ResourceId!] = transition.Marker;
         }
 
-        markers[candidate.ResourceId!] = current;
-        return MarkerMismatch(index, candidate, expectedState, current);
-    }
+        var status = transition.Status switch
+        {
+            ResourceLifecycleMarkerTransitionStatus.ReadyToClear => ResourceLifecycleRestoreCandidateStatus.Restorable,
+            ResourceLifecycleMarkerTransitionStatus.Cleared => ResourceLifecycleRestoreCandidateStatus.Restored,
+            ResourceLifecycleMarkerTransitionStatus.AlreadyCleared => ResourceLifecycleRestoreCandidateStatus.AlreadyRestored,
+            _ => ResourceLifecycleRestoreCandidateStatus.Failed,
+        };
 
-    private static ResourceLifecycleRestoreCandidateResult PreviewCandidate(
-        int index,
-        ResourceLifecycleRestoreCandidate candidate,
-        ResourceLifecycleMarkerState expectedState,
-        TenantScope tenant,
-        IReadOnlyDictionary<string, ResourceLifecycleMarker> markers,
-        IReadOnlyDictionary<string, Resource> latestResources)
-    {
-        if (!latestResources.ContainsKey(candidate.ResourceId!))
-            return TargetNotFound(index, candidate, tenant);
-
-        if (!markers.TryGetValue(candidate.ResourceId!, out var marker))
-            return CandidateResult(index, candidate, ResourceLifecycleRestoreCandidateStatus.AlreadyRestored);
-
-        return marker.State == expectedState
-            ? CandidateResult(index, candidate, ResourceLifecycleRestoreCandidateStatus.Restorable, marker)
-            : MarkerMismatch(index, candidate, expectedState, marker);
+        return CandidateResult(index, candidate, status, transition.Marker, transition.Diagnostics);
     }
 
     private static ResourceLifecycleRestoreCandidateResult? ValidateShape(
@@ -236,30 +245,6 @@ public sealed class ResourceLifecycleRestoreService : IResourceLifecycleRestoreS
 
         return null;
     }
-
-    private static ResourceLifecycleRestoreCandidateResult TargetNotFound(
-        int index,
-        ResourceLifecycleRestoreCandidate candidate,
-        TenantScope tenant) =>
-        Failure(
-            index,
-            candidate,
-            ResourcePolicyDiagnosticCodes.LifecycleMarkerTargetNotFound,
-            $"Resource '{candidate.ResourceId}' was not found in tenant '{tenant.TenantId}'.",
-            "resourceId");
-
-    private static ResourceLifecycleRestoreCandidateResult MarkerMismatch(
-        int index,
-        ResourceLifecycleRestoreCandidate candidate,
-        ResourceLifecycleMarkerState expectedState,
-        ResourceLifecycleMarker marker) =>
-        Failure(
-            index,
-            candidate,
-            ResourcePolicyDiagnosticCodes.LifecycleRestoreMarkerMismatch,
-            $"Resource '{candidate.ResourceId}' is marked as {marker.State}; expected {expectedState}.",
-            "expectedState",
-            marker);
 
     private static ResourceLifecycleRestoreCandidateResult Failure(
         int index,

--- a/src/core/Aster.Core/Services/ResourcePolicyApplicationService.cs
+++ b/src/core/Aster.Core/Services/ResourcePolicyApplicationService.cs
@@ -170,7 +170,16 @@ public sealed class ResourcePolicyApplicationService : IResourcePolicyApplicatio
             }
 
             markers.TryGetValue(candidate.ResourceId!, out var existing);
-            results[index] = await ApplyMarkerAsync(index, candidate, markerState, tenant, existing, request, markers, cancellationToken);
+            results[index] = await ApplyMarkerAsync(
+                index,
+                candidate,
+                markerState,
+                targetExists: latest is not null,
+                tenant,
+                existing,
+                request,
+                markers,
+                cancellationToken);
             processedLifecycleResults[key] = results[index]!;
         }
 
@@ -227,6 +236,7 @@ public sealed class ResourcePolicyApplicationService : IResourcePolicyApplicatio
         int index,
         ResourcePolicyApplicationCandidate candidate,
         ResourceLifecycleMarkerState markerState,
+        bool targetExists,
         TenantScope tenant,
         ResourceLifecycleMarker? existing,
         ResourcePolicyApplicationRequest request,
@@ -240,6 +250,8 @@ public sealed class ResourcePolicyApplicationService : IResourcePolicyApplicatio
             State = markerState,
             MarkedAt = request.AppliedAt,
             Reason = candidate.Reason ?? request.Reason,
+            TargetExists = targetExists,
+            HasTargetExistence = true,
             HasCurrentMarker = true,
             CurrentMarker = existing,
         }, cancellationToken);

--- a/test/Aster.Tests/Policies/LifecycleMarkerTransitionTests.cs
+++ b/test/Aster.Tests/Policies/LifecycleMarkerTransitionTests.cs
@@ -110,6 +110,96 @@ public sealed class LifecycleMarkerTransitionTests : IDisposable
         Assert.Null(persisted);
     }
 
+    [Fact]
+    public async Task ClearAsync_WhenMarkerMatchesAndApplyIsFalse_IsReadyToClear()
+    {
+        await PolicyTestFixtures.SaveResourceAsync(provider, "product-1");
+        var transition = provider.GetRequiredService<IResourceLifecycleMarkerTransitionService>();
+        var marker = (await transition.ApplyAsync(ApplyRequest("product-1", ResourceLifecycleMarkerState.Archived))).Marker!;
+
+        var result = await transition.ClearAsync(ClearRequest(
+            "product-1",
+            ResourceLifecycleMarkerState.Archived,
+            apply: false,
+            currentMarker: marker));
+
+        Assert.Equal(ResourceLifecycleMarkerTransitionStatus.ReadyToClear, result.Status);
+        Assert.Equal(marker, result.Marker);
+        var persisted = await provider.GetRequiredService<IResourceLifecycleMarkerStore>()
+            .GetMarkerAsync("product-1", TenantScope.Default);
+        Assert.Equal(marker, persisted);
+    }
+
+    [Fact]
+    public async Task ClearAsync_WhenMarkerMatchesAndApplyIsTrue_ClearsMarker()
+    {
+        await PolicyTestFixtures.SaveResourceAsync(provider, "product-1");
+        var transition = provider.GetRequiredService<IResourceLifecycleMarkerTransitionService>();
+        var marker = (await transition.ApplyAsync(ApplyRequest("product-1", ResourceLifecycleMarkerState.Archived))).Marker!;
+
+        var result = await transition.ClearAsync(ClearRequest(
+            "product-1",
+            ResourceLifecycleMarkerState.Archived,
+            apply: true,
+            currentMarker: marker));
+
+        Assert.Equal(ResourceLifecycleMarkerTransitionStatus.Cleared, result.Status);
+        Assert.Equal(marker, result.Marker);
+        var persisted = await provider.GetRequiredService<IResourceLifecycleMarkerStore>()
+            .GetMarkerAsync("product-1", TenantScope.Default);
+        Assert.Null(persisted);
+    }
+
+    [Fact]
+    public async Task ClearAsync_WhenMarkerIsAlreadyMissing_IsAlreadyCleared()
+    {
+        await PolicyTestFixtures.SaveResourceAsync(provider, "product-1");
+        var transition = provider.GetRequiredService<IResourceLifecycleMarkerTransitionService>();
+
+        var result = await transition.ClearAsync(ClearRequest(
+            "product-1",
+            ResourceLifecycleMarkerState.Archived,
+            apply: true));
+
+        Assert.Equal(ResourceLifecycleMarkerTransitionStatus.AlreadyCleared, result.Status);
+        Assert.Empty(result.Diagnostics);
+        Assert.Null(result.Marker);
+    }
+
+    [Fact]
+    public async Task ClearAsync_WhenMarkerStateDiffers_ReturnsMarkerMismatch()
+    {
+        await PolicyTestFixtures.SaveResourceAsync(provider, "product-1");
+        var transition = provider.GetRequiredService<IResourceLifecycleMarkerTransitionService>();
+        var marker = (await transition.ApplyAsync(ApplyRequest("product-1", ResourceLifecycleMarkerState.SoftDeleted))).Marker!;
+
+        var result = await transition.ClearAsync(ClearRequest(
+            "product-1",
+            ResourceLifecycleMarkerState.Archived,
+            apply: true,
+            currentMarker: marker));
+
+        Assert.Equal(ResourceLifecycleMarkerTransitionStatus.MarkerMismatch, result.Status);
+        Assert.Equal(marker, result.Marker);
+        var diagnostic = Assert.Single(result.Diagnostics);
+        Assert.Equal(ResourcePolicyDiagnosticCodes.LifecycleRestoreMarkerMismatch, diagnostic.Code);
+    }
+
+    [Fact]
+    public async Task ClearAsync_WhenTargetIsMissing_ReturnsTargetNotFound()
+    {
+        var transition = provider.GetRequiredService<IResourceLifecycleMarkerTransitionService>();
+
+        var result = await transition.ClearAsync(ClearRequest(
+            "missing",
+            ResourceLifecycleMarkerState.Archived,
+            apply: true));
+
+        Assert.Equal(ResourceLifecycleMarkerTransitionStatus.Failed, result.Status);
+        var diagnostic = Assert.Single(result.Diagnostics);
+        Assert.Equal(ResourcePolicyDiagnosticCodes.LifecycleMarkerTargetNotFound, diagnostic.Code);
+    }
+
     private static ResourceLifecycleMarkerTransitionApplyRequest ApplyRequest(
         string resourceId,
         ResourceLifecycleMarkerState state,
@@ -121,6 +211,23 @@ public sealed class LifecycleMarkerTransitionTests : IDisposable
             State = state,
             MarkedAt = MarkedAt,
             HasCurrentMarker = currentMarker is not null,
+            CurrentMarker = currentMarker,
+        };
+
+    private static ResourceLifecycleMarkerTransitionClearRequest ClearRequest(
+        string resourceId,
+        ResourceLifecycleMarkerState expectedState,
+        bool apply,
+        ResourceLifecycleMarker? currentMarker = null) =>
+        new()
+        {
+            TenantScope = TenantScope.Default,
+            ResourceId = resourceId,
+            ExpectedState = expectedState,
+            Apply = apply,
+            TargetExists = resourceId != "missing",
+            HasTargetExistence = true,
+            HasCurrentMarker = currentMarker is not null || resourceId != "missing",
             CurrentMarker = currentMarker,
         };
 }


### PR DESCRIPTION
## Summary
- add clear semantics to the internal lifecycle marker transition service
- route lifecycle restore preview/application through transition clear results
- keep policy application on preloaded target-existence/current-marker transition requests

## Verification
- dotnet test test/Aster.Tests/Aster.Tests.csproj --filter "FullyQualifiedName~LifecycleRestore"
- dotnet test test/Aster.Tests/Aster.Tests.csproj --filter "FullyQualifiedName~LifecycleMarker|FullyQualifiedName~LifecycleRestore"
- dotnet test Aster.sln

Refs #46
Closes #49
