### PR TITLE
Deepen lifecycle marker transitions

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,17 @@
+# Aster
+
+Aster is a headless SDK for resource definitions, versioned resources, activation state, lifecycle markers, policy workflows, portability, and provider-backed querying.
+
+## Language
+
+**Resource**:
+A versioned domain record stored under a resource definition. A resource can have operational state beside its immutable versions.
+_Avoid_: Entity, item, record
+
+**Lifecycle Marker**:
+Operational state that marks a resource as archived or soft-deleted without rewriting the resource version.
+_Avoid_: Resource status, lifecycle flag, deletion flag
+
+**Lifecycle Marker Transition**:
+A requested change to a resource's lifecycle marker, such as applying an archive or soft-delete marker, or clearing an expected marker during restore.
+_Avoid_: Marker update, status change, delete operation

--- a/src/core/Aster.Core/Extensions/AsterCoreServiceCollectionExtensions.cs
+++ b/src/core/Aster.Core/Extensions/AsterCoreServiceCollectionExtensions.cs
@@ -99,10 +99,15 @@ public static class AsterCoreServiceCollectionExtensions
         services.AddSingleton<IResourcePortabilityService, ResourcePortabilityService>();
         services.AddSingleton<IResourcePolicyValidator, ResourcePolicyValidator>();
         services.AddSingleton<IResourcePolicyEvaluationService, ResourcePolicyEvaluationService>();
-        services.AddSingleton<IResourcePolicyApplicationService, ResourcePolicyApplicationService>();
-        services.AddSingleton<IResourcePolicyPruningApplicationService, ResourcePolicyPruningApplicationService>();
         services.AddSingleton<ResourceLifecycleMarkerTransitionService>();
         services.AddSingleton<IResourceLifecycleMarkerTransitionService>(sp => sp.GetRequiredService<ResourceLifecycleMarkerTransitionService>());
+        services.AddSingleton<IResourcePolicyApplicationService>(sp =>
+            new ResourcePolicyApplicationService(
+                sp.GetRequiredService<IResourceDefinitionStore>(),
+                sp.GetRequiredService<IResourceVersionReader>(),
+                sp.GetRequiredService<IResourceLifecycleMarkerStore>(),
+                sp.GetRequiredService<IResourceLifecycleMarkerTransitionService>()));
+        services.AddSingleton<IResourcePolicyPruningApplicationService, ResourcePolicyPruningApplicationService>();
         services.AddSingleton<IResourceLifecycleMarkerService>(sp =>
             new ResourceLifecycleMarkerService(sp.GetRequiredService<IResourceLifecycleMarkerTransitionService>()));
         services.AddSingleton<IResourceLifecycleRestoreService, ResourceLifecycleRestoreService>();

--- a/src/core/Aster.Core/Extensions/AsterCoreServiceCollectionExtensions.cs
+++ b/src/core/Aster.Core/Extensions/AsterCoreServiceCollectionExtensions.cs
@@ -101,7 +101,10 @@ public static class AsterCoreServiceCollectionExtensions
         services.AddSingleton<IResourcePolicyEvaluationService, ResourcePolicyEvaluationService>();
         services.AddSingleton<IResourcePolicyApplicationService, ResourcePolicyApplicationService>();
         services.AddSingleton<IResourcePolicyPruningApplicationService, ResourcePolicyPruningApplicationService>();
-        services.AddSingleton<IResourceLifecycleMarkerService, ResourceLifecycleMarkerService>();
+        services.AddSingleton<ResourceLifecycleMarkerTransitionService>();
+        services.AddSingleton<IResourceLifecycleMarkerTransitionService>(sp => sp.GetRequiredService<ResourceLifecycleMarkerTransitionService>());
+        services.AddSingleton<IResourceLifecycleMarkerService>(sp =>
+            new ResourceLifecycleMarkerService(sp.GetRequiredService<IResourceLifecycleMarkerTransitionService>()));
         services.AddSingleton<IResourceLifecycleRestoreService, ResourceLifecycleRestoreService>();
         services.AddSingleton<IResourceVersionHistoryService, ResourceVersionHistoryService>();
 

--- a/src/core/Aster.Core/Extensions/AsterCoreServiceCollectionExtensions.cs
+++ b/src/core/Aster.Core/Extensions/AsterCoreServiceCollectionExtensions.cs
@@ -110,7 +110,11 @@ public static class AsterCoreServiceCollectionExtensions
         services.AddSingleton<IResourcePolicyPruningApplicationService, ResourcePolicyPruningApplicationService>();
         services.AddSingleton<IResourceLifecycleMarkerService>(sp =>
             new ResourceLifecycleMarkerService(sp.GetRequiredService<IResourceLifecycleMarkerTransitionService>()));
-        services.AddSingleton<IResourceLifecycleRestoreService, ResourceLifecycleRestoreService>();
+        services.AddSingleton<IResourceLifecycleRestoreService>(sp =>
+            new ResourceLifecycleRestoreService(
+                sp.GetRequiredService<IResourceVersionReader>(),
+                sp.GetRequiredService<IResourceLifecycleMarkerClearStore>(),
+                sp.GetRequiredService<IResourceLifecycleMarkerTransitionService>()));
         services.AddSingleton<IResourceVersionHistoryService, ResourceVersionHistoryService>();
 
         // Query service

--- a/src/core/Aster.Core/Properties/AssemblyInfo.cs
+++ b/src/core/Aster.Core/Properties/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("Aster.Tests")]

--- a/src/core/Aster.Core/Services/ResourceLifecycleMarkerService.cs
+++ b/src/core/Aster.Core/Services/ResourceLifecycleMarkerService.cs
@@ -1,7 +1,5 @@
 using Aster.Core.Abstractions;
 using Aster.Core.Models.Instances;
-using Aster.Core.Models.Policies;
-using Aster.Core.Models.Querying;
 
 namespace Aster.Core.Services;
 
@@ -10,8 +8,7 @@ namespace Aster.Core.Services;
 /// </summary>
 public sealed class ResourceLifecycleMarkerService : IResourceLifecycleMarkerService
 {
-    private readonly IResourceVersionReader versionReader;
-    private readonly IResourceLifecycleMarkerStore markerStore;
+    private readonly IResourceLifecycleMarkerTransitionService transitions;
 
     /// <summary>
     /// Initializes a new instance of <see cref="ResourceLifecycleMarkerService"/>.
@@ -19,11 +16,14 @@ public sealed class ResourceLifecycleMarkerService : IResourceLifecycleMarkerSer
     public ResourceLifecycleMarkerService(
         IResourceVersionReader versionReader,
         IResourceLifecycleMarkerStore markerStore)
+        : this(new ResourceLifecycleMarkerTransitionService(versionReader, markerStore))
     {
-        ArgumentNullException.ThrowIfNull(versionReader);
-        ArgumentNullException.ThrowIfNull(markerStore);
-        this.versionReader = versionReader;
-        this.markerStore = markerStore;
+    }
+
+    internal ResourceLifecycleMarkerService(IResourceLifecycleMarkerTransitionService transitions)
+    {
+        ArgumentNullException.ThrowIfNull(transitions);
+        this.transitions = transitions;
     }
 
     /// <inheritdoc />
@@ -35,50 +35,7 @@ public sealed class ResourceLifecycleMarkerService : IResourceLifecycleMarkerSer
         ArgumentException.ThrowIfNullOrWhiteSpace(request.ResourceId);
         var tenant = TenantScopeResolver.Resolve(request.TenantScope);
 
-        if (request.State == ResourceLifecycleMarkerState.None || !Enum.IsDefined(request.State))
-        {
-            return Failure(
-                ResourcePolicyDiagnosticCodes.PolicyInvalid,
-                "Lifecycle marker writes must apply Archived or SoftDeleted state.",
-                request.ResourceId);
-        }
-
-        var resources = await versionReader.ReadVersionsAsync(new ResourceVersionReadRequest
-        {
-            TenantScope = tenant,
-            Scope = ResourceVersionScope.Latest,
-            ResourceIds = [request.ResourceId],
-        }, cancellationToken);
-
-        if (!resources.Any(resource => string.Equals(resource.ResourceId, request.ResourceId, StringComparison.Ordinal)))
-        {
-            return Failure(
-                ResourcePolicyDiagnosticCodes.LifecycleMarkerTargetNotFound,
-                $"Resource '{request.ResourceId}' was not found in tenant '{tenant.TenantId}'.",
-                request.ResourceId);
-        }
-
-        var existing = await markerStore.GetMarkerAsync(request.ResourceId, tenant, cancellationToken);
-        if (existing is not null)
-        {
-            if (existing.State == request.State)
-                return new ResourceLifecycleMarkerResult { Marker = existing };
-
-            return new ResourceLifecycleMarkerResult
-            {
-                Marker = existing,
-                Diagnostics =
-                [
-                    ResourcePolicyValidator.Diagnostic(
-                        ResourcePolicyDiagnosticCodes.LifecycleMarkerConflict,
-                        $"Resource '{request.ResourceId}' is already marked as {existing.State}.",
-                        "state",
-                        resourceId: request.ResourceId),
-                ],
-            };
-        }
-
-        var marker = await markerStore.SaveMarkerAsync(new ResourceLifecycleMarker
+        var transition = await transitions.ApplyAsync(new ResourceLifecycleMarkerTransitionApplyRequest
         {
             TenantScope = tenant,
             ResourceId = request.ResourceId,
@@ -87,18 +44,10 @@ public sealed class ResourceLifecycleMarkerService : IResourceLifecycleMarkerSer
             Reason = request.Reason,
         }, cancellationToken);
 
-        return new ResourceLifecycleMarkerResult { Marker = marker };
-    }
-
-    private static ResourceLifecycleMarkerResult Failure(string code, string message, string resourceId) =>
-        new()
+        return new ResourceLifecycleMarkerResult
         {
-            Diagnostics =
-            [
-                ResourcePolicyValidator.Diagnostic(
-                    code,
-                    message,
-                    resourceId: resourceId),
-            ],
+            Marker = transition.Marker,
+            Diagnostics = transition.Diagnostics,
         };
+    }
 }

--- a/src/core/Aster.Core/Services/ResourceLifecycleMarkerTransitionService.cs
+++ b/src/core/Aster.Core/Services/ResourceLifecycleMarkerTransitionService.cs
@@ -1,0 +1,172 @@
+using Aster.Core.Abstractions;
+using Aster.Core.Models.Instances;
+using Aster.Core.Models.Policies;
+using Aster.Core.Models.Querying;
+using Aster.Core.Models.Tenancy;
+
+namespace Aster.Core.Services;
+
+internal interface IResourceLifecycleMarkerTransitionService
+{
+    ValueTask<ResourceLifecycleMarkerTransitionResult> ApplyAsync(
+        ResourceLifecycleMarkerTransitionApplyRequest request,
+        CancellationToken cancellationToken = default);
+}
+
+internal sealed class ResourceLifecycleMarkerTransitionService : IResourceLifecycleMarkerTransitionService
+{
+    private readonly IResourceVersionReader versionReader;
+    private readonly IResourceLifecycleMarkerStore markerStore;
+
+    public ResourceLifecycleMarkerTransitionService(
+        IResourceVersionReader versionReader,
+        IResourceLifecycleMarkerStore markerStore)
+    {
+        ArgumentNullException.ThrowIfNull(versionReader);
+        ArgumentNullException.ThrowIfNull(markerStore);
+        this.versionReader = versionReader;
+        this.markerStore = markerStore;
+    }
+
+    public async ValueTask<ResourceLifecycleMarkerTransitionResult> ApplyAsync(
+        ResourceLifecycleMarkerTransitionApplyRequest request,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        ArgumentException.ThrowIfNullOrWhiteSpace(request.ResourceId);
+
+        if (request.State == ResourceLifecycleMarkerState.None || !Enum.IsDefined(request.State))
+        {
+            return Failure(
+                ResourceLifecycleMarkerTransitionStatus.Failed,
+                ResourcePolicyDiagnosticCodes.PolicyInvalid,
+                "Lifecycle marker writes must apply Archived or SoftDeleted state.",
+                request.ResourceId);
+        }
+
+        if (!await TargetExistsAsync(request, cancellationToken))
+        {
+            return Failure(
+                ResourceLifecycleMarkerTransitionStatus.Failed,
+                ResourcePolicyDiagnosticCodes.LifecycleMarkerTargetNotFound,
+                $"Resource '{request.ResourceId}' was not found in tenant '{request.TenantScope.TenantId}'.",
+                request.ResourceId);
+        }
+
+        var existing = await ResolveCurrentMarkerAsync(request, cancellationToken);
+        if (existing is not null)
+        {
+            if (existing.State == request.State)
+            {
+                return new ResourceLifecycleMarkerTransitionResult
+                {
+                    Status = ResourceLifecycleMarkerTransitionStatus.AlreadySatisfied,
+                    Marker = existing,
+                };
+            }
+
+            return new ResourceLifecycleMarkerTransitionResult
+            {
+                Status = ResourceLifecycleMarkerTransitionStatus.Failed,
+                Marker = existing,
+                Diagnostics =
+                [
+                    ResourcePolicyValidator.Diagnostic(
+                        ResourcePolicyDiagnosticCodes.LifecycleMarkerConflict,
+                        $"Resource '{request.ResourceId}' is already marked as {existing.State}.",
+                        "state",
+                        resourceId: request.ResourceId),
+                ],
+            };
+        }
+
+        var marker = await markerStore.SaveMarkerAsync(new ResourceLifecycleMarker
+        {
+            TenantScope = request.TenantScope,
+            ResourceId = request.ResourceId,
+            State = request.State,
+            MarkedAt = request.MarkedAt,
+            Reason = request.Reason,
+        }, cancellationToken);
+
+        return new ResourceLifecycleMarkerTransitionResult
+        {
+            Status = ResourceLifecycleMarkerTransitionStatus.Applied,
+            Marker = marker,
+        };
+    }
+
+    private async ValueTask<bool> TargetExistsAsync(
+        ResourceLifecycleMarkerTransitionApplyRequest request,
+        CancellationToken cancellationToken)
+    {
+        var resources = await versionReader.ReadVersionsAsync(new ResourceVersionReadRequest
+        {
+            TenantScope = request.TenantScope,
+            Scope = ResourceVersionScope.Latest,
+            ResourceIds = [request.ResourceId],
+        }, cancellationToken);
+
+        return resources.Any(resource => string.Equals(resource.ResourceId, request.ResourceId, StringComparison.Ordinal));
+    }
+
+    private async ValueTask<ResourceLifecycleMarker?> ResolveCurrentMarkerAsync(
+        ResourceLifecycleMarkerTransitionApplyRequest request,
+        CancellationToken cancellationToken)
+    {
+        if (request.HasCurrentMarker)
+            return request.CurrentMarker;
+
+        return await markerStore.GetMarkerAsync(request.ResourceId, request.TenantScope, cancellationToken);
+    }
+
+    private static ResourceLifecycleMarkerTransitionResult Failure(
+        ResourceLifecycleMarkerTransitionStatus status,
+        string code,
+        string message,
+        string resourceId) =>
+        new()
+        {
+            Status = status,
+            Diagnostics =
+            [
+                ResourcePolicyValidator.Diagnostic(
+                    code,
+                    message,
+                    resourceId: resourceId),
+            ],
+        };
+}
+
+internal sealed class ResourceLifecycleMarkerTransitionApplyRequest
+{
+    public required TenantScope TenantScope { get; init; }
+
+    public required string ResourceId { get; init; }
+
+    public required ResourceLifecycleMarkerState State { get; init; }
+
+    public required DateTimeOffset MarkedAt { get; init; }
+
+    public string? Reason { get; init; }
+
+    public ResourceLifecycleMarker? CurrentMarker { get; init; }
+
+    public bool HasCurrentMarker { get; init; }
+}
+
+internal sealed record ResourceLifecycleMarkerTransitionResult
+{
+    public required ResourceLifecycleMarkerTransitionStatus Status { get; init; }
+
+    public ResourceLifecycleMarker? Marker { get; init; }
+
+    public IReadOnlyList<ResourcePolicyDiagnostic> Diagnostics { get; init; } = [];
+}
+
+internal enum ResourceLifecycleMarkerTransitionStatus
+{
+    Applied,
+    AlreadySatisfied,
+    Failed,
+}

--- a/src/core/Aster.Core/Services/ResourceLifecycleMarkerTransitionService.cs
+++ b/src/core/Aster.Core/Services/ResourceLifecycleMarkerTransitionService.cs
@@ -11,12 +11,17 @@ internal interface IResourceLifecycleMarkerTransitionService
     ValueTask<ResourceLifecycleMarkerTransitionResult> ApplyAsync(
         ResourceLifecycleMarkerTransitionApplyRequest request,
         CancellationToken cancellationToken = default);
+
+    ValueTask<ResourceLifecycleMarkerTransitionResult> ClearAsync(
+        ResourceLifecycleMarkerTransitionClearRequest request,
+        CancellationToken cancellationToken = default);
 }
 
 internal sealed class ResourceLifecycleMarkerTransitionService : IResourceLifecycleMarkerTransitionService
 {
     private readonly IResourceVersionReader versionReader;
     private readonly IResourceLifecycleMarkerStore markerStore;
+    private readonly IResourceLifecycleMarkerClearStore? markerClearStore;
 
     public ResourceLifecycleMarkerTransitionService(
         IResourceVersionReader versionReader,
@@ -26,6 +31,7 @@ internal sealed class ResourceLifecycleMarkerTransitionService : IResourceLifecy
         ArgumentNullException.ThrowIfNull(markerStore);
         this.versionReader = versionReader;
         this.markerStore = markerStore;
+        markerClearStore = markerStore as IResourceLifecycleMarkerClearStore;
     }
 
     public async ValueTask<ResourceLifecycleMarkerTransitionResult> ApplyAsync(
@@ -96,10 +102,88 @@ internal sealed class ResourceLifecycleMarkerTransitionService : IResourceLifecy
         };
     }
 
+    public async ValueTask<ResourceLifecycleMarkerTransitionResult> ClearAsync(
+        ResourceLifecycleMarkerTransitionClearRequest request,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        ArgumentException.ThrowIfNullOrWhiteSpace(request.ResourceId);
+
+        if (request.ExpectedState == ResourceLifecycleMarkerState.None || !Enum.IsDefined(request.ExpectedState))
+        {
+            return Failure(
+                ResourceLifecycleMarkerTransitionStatus.Failed,
+                ResourcePolicyDiagnosticCodes.LifecycleRestoreStateUnsupported,
+                $"Lifecycle restore expected state '{request.ExpectedState}' is not supported.",
+                request.ResourceId);
+        }
+
+        if (!await TargetExistsAsync(request, cancellationToken))
+        {
+            return Failure(
+                ResourceLifecycleMarkerTransitionStatus.Failed,
+                ResourcePolicyDiagnosticCodes.LifecycleMarkerTargetNotFound,
+                $"Resource '{request.ResourceId}' was not found in tenant '{request.TenantScope.TenantId}'.",
+                request.ResourceId);
+        }
+
+        var existing = await ResolveCurrentMarkerAsync(request, cancellationToken);
+        if (existing is null)
+        {
+            return new ResourceLifecycleMarkerTransitionResult
+            {
+                Status = ResourceLifecycleMarkerTransitionStatus.AlreadyCleared,
+            };
+        }
+
+        if (existing.State != request.ExpectedState)
+            return MarkerMismatch(request, existing);
+
+        if (!request.Apply)
+        {
+            return new ResourceLifecycleMarkerTransitionResult
+            {
+                Status = ResourceLifecycleMarkerTransitionStatus.ReadyToClear,
+                Marker = existing,
+            };
+        }
+
+        var clearStore = markerClearStore
+            ?? throw new InvalidOperationException(
+                $"The active {nameof(IResourceLifecycleMarkerStore)} registration must also implement {nameof(IResourceLifecycleMarkerClearStore)} to clear lifecycle markers.");
+        var removed = await clearStore.ClearMarkerAsync(
+            request.ResourceId,
+            request.TenantScope,
+            request.ExpectedState,
+            cancellationToken);
+        if (removed)
+        {
+            return new ResourceLifecycleMarkerTransitionResult
+            {
+                Status = ResourceLifecycleMarkerTransitionStatus.Cleared,
+                Marker = existing,
+            };
+        }
+
+        var current = await markerStore.GetMarkerAsync(request.ResourceId, request.TenantScope, cancellationToken);
+        if (current is null)
+        {
+            return new ResourceLifecycleMarkerTransitionResult
+            {
+                Status = ResourceLifecycleMarkerTransitionStatus.AlreadyCleared,
+            };
+        }
+
+        return MarkerMismatch(request, current);
+    }
+
     private async ValueTask<bool> TargetExistsAsync(
-        ResourceLifecycleMarkerTransitionApplyRequest request,
+        ResourceLifecycleMarkerTransitionRequest request,
         CancellationToken cancellationToken)
     {
+        if (request.HasTargetExistence)
+            return request.TargetExists;
+
         var resources = await versionReader.ReadVersionsAsync(new ResourceVersionReadRequest
         {
             TenantScope = request.TenantScope,
@@ -111,7 +195,7 @@ internal sealed class ResourceLifecycleMarkerTransitionService : IResourceLifecy
     }
 
     private async ValueTask<ResourceLifecycleMarker?> ResolveCurrentMarkerAsync(
-        ResourceLifecycleMarkerTransitionApplyRequest request,
+        ResourceLifecycleMarkerTransitionRequest request,
         CancellationToken cancellationToken)
     {
         if (request.HasCurrentMarker)
@@ -119,6 +203,23 @@ internal sealed class ResourceLifecycleMarkerTransitionService : IResourceLifecy
 
         return await markerStore.GetMarkerAsync(request.ResourceId, request.TenantScope, cancellationToken);
     }
+
+    private static ResourceLifecycleMarkerTransitionResult MarkerMismatch(
+        ResourceLifecycleMarkerTransitionClearRequest request,
+        ResourceLifecycleMarker marker) =>
+        new()
+        {
+            Status = ResourceLifecycleMarkerTransitionStatus.MarkerMismatch,
+            Marker = marker,
+            Diagnostics =
+            [
+                ResourcePolicyValidator.Diagnostic(
+                    ResourcePolicyDiagnosticCodes.LifecycleRestoreMarkerMismatch,
+                    $"Resource '{request.ResourceId}' is marked as {marker.State}; expected {request.ExpectedState}.",
+                    "expectedState",
+                    resourceId: request.ResourceId),
+            ],
+        };
 
     private static ResourceLifecycleMarkerTransitionResult Failure(
         ResourceLifecycleMarkerTransitionStatus status,
@@ -138,21 +239,35 @@ internal sealed class ResourceLifecycleMarkerTransitionService : IResourceLifecy
         };
 }
 
-internal sealed class ResourceLifecycleMarkerTransitionApplyRequest
+internal abstract class ResourceLifecycleMarkerTransitionRequest
 {
     public required TenantScope TenantScope { get; init; }
 
     public required string ResourceId { get; init; }
 
+    public bool TargetExists { get; init; }
+
+    public bool HasTargetExistence { get; init; }
+
+    public ResourceLifecycleMarker? CurrentMarker { get; init; }
+
+    public bool HasCurrentMarker { get; init; }
+}
+
+internal sealed class ResourceLifecycleMarkerTransitionApplyRequest : ResourceLifecycleMarkerTransitionRequest
+{
     public required ResourceLifecycleMarkerState State { get; init; }
 
     public required DateTimeOffset MarkedAt { get; init; }
 
     public string? Reason { get; init; }
+}
 
-    public ResourceLifecycleMarker? CurrentMarker { get; init; }
+internal sealed class ResourceLifecycleMarkerTransitionClearRequest : ResourceLifecycleMarkerTransitionRequest
+{
+    public required ResourceLifecycleMarkerState ExpectedState { get; init; }
 
-    public bool HasCurrentMarker { get; init; }
+    public bool Apply { get; init; }
 }
 
 internal sealed record ResourceLifecycleMarkerTransitionResult
@@ -168,5 +283,9 @@ internal enum ResourceLifecycleMarkerTransitionStatus
 {
     Applied,
     AlreadySatisfied,
+    ReadyToClear,
+    Cleared,
+    AlreadyCleared,
+    MarkerMismatch,
     Failed,
 }

--- a/src/core/Aster.Core/Services/ResourceLifecycleRestoreService.cs
+++ b/src/core/Aster.Core/Services/ResourceLifecycleRestoreService.cs
@@ -13,6 +13,7 @@ public sealed class ResourceLifecycleRestoreService : IResourceLifecycleRestoreS
 {
     private readonly IResourceVersionReader versionReader;
     private readonly IResourceLifecycleMarkerClearStore markerStore;
+    private readonly IResourceLifecycleMarkerTransitionService transitions;
 
     /// <summary>
     /// Initializes a new instance of <see cref="ResourceLifecycleRestoreService"/>.
@@ -20,11 +21,24 @@ public sealed class ResourceLifecycleRestoreService : IResourceLifecycleRestoreS
     public ResourceLifecycleRestoreService(
         IResourceVersionReader versionReader,
         IResourceLifecycleMarkerClearStore markerStore)
+        : this(
+            versionReader,
+            markerStore,
+            new ResourceLifecycleMarkerTransitionService(versionReader, markerStore))
+    {
+    }
+
+    internal ResourceLifecycleRestoreService(
+        IResourceVersionReader versionReader,
+        IResourceLifecycleMarkerClearStore markerStore,
+        IResourceLifecycleMarkerTransitionService transitions)
     {
         ArgumentNullException.ThrowIfNull(versionReader);
         ArgumentNullException.ThrowIfNull(markerStore);
+        ArgumentNullException.ThrowIfNull(transitions);
         this.versionReader = versionReader;
         this.markerStore = markerStore;
+        this.transitions = transitions;
     }
 
     /// <inheritdoc />
@@ -126,67 +140,62 @@ public sealed class ResourceLifecycleRestoreService : IResourceLifecycleRestoreS
                 continue;
             }
 
-            results[index] = apply
-                ? await ApplyCandidateAsync(index, candidate, expectedState, tenant, markers, latestResources, cancellationToken)
-                : PreviewCandidate(index, candidate, expectedState, tenant, markers, latestResources);
+            results[index] = await EvaluateCandidateAsync(
+                index,
+                candidate,
+                expectedState,
+                tenant,
+                apply,
+                markers,
+                latestResources.ContainsKey(candidate.ResourceId!),
+                cancellationToken);
         }
 
         return results.Select(static result => result!).ToList();
     }
 
-    private async ValueTask<ResourceLifecycleRestoreCandidateResult> ApplyCandidateAsync(
+    private async ValueTask<ResourceLifecycleRestoreCandidateResult> EvaluateCandidateAsync(
         int index,
         ResourceLifecycleRestoreCandidate candidate,
         ResourceLifecycleMarkerState expectedState,
         TenantScope tenant,
+        bool apply,
         IDictionary<string, ResourceLifecycleMarker> markers,
-        IReadOnlyDictionary<string, Resource> latestResources,
+        bool targetExists,
         CancellationToken cancellationToken)
     {
-        if (!latestResources.ContainsKey(candidate.ResourceId!))
-            return TargetNotFound(index, candidate, tenant);
+        markers.TryGetValue(candidate.ResourceId!, out var marker);
+        var transition = await transitions.ClearAsync(new ResourceLifecycleMarkerTransitionClearRequest
+        {
+            TenantScope = tenant,
+            ResourceId = candidate.ResourceId!,
+            ExpectedState = expectedState,
+            Apply = apply,
+            TargetExists = targetExists,
+            HasTargetExistence = true,
+            CurrentMarker = marker,
+            HasCurrentMarker = true,
+        }, cancellationToken);
 
-        if (!markers.TryGetValue(candidate.ResourceId!, out var marker))
-            return CandidateResult(index, candidate, ResourceLifecycleRestoreCandidateStatus.AlreadyRestored);
-
-        if (marker.State != expectedState)
-            return MarkerMismatch(index, candidate, expectedState, marker);
-
-        var removed = await markerStore.ClearMarkerAsync(candidate.ResourceId!, tenant, expectedState, cancellationToken);
-        if (removed)
+        if (transition.Status is ResourceLifecycleMarkerTransitionStatus.Cleared
+            or ResourceLifecycleMarkerTransitionStatus.AlreadyCleared)
         {
             markers.Remove(candidate.ResourceId!);
-            return CandidateResult(index, candidate, ResourceLifecycleRestoreCandidateStatus.Restored, marker);
         }
-
-        var current = await markerStore.GetMarkerAsync(candidate.ResourceId!, tenant, cancellationToken);
-        if (current is null)
+        else if (transition.Status == ResourceLifecycleMarkerTransitionStatus.MarkerMismatch && transition.Marker is not null)
         {
-            markers.Remove(candidate.ResourceId!);
-            return CandidateResult(index, candidate, ResourceLifecycleRestoreCandidateStatus.AlreadyRestored);
+            markers[candidate.ResourceId!] = transition.Marker;
         }
 
-        markers[candidate.ResourceId!] = current;
-        return MarkerMismatch(index, candidate, expectedState, current);
-    }
+        var status = transition.Status switch
+        {
+            ResourceLifecycleMarkerTransitionStatus.ReadyToClear => ResourceLifecycleRestoreCandidateStatus.Restorable,
+            ResourceLifecycleMarkerTransitionStatus.Cleared => ResourceLifecycleRestoreCandidateStatus.Restored,
+            ResourceLifecycleMarkerTransitionStatus.AlreadyCleared => ResourceLifecycleRestoreCandidateStatus.AlreadyRestored,
+            _ => ResourceLifecycleRestoreCandidateStatus.Failed,
+        };
 
-    private static ResourceLifecycleRestoreCandidateResult PreviewCandidate(
-        int index,
-        ResourceLifecycleRestoreCandidate candidate,
-        ResourceLifecycleMarkerState expectedState,
-        TenantScope tenant,
-        IReadOnlyDictionary<string, ResourceLifecycleMarker> markers,
-        IReadOnlyDictionary<string, Resource> latestResources)
-    {
-        if (!latestResources.ContainsKey(candidate.ResourceId!))
-            return TargetNotFound(index, candidate, tenant);
-
-        if (!markers.TryGetValue(candidate.ResourceId!, out var marker))
-            return CandidateResult(index, candidate, ResourceLifecycleRestoreCandidateStatus.AlreadyRestored);
-
-        return marker.State == expectedState
-            ? CandidateResult(index, candidate, ResourceLifecycleRestoreCandidateStatus.Restorable, marker)
-            : MarkerMismatch(index, candidate, expectedState, marker);
+        return CandidateResult(index, candidate, status, transition.Marker, transition.Diagnostics);
     }
 
     private static ResourceLifecycleRestoreCandidateResult? ValidateShape(
@@ -236,30 +245,6 @@ public sealed class ResourceLifecycleRestoreService : IResourceLifecycleRestoreS
 
         return null;
     }
-
-    private static ResourceLifecycleRestoreCandidateResult TargetNotFound(
-        int index,
-        ResourceLifecycleRestoreCandidate candidate,
-        TenantScope tenant) =>
-        Failure(
-            index,
-            candidate,
-            ResourcePolicyDiagnosticCodes.LifecycleMarkerTargetNotFound,
-            $"Resource '{candidate.ResourceId}' was not found in tenant '{tenant.TenantId}'.",
-            "resourceId");
-
-    private static ResourceLifecycleRestoreCandidateResult MarkerMismatch(
-        int index,
-        ResourceLifecycleRestoreCandidate candidate,
-        ResourceLifecycleMarkerState expectedState,
-        ResourceLifecycleMarker marker) =>
-        Failure(
-            index,
-            candidate,
-            ResourcePolicyDiagnosticCodes.LifecycleRestoreMarkerMismatch,
-            $"Resource '{candidate.ResourceId}' is marked as {marker.State}; expected {expectedState}.",
-            "expectedState",
-            marker);
 
     private static ResourceLifecycleRestoreCandidateResult Failure(
         int index,

--- a/src/core/Aster.Core/Services/ResourcePolicyApplicationService.cs
+++ b/src/core/Aster.Core/Services/ResourcePolicyApplicationService.cs
@@ -15,6 +15,7 @@ public sealed class ResourcePolicyApplicationService : IResourcePolicyApplicatio
     private readonly IResourceDefinitionStore definitionStore;
     private readonly IResourceVersionReader versionReader;
     private readonly IResourceLifecycleMarkerStore markerStore;
+    private readonly IResourceLifecycleMarkerTransitionService transitions;
 
     /// <summary>
     /// Initializes a new instance of <see cref="ResourcePolicyApplicationService"/>.
@@ -26,13 +27,28 @@ public sealed class ResourcePolicyApplicationService : IResourcePolicyApplicatio
         IResourceDefinitionStore definitionStore,
         IResourceVersionReader versionReader,
         IResourceLifecycleMarkerStore markerStore)
+        : this(
+            definitionStore,
+            versionReader,
+            markerStore,
+            new ResourceLifecycleMarkerTransitionService(versionReader, markerStore))
+    {
+    }
+
+    internal ResourcePolicyApplicationService(
+        IResourceDefinitionStore definitionStore,
+        IResourceVersionReader versionReader,
+        IResourceLifecycleMarkerStore markerStore,
+        IResourceLifecycleMarkerTransitionService transitions)
     {
         ArgumentNullException.ThrowIfNull(definitionStore);
         ArgumentNullException.ThrowIfNull(versionReader);
         ArgumentNullException.ThrowIfNull(markerStore);
+        ArgumentNullException.ThrowIfNull(transitions);
         this.definitionStore = definitionStore;
         this.versionReader = versionReader;
         this.markerStore = markerStore;
+        this.transitions = transitions;
     }
 
     /// <inheritdoc />
@@ -124,18 +140,8 @@ public sealed class ResourcePolicyApplicationService : IResourcePolicyApplicatio
                 continue;
             }
 
-            if (!latestResources.TryGetValue(candidate.ResourceId!, out var latest))
-            {
-                results[index] = Failure(
-                    index,
-                    candidate,
-                    ResourcePolicyDiagnosticCodes.LifecycleMarkerTargetNotFound,
-                    $"Resource '{candidate.ResourceId}' was not found in tenant '{tenant.TenantId}'.",
-                    "resourceId");
-                continue;
-            }
-
-            if (candidate.ResourceVersion is { } resourceVersion && latest.Version != resourceVersion)
+            latestResources.TryGetValue(candidate.ResourceId!, out var latest);
+            if (latest is not null && candidate.ResourceVersion is { } resourceVersion && latest.Version != resourceVersion)
             {
                 results[index] = Failure(
                     index,
@@ -146,11 +152,14 @@ public sealed class ResourcePolicyApplicationService : IResourcePolicyApplicatio
                 continue;
             }
 
-            var policyFailure = await ValidatePolicyAsync(index, candidate, latest, tenant, definitions, cancellationToken);
-            if (policyFailure is not null)
+            if (latest is not null)
             {
-                results[index] = policyFailure;
-                continue;
+                var policyFailure = await ValidatePolicyAsync(index, candidate, latest, tenant, definitions, cancellationToken);
+                if (policyFailure is not null)
+                {
+                    results[index] = policyFailure;
+                    continue;
+                }
             }
 
             var key = new LifecycleCandidateKey(candidate.ResourceId!, markerState);
@@ -224,35 +233,28 @@ public sealed class ResourcePolicyApplicationService : IResourcePolicyApplicatio
         IDictionary<string, ResourceLifecycleMarker> markers,
         CancellationToken cancellationToken)
     {
-        if (existing is not null)
-        {
-            return existing.State == markerState
-                ? CandidateResult(index, candidate, ResourcePolicyApplicationCandidateStatus.AlreadySatisfied, existing)
-                : CandidateResult(
-                    index,
-                    candidate,
-                    ResourcePolicyApplicationCandidateStatus.Failed,
-                    existing,
-                    [
-                        ResourcePolicyValidator.Diagnostic(
-                            ResourcePolicyDiagnosticCodes.LifecycleMarkerConflict,
-                            $"Resource '{candidate.ResourceId}' is already marked as {existing.State}.",
-                            "state",
-                            resourceId: candidate.ResourceId),
-                    ]);
-        }
-
-        var marker = await markerStore.SaveMarkerAsync(new ResourceLifecycleMarker
+        var transition = await transitions.ApplyAsync(new ResourceLifecycleMarkerTransitionApplyRequest
         {
             TenantScope = tenant,
             ResourceId = candidate.ResourceId!,
             State = markerState,
             MarkedAt = request.AppliedAt,
             Reason = candidate.Reason ?? request.Reason,
+            HasCurrentMarker = true,
+            CurrentMarker = existing,
         }, cancellationToken);
-        markers[candidate.ResourceId!] = marker;
 
-        return CandidateResult(index, candidate, ResourcePolicyApplicationCandidateStatus.Applied, marker);
+        if (transition.Status == ResourceLifecycleMarkerTransitionStatus.Applied && transition.Marker is not null)
+            markers[candidate.ResourceId!] = transition.Marker;
+
+        var status = transition.Status switch
+        {
+            ResourceLifecycleMarkerTransitionStatus.Applied => ResourcePolicyApplicationCandidateStatus.Applied,
+            ResourceLifecycleMarkerTransitionStatus.AlreadySatisfied => ResourcePolicyApplicationCandidateStatus.AlreadySatisfied,
+            _ => ResourcePolicyApplicationCandidateStatus.Failed,
+        };
+
+        return CandidateResult(index, candidate, status, transition.Marker, transition.Diagnostics);
     }
 
     private static ResourcePolicyApplicationCandidateResult DuplicateResult(

--- a/src/core/Aster.Core/Services/ResourcePolicyApplicationService.cs
+++ b/src/core/Aster.Core/Services/ResourcePolicyApplicationService.cs
@@ -170,7 +170,16 @@ public sealed class ResourcePolicyApplicationService : IResourcePolicyApplicatio
             }
 
             markers.TryGetValue(candidate.ResourceId!, out var existing);
-            results[index] = await ApplyMarkerAsync(index, candidate, markerState, tenant, existing, request, markers, cancellationToken);
+            results[index] = await ApplyMarkerAsync(
+                index,
+                candidate,
+                markerState,
+                targetExists: latest is not null,
+                tenant,
+                existing,
+                request,
+                markers,
+                cancellationToken);
             processedLifecycleResults[key] = results[index]!;
         }
 
@@ -227,6 +236,7 @@ public sealed class ResourcePolicyApplicationService : IResourcePolicyApplicatio
         int index,
         ResourcePolicyApplicationCandidate candidate,
         ResourceLifecycleMarkerState markerState,
+        bool targetExists,
         TenantScope tenant,
         ResourceLifecycleMarker? existing,
         ResourcePolicyApplicationRequest request,
@@ -240,6 +250,8 @@ public sealed class ResourcePolicyApplicationService : IResourcePolicyApplicatio
             State = markerState,
             MarkedAt = request.AppliedAt,
             Reason = candidate.Reason ?? request.Reason,
+            TargetExists = targetExists,
+            HasTargetExistence = true,
             HasCurrentMarker = true,
             CurrentMarker = existing,
         }, cancellationToken);

--- a/test/Aster.Tests/Policies/LifecycleMarkerTransitionProviderParityTests.cs
+++ b/test/Aster.Tests/Policies/LifecycleMarkerTransitionProviderParityTests.cs
@@ -1,0 +1,231 @@
+using Aster.Core.Abstractions;
+using Aster.Core.Models.Instances;
+using Aster.Core.Models.Policies;
+using Aster.Core.Models.Portability;
+using Aster.Core.Models.Querying;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Aster.Tests.Policies;
+
+public sealed class LifecycleMarkerTransitionProviderParityTests : IDisposable
+{
+    private static readonly DateTimeOffset TransitionedAt = new(2026, 6, 26, 10, 0, 0, TimeSpan.Zero);
+    private readonly string databasePath = Path.Combine(Path.GetTempPath(), $"aster-marker-transition-parity-{Guid.NewGuid():N}.db");
+
+    public void Dispose() => PolicyTestFixtures.DeleteSqliteFiles(databasePath);
+
+    [Fact]
+    public async Task BuiltInProviders_ObserveSameLifecycleMarkerTransitionBehavior()
+    {
+        await using var inMemory = PolicyTestFixtures.CreateCoreProvider();
+        await using var sqlite = PolicyTestFixtures.CreateSqliteProvider(databasePath);
+
+        var inMemorySnapshot = await CaptureTransitionSnapshotAsync(inMemory);
+        var sqliteSnapshot = await CaptureTransitionSnapshotAsync(sqlite);
+        var expected = new ProviderTransitionSnapshot(
+            ManualResult: "True:manual-archived:Archived",
+            PolicyStatuses: "policy-archived:Applied:Archived,policy-soft-deleted:Applied:SoftDeleted",
+            RestorePreviewStatuses: "restore-target:Restorable:Archived",
+            RestoreStatuses: "restore-target:Restored:Archived",
+            ArchivedQueryIds: "manual-archived|policy-archived",
+            SoftDeletedQueryIds: "policy-soft-deleted",
+            UnmarkedQueryIds: "restore-target|unmarked",
+            HistoryStates: "manual-archived[1:Archived:]|policy-archived[1:Archived:]|policy-soft-deleted[1:SoftDeleted:]|restore-target[1:None:|2:None:Published]|unmarked[1:None:]",
+            ExportedMarkers: "manual-archived:Archived|policy-archived:Archived|policy-soft-deleted:SoftDeleted",
+            ExportedResourceVersions: "manual-archived:1:manual-archived-1|policy-archived:1:policy-archived-1|policy-soft-deleted:1:policy-soft-deleted-1|restore-target:1:restore-target-1|restore-target:2:restore-target-2|unmarked:1:unmarked-1",
+            VersionsUnchanged: true,
+            ActivationUnchanged: true);
+
+        Assert.Equal(expected, inMemorySnapshot);
+        Assert.Equal(expected, sqliteSnapshot);
+        Assert.Equal(inMemorySnapshot, sqliteSnapshot);
+    }
+
+    private static async Task<ProviderTransitionSnapshot> CaptureTransitionSnapshotAsync(IServiceProvider provider)
+    {
+        await SeedAsync(provider);
+        var versionsBefore = await ReadAllVersionsAsync(provider);
+        var activeBefore = await ReadPublishedVersionsAsync(provider, "restore-target");
+
+        var markerService = provider.GetRequiredService<IResourceLifecycleMarkerService>();
+        var manual = await markerService.ApplyAsync(new ResourceLifecycleMarkerRequest
+        {
+            ResourceId = "manual-archived",
+            State = ResourceLifecycleMarkerState.Archived,
+            MarkedAt = TransitionedAt,
+            Reason = "manual parity",
+        });
+
+        var policy = await provider.GetRequiredService<IResourcePolicyApplicationService>().ApplyAsync(new ResourcePolicyApplicationRequest
+        {
+            AppliedAt = TransitionedAt,
+            Reason = "policy parity",
+            Candidates =
+            [
+                PolicyTestFixtures.ApplicationCandidate("policy-archived", "archive"),
+                PolicyTestFixtures.ApplicationCandidate(
+                    "policy-soft-deleted",
+                    "soft-delete",
+                    ResourcePolicyKind.SoftDelete,
+                    ResourcePolicyOutcome.SoftDelete),
+            ],
+        });
+
+        await markerService.ApplyAsync(new ResourceLifecycleMarkerRequest
+        {
+            ResourceId = "restore-target",
+            State = ResourceLifecycleMarkerState.Archived,
+            MarkedAt = TransitionedAt,
+            Reason = "restore parity",
+        });
+
+        var restoreService = provider.GetRequiredService<IResourceLifecycleRestoreService>();
+        var restoreRequest = new ResourceLifecycleRestoreRequest
+        {
+            Candidates = [RestoreCandidate("restore-target", ResourceLifecycleMarkerState.Archived)],
+            RestoredAt = TransitionedAt,
+        };
+        var restorePreview = await restoreService.PreviewRestoreAsync(restoreRequest);
+        var restore = await restoreService.RestoreAsync(restoreRequest);
+
+        var versionsAfter = await ReadAllVersionsAsync(provider);
+        var activeAfter = await ReadPublishedVersionsAsync(provider, "restore-target");
+        Assert.Equal(versionsBefore, versionsAfter);
+        Assert.Equal(activeBefore, activeAfter);
+
+        var archivedIds = await QueryResourceIdsAsync(provider, ResourceLifecycleMarkerState.Archived);
+        var softDeletedIds = await QueryResourceIdsAsync(provider, ResourceLifecycleMarkerState.SoftDeleted);
+        var unmarkedIds = await QueryResourceIdsAsync(provider, ResourceLifecycleMarkerState.None);
+        var histories = await ReadHistoryStatesAsync(provider);
+        var exported = await ExportMarkerSnapshotAsync(provider);
+
+        return new ProviderTransitionSnapshot(
+            ManualResult: $"{manual.Succeeded}:{manual.Marker?.ResourceId}:{manual.Marker?.State}",
+            PolicyStatuses: string.Join(",", policy.Candidates.Select(static candidate => $"{candidate.ResourceId}:{candidate.Status}:{candidate.Marker?.State}")),
+            RestorePreviewStatuses: string.Join(",", restorePreview.Candidates.Select(static candidate => $"{candidate.ResourceId}:{candidate.Status}:{candidate.Marker?.State}")),
+            RestoreStatuses: string.Join(",", restore.Candidates.Select(static candidate => $"{candidate.ResourceId}:{candidate.Status}:{candidate.Marker?.State}")),
+            ArchivedQueryIds: archivedIds,
+            SoftDeletedQueryIds: softDeletedIds,
+            UnmarkedQueryIds: unmarkedIds,
+            HistoryStates: histories,
+            ExportedMarkers: exported.Markers,
+            ExportedResourceVersions: exported.ResourceVersions,
+            VersionsUnchanged: versionsBefore == versionsAfter,
+            ActivationUnchanged: activeBefore == activeAfter);
+    }
+
+    private static async Task SeedAsync(IServiceProvider provider)
+    {
+        await PolicyTestFixtures.RegisterProductDefinitionAsync(
+            provider,
+            policies:
+            [
+                PolicyTestFixtures.ArchivePolicy("archive"),
+                PolicyTestFixtures.SoftDeletePolicy("soft-delete"),
+            ]);
+        await PolicyTestFixtures.SaveResourceAsync(provider, "manual-archived");
+        await PolicyTestFixtures.SaveResourceAsync(provider, "policy-archived");
+        await PolicyTestFixtures.SaveResourceAsync(provider, "policy-soft-deleted");
+        await PolicyTestFixtures.SaveResourceAsync(provider, "restore-target");
+        await PolicyTestFixtures.SaveResourceAsync(provider, "restore-target", version: 2);
+        await PolicyTestFixtures.SaveResourceAsync(provider, "unmarked");
+        await PolicyTestFixtures.ActivateAsync(provider, "restore-target", version: 2);
+    }
+
+    private static ResourceLifecycleRestoreCandidate RestoreCandidate(
+        string resourceId,
+        ResourceLifecycleMarkerState expectedState) =>
+        new()
+        {
+            ResourceId = resourceId,
+            ExpectedState = expectedState,
+        };
+
+    private static async Task<string> QueryResourceIdsAsync(IServiceProvider provider, ResourceLifecycleMarkerState state)
+    {
+        var resources = await provider.GetRequiredService<IResourceQueryService>().QueryAsync(new ResourceQuery
+        {
+            LifecycleState = state,
+            Sorts = [new SortExpression("ResourceId")],
+        });
+
+        return Join(resources.Select(static resource => resource.ResourceId));
+    }
+
+    private static async Task<string> ReadHistoryStatesAsync(IServiceProvider provider)
+    {
+        var result = await provider.GetRequiredService<IResourceVersionHistoryService>().GetHistoriesAsync(
+            new ResourceVersionHistoryBatchRequest
+            {
+                ResourceIds = ["manual-archived", "policy-archived", "policy-soft-deleted", "restore-target", "unmarked"],
+            });
+
+        return Join(result.Histories.Select(static history =>
+            $"{history.ResourceId}[{Join(history.Versions.Select(static version => $"{version.Version}:{version.LifecycleState}:{Join(version.ActiveChannels)}"))}]"));
+    }
+
+    private static async Task<ExportSnapshot> ExportMarkerSnapshotAsync(IServiceProvider provider)
+    {
+        var result = await provider.GetRequiredService<IResourcePortabilityService>().ExportAsync(new PortableSnapshotExportRequest
+        {
+            ScopeMode = PortableExportScopeMode.SelectedResources,
+            ResourceIds = ["manual-archived", "policy-archived", "policy-soft-deleted", "restore-target", "unmarked"],
+            ResourceVersionScope = PortableResourceVersionScope.AllVersions,
+        });
+        var snapshot = result.Snapshot!;
+
+        return new ExportSnapshot(
+            Markers: Join(snapshot.LifecycleMarkers
+                .OrderBy(static marker => marker.ResourceId, StringComparer.Ordinal)
+                .Select(static marker => $"{marker.ResourceId}:{marker.State}")),
+            ResourceVersions: Join(snapshot.Resources
+                .OrderBy(static resource => resource.ResourceId, StringComparer.Ordinal)
+                .ThenBy(static resource => resource.Version)
+                .Select(static resource => $"{resource.ResourceId}:{resource.Version}:{resource.Id}")));
+    }
+
+    private static async Task<string> ReadAllVersionsAsync(IServiceProvider provider)
+    {
+        var versions = await provider.GetRequiredService<IResourceVersionReader>().ReadVersionsAsync(new ResourceVersionReadRequest
+        {
+            Scope = ResourceVersionScope.AllVersions,
+        });
+
+        return Join(versions
+            .OrderBy(static resource => resource.ResourceId, StringComparer.Ordinal)
+            .ThenBy(static resource => resource.Version)
+            .Select(static resource => $"{resource.ResourceId}:{resource.Version}:{resource.Id}"));
+    }
+
+    private static async Task<string> ReadPublishedVersionsAsync(IServiceProvider provider, string resourceId)
+    {
+        var versions = await provider.GetRequiredService<IResourceVersionReader>().ReadVersionsAsync(new ResourceVersionReadRequest
+        {
+            Scope = ResourceVersionScope.Active,
+            ActivationChannel = "Published",
+            ResourceIds = [resourceId],
+        });
+
+        return Join(versions
+            .OrderBy(static resource => resource.Version)
+            .Select(static resource => $"{resource.ResourceId}:{resource.Version}:{resource.Id}"));
+    }
+
+    private static string Join(IEnumerable<string> values) => string.Join("|", values);
+
+    private sealed record ProviderTransitionSnapshot(
+        string ManualResult,
+        string PolicyStatuses,
+        string RestorePreviewStatuses,
+        string RestoreStatuses,
+        string ArchivedQueryIds,
+        string SoftDeletedQueryIds,
+        string UnmarkedQueryIds,
+        string HistoryStates,
+        string ExportedMarkers,
+        string ExportedResourceVersions,
+        bool VersionsUnchanged,
+        bool ActivationUnchanged);
+
+    private sealed record ExportSnapshot(string Markers, string ResourceVersions);
+}

--- a/test/Aster.Tests/Policies/LifecycleMarkerTransitionTests.cs
+++ b/test/Aster.Tests/Policies/LifecycleMarkerTransitionTests.cs
@@ -110,6 +110,96 @@ public sealed class LifecycleMarkerTransitionTests : IDisposable
         Assert.Null(persisted);
     }
 
+    [Fact]
+    public async Task ClearAsync_WhenMarkerMatchesAndApplyIsFalse_IsReadyToClear()
+    {
+        await PolicyTestFixtures.SaveResourceAsync(provider, "product-1");
+        var transition = provider.GetRequiredService<IResourceLifecycleMarkerTransitionService>();
+        var marker = (await transition.ApplyAsync(ApplyRequest("product-1", ResourceLifecycleMarkerState.Archived))).Marker!;
+
+        var result = await transition.ClearAsync(ClearRequest(
+            "product-1",
+            ResourceLifecycleMarkerState.Archived,
+            apply: false,
+            currentMarker: marker));
+
+        Assert.Equal(ResourceLifecycleMarkerTransitionStatus.ReadyToClear, result.Status);
+        Assert.Equal(marker, result.Marker);
+        var persisted = await provider.GetRequiredService<IResourceLifecycleMarkerStore>()
+            .GetMarkerAsync("product-1", TenantScope.Default);
+        Assert.Equal(marker, persisted);
+    }
+
+    [Fact]
+    public async Task ClearAsync_WhenMarkerMatchesAndApplyIsTrue_ClearsMarker()
+    {
+        await PolicyTestFixtures.SaveResourceAsync(provider, "product-1");
+        var transition = provider.GetRequiredService<IResourceLifecycleMarkerTransitionService>();
+        var marker = (await transition.ApplyAsync(ApplyRequest("product-1", ResourceLifecycleMarkerState.Archived))).Marker!;
+
+        var result = await transition.ClearAsync(ClearRequest(
+            "product-1",
+            ResourceLifecycleMarkerState.Archived,
+            apply: true,
+            currentMarker: marker));
+
+        Assert.Equal(ResourceLifecycleMarkerTransitionStatus.Cleared, result.Status);
+        Assert.Equal(marker, result.Marker);
+        var persisted = await provider.GetRequiredService<IResourceLifecycleMarkerStore>()
+            .GetMarkerAsync("product-1", TenantScope.Default);
+        Assert.Null(persisted);
+    }
+
+    [Fact]
+    public async Task ClearAsync_WhenMarkerIsAlreadyMissing_IsAlreadyCleared()
+    {
+        await PolicyTestFixtures.SaveResourceAsync(provider, "product-1");
+        var transition = provider.GetRequiredService<IResourceLifecycleMarkerTransitionService>();
+
+        var result = await transition.ClearAsync(ClearRequest(
+            "product-1",
+            ResourceLifecycleMarkerState.Archived,
+            apply: true));
+
+        Assert.Equal(ResourceLifecycleMarkerTransitionStatus.AlreadyCleared, result.Status);
+        Assert.Empty(result.Diagnostics);
+        Assert.Null(result.Marker);
+    }
+
+    [Fact]
+    public async Task ClearAsync_WhenMarkerStateDiffers_ReturnsMarkerMismatch()
+    {
+        await PolicyTestFixtures.SaveResourceAsync(provider, "product-1");
+        var transition = provider.GetRequiredService<IResourceLifecycleMarkerTransitionService>();
+        var marker = (await transition.ApplyAsync(ApplyRequest("product-1", ResourceLifecycleMarkerState.SoftDeleted))).Marker!;
+
+        var result = await transition.ClearAsync(ClearRequest(
+            "product-1",
+            ResourceLifecycleMarkerState.Archived,
+            apply: true,
+            currentMarker: marker));
+
+        Assert.Equal(ResourceLifecycleMarkerTransitionStatus.MarkerMismatch, result.Status);
+        Assert.Equal(marker, result.Marker);
+        var diagnostic = Assert.Single(result.Diagnostics);
+        Assert.Equal(ResourcePolicyDiagnosticCodes.LifecycleRestoreMarkerMismatch, diagnostic.Code);
+    }
+
+    [Fact]
+    public async Task ClearAsync_WhenTargetIsMissing_ReturnsTargetNotFound()
+    {
+        var transition = provider.GetRequiredService<IResourceLifecycleMarkerTransitionService>();
+
+        var result = await transition.ClearAsync(ClearRequest(
+            "missing",
+            ResourceLifecycleMarkerState.Archived,
+            apply: true));
+
+        Assert.Equal(ResourceLifecycleMarkerTransitionStatus.Failed, result.Status);
+        var diagnostic = Assert.Single(result.Diagnostics);
+        Assert.Equal(ResourcePolicyDiagnosticCodes.LifecycleMarkerTargetNotFound, diagnostic.Code);
+    }
+
     private static ResourceLifecycleMarkerTransitionApplyRequest ApplyRequest(
         string resourceId,
         ResourceLifecycleMarkerState state,
@@ -121,6 +211,23 @@ public sealed class LifecycleMarkerTransitionTests : IDisposable
             State = state,
             MarkedAt = MarkedAt,
             HasCurrentMarker = currentMarker is not null,
+            CurrentMarker = currentMarker,
+        };
+
+    private static ResourceLifecycleMarkerTransitionClearRequest ClearRequest(
+        string resourceId,
+        ResourceLifecycleMarkerState expectedState,
+        bool apply,
+        ResourceLifecycleMarker? currentMarker = null) =>
+        new()
+        {
+            TenantScope = TenantScope.Default,
+            ResourceId = resourceId,
+            ExpectedState = expectedState,
+            Apply = apply,
+            TargetExists = resourceId != "missing",
+            HasTargetExistence = true,
+            HasCurrentMarker = currentMarker is not null || resourceId != "missing",
             CurrentMarker = currentMarker,
         };
 }

--- a/test/Aster.Tests/Policies/LifecycleMarkerTransitionTests.cs
+++ b/test/Aster.Tests/Policies/LifecycleMarkerTransitionTests.cs
@@ -1,0 +1,126 @@
+using Aster.Core.Abstractions;
+using Aster.Core.Models.Instances;
+using Aster.Core.Models.Policies;
+using Aster.Core.Models.Tenancy;
+using Aster.Core.Services;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Aster.Tests.Policies;
+
+public sealed class LifecycleMarkerTransitionTests : IDisposable
+{
+    private static readonly DateTimeOffset MarkedAt = new(2026, 6, 26, 9, 0, 0, TimeSpan.Zero);
+    private readonly ServiceProvider provider = PolicyTestFixtures.CreateCoreProvider();
+
+    public void Dispose() => provider.Dispose();
+
+    [Fact]
+    public async Task ApplyAsync_AppliesMarkerWhenTargetExists()
+    {
+        await PolicyTestFixtures.SaveResourceAsync(provider, "product-1");
+        var transition = provider.GetRequiredService<IResourceLifecycleMarkerTransitionService>();
+
+        var result = await transition.ApplyAsync(ApplyRequest("product-1", ResourceLifecycleMarkerState.Archived));
+
+        Assert.Equal(ResourceLifecycleMarkerTransitionStatus.Applied, result.Status);
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(ResourceLifecycleMarkerState.Archived, result.Marker!.State);
+        Assert.Equal("product-1", result.Marker.ResourceId);
+    }
+
+    [Fact]
+    public async Task ApplyAsync_ReapplyingSameStateIsAlreadySatisfied()
+    {
+        await PolicyTestFixtures.SaveResourceAsync(provider, "product-1");
+        var transition = provider.GetRequiredService<IResourceLifecycleMarkerTransitionService>();
+
+        var first = await transition.ApplyAsync(ApplyRequest("product-1", ResourceLifecycleMarkerState.Archived));
+        var second = await transition.ApplyAsync(ApplyRequest("product-1", ResourceLifecycleMarkerState.Archived));
+
+        Assert.Equal(ResourceLifecycleMarkerTransitionStatus.Applied, first.Status);
+        Assert.Equal(ResourceLifecycleMarkerTransitionStatus.AlreadySatisfied, second.Status);
+        Assert.Empty(second.Diagnostics);
+        Assert.Equal(first.Marker, second.Marker);
+    }
+
+    [Fact]
+    public async Task ApplyAsync_RejectsUnsupportedState()
+    {
+        await PolicyTestFixtures.SaveResourceAsync(provider, "product-1");
+        var transition = provider.GetRequiredService<IResourceLifecycleMarkerTransitionService>();
+
+        var result = await transition.ApplyAsync(ApplyRequest("product-1", ResourceLifecycleMarkerState.None));
+
+        Assert.Equal(ResourceLifecycleMarkerTransitionStatus.Failed, result.Status);
+        var diagnostic = Assert.Single(result.Diagnostics);
+        Assert.Equal(ResourcePolicyDiagnosticCodes.PolicyInvalid, diagnostic.Code);
+        Assert.Null(result.Marker);
+    }
+
+    [Fact]
+    public async Task ApplyAsync_RejectsMissingTarget()
+    {
+        var transition = provider.GetRequiredService<IResourceLifecycleMarkerTransitionService>();
+
+        var result = await transition.ApplyAsync(ApplyRequest("missing", ResourceLifecycleMarkerState.Archived));
+
+        Assert.Equal(ResourceLifecycleMarkerTransitionStatus.Failed, result.Status);
+        var diagnostic = Assert.Single(result.Diagnostics);
+        Assert.Equal(ResourcePolicyDiagnosticCodes.LifecycleMarkerTargetNotFound, diagnostic.Code);
+        Assert.Null(result.Marker);
+    }
+
+    [Fact]
+    public async Task ApplyAsync_RejectsConflictingExistingMarker()
+    {
+        await PolicyTestFixtures.SaveResourceAsync(provider, "product-1");
+        var transition = provider.GetRequiredService<IResourceLifecycleMarkerTransitionService>();
+        var archived = await transition.ApplyAsync(ApplyRequest("product-1", ResourceLifecycleMarkerState.Archived));
+
+        var result = await transition.ApplyAsync(ApplyRequest("product-1", ResourceLifecycleMarkerState.SoftDeleted));
+
+        Assert.Equal(ResourceLifecycleMarkerTransitionStatus.Failed, result.Status);
+        Assert.Equal(archived.Marker, result.Marker);
+        var diagnostic = Assert.Single(result.Diagnostics);
+        Assert.Equal(ResourcePolicyDiagnosticCodes.LifecycleMarkerConflict, diagnostic.Code);
+    }
+
+    [Fact]
+    public async Task ApplyAsync_UsesPreloadedCurrentMarker()
+    {
+        await PolicyTestFixtures.SaveResourceAsync(provider, "product-1");
+        var transition = provider.GetRequiredService<IResourceLifecycleMarkerTransitionService>();
+        var existing = new ResourceLifecycleMarker
+        {
+            TenantScope = TenantScope.Default,
+            ResourceId = "product-1",
+            State = ResourceLifecycleMarkerState.Archived,
+            MarkedAt = MarkedAt,
+        };
+
+        var result = await transition.ApplyAsync(ApplyRequest(
+            "product-1",
+            ResourceLifecycleMarkerState.Archived,
+            currentMarker: existing));
+
+        Assert.Equal(ResourceLifecycleMarkerTransitionStatus.AlreadySatisfied, result.Status);
+        Assert.Equal(existing, result.Marker);
+        var persisted = await provider.GetRequiredService<IResourceLifecycleMarkerStore>()
+            .GetMarkerAsync("product-1", TenantScope.Default);
+        Assert.Null(persisted);
+    }
+
+    private static ResourceLifecycleMarkerTransitionApplyRequest ApplyRequest(
+        string resourceId,
+        ResourceLifecycleMarkerState state,
+        ResourceLifecycleMarker? currentMarker = null) =>
+        new()
+        {
+            TenantScope = TenantScope.Default,
+            ResourceId = resourceId,
+            State = state,
+            MarkedAt = MarkedAt,
+            HasCurrentMarker = currentMarker is not null,
+            CurrentMarker = currentMarker,
+        };
+}

--- a/test/Aster.Tests/Portability/PortabilityImportTests.cs
+++ b/test/Aster.Tests/Portability/PortabilityImportTests.cs
@@ -403,7 +403,7 @@ public sealed class PortabilityImportTests : IDisposable
     {
         var service = new ResourcePortabilityService(
             new ThrowingApplyPortabilityStore(),
-            new NoopResourceLifecycleHookDispatcher());
+            new Lifecycle.NoopResourceLifecycleHookDispatcher());
 
         var result = await service.ImportAsync(CreateSnapshot());
 

--- a/test/Aster.Tests/SqliteJson/SqliteJsonResourceStoreTests.cs
+++ b/test/Aster.Tests/SqliteJson/SqliteJsonResourceStoreTests.cs
@@ -297,7 +297,7 @@ public sealed class SqliteJsonResourceStoreTests : IDisposable
             store,
             store,
             new GuidIdentityGenerator(),
-            new NoopResourceLifecycleHookDispatcher(),
+            new Lifecycle.NoopResourceLifecycleHookDispatcher(),
             NullLogger<DefaultResourceManager>.Instance);
 
     private static string GetTitle(Resource resource)


### PR DESCRIPTION
## Summary
- introduce an internal Lifecycle Marker Transition module for applying and clearing archive/soft-delete markers
- route manual marker writes, policy application, and lifecycle restore through the shared transition seam while preserving public workflow result shapes
- add focused transition tests and end-to-end in-memory/SQLite JSON provider parity coverage for queries, history, portability markers, versions, and activation state

## Slice PRs
- #51 Introduce lifecycle marker transition module
- #52 Route policy application through lifecycle transitions
- #53 Route lifecycle restore through marker transitions
- #54 Prove lifecycle marker transition provider parity

## Verification
- dotnet test test/Aster.Tests/Aster.Tests.csproj --filter "FullyQualifiedName~LifecycleMarker"
- dotnet test test/Aster.Tests/Aster.Tests.csproj --filter "FullyQualifiedName~PolicyApplication"
- dotnet test test/Aster.Tests/Aster.Tests.csproj --filter "FullyQualifiedName~LifecycleRestore"
- dotnet test test/Aster.Tests/Aster.Tests.csproj --filter "FullyQualifiedName~LifecycleMarker|FullyQualifiedName~PolicyApplication"
- dotnet test test/Aster.Tests/Aster.Tests.csproj --filter "FullyQualifiedName~LifecycleMarker|FullyQualifiedName~LifecycleRestore"
- dotnet test test/Aster.Tests/Aster.Tests.csproj --filter "FullyQualifiedName~LifecycleMarkerTransitionProviderParityTests"
- dotnet test test/Aster.Tests/Aster.Tests.csproj --filter "FullyQualifiedName~LifecycleMarkerTransition|FullyQualifiedName~PolicyApplication|FullyQualifiedName~LifecycleRestore|FullyQualifiedName~LifecycleStateQuery|FullyQualifiedName~ResourceVersionHistory|FullyQualifiedName~PortabilityLifecycleMarker"
- dotnet test Aster.sln

Closes #46
