### PR TITLE
Preserve lifecycle transition diagnostic paths

### DIFF
--- a/src/core/Aster.Core/Services/ResourceLifecycleMarkerTransitionService.cs
+++ b/src/core/Aster.Core/Services/ResourceLifecycleMarkerTransitionService.cs
@@ -56,7 +56,8 @@ internal sealed class ResourceLifecycleMarkerTransitionService : IResourceLifecy
                 ResourceLifecycleMarkerTransitionStatus.Failed,
                 ResourcePolicyDiagnosticCodes.LifecycleMarkerTargetNotFound,
                 $"Resource '{request.ResourceId}' was not found in tenant '{request.TenantScope.TenantId}'.",
-                request.ResourceId);
+                request.ResourceId,
+                request.TargetNotFoundDiagnosticPath);
         }
 
         var existing = await ResolveCurrentMarkerAsync(request, cancellationToken);
@@ -124,7 +125,8 @@ internal sealed class ResourceLifecycleMarkerTransitionService : IResourceLifecy
                 ResourceLifecycleMarkerTransitionStatus.Failed,
                 ResourcePolicyDiagnosticCodes.LifecycleMarkerTargetNotFound,
                 $"Resource '{request.ResourceId}' was not found in tenant '{request.TenantScope.TenantId}'.",
-                request.ResourceId);
+                request.ResourceId,
+                request.TargetNotFoundDiagnosticPath);
         }
 
         var existing = await ResolveCurrentMarkerAsync(request, cancellationToken);
@@ -225,7 +227,8 @@ internal sealed class ResourceLifecycleMarkerTransitionService : IResourceLifecy
         ResourceLifecycleMarkerTransitionStatus status,
         string code,
         string message,
-        string resourceId) =>
+        string resourceId,
+        string? path = null) =>
         new()
         {
             Status = status,
@@ -234,6 +237,7 @@ internal sealed class ResourceLifecycleMarkerTransitionService : IResourceLifecy
                 ResourcePolicyValidator.Diagnostic(
                     code,
                     message,
+                    path,
                     resourceId: resourceId),
             ],
         };
@@ -252,6 +256,8 @@ internal abstract class ResourceLifecycleMarkerTransitionRequest
     public ResourceLifecycleMarker? CurrentMarker { get; init; }
 
     public bool HasCurrentMarker { get; init; }
+
+    public string? TargetNotFoundDiagnosticPath { get; init; }
 }
 
 internal sealed class ResourceLifecycleMarkerTransitionApplyRequest : ResourceLifecycleMarkerTransitionRequest

--- a/src/core/Aster.Core/Services/ResourceLifecycleRestoreService.cs
+++ b/src/core/Aster.Core/Services/ResourceLifecycleRestoreService.cs
@@ -173,6 +173,7 @@ public sealed class ResourceLifecycleRestoreService : IResourceLifecycleRestoreS
             Apply = apply,
             TargetExists = targetExists,
             HasTargetExistence = true,
+            TargetNotFoundDiagnosticPath = "resourceId",
             CurrentMarker = marker,
             HasCurrentMarker = true,
         }, cancellationToken);

--- a/src/core/Aster.Core/Services/ResourcePolicyApplicationService.cs
+++ b/src/core/Aster.Core/Services/ResourcePolicyApplicationService.cs
@@ -252,6 +252,7 @@ public sealed class ResourcePolicyApplicationService : IResourcePolicyApplicatio
             Reason = candidate.Reason ?? request.Reason,
             TargetExists = targetExists,
             HasTargetExistence = true,
+            TargetNotFoundDiagnosticPath = "resourceId",
             HasCurrentMarker = true,
             CurrentMarker = existing,
         }, cancellationToken);

--- a/test/Aster.Tests/Lifecycle/LifecycleRestorePreviewTests.cs
+++ b/test/Aster.Tests/Lifecycle/LifecycleRestorePreviewTests.cs
@@ -86,6 +86,8 @@ public sealed class LifecycleRestorePreviewTests : IDisposable
     private static void AssertDiagnostic(ResourceLifecycleRestoreCandidateResult result, string code)
     {
         Assert.Equal(ResourceLifecycleRestoreCandidateStatus.Failed, result.Status);
-        Assert.Contains(result.Diagnostics, diagnostic => diagnostic.Code == code);
+        var diagnostic = Assert.Single(result.Diagnostics.Where(diagnostic => diagnostic.Code == code));
+        if (code == ResourcePolicyDiagnosticCodes.LifecycleMarkerTargetNotFound)
+            Assert.Equal("resourceId", diagnostic.Path);
     }
 }

--- a/test/Aster.Tests/Policies/PolicyApplicationDiagnosticsTests.cs
+++ b/test/Aster.Tests/Policies/PolicyApplicationDiagnosticsTests.cs
@@ -183,6 +183,9 @@ public sealed class PolicyApplicationDiagnosticsTests : IDisposable
     {
         var candidate = Assert.Single(result.Candidates);
         Assert.Equal(ResourcePolicyApplicationCandidateStatus.Failed, candidate.Status);
-        Assert.Equal(code, candidate.Diagnostics.Single().Code);
+        var diagnostic = candidate.Diagnostics.Single();
+        Assert.Equal(code, diagnostic.Code);
+        if (code == ResourcePolicyDiagnosticCodes.LifecycleMarkerTargetNotFound)
+            Assert.Equal("resourceId", diagnostic.Path);
     }
 }


### PR DESCRIPTION
## Summary
- preserve caller-specific `resourceId` diagnostic paths for policy application and lifecycle restore missing-target results after transition delegation
- keep manual marker writes on the previous no-path diagnostic behavior
- add workflow-level assertions for the missing-target diagnostic path

## Verification
- dotnet test test/Aster.Tests/Aster.Tests.csproj --filter "FullyQualifiedName~PolicyApplicationDiagnosticsTests|FullyQualifiedName~LifecycleRestorePreviewTests|FullyQualifiedName~LifecycleMarkerTransitionTests"
- dotnet test test/Aster.Tests/Aster.Tests.csproj --filter "FullyQualifiedName~LifecycleMarkerTransition|FullyQualifiedName~PolicyApplication|FullyQualifiedName~LifecycleRestore|FullyQualifiedName~LifecycleStateQuery|FullyQualifiedName~ResourceVersionHistory|FullyQualifiedName~PortabilityLifecycleMarker"
- dotnet test Aster.sln
